### PR TITLE
Fix droplet deploy workflow secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,14 +33,14 @@ jobs:
         run: flake8 . --max-line-length=120 --extend-ignore=E402,E203 --exclude venv,.venv
       - run: pytest --maxfail=1 --disable-warnings -q
       - name: Archive bot for transfer
-        run: git archive --format=tar.gz HEAD > bot-dist.tar.gz
+        run: git archive --format=tar.gz --output=bot-dist.tar.gz HEAD
 
       - name: Copy bot-dist.tar.gz to droplet
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.DROPLET_HOST }}
           username: ${{ secrets.DROPLET_USER }}
-          key: ${{ secrets.DROPLET_KEY }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
           source: bot-dist.tar.gz
           target: ~/ai-trading-bot/bot-dist.tar.gz
       - name: SSH & deploy
@@ -48,7 +48,7 @@ jobs:
         with:
           host: ${{ secrets.DROPLET_HOST }}
           username: ${{ secrets.DROPLET_USER }}
-          key: ${{ secrets.DROPLET_KEY }}
+          key: ${{ secrets.DROPLET_SSH_KEY }}
           script: |
             set -e
             cd ~/ai-trading-bot


### PR DESCRIPTION
## Summary
- update droplet workflow to use `DROPLET_SSH_KEY`
- ensure archive uses git archive output flag

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847acc0e00083309539105cc931ee3a