### PR TITLE
Fix fallback minute data handling

### DIFF
--- a/config.sample.py
+++ b/config.sample.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import os
+from dotenv import load_dotenv
+
+ROOT_DIR = Path(__file__).resolve().parent
+ENV_PATH = ROOT_DIR / '.env'
+load_dotenv(ENV_PATH)
+
+ALPACA_API_KEY = os.environ.get('ALPACA_API_KEY') or os.environ.get('APCA_API_KEY_ID')
+ALPACA_SECRET_KEY = os.environ.get('ALPACA_SECRET_KEY') or os.environ.get('APCA_API_SECRET_KEY')
+ALPACA_BASE_URL = os.environ.get('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
+ALPACA_PAPER = 'paper' in ALPACA_BASE_URL.lower()
+FINNHUB_API_KEY = os.environ.get('FINNHUB_API_KEY')
+NEWS_API_KEY = os.environ.get('NEWS_API_KEY')
+IEX_API_TOKEN = os.environ.get('IEX_API_TOKEN')
+SENTRY_DSN = os.environ.get('SENTRY_DSN')
+BOT_MODE = os.environ.get('BOT_MODE', 'balanced')
+MODEL_PATH = os.environ.get('MODEL_PATH', 'trained_model.pkl')
+HALT_FLAG_PATH = os.environ.get('HALT_FLAG_PATH', 'halt.flag')
+MAX_PORTFOLIO_POSITIONS = int(os.environ.get('MAX_PORTFOLIO_POSITIONS', '20'))
+LIMIT_ORDER_SLIPPAGE = float(os.environ.get('LIMIT_ORDER_SLIPPAGE', '0.005'))
+HEALTHCHECK_PORT = int(os.environ.get('HEALTHCHECK_PORT', '8081'))
+RUN_HEALTHCHECK = os.environ.get('RUN_HEALTHCHECK', '0')
+BUY_THRESHOLD = float(os.environ.get('BUY_THRESHOLD', '0.5'))
+WEBHOOK_SECRET = os.environ.get('WEBHOOK_SECRET', '')
+WEBHOOK_PORT = int(os.environ.get('WEBHOOK_PORT', '9000'))
+
+
+def validate_alpaca_credentials() -> None:
+    """Ensure required Alpaca credentials are present."""
+    if not ALPACA_API_KEY or not ALPACA_SECRET_KEY or not ALPACA_BASE_URL:
+        raise RuntimeError(
+            "Missing Alpaca credentials. Please set ALPACA_API_KEY, "
+            "ALPACA_SECRET_KEY and ALPACA_BASE_URL in your environment"
+        )
+

--- a/retrain.py
+++ b/retrain.py
@@ -474,6 +474,17 @@ def retrain_meta_learner(
         logger.warning("No minute bars returned; skipping retrain")
         return False
 
+    filtered: dict[str, pd.DataFrame] = {}
+    for sym, df in raw_store.items():
+        if df is None or df.empty:
+            logger.warning(f"[retrain_meta_learner] {sym} empty minute df; skipping")
+            continue
+        filtered[sym] = df
+    raw_store = filtered
+    if not raw_store:
+        logger.warning("All minute DataFrames empty; skipping retrain")
+        return False
+
     df_all = build_feature_label_df(raw_store, Δ_minutes=Δ_minutes, threshold_pct=threshold_pct)
     if df_all.empty:
         print("  ⚠️ No usable rows after building (Δ, threshold) → skipping retrain.")


### PR DESCRIPTION
## Summary
- add sample config for deployments
- improve IEX minute data fallback handling and ensure indices are datetime
- return OHLCV columns in consistent case
- filter out empty dataframes before retraining

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843692d0960833086dfcacdde62b143