### PR TITLE
Remove deprecated feed parameter

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -26,7 +26,7 @@ import finnhub
 
 load_dotenv()
 
-# ✅ FORCE IEX feed compatibility
+# Alpaca historical data client
 _DATA_CLIENT = StockHistoricalDataClient(
     api_key=ALPACA_API_KEY,
     secret_key=ALPACA_SECRET_KEY,
@@ -59,7 +59,7 @@ def get_historical_data(symbol: str, start_date: date, end_date: date, timeframe
         timeframe=tf,
     )
     try:
-        bars = _DATA_CLIENT.get_stock_bars(req, feed="iex").df  # ✅ Explicit IEX feed usage
+        bars = _DATA_CLIENT.get_stock_bars(req).df
     except Exception as e:
         logger.warning(f"[get_historical_data] API error for {symbol}: {e}")
         raise


### PR DESCRIPTION
## Summary
- adjust Alpaca data client comment
- drop obsolete `feed="iex"` usage when fetching bars

## Testing
- `python -m py_compile data_fetcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f1d08e948330a1205876c2a2511e