### PR TITLE
Fix droplet CI install command

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -65,7 +65,7 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade pip
-            pip install -r requirements.txt
+            python3 -m pip install --no-cache-dir -r requirements.txt
             sudo systemctl restart tradingbot
             echo "✅ Bot deployed and service restarted"
           EOF


### PR DESCRIPTION
## Summary
- ensure droplet deployment installs only production requirements without caching

## Testing
- `pre-commit` *(fails: no hooks installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849a76a6fcc83309162ea84294a167f