### PR TITLE
Remove invalid secrets permission

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -2,7 +2,6 @@ name: Droplet CI & Nightly Health-Check
 permissions:
   contents: read
   issues: write
-  secrets: read
 
 on:
   push:


### PR DESCRIPTION
## Summary
- remove `secrets: read` from workflow permissions

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848d0749dec833087a1864e269a4cc2