### PR TITLE
Startup cleanup and auditing improvements

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -665,7 +665,7 @@ def audit_positions(ctx: "BotContext") -> None:
     try:
         remote = {p.symbol: int(p.qty) for p in ctx.api.list_positions()}
     except Exception as e:
-        logger.warning(f"[reconcile_positions] failed to fetch remote positions: {e}")
+        logger.warning(f"[audit_positions] failed to fetch remote positions: {e}")
         return
     for sym, rq in remote.items():
         lq = local.get(sym, 0)


### PR DESCRIPTION
## Summary
- ensure open orders are canceled and stale targets cleared
- rename reconcile_positions to audit_positions and update usage
- bypass the first regime check
- audit broker positions on startup

## Testing
- `python -m py_compile bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409b27452c8330bc9b2647f26810f6