### PR TITLE
Fix GitHub CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,13 @@ name: CI
 
 on:
   push:
+    branches: [ main ]
   pull_request:
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
+    branches: [ main ]
 
 jobs:
-  build-and-test:
+  lint:
+    name: Lint & Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -17,25 +16,28 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install dependencies
-        run: pip install -r requirements.txt
-      - name: Lint with Black
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install black flake8 pytest
+      - name: Check formatting with Black
         run: black --check .
-      - name: Lint with Flake8
+      - name: Check style with Flake8
         run: flake8 .
-      - name: Test with pytest
-        run: pytest --maxfail=1 --disable-warnings -q
 
-  notify:
-    if: failure()
-    needs: build-and-test
+  test:
+    name: Run Tests
     runs-on: ubuntu-latest
+    needs: lint
     steps:
       - uses: actions/checkout@v3
-      - uses: slackapi/slack-github-action@v1
+      - uses: actions/setup-python@v4
         with:
-          payload: |
-            {
-              "text": ":x: CI failed in <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|this run>."
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run pytest
+        run: pytest --maxfail=1 --disable-warnings -q

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -4,18 +4,21 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    branches: [ main ]
 
 jobs:
-  notify-on-failure:
+  notify:
     if: failure()
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-      - name: Notify Slack
-        uses: ./.github/actions/slack-notify
+      - uses: actions/checkout@v3
+      - name: Send failure notification to Slack
+        uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |
-            { "text": ":x: CI failed for ${{ github.workflow }} – ${{ github.run_number }}" }
+            {
+              "text": ":x: *${{ github.workflow }}* failed on `${{ github.ref }}` by `${{ github.actor }}`\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+

--- a/.github/workflows/ssh-test.yml
+++ b/.github/workflows/ssh-test.yml
@@ -1,35 +1,28 @@
-name: SSH & run tests
+name: SSH & Run Tests
 
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
 
 jobs:
-  ssh-test:
+  droplet-test:
+    name: SSH to Droplet & Run Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Create & activate venv
-        run: |
-          ssh -i "${{ secrets.DROPLET_SSH_KEY }}" ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} << 'EOF'
-          cd ~/ai-trading-bot
-          python3 -m venv venv
-          source venv/bin/activate
-          EOF
+      - uses: actions/checkout@v3
+      - name: SSH & Run
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: ${{ secrets.DROPLET_USER }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          script: |
+            cd ~/ai-trading-bot
+            source venv/bin/activate
+            pip install --upgrade pip
+            pip install -r requirements.txt
+            pytest --maxfail=1 --disable-warnings -q
+            curl -fsS http://localhost:8000/health || exit 1
 
-      - name: Install dependencies on droplet
-        run: |
-          ssh -i "${{ secrets.DROPLET_SSH_KEY }}" ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} << 'EOF'
-          cd ~/ai-trading-bot
-          source venv/bin/activate
-          pip install -r requirements.txt
-          EOF
-
-      - name: Run tests & health-check
-        run: |
-          ssh -i "${{ secrets.DROPLET_SSH_KEY }}" ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} << 'EOF'
-          cd ~/ai-trading-bot
-          source venv/bin/activate
-          pytest --maxfail=1 --disable-warnings -q
-          curl -fsS http://localhost:8000/health || exit 1
-          EOF


### PR DESCRIPTION
## Summary
- update CI workflow to install dependencies and run lint/tests with Python 3.12
- simplify droplet SSH workflow with appleboy/ssh-action and install deps before running tests
- fix Slack notification workflow to use slackapi action

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845972087688330bc166c53571434fd