### PR TITLE
Fix workflows failing on slack notifications, droplet deploy, doc publish

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -10,6 +10,7 @@ runs:
   using: composite
   steps:
     - uses: slackapi/slack-github-action@v1
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook_url }}
       with:
-        webhook-url: ${{ inputs.webhook_url }}
         payload: '{"text": "${{ inputs.text }}"}'

--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Archive bot for transfer
-        run: tar czf bot-dist.tar.gz .
+        run: tar --exclude=bot-dist.tar.gz -czf bot-dist.tar.gz .
       - name: Copy files to droplet
         run: |
           if [ -z "$DROPLET_HOST" ]; then

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,7 +1,7 @@
 name: Publish Docs
 
 permissions:
-  contents: read
+  contents: write
   pages: write
 
 on:


### PR DESCRIPTION
## Summary
- fix Slack webhook usage for slack-notify composite action
- exclude output archive from deployment tarball
- grant write permissions for docs deployment

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848f399910883308df10d05b31f5eb3