### PR TITLE
Fix droplet pip install path

### DIFF
--- a/.github/workflows/ssh-test.yml
+++ b/.github/workflows/ssh-test.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           ssh -i "${{ secrets.DROPLET_SSH_KEY }}" ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} << 'EOF'
           cd ~/ai-trading-bot
+          source venv/bin/activate
           pip install -r requirements.txt
           EOF
 


### PR DESCRIPTION
## Summary
- ensure pip installs to the droplet's virtualenv during ssh-test

## Testing
- `pytest -k test_fetch_data -q`

------
https://chatgpt.com/codex/tasks/task_e_684584894cd08330a5458d1e1abc3e04