### PR TITLE
Fix MFI dtype warning

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2512,6 +2512,7 @@ def prepare_indicators(df: pd.DataFrame, freq: str = "daily") -> pd.DataFrame:
         df["cci"] = np.nan
 
     try:
+        df[["High", "Low", "Close", "Volume"]] = df[["High", "Low", "Close", "Volume"]].astype(float)
         df["mfi"] = ta.mfi(df["High"], df["Low"], df["Close"], df["Volume"], length=14).astype(float)
     except Exception:
         df["mfi"] = np.nan


### PR DESCRIPTION
## Summary
- ensure Money Flow Index inputs are floats to avoid pandas FutureWarning

## Testing
- `python -m py_compile bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a5e366848330aaa9a2a0cf654bd6