### PR TITLE
Fix Alpaca client usage and optional env check

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,8 +6,8 @@ ROOT_DIR = Path(__file__).resolve().parent
 ENV_PATH = ROOT_DIR / '.env'
 load_dotenv(ENV_PATH)
 
-required = ['APCA_API_KEY_ID','APCA_API_SECRET_KEY']  # FUNDAMENTAL_API_KEY optional
-missing = [v for v in required if v not in os.environ]
+required_env_vars = ['APCA_API_KEY_ID','APCA_API_SECRET_KEY']  # FUNDAMENTAL_API_KEY optional
+missing = [v for v in required_env_vars if v not in os.environ]
 if missing:
     raise RuntimeError(f"Missing required environment variables: {missing}")
 

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -18,7 +18,7 @@ ALPACA_BASE_URL = config.ALPACA_BASE_URL
 import alpaca_trade_api as tradeapi
 
 # Global Alpaca client using config credentials
-api = tradeapi.REST(
+client = tradeapi.REST(
     key_id=ALPACA_API_KEY,
     secret_key=ALPACA_SECRET_KEY,
     base_url=ALPACA_BASE_URL,
@@ -167,11 +167,11 @@ def get_minute_df(symbol, start_date, end_date):
 
     bars = None
     try:
-        bars = api.get_bars(symbol, TimeFrame.Minute, start=start_date, end=end_date)
+        bars = client.get_bars(symbol, TimeFrame.Minute, start=start_date, end=end_date)
     except APIError as e:
         if "subscription does not permit" in str(e).lower():
             try:
-                bars = api.get_bars(
+                bars = client.get_bars(
                     symbol,
                     TimeFrame.Minute,
                     start=start_date,


### PR DESCRIPTION
## Summary
- simplify env var check in config
- rename Alpaca client variable in data_fetcher
- fetch minute bars using `client` instead of `api`

## Testing
- `python -m py_compile config.py data_fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_6843b949495c8330949c97e2e6fcaebf