### PR TITLE
Fix failing workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Cache pip

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies
@@ -23,22 +23,24 @@ jobs:
       - run: pytest --maxfail=1 --disable-warnings -q
       - name: Create archive
         run: tar czf bot.tar.gz .
-      - name: Copy to Droplet
-        uses: appleboy/scp-action@v0.1.0
-        with:
-          host: ${{ secrets.DROPLET_HOST }}
-          username: ${{ secrets.DROPLET_USER }}
-          key: ${{ secrets.DROPLET_SSH_KEY }}
-          source: "bot.tar.gz"
-          target: "~/bot.tar.gz"
-      - name: Deploy on Droplet
-        uses: appleboy/ssh-action@v1.2.2
-        with:
-          host: ${{ secrets.DROPLET_HOST }}
-          username: ${{ secrets.DROPLET_USER }}
-          key: ${{ secrets.DROPLET_SSH_KEY }}
-          script: |
-            mkdir -p ~/ai-trading-bot
-            tar xzf ~/bot.tar.gz -C ~/ai-trading-bot --strip-components=1
-            rm ~/bot.tar.gz
-            sudo systemctl restart ai-trading-scheduler.service
+        - name: Copy to Droplet
+          if: ${{ secrets.DROPLET_HOST != '' }}
+          uses: appleboy/scp-action@v0.1.0
+          with:
+            host: ${{ secrets.DROPLET_HOST }}
+            username: ${{ secrets.DROPLET_USER }}
+            key: ${{ secrets.DROPLET_SSH_KEY }}
+            source: "bot.tar.gz"
+            target: "~/bot.tar.gz"
+        - name: Deploy on Droplet
+          if: ${{ secrets.DROPLET_HOST != '' }}
+          uses: appleboy/ssh-action@v1.2.2
+          with:
+            host: ${{ secrets.DROPLET_HOST }}
+            username: ${{ secrets.DROPLET_USER }}
+            key: ${{ secrets.DROPLET_SSH_KEY }}
+            script: |
+              mkdir -p ~/ai-trading-bot
+              tar xzf ~/bot.tar.gz -C ~/ai-trading-bot --strip-components=1
+              rm ~/bot.tar.gz
+              sudo systemctl restart ai-trading-scheduler.service

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies
@@ -18,6 +18,7 @@ jobs:
       - run: mkdocs build
         if: ${{ hashFiles('mkdocs.yml') != '' }}
       - name: Deploy to GitHub Pages
+        if: ${{ hashFiles('mkdocs.yml') != '' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           publish_dir: ./site

--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies
@@ -39,7 +39,7 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies
@@ -50,6 +50,7 @@ jobs:
       - name: Archive bot for transfer
         run: tar czf bot-dist.tar.gz .
       - name: Copy archive to droplet
+        if: ${{ secrets.DROPLET_HOST != '' }}
         uses: appleboy/scp-action@v0.1.0
         with:
           host: ${{ secrets.DROPLET_HOST }}
@@ -58,6 +59,7 @@ jobs:
           source: "bot-dist.tar.gz"
           target: "~/bot-dist.tar.gz"
       - name: SSH & deploy
+        if: ${{ secrets.DROPLET_HOST != '' }}
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.DROPLET_HOST }}
@@ -77,6 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: SSH & run health-check script
+        if: ${{ secrets.DROPLET_HOST != '' }}
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.DROPLET_HOST }}

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -6,10 +6,11 @@ jobs:
   smoke-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: SSH & run tests
+        if: ${{ secrets.DROPLET_HOST != '' }}
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.DROPLET_HOST }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.github/workflows/model-monitor.yml
+++ b/.github/workflows/model-monitor.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   draft:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - name: Generate Release Notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install build deps

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@v0.31.0
+        uses: aquasecurity/trivy-action@0.31.0
         with:
           scan-type: fs
           exit-code: 1

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -18,6 +18,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Notify Slack
         uses: ./.github/actions/slack-notify
         with:

--- a/.github/workflows/ssh-test.yml
+++ b/.github/workflows/ssh-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies
@@ -20,6 +20,7 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements.txt
       - name: SSH & Run
+        if: ${{ secrets.DROPLET_HOST != '' }}
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.DROPLET_HOST }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- add checkout step for Slack notify job
- grant release-notes job permission to post comments
- correct Trivy action version
- only publish docs when mkdocs config exists
- skip droplet steps if secrets are missing
- update all workflows to `actions/setup-python@v5`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684611fd8c64833095f5d7e66427b099