### PR TITLE
Fix droplet CI workflow syntax

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -71,7 +71,7 @@ jobs:
             pip install --upgrade pip
             pip install -r requirements.txt
             systemctl start ai-trading-scheduler
-EOF
+            EOF
 
   nightly-health-check:
     if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Summary
- fix invalid YAML indentation in `droplet-ci.yml`

## Testing
- `yamllint .github/workflows/droplet-ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d83e0cf88330bd43669c3713aa59