### PR TITLE
Fix Droplet CI YAML heredoc

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -71,7 +71,7 @@ jobs:
             pip install --upgrade pip
             pip install -r requirements.txt
             systemctl start ai-trading-scheduler
-            EOF
+          EOF
 
   nightly-health-check:
     if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Summary
- fix heredoc indentation to properly terminate in droplet-ci.yml

## Testing
- `python -m pytest --maxfail=1 --disable-warnings -q`
- `black --check .`
- `flake8 . --max-line-length=120 --extend-ignore=E402,E203 --exclude venv,.venv`


------
https://chatgpt.com/codex/tasks/task_e_6848dd177ed083309cb04acfa8a51526