### PR TITLE
Fix droplet deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,16 @@ jobs:
           echo "${{ secrets.DROPLET_SSH_KEY }}" > droplet_key.pem
           chmod 600 droplet_key.pem
 
+      # ensure the deploy directory exists on the droplet
+      - name: Create remote deploy directory
+        run: |
+          ssh \
+            -i droplet_key.pem \
+            -o StrictHostKeyChecking=no \
+            ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} \
+            "mkdir -p ~/ai-trading-bot"
+
+      # now copy the tarball over
       - name: Copy to droplet via scp
         run: |
           scp \


### PR DESCRIPTION
## Summary
- ensure deploy directory exists before scp in droplet workflow

## Testing
- `pytest -q`
- `flake8 . --max-line-length=120 --extend-ignore=E402,E203 --exclude venv,.venv`


------
https://chatgpt.com/codex/tasks/task_e_684837e2c0588330b5b616fb954a87fd