### PR TITLE
Fix SSH test workflow virtualenv

### DIFF
--- a/.github/workflows/ssh-test.yml
+++ b/.github/workflows/ssh-test.yml
@@ -22,10 +22,20 @@ jobs:
 
     - name: Install dependencies & run tests
       run: |
+        # remove any old virtual environment
+        rm -rf venv
+
+        # create a fresh venv in workspace
         python3 -m venv venv
         source venv/bin/activate
-        pip install --upgrade pip
-        pip install pandas
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-        pytest --maxfail=1 --disable-warnings -q
+
+        # upgrade pip via the venv Python interpreter
+        python3 -m pip install --upgrade pip
+
+        # install core dependencies
+        python3 -m pip install pandas
+        python3 -m pip install -r requirements.txt
+        python3 -m pip install -r requirements-dev.txt
+
+        # run pytest under the venv interpreter
+        python3 -m pytest --maxfail=1 --disable-warnings -q


### PR DESCRIPTION
## Summary
- recreate and activate a clean virtual environment in the SSH test workflow
- use `python3 -m pip` for installations
- run `pytest` via the venv interpreter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684743707cf88330bc7aa8c299563f55