### PR TITLE
Fix Alpaca data feed and remove obsolete paper check

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3390,9 +3390,6 @@ def initial_rebalance(ctx: BotContext, symbols: List[str]) -> None:
     if equity < PDT_EQUITY_THRESHOLD:
         logger.info("INITIAL_REBALANCE_SKIPPED_PDT", extra={"equity": equity})
         return
-    if ctx.api.paper != ALPACA_PAPER:
-        logger.error("INITIAL_REBALANCE_ACCOUNT_MISMATCH", extra={"endpoint": ALPACA_BASE_URL})
-        return
 
     cash = float(acct.cash)
     buying_power = float(getattr(acct, "buying_power", cash))

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -27,8 +27,9 @@ import finnhub
 load_dotenv()
 
 _DATA_CLIENT = StockHistoricalDataClient(
-    ALPACA_API_KEY,
-    ALPACA_SECRET_KEY,
+    api_key=ALPACA_API_KEY,
+    secret_key=ALPACA_SECRET_KEY,
+    feed="iex",
 )
 
 class DataFetchError(Exception):


### PR DESCRIPTION
## Summary
- use IEX feed for StockHistoricalDataClient to avoid SIP errors
- drop invalid `TradingClient.paper` check

## Testing
- `python -m py_compile data_fetcher.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e167aab88330aa865f5ec888fb81