### PR TITLE
Fix CI workflows and droplet steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,45 +9,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.12'
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Install dev dependencies
-        run: pip install black flake8 pytest
-
-  lint:
-    needs: prepare
-    runs-on: ubuntu-latest
-    steps:
-      - run: black .
-      - run: black --check .
-        continue-on-error: true
-      - run: flake8 .
-
-  test:
-    needs: prepare
-    runs-on: ubuntu-latest
-    steps:
-      - run: pytest --maxfail=1 --disable-warnings -q
+        run: pip install -r requirements.txt
+      - name: Lint with Black
+        run: black --check .
+      - name: Lint with Flake8
+        run: flake8 .
+      - name: Test with pytest
+        run: pytest --maxfail=1 --disable-warnings -q
 
   notify:
     if: failure()
-    needs: [lint, test]
+    needs: build-and-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -10,10 +10,12 @@ jobs:
     if: failure()
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: ./.github/actions/slack-notify
         with:
           payload: |
-            {"text": ":x: Lint or tests failed on `${{ github.workflow }}` (`${{ github.ref }}`). See <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|details>."}
+            { "text": ":x: CI failed for ${{ github.workflow }} – ${{ github.run_number }}" }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ssh-test.yml
+++ b/.github/workflows/ssh-test.yml
@@ -15,6 +15,12 @@ jobs:
           cd ~/ai-trading-bot
           python3 -m venv venv
           source venv/bin/activate
+          EOF
+
+      - name: Install dependencies on droplet
+        run: |
+          ssh -i "${{ secrets.DROPLET_SSH_KEY }}" ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} << 'EOF'
+          cd ~/ai-trading-bot
           pip install -r requirements.txt
           EOF
 


### PR DESCRIPTION
## Summary
- fix droplet ssh test workflow to install requirements in a dedicated step
- collapse CI workflow to a single job that installs, lints and tests
- use local slack notify action with checkout step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845195f44a88330a9889c9cc1060ad5