### PR TITLE
Fix deploy SCP target directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,8 +44,8 @@ jobs:
           username: ${{ secrets.DROPLET_USER }}
           key: ${{ secrets.DROPLET_SSH_KEY }}
           source: bot-dist.tar.gz
-          # explicitly copy into a file, not a folder
-          target: ~/ai-trading-bot/bot-dist.tar.gz
+          # copy into this directory (not as a file path)
+          target: ~/ai-trading-bot
           overwrite: true
       - name: SSH & deploy
         uses: appleboy/ssh-action@v0.1.7


### PR DESCRIPTION
## Summary
- fix SCP target path in deploy workflow to copy into `~/ai-trading-bot`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bf1df4088330b572f12c0f038f13