### PR TITLE
Fix droplet CI workflow and add debug steps

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -27,10 +27,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -r requirements-dev.txt
+      - name: Debug: list installed packages
+        run: pip list
+      - name: Debug: verify pandas import
+        run: python -c "import pandas; print('pandas', pandas.__version__)"
       - run: black .
       - run: black --check .
       - run: flake8 . --max-line-length=120 --extend-ignore=E402,E203 --exclude venv,.venv
-      - run: pytest --maxfail=1 --disable-warnings -q
+      - name: Run tests
+        run: python -m pytest --maxfail=1 --disable-warnings -q
 
   deploy-to-droplet:
     needs: lint-and-test


### PR DESCRIPTION
## Summary
- add pip list and pandas import checks to debug dependency issues
- use `python -m pytest` for running tests
- keep concurrency block quoted and preserve deploy jobs

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684883b00adc8330a6a9423a34eb8c89