### PR TITLE
Make FUNDAMENTAL_API_KEY optional

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,10 +6,12 @@ ROOT_DIR = Path(__file__).resolve().parent
 ENV_PATH = ROOT_DIR / '.env'
 load_dotenv(ENV_PATH)
 
-required = ['APCA_API_KEY_ID','APCA_API_SECRET_KEY','FUNDAMENTAL_API_KEY']
+required = ['APCA_API_KEY_ID','APCA_API_SECRET_KEY']
 missing = [v for v in required if v not in os.environ]
 if missing:
     raise RuntimeError(f"Missing required environment variables: {missing}")
+
+FUNDAMENTAL_API_KEY = os.getenv('FUNDAMENTAL_API_KEY', None)
 
 ALPACA_API_KEY = os.environ.get('ALPACA_API_KEY') or os.environ.get('APCA_API_KEY_ID')
 ALPACA_SECRET_KEY = os.environ.get('ALPACA_SECRET_KEY') or os.environ.get('APCA_API_SECRET_KEY')


### PR DESCRIPTION
## Summary
- make `FUNDAMENTAL_API_KEY` optional and load via `os.getenv`

## Testing
- `python -m py_compile config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843aca875608330a4459359c217fb65