### PR TITLE
Fix APIConnectionError import in Alpaca modules

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -22,7 +22,8 @@ BACKTEST_WINDOW_DAYS = 365
 import pandas as pd
 import numpy as np
 from data_fetcher import get_historical_data, DataFetchError
-from alpaca_trade_api.rest import APIError, APIConnectionError
+from alpaca_trade_api.rest import APIError
+from alpaca_trade_api.exceptions import APIConnectionError
 from tenacity import RetryError
 
 

--- a/bot.py
+++ b/bot.py
@@ -49,7 +49,8 @@ from alpaca.trading.requests import (
     LimitOrderRequest,
 )
 from alpaca.trading.models import Order
-from alpaca_trade_api.rest import REST, APIError, APIConnectionError
+from alpaca_trade_api.rest import REST, APIError
+from alpaca_trade_api.exceptions import APIConnectionError
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.models import Quote
 from alpaca.data.requests import StockBarsRequest, StockLatestQuoteRequest

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -28,7 +28,8 @@ import numpy as np
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.requests import StockBarsRequest
 from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
-from alpaca_trade_api.rest import APIError, APIConnectionError
+from alpaca_trade_api.rest import APIError
+from alpaca_trade_api.exceptions import APIConnectionError
 from tenacity import (
     retry,
     stop_after_attempt,

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -14,7 +14,8 @@ from alpaca.trading.client import TradingClient
 from alpaca.trading.requests import MarketOrderRequest, LimitOrderRequest
 from alpaca.trading.enums import OrderSide, TimeInForce
 from alpaca.trading.models import Order
-from alpaca_trade_api.rest import APIError, APIConnectionError
+from alpaca_trade_api.rest import APIError
+from alpaca_trade_api.exceptions import APIConnectionError
 from alpaca.data.models import Quote
 from alpaca.data.requests import StockLatestQuoteRequest
 


### PR DESCRIPTION
## Summary
- update Alpaca exception imports in bot, data_fetcher, trade_execution, backtest
- ensure APIConnectionError comes from alpaca_trade_api.exceptions

## Testing
- `venv/bin/python bot.py` *(fails: ModuleNotFoundError: pandas_market_calendars)*
- `venv/bin/python -m py_compile bot.py data_fetcher.py trade_execution.py backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_684347919a048330934bc314d1e0da6c