### PR TITLE
Fix droplet CI access to secrets

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -1,7 +1,4 @@
 name: Droplet CI & Nightly Health-Check
-permissions:
-  contents: read
-  issues: write
 
 on:
   push:


### PR DESCRIPTION
## Summary
- remove explicit `permissions` block from `.github/workflows/droplet-ci.yml` to restore default secret access

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848d25c6f2c833090f0372fd07239d4