### PR TITLE
Centralize env config and modernize Alpaca

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import os
+from dotenv import load_dotenv
+
+ROOT_DIR = Path(__file__).resolve().parent
+ENV_PATH = ROOT_DIR / '.env'
+load_dotenv(ENV_PATH)
+
+APCA_API_KEY_ID = os.environ.get('APCA_API_KEY_ID')
+APCA_API_SECRET_KEY = os.environ.get('APCA_API_SECRET_KEY')
+ALPACA_BASE_URL = os.environ.get('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
+FINNHUB_API_KEY = os.environ.get('FINNHUB_API_KEY')
+NEWS_API_KEY = os.environ.get('NEWS_API_KEY')
+SENTRY_DSN = os.environ.get('SENTRY_DSN')
+BOT_MODE = os.environ.get('BOT_MODE', 'balanced')
+MODEL_PATH = os.environ.get('MODEL_PATH', 'trained_model.pkl')
+HALT_FLAG_PATH = os.environ.get('HALT_FLAG_PATH', 'halt.flag')
+MAX_PORTFOLIO_POSITIONS = int(os.environ.get('MAX_PORTFOLIO_POSITIONS', '20'))
+LIMIT_ORDER_SLIPPAGE = float(os.environ.get('LIMIT_ORDER_SLIPPAGE', '0.005'))
+HEALTHCHECK_PORT = int(os.environ.get('HEALTHCHECK_PORT', '8081'))
+RUN_HEALTHCHECK = os.environ.get('RUN_HEALTHCHECK', '0')
+BUY_THRESHOLD = float(os.environ.get('BUY_THRESHOLD', '0.5'))
+WEBHOOK_SECRET = os.environ.get('WEBHOOK_SECRET', '')
+WEBHOOK_PORT = int(os.environ.get('WEBHOOK_PORT', '9000'))

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,5 +1,3 @@
-import os
-from dotenv import load_dotenv
 import random
 import time as pytime
 from dataclasses import dataclass
@@ -7,8 +5,7 @@ from datetime import datetime, date, timedelta, timezone
 from collections import deque
 from typing import Optional, Sequence
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
+from config import FINNHUB_API_KEY
 
 import pandas as pd
 import yfinance as yf
@@ -21,7 +18,7 @@ import finnhub
 class DataFetchError(Exception):
     pass
 
-finnhub_client = finnhub.Client(api_key=os.getenv("FINNHUB_API_KEY"))
+finnhub_client = finnhub.Client(api_key=FINNHUB_API_KEY)
 
 class FinnhubFetcher:
     def __init__(self, calls_per_minute: int = 60) -> None:

--- a/predict.py
+++ b/predict.py
@@ -1,15 +1,13 @@
 import argparse
 import os
-from dotenv import load_dotenv
 import pandas as pd
 import joblib
 import requests
 import json
 from retrain import prepare_indicators
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
-NEWS_API_KEY = os.getenv("NEWS_API_KEY")
+from config import NEWS_API_KEY
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 INACTIVE_FEATURES_FILE = os.path.join(BASE_DIR, "inactive_features.json")
 MODELS_DIR = os.path.join(BASE_DIR, "models")

--- a/retrain.py
+++ b/retrain.py
@@ -1,5 +1,4 @@
 import os
-from dotenv import load_dotenv
 import json
 import csv
 import random
@@ -14,9 +13,9 @@ from lightgbm import LGBMClassifier
 
 import pandas_ta as ta
 
+from config import NEWS_API_KEY
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
-NEWS_API_KEY = os.getenv("NEWS_API_KEY")
 def abspath(p: str) -> str:
     return os.path.join(BASE_DIR, p)
 FEATURE_PERF_FILE = abspath("feature_perf.csv")

--- a/webhook_listener.py
+++ b/webhook_listener.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 import os
-from dotenv import load_dotenv
 import hmac
 import hashlib
 import subprocess
 from flask import Flask, request, abort
 
+from config import WEBHOOK_SECRET, WEBHOOK_PORT
+
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-load_dotenv(dotenv_path=os.path.join(BASE_DIR, '.env'))
 
 app = Flask(__name__)
-SECRET = os.environ.get("WEBHOOK_SECRET", "").encode()
+SECRET = WEBHOOK_SECRET.encode()
 
 
 def verify_sig(data: bytes, signature: str) -> bool:
@@ -35,5 +35,4 @@ def hook():
 
 
 if __name__ == "__main__":
-    port = int(os.getenv("WEBHOOK_PORT", "9000"))
-    app.run(host="0.0.0.0", port=port)
+    app.run(host="0.0.0.0", port=WEBHOOK_PORT)


### PR DESCRIPTION
## Summary
- centralize dotenv loading in new `config.py`
- update modules to import credentials from `config.py`
- modernize Alpaca client initialization
- adjust webhook listener and prediction scripts

## Testing
- `python -m py_compile config.py data_fetcher.py predict.py retrain.py webhook_listener.py bot.py trade_execution.py risk_engine.py strategy_allocator.py capital_scaling.py`

------
https://chatgpt.com/codex/tasks/task_e_6841252505e8833096c098fca61ede2f