### PR TITLE
Add market hour guard and refine data fetching

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,8 @@
 """Utility functions for common operations across the bot."""
 
 import pandas as pd
+from datetime import datetime, time
+from zoneinfo import ZoneInfo
 
 
 def get_latest_close(df: pd.DataFrame) -> float:
@@ -16,3 +18,11 @@ def get_latest_close(df: pd.DataFrame) -> float:
     if pd.isna(last) or last == 0:
         return 1.0
     return float(last)
+
+
+def is_market_open() -> bool:
+    """Return True if current time in New York is between 9:30 and 16:00."""
+    now = datetime.now(ZoneInfo("America/New_York"))
+    start = time(9, 30)
+    end = time(16, 0)
+    return start <= now.time() <= end


### PR DESCRIPTION
## Summary
- enhance utilities with market hours helper
- allow minute API errors to propagate in data_fetcher and fall back to daily bars
- skip fetching when market is closed and trade sequentially
- streamline trade logic return values

## Testing
- `python -m py_compile utils.py data_fetcher.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68430953aa108330b60ede1d31957b51