### PR TITLE
Fix droplet CI secrets

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -2,6 +2,7 @@ name: Droplet CI & Nightly Health-Check
 permissions:
   contents: read
   issues: write
+  secrets: read
 
 on:
   push:


### PR DESCRIPTION
## Summary
- grant the workflow permission to read secrets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ce602ad883309a5a501d46335347