### PR TITLE
Implement Stage 7 multi-asset framework

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,0 +1,130 @@
+import os
+import random
+import time as pytime
+from dataclasses import dataclass
+from datetime import datetime, date, timedelta, timezone
+from collections import deque
+from typing import Optional, Sequence
+
+import pandas as pd
+import yfinance as yf
+from alpaca_trade_api.rest import REST, TimeFrame, APIError
+from tenacity import retry, stop_after_attempt, wait_exponential, wait_random, retry_if_exception_type
+import finnhub
+
+class DataFetchError(Exception):
+    pass
+
+finnhub_client = finnhub.Client(api_key=os.getenv("FINNHUB_API_KEY"))
+
+class FinnhubFetcher:
+    def __init__(self, calls_per_minute: int = 60) -> None:
+        self.max_calls = calls_per_minute
+        self._timestamps = deque()
+        self.client = finnhub_client
+
+    def _throttle(self) -> None:
+        while True:
+            now_ts = pytime.time()
+            while self._timestamps and now_ts - self._timestamps[0] > 60:
+                self._timestamps.popleft()
+            if len(self._timestamps) < self.max_calls:
+                self._timestamps.append(now_ts)
+                return
+            wait_secs = 60 - (now_ts - self._timestamps[0]) + random.uniform(0.1, 0.5)
+            pytime.sleep(wait_secs)
+
+    def _parse_period(self, period: str) -> int:
+        if period.endswith("mo"):
+            return int(period[:-2]) * 30 * 86400
+        num = int(period[:-1])
+        unit = period[-1]
+        if unit == "d":
+            return num * 86400
+        raise ValueError(f"Unsupported period: {period}")
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=10) + wait_random(0.1, 1), retry=retry_if_exception_type(Exception))
+    def fetch(self, symbols, period="1mo", interval="1d") -> pd.DataFrame:
+        syms = symbols if isinstance(symbols, (list, tuple)) else [symbols]
+        now_ts = int(pytime.time())
+        span = self._parse_period(period)
+        start_ts = now_ts - span
+        resolution = 'D' if interval == '1d' else '1'
+        frames = []
+        for sym in syms:
+            self._throttle()
+            resp = self.client.stock_candles(sym, resolution, _from=start_ts, to=now_ts)
+            if resp.get('s') != 'ok':
+                frames.append(pd.DataFrame())
+                continue
+            df = pd.DataFrame({
+                'Open': resp['o'],
+                'High': resp['h'],
+                'Low': resp['l'],
+                'Close': resp['c'],
+                'Volume': resp['v'],
+            }, index=pd.to_datetime(resp['t'], unit='s', utc=True))
+            df.index = df.index.tz_convert(None)
+            frames.append(df)
+        if not frames:
+            return pd.DataFrame()
+        if len(frames) == 1:
+            return frames[0]
+        return pd.concat(frames, axis=1, keys=syms, names=['Symbol','Field'])
+
+fh = FinnhubFetcher()
+
+@dataclass
+class DataFetcher:
+    """Unified data adapter supporting multiple feeds."""
+
+    def __post_init__(self) -> None:
+        self._daily_cache: dict[str, Optional[pd.DataFrame]] = {}
+        self._minute_cache: dict[str, Optional[pd.DataFrame]] = {}
+        self._minute_timestamps: dict[str, datetime] = {}
+
+    def get_daily_df(self, ctx, symbol: str) -> Optional[pd.DataFrame]:
+        if symbol in self._daily_cache:
+            return self._daily_cache[symbol]
+        try:
+            bars = ctx.api.get_bars(symbol, TimeFrame.Day, limit=1000, feed="iex").df
+            bars.index = pd.to_datetime(bars.index).tz_localize(None)
+            df = bars.rename(columns={"open":"Open","high":"High","low":"Low","close":"Close","volume":"Volume"})
+        except Exception:
+            try:
+                df = fh.fetch(symbol, period="1mo", interval="1d")
+            except Exception:
+                df_yf = yf.download(symbol, period="1mo", interval="1d", progress=False)
+                if df_yf.empty:
+                    df = None
+                else:
+                    df_yf.index = pd.to_datetime(df_yf.index).tz_localize(None)
+                    df = df_yf.rename(columns=lambda c: c.title())[ ["Open","High","Low","Close","Volume"] ]
+        self._daily_cache[symbol] = df
+        return df
+
+    def get_minute_df(self, ctx, symbol: str) -> Optional[pd.DataFrame]:
+        now = datetime.now(timezone.utc)
+        ts = self._minute_timestamps.get(symbol)
+        if ts and (now - ts) < timedelta(seconds=60):
+            return self._minute_cache.get(symbol)
+        df = None
+        try:
+            bars = ctx.api.get_bars(symbol, TimeFrame.Minute, limit=390, feed="iex").df
+            if not bars.empty:
+                bars = bars.rename(columns={"open":"Open","high":"High","low":"Low","close":"Close","volume":"Volume"})
+                if "symbol" in bars.columns:
+                    bars = bars.drop(columns=["symbol"])
+                bars.index = pd.to_datetime(bars.index).tz_localize(None)
+                df = bars[["Open","High","Low","Close","Volume"]]
+        except Exception:
+            try:
+                df = fh.fetch(symbol, period="5d", interval="1m")
+            except Exception:
+                df_yf = yf.download(symbol, period="5d", interval="1m", progress=False)
+                if not df_yf.empty:
+                    df_yf.index = pd.to_datetime(df_yf.index).tz_localize(None)
+                    df = df_yf.rename(columns=lambda c: c.title())[ ["Open","High","Low","Close","Volume"] ]
+        self._minute_cache[symbol] = df
+        self._minute_timestamps[symbol] = now
+        return df

