### PR TITLE
Switch to Alpaca data and robust order flow

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,8 +6,8 @@ ROOT_DIR = Path(__file__).resolve().parent
 ENV_PATH = ROOT_DIR / '.env'
 load_dotenv(ENV_PATH)
 
-APCA_API_KEY_ID = os.environ.get('APCA_API_KEY_ID')
-APCA_API_SECRET_KEY = os.environ.get('APCA_API_SECRET_KEY')
+ALPACA_API_KEY = os.environ.get('ALPACA_API_KEY') or os.environ.get('APCA_API_KEY_ID')
+ALPACA_SECRET_KEY = os.environ.get('ALPACA_SECRET_KEY') or os.environ.get('APCA_API_SECRET_KEY')
 ALPACA_BASE_URL = os.environ.get('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
 ALPACA_PAPER = 'paper' in ALPACA_BASE_URL.lower()
 FINNHUB_API_KEY = os.environ.get('FINNHUB_API_KEY')
@@ -23,3 +23,13 @@ RUN_HEALTHCHECK = os.environ.get('RUN_HEALTHCHECK', '0')
 BUY_THRESHOLD = float(os.environ.get('BUY_THRESHOLD', '0.5'))
 WEBHOOK_SECRET = os.environ.get('WEBHOOK_SECRET', '')
 WEBHOOK_PORT = int(os.environ.get('WEBHOOK_PORT', '9000'))
+
+
+def validate_alpaca_credentials() -> None:
+    """Ensure required Alpaca credentials are present."""
+    if not ALPACA_API_KEY or not ALPACA_SECRET_KEY or not ALPACA_BASE_URL:
+        raise RuntimeError(
+            "Missing Alpaca credentials. Please set ALPACA_API_KEY, "
+            "ALPACA_SECRET_KEY and ALPACA_BASE_URL in your environment"
+        )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ tenacity>=8.2.0
 ratelimit>=2.2.1
 pandas>=1.4.0
 pandas_ta>=0.3.14b0
-yfinance>=0.2.4
 requests>=2.27.1
 beautifulsoup4>=4.11.1
 flask>=2.1.0


### PR DESCRIPTION
## Summary
- ensure Alpaca credentials exist
- rewrite data fetcher to use Alpaca API exclusively
- drop all yfinance usage
- use Alpaca for backtest data
- improve initial rebalance order flow

## Testing
- `python -m py_compile data_fetcher.py backtest.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6841cf7b39fc83309fa03510eb324678