### PR TITLE
Fix OHLCV fallback and retraining checks

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -133,7 +133,16 @@ def get_daily_df(symbol: str, start: date, end: date) -> pd.DataFrame:
         df = df.drop(columns=["symbol"], errors="ignore")
     df.index = pd.to_datetime(df.index).tz_localize(None)
     df["timestamp"] = df.index
-    return df[["timestamp", "open", "high", "low", "close", "volume"]]
+
+    rename_map = {c: c.lower() for c in df.columns if c.lower() in {"open", "high", "low", "close", "volume"}}
+    if rename_map:
+        df = df.rename(columns=rename_map)
+
+    try:
+        return df[["timestamp", "open", "high", "low", "close", "volume"]]
+    except KeyError:
+        logger.warning(f"Missing OHLCV columns for {symbol}; returning empty DataFrame")
+        return pd.DataFrame()
 
 
 def get_minute_df(symbol: str, start_date, end_date) -> pd.DataFrame:
@@ -160,9 +169,16 @@ def get_minute_df(symbol: str, start_date, end_date) -> pd.DataFrame:
         df = df.drop(columns=["symbol"], errors="ignore")
     df.index = pd.to_datetime(df.index).tz_localize(None)
     df["timestamp"] = df.index
-    if df.empty or "close" not in df.columns:
+
+    rename_map = {c: c.lower() for c in df.columns if c.lower() in {"open", "high", "low", "close", "volume"}}
+    if rename_map:
+        df = df.rename(columns=rename_map)
+
+    try:
+        return df[["timestamp", "open", "high", "low", "close", "volume"]]
+    except KeyError:
+        logger.warning(f"Missing OHLCV columns for {symbol}; returning empty DataFrame")
         return pd.DataFrame()
-    return df[["timestamp", "open", "high", "low", "close", "volume"]]
 
 finnhub_client = finnhub.Client(api_key=FINNHUB_API_KEY)
 

--- a/retrain.py
+++ b/retrain.py
@@ -332,6 +332,9 @@ def build_feature_label_df(
     rows = []
     for sym, raw in raw_store.items():
         try:
+            if raw is None or raw.empty:
+                print(f"[build_feature_label_df] – {sym} returned no minute data; skipping symbol.")
+                continue
             if raw.shape[0] < MINUTES_REQUIRED:
                 print(f"[build_feature_label_df] – skipping {sym}, only {raw.shape[0]} < {MINUTES_REQUIRED}")
                 continue


### PR DESCRIPTION
## Summary
- normalize column names when falling back to IEX and guard against missing OHLCV data
- skip empty minute DataFrames in retraining

## Testing
- `python -m py_compile data_fetcher.py retrain.py bot.py trade_execution.py`

------
https://chatgpt.com/codex/tasks/task_e_68435c61ef5c83309dd8acd619629efe