### PR TITLE
Modernize latest quote calls

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -46,7 +46,7 @@ from alpaca.trading.requests import (
 from alpaca.trading.models import Order
 from alpaca.common.exceptions import APIError
 from alpaca.data.historical import StockHistoricalDataClient
-from alpaca.data.requests import StockBarsRequest
+from alpaca.data.requests import StockBarsRequest, QuoteRequest
 from alpaca.data.timeframe import TimeFrame
 
 from sklearn.ensemble import RandomForestClassifier
@@ -1671,7 +1671,9 @@ def liquidity_factor(ctx: BotContext, symbol: str) -> float:
         return 0.0
     avg_vol = df["Volume"].tail(30).mean()
     try:
-        quote_data = ctx.data_client.get_stock_latest_quote([symbol])  # Updated for alpaca-py 0.16+
+        # Modernized using QuoteRequest for alpaca-py >=0.16
+        req = QuoteRequest(symbols=[symbol])
+        quote_data = ctx.data_client.get_stock_latest_quote(req)
         quote = quote_data[symbol]
         spread = (quote.ask_price - quote.bid_price) if quote.ask_price and quote.bid_price else 0.0
     except Exception:
@@ -1857,7 +1859,9 @@ def vwap_pegged_submit(
             break
         vwap_price = ta.vwap(df["High"], df["Low"], df["Close"], df["Volume"]).iloc[-1]
         try:
-            quote_data = ctx.data_client.get_stock_latest_quote([symbol])  # Updated for alpaca-py 0.16+
+            # Modernized using QuoteRequest for alpaca-py >=0.16
+            req = QuoteRequest(symbols=[symbol])
+            quote_data = ctx.data_client.get_stock_latest_quote(req)
             quote = quote_data[symbol]
             spread = (quote.ask_price - quote.bid_price) if quote.ask_price and quote.bid_price else 0.0
         except Exception:
@@ -1971,7 +1975,9 @@ def pov_submit(
         interval = cfg.sleep_interval
 
         try:
-            quote_data = ctx.data_client.get_stock_latest_quote([symbol])  # Updated for alpaca-py 0.16+
+            # Modernized using QuoteRequest for alpaca-py >=0.16
+            req = QuoteRequest(symbols=[symbol])
+            quote_data = ctx.data_client.get_stock_latest_quote(req)
             quote = quote_data[symbol]
             spread = (quote.ask_price - quote.bid_price) if quote.ask_price and quote.bid_price else 0.0
         except Exception:
@@ -3235,7 +3241,9 @@ def run_multi_strategy(ctx: BotContext) -> None:
     acct = ctx.api.get_account()
     cash = float(getattr(acct, "cash", 0))
     for sig in final:
-        quote_data = ctx.data_client.get_stock_latest_quote([sig.symbol])  # Updated for alpaca-py 0.16+
+        # Modernized using QuoteRequest for alpaca-py >=0.16
+        req = QuoteRequest(symbols=[sig.symbol])
+        quote_data = ctx.data_client.get_stock_latest_quote(req)
         quote = quote_data[sig.symbol]
         price = float(getattr(quote, "ask_price", 0) or 0)
         qty = ctx.risk_engine.position_size(sig, cash, price)
@@ -3377,7 +3385,9 @@ def initial_rebalance(ctx: BotContext, symbols: List[str]) -> None:
     per_symbol = cash / n
     for sym in symbols:
         try:
-            quote_data = ctx.data_client.get_stock_latest_quote([sym])  # Updated for alpaca-py 0.16+
+            # Modernized using QuoteRequest for alpaca-py >=0.16
+            req = QuoteRequest(symbols=[sym])
+            quote_data = ctx.data_client.get_stock_latest_quote(req)
             quote = quote_data[sym]
             price = float(getattr(quote, "ask_price", 0) or 0)
             if price <= 0:

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -13,6 +13,7 @@ from alpaca.trading.requests import MarketOrderRequest, LimitOrderRequest
 from alpaca.trading.enums import OrderSide, TimeInForce
 from alpaca.trading.models import Order
 from alpaca.common.exceptions import APIError
+from alpaca.data.requests import QuoteRequest
 
 class ExecutionEngine:
     """Institutional-grade execution engine for dynamic order routing."""
@@ -36,7 +37,9 @@ class ExecutionEngine:
 
     def _latest_quote(self, symbol: str) -> Tuple[float, float]:
         try:
-            quote_data = self.ctx.data_client.get_stock_latest_quote([symbol])  # Updated for alpaca-py 0.16+
+            # Modernized using QuoteRequest for alpaca-py >=0.16
+            req = QuoteRequest(symbols=[symbol])
+            quote_data = self.ctx.data_client.get_stock_latest_quote(req)
             q = quote_data[symbol]
             bid = float(getattr(q, 'bid_price', 0) or 0)
             ask = float(getattr(q, 'ask_price', 0) or 0)


### PR DESCRIPTION
## Summary
- use QuoteRequest in ExecutionEngine for `_latest_quote`
- modernize all `get_stock_latest_quote` calls in bot

## Testing
- `python -m py_compile bot.py trade_execution.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841120dab808330a8368f533eec62a5