--- a/risk_engine.py
+++ b/risk_engine.py
@@ -1,0 +1,29 @@
+from typing import Dict
+from strategies import TradeSignal
+
+class RiskEngine:
+    """Cross-strategy risk manager."""
+
+    def __init__(self) -> None:
+        self.global_limit = 1.0
+        self.asset_limits: Dict[str, float] = {}
+        self.strategy_limits: Dict[str, float] = {}
+        self.exposure: Dict[str, float] = {}
+
+    def can_trade(self, signal: TradeSignal) -> bool:
+        asset_exp = self.exposure.get(signal.asset_class, 0.0)
+        asset_cap = self.asset_limits.get(signal.asset_class, self.global_limit)
+        if asset_exp + signal.weight > asset_cap:
+            return False
+        strat_cap = self.strategy_limits.get(signal.strategy, self.global_limit)
+        return signal.weight <= strat_cap
+
+    def register_fill(self, signal: TradeSignal) -> None:
+        self.exposure[signal.asset_class] = self.exposure.get(signal.asset_class, 0.0) + signal.weight
+
+    def position_size(self, signal: TradeSignal, cash: float, price: float) -> int:
+        if not self.can_trade(signal) or price <= 0:
+            return 0
+        dollars = cash * min(signal.weight, 1.0)
+        qty = int(dollars / price)
+        return max(qty, 0)

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,0 +1,11 @@
+from .base import Strategy, TradeSignal, asset_class_for
+from .momentum import MomentumStrategy
+from .mean_reversion import MeanReversionStrategy
+
+__all__ = [
+    "Strategy",
+    "TradeSignal",
+    "MomentumStrategy",
+    "MeanReversionStrategy",
+    "asset_class_for",
+]

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import List
+
+
+def asset_class_for(symbol: str) -> str:
+    sym = symbol.upper()
+    if sym.endswith("USD") and len(sym) == 6:
+        return "forex"
+    if sym.startswith("BTC") or sym.startswith("ETH"):
+        return "crypto"
+    return "equity"
+
+@dataclass
+class TradeSignal:
+    symbol: str
+    side: str  # 'buy' or 'sell'
+    confidence: float
+    strategy: str
+    asset_class: str = "equity"
+    weight: float = 1.0
+    price: float = 0.0
+
+class Strategy:
+    """Base strategy interface."""
+
+    name: str = "base"
+    asset_class: str = "equity"
+
+    def generate(self, ctx) -> List[TradeSignal]:
+        """Return a list of TradeSignal objects."""
+        return []

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -1,0 +1,30 @@
+from typing import List
+import pandas as pd
+from .base import Strategy, TradeSignal, asset_class_for
+
+class MeanReversionStrategy(Strategy):
+    """Simple mean reversion strategy using z-score."""
+
+    name = "mean_reversion"
+
+    def __init__(self, lookback: int = 20, z: float = 2.0) -> None:
+        self.lookback = lookback
+        self.z = z
+
+    def generate(self, ctx) -> List[TradeSignal]:
+        signals: List[TradeSignal] = []
+        tickers = getattr(ctx, "tickers", [])
+        for sym in tickers:
+            df = ctx.data_fetcher.get_daily_df(ctx, sym)
+            if df is None or len(df) <= self.lookback:
+                continue
+            ma = df["Close"].rolling(self.lookback).mean().iloc[-1]
+            sd = df["Close"].rolling(self.lookback).std().iloc[-1]
+            if pd.isna(ma) or pd.isna(sd) or sd == 0:
+                continue
+            z = (df["Close"].iloc[-1] - ma) / sd
+            if z > self.z:
+                signals.append(TradeSignal(symbol=sym, side="sell", confidence=abs(z), strategy=self.name, asset_class=asset_class_for(sym)))
+            elif z < -self.z:
+                signals.append(TradeSignal(symbol=sym, side="buy", confidence=abs(z), strategy=self.name, asset_class=asset_class_for(sym)))
+        return signals

--- a/strategies/momentum.py
+++ b/strategies/momentum.py
@@ -1,0 +1,25 @@
+from typing import List
+import pandas as pd
+from .base import Strategy, TradeSignal, asset_class_for
+
+class MomentumStrategy(Strategy):
+    """Simple momentum strategy using recent returns."""
+
+    name = "momentum"
+
+    def __init__(self, lookback: int = 20) -> None:
+        self.lookback = lookback
+
+    def generate(self, ctx) -> List[TradeSignal]:
+        signals: List[TradeSignal] = []
+        tickers = getattr(ctx, "tickers", [])
+        for sym in tickers:
+            df = ctx.data_fetcher.get_daily_df(ctx, sym)
+            if df is None or len(df) <= self.lookback:
+                continue
+            ret = df["Close"].pct_change(self.lookback).iloc[-1]
+            if pd.isna(ret):
+                continue
+            side = "buy" if ret > 0 else "sell"
+            signals.append(TradeSignal(symbol=sym, side=side, confidence=abs(ret), strategy=self.name, asset_class=asset_class_for(sym)))
+        return signals

--- a/strategy_allocator.py
+++ b/strategy_allocator.py
@@ -1,0 +1,21 @@
+from typing import Dict, List
+from strategies import TradeSignal
+
+class StrategyAllocator:
+    """Dynamic allocation of strategy weights."""
+
+    def __init__(self) -> None:
+        self.weights: Dict[str, float] = {}
+
+    def update_reward(self, strategy: str, reward: float) -> None:
+        w = self.weights.get(strategy, 1.0)
+        self.weights[strategy] = max(0.1, min(2.0, w + reward))
+
+    def allocate(self, signals: Dict[str, List[TradeSignal]]) -> List[TradeSignal]:
+        results: List[TradeSignal] = []
+        for strat, sigs in signals.items():
+            weight = self.weights.get(strat, 1.0)
+            for s in sigs:
+                s.weight *= weight
+                results.append(s)
+        return results


### PR DESCRIPTION
## Summary
- create modular strategies package with momentum and mean reversion
- add strategy allocator and risk engine modules
- expand execution engine for asset specific routing
- add unified data fetcher
- integrate new components in `bot.py`

## Testing
- `python -m py_compile strategies/base.py strategies/momentum.py strategies/mean_reversion.py strategy_allocator.py risk_engine.py data_fetcher.py trade_execution.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6841080376708330b25d82e481838aa8