### PR TITLE
Update GitHub Action workflows

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -76,6 +76,8 @@ jobs:
     name: Nightly Health-Check & Auto-Refactorer
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5

--- a/.github/workflows/model-monitor.yml
+++ b/.github/workflows/model-monitor.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   monitor:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5

--- a/.github/workflows/refactor.yml
+++ b/.github/workflows/refactor.yml
@@ -10,6 +10,8 @@ jobs:
   refactor:
     if: contains(github.event.comment.body, '/refactor')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run Trivy scan
-        uses: aquasecurity/trivy-action@v0.19.0
+        uses: aquasecurity/trivy-action@v0.23.1
         with:
           scan-type: filesystem

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v2
         with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          slack-message: ':x: Workflow `${{ github.workflow }}` failed (<${{ github.event.workflow_run.html_url }}|details>)'
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          message: ':x: Workflow `${{ github.workflow }}` failed (<${{ github.event.workflow_run.html_url }}|details>)'

--- a/.github/workflows/ssh-test.yml
+++ b/.github/workflows/ssh-test.yml
@@ -28,6 +28,8 @@ jobs:
           username: ${{ secrets.DROPLET_USER }}
           key: ${{ secrets.DROPLET_SSH_KEY }}
           script: |
+            python3 -m venv ~/venv
+            source ~/venv/bin/activate
             pip install -r requirements.txt
             pip install -r requirements-dev.txt
             pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- pin Trivy to `v0.23.1`
- rename Slack action inputs
- ensure jobs committing to repo have `contents: write` permissions
- wrap master SSH action commands in a venv

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470247c7508330b06a8c7dae6f2fb2