### PR TITLE
Fix dotenv loading paths

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -59,6 +59,9 @@ import joblib
 from dotenv import load_dotenv
 import sentry_sdk
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
+
 from prometheus_client import start_http_server, Counter, Gauge, Histogram
 import finnhub
 from finnhub import FinnhubAPIException
@@ -112,7 +115,6 @@ from ratelimit import limits, sleep_and_retry
 import warnings
 
 # ─── A. CONFIGURATION CONSTANTS ─────────────────────────────────────────────────
-load_dotenv()
 RUN_HEALTH = os.getenv("RUN_HEALTHCHECK", "1") == "1"
 
 # Logging: set root logger to INFO, send to both stderr and a log file

--- a/bot.py.bak
+++ b/bot.py.bak
@@ -39,11 +39,13 @@ from dotenv import load_dotenv
 import sentry_sdk
 from prometheus_client import start_http_server, Counter, Gauge
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
+
 # for check_daily_loss()
 day_start_equity: Optional[Tuple[date, float]] = None
 
 # ─── A. ENVIRONMENT, SENTRY & LOGGING ────────────────────────────────────────
-load_dotenv()
 RUN_HEALTH = os.getenv("RUN_HEALTHCHECK", "1") == "1"
 sentry_sdk.init(
     dsn=os.getenv("SENTRY_DSN"),

--- a/bot.py.bak2
+++ b/bot.py.bak2
@@ -39,11 +39,13 @@ from dotenv import load_dotenv
 import sentry_sdk
 from prometheus_client import start_http_server, Counter, Gauge
 
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
+
 # for check_daily_loss()
 day_start_equity: Optional[Tuple[date, float]] = None
 
 # ─── A. ENVIRONMENT, SENTRY & LOGGING ────────────────────────────────────────
-load_dotenv()
 RUN_HEALTH = os.getenv("RUN_HEALTHCHECK", "1") == "1"
 sentry_sdk.init(
     dsn=os.getenv("SENTRY_DSN"),

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,10 +1,14 @@
 import os
+from dotenv import load_dotenv
 import random
 import time as pytime
 from dataclasses import dataclass
 from datetime import datetime, date, timedelta, timezone
 from collections import deque
 from typing import Optional, Sequence
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
 
 import pandas as pd
 import yfinance as yf

--- a/predict.py
+++ b/predict.py
@@ -1,13 +1,14 @@
 import argparse
 import os
+from dotenv import load_dotenv
 import pandas as pd
 import joblib
 import requests
 import json
-from dotenv import load_dotenv
 from retrain import prepare_indicators
 
-load_dotenv()
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
 NEWS_API_KEY = os.getenv("NEWS_API_KEY")
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 INACTIVE_FEATURES_FILE = os.path.join(BASE_DIR, "inactive_features.json")

--- a/retrain.py
+++ b/retrain.py
@@ -1,13 +1,11 @@
 import os
+from dotenv import load_dotenv
 import json
 import csv
 import random
 import joblib
 import pandas as pd
 import numpy as np
-import requests
-from dotenv import load_dotenv
-
 from datetime import datetime, date, time, timedelta
 from sklearn.model_selection import RandomizedSearchCV, TimeSeriesSplit, ParameterSampler, cross_val_score
 from sklearn.pipeline import make_pipeline
@@ -16,9 +14,9 @@ from lightgbm import LGBMClassifier
 
 import pandas_ta as ta
 
-load_dotenv()
-NEWS_API_KEY = os.getenv("NEWS_API_KEY")
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
+NEWS_API_KEY = os.getenv("NEWS_API_KEY")
 def abspath(p: str) -> str:
     return os.path.join(BASE_DIR, p)
 FEATURE_PERF_FILE = abspath("feature_perf.csv")

--- a/webhook_listener.py
+++ b/webhook_listener.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 import os
+from dotenv import load_dotenv
 import hmac
 import hashlib
 import subprocess
 from flask import Flask, request, abort
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
 
 app = Flask(__name__)
 SECRET = os.environ.get("WEBHOOK_SECRET", "").encode()


### PR DESCRIPTION
## Summary
- load `.env` relative to each script
- update backup scripts

## Testing
- `python -m py_compile bot.py data_fetcher.py predict.py retrain.py webhook_listener.py`

------
https://chatgpt.com/codex/tasks/task_e_68412206df2483309f0a348f8759cdf0