### PR TITLE
Fix droplet path in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,15 @@ jobs:
             -i droplet_key.pem \
             -o StrictHostKeyChecking=no \
             ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} \
-            "mkdir -p ~/ai-trading-bot"
+            "mkdir -p /home/${{ secrets.DROPLET_USER }}/ai-trading-bot"
+
+      - name: Debug - list remote directory before copy
+        run: |
+          ssh \
+            -i droplet_key.pem \
+            -o StrictHostKeyChecking=no \
+            ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} \
+            "ls -la /home/${{ secrets.DROPLET_USER }}/ai-trading-bot"
 
       # now copy the tarball over
       - name: Copy to droplet via scp
@@ -58,7 +66,15 @@ jobs:
             -i droplet_key.pem \
             -o StrictHostKeyChecking=no \
             bot-dist.tar.gz \
-            ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }}:~/ai-trading-bot/
+            "${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }}:/home/${{ secrets.DROPLET_USER }}/ai-trading-bot/"
+
+      - name: Debug - list remote directory after copy
+        run: |
+          ssh \
+            -i droplet_key.pem \
+            -o StrictHostKeyChecking=no \
+            ${{ secrets.DROPLET_USER }}@${{ secrets.DROPLET_HOST }} \
+            "ls -la /home/${{ secrets.DROPLET_USER }}/ai-trading-bot"
       - name: SSH & deploy
         uses: appleboy/ssh-action@v0.1.7
         with:
@@ -67,7 +83,7 @@ jobs:
           key: ${{ secrets.DROPLET_SSH_KEY }}
           script: |
             set -e
-            cd ~/ai-trading-bot
+            cd /home/${{ secrets.DROPLET_USER }}/ai-trading-bot
             # unpack the file we just SCP’d
             tar xf bot-dist.tar.gz
             # recreate virtualenv to avoid system-managed errors


### PR DESCRIPTION
## Summary
- use an absolute remote path when creating the droplet dir and copying the archive
- add debug steps to list the directory contents before and after copy
- use the same absolute path when deploying

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483ddcdc008330864d3b69888abe7f