### PR TITLE
Fix minute fetch fallback and retrain call

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -176,17 +176,12 @@ class DataFetcher:
             df = get_historical_data(symbol, start, end, '1Min')
             if df is not None and not df.empty:
                 df = df[["Open", "High", "Low", "Close", "Volume"]]
-        except APIError as e:
-            logger.warning(f"[get_minute_df] Alpaca fetch failed for {symbol}: {e}")
-            try:
-                df = fh.fetch(symbol, period="5d", interval="1m")
-            except Exception:
-                df = None
         except Exception as e:
-            logger.warning(f"[get_minute_df] Alpaca fetch failed for {symbol}: {e}")
+            logger.warning(f"[get_minute_df] Primary fetch failed for {symbol}: {e}")
             try:
                 df = fh.fetch(symbol, period="5d", interval="1m")
-            except Exception:
+            except Exception as fe:
+                logger.warning(f"[get_minute_df] Finnhub fallback failed for {symbol}: {fe}")
                 df = None
         self._minute_cache[symbol] = df
         self._minute_timestamps[symbol] = now

--- a/retrain.py
+++ b/retrain.py
@@ -239,7 +239,7 @@ def gather_minute_data(ctx, symbols, lookback_days: int = 5) -> dict[str, pd.Dat
     for sym in symbols:
         bars = None
         try:
-            bars = ctx.data_fetcher.get_historical_minute(ctx, sym, start_dt, end_dt)
+            bars = ctx.data_fetcher.get_minute_df(ctx, sym)
         except Exception as e:
             bars = None
             print(f"[gather_minute_data] ✗ {sym} → exception {start_dt}→{end_dt}: {e}")


### PR DESCRIPTION
## Summary
- update minute bar fetching to try finnhub when Alpaca fails
- use `get_minute_df` in retrain script

## Testing
- `python -m py_compile data_fetcher.py retrain.py && echo "ok"`

------
https://chatgpt.com/codex/tasks/task_e_6841eca37fd08330ac3b26dff5120d04