### PR TITLE
Add CI/CD workflows and pre-commit config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,32 @@
-on: [push, pull_request]
+name: CI
+
+on:
+  push:
+  pull_request:
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
-      - run: pip install -r requirements.txt
-      - run: black --check .
-      - name: Run Flake8
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
         run: |
-          flake8 bot.py data_fetcher.py utils.py
-      - run: pytest --maxfail=1 --disable-warnings -q
+          pip install -r requirements.txt
+          pip install isort mypy
+      - name: Black
+        run: black --check .
+      - name: Isort
+        run: isort --check-only .
+      - name: Flake8
+        run: flake8 .
+      - name: Mypy
+        run: mypy .
+      - name: Pytest
+        run: pytest --maxfail=1 --disable-warnings -q
+

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,21 @@
+name: CodeQL
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+      - uses: github/codeql-action/analyze@v3
+

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,23 @@
+name: Coverage
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install coverage[toml] codecov pytest-cov
+      - name: Run tests with coverage
+        run: pytest --cov=.
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,24 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build image
+        run: |
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/ai-trading-bot:${GITHUB_REF_NAME} .
+      - name: Push image
+        run: |
+          docker push ${{ secrets.DOCKER_USERNAME }}/ai-trading-bot:${GITHUB_REF_NAME}
+

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,19 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run integration tests
+        run: pytest -m integration --maxfail=1 --disable-warnings -q
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Build wheel
+        run: |
+          pip install build
+          python -m build --wheel
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.6.1
+    hooks:
+      - id: mypy
+


### PR DESCRIPTION
## Summary
- expand CI test matrix and add lint/mypy/pytest steps
- add dependabot configuration for weekly pip updates
- add CodeQL security scanning
- add coverage job with Codecov upload
- add nightly integration tests
- add release workflow for publishing wheels to PyPI
- add Docker image build and publish on release
- add pre-commit hooks configuration

## Testing
- `pytest --maxfail=1 --disable-warnings -q`
- `black --check .`
- `flake8 .`
- `isort --check-only .` *(fails: imports incorrectly sorted)*
- `mypy .` *(fails: several type errors)*
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_68445918ae78833093a1bdc21f252fba