### PR TITLE
Fix StockHistoricalDataClient instantiation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1164,7 +1164,7 @@ API_KEY = APCA_API_KEY_ID
 SECRET_KEY = APCA_API_SECRET_KEY
 BASE_URL = ALPACA_BASE_URL
 trading_client = TradingClient(API_KEY, SECRET_KEY, paper=True)
-data_client = StockHistoricalDataClient(API_KEY, SECRET_KEY, paper=True)
+data_client = StockHistoricalDataClient(API_KEY, SECRET_KEY)
 ctx = BotContext(
     api=trading_client,
     data_client=data_client,


### PR DESCRIPTION
## Summary
- align Alpaca StockHistoricalDataClient usage with v0.40.1 SDK by removing `paper=True`

## Testing
- `python -m py_compile bot.py data_fetcher.py trade_execution.py`

------
https://chatgpt.com/codex/tasks/task_e_6841aeee98dc83309efefbbecda6fb12