### PR TITLE
Add SSH test and Slack failure notification workflows

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+
+jobs:
+  notify-on-failure:
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "text": ":x: Build or tests failed in *${{ github.repo }}* on branch *${{ github.ref_name }}* (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>)"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ssh-test.yml
+++ b/.github/workflows/ssh-test.yml
@@ -1,0 +1,36 @@
+name: SSH & run tests
+
+on: [push]
+
+jobs:
+  ssh-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: SSH & prepare remote
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USER }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          script: |
+            set -e
+            cd ~/ai-trading-bot
+
+            # create & activate venv if needed
+            if [ ! -d venv ]; then
+              python3 -m venv venv
+            fi
+            source venv/bin/activate
+            pip install --upgrade pip
+            pip install -r requirements.txt
+
+            # start the bot web service if not running
+            sudo systemctl restart ai-trading-scheduler.service
+            # give it a moment to bind port 8000
+            sleep 5
+
+            pytest --maxfail=1 --disable-warnings -q
+            curl -fsS http://localhost:8000/health


### PR DESCRIPTION
## Summary
- add remote ssh test workflow to ensure droplet tests run
- add slack notification workflow for failures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6845003585408330b63e328c674d8045