### PR TITLE
Fix Alpaca imports and MFI dtype

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -23,7 +23,6 @@ import pandas as pd
 import numpy as np
 from data_fetcher import get_historical_data, DataFetchError
 from alpaca_trade_api.rest import APIError
-from alpaca_trade_api.exceptions import APIConnectionError
 from tenacity import RetryError
 
 
@@ -50,7 +49,7 @@ def load_price_data(symbol: str, start: str, end: str) -> pd.DataFrame:
             df_final = get_historical_data(symbol, datetime.fromisoformat(start).date(),
                                           datetime.fromisoformat(end).date(), '1Day')
             break
-        except (APIError, APIConnectionError, DataFetchError, RetryError) as e:
+        except (APIError, DataFetchError, RetryError) as e:
             if attempt < 3:
                 print(f"  ▶ Failed to fetch {symbol} (attempt {attempt}/3): {e!r}. Sleeping 2s…")
                 time.sleep(2)

--- a/bot.py
+++ b/bot.py
@@ -3082,7 +3082,10 @@ def prepare_indicators(df: pd.DataFrame, freq: str = "daily") -> pd.DataFrame:
     # Ensure numeric dtype before computing MFI
     df[["High", "Low", "close", "Volume"]] = df[["High", "Low", "close", "Volume"]].astype(float)
     try:
-        df["mfi"] = ta.mfi(df["High"], df["Low"], df["close"], df["Volume"], length=14)
+        mfi_vals = ta.mfi(
+            df["High"], df["Low"], df["close"], df["Volume"], length=14
+        )
+        df["mfi"] = mfi_vals.astype(float)
     except Exception as e:
         logger.warning(f"prepare_indicators: failed to compute MFI: {e}")
         df["mfi"] = None

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -15,7 +15,6 @@ from alpaca.trading.requests import MarketOrderRequest, LimitOrderRequest
 from alpaca.trading.enums import OrderSide, TimeInForce
 from alpaca.trading.models import Order
 from alpaca_trade_api.rest import APIError
-from alpaca_trade_api.exceptions import APIConnectionError
 from alpaca.data.models import Quote
 from alpaca.data.requests import StockLatestQuoteRequest
 
@@ -186,7 +185,7 @@ class ExecutionEngine:
                     )
                     order = api.submit_order(order_data=order_req)
                     break
-                except (APIConnectionError, TimeoutError) as e:
+                except (APIError, TimeoutError) as e:
                     time.sleep(1)
                     if attempt == 1:
                         self.logger.warning(f'submit_order failed for {symbol}: {e}')


### PR DESCRIPTION
## Summary
- clean up unused APIConnectionError imports
- update trade_execution submission retry logic to catch APIError
- ensure MFI output cast to float

## Testing
- `python -m py_compile $(git ls-files '*.py' | tr '\n' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_68435980b43083308a66d28d3e9ed304