### PR TITLE
Update droplet deployment job

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -65,6 +65,8 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install --upgrade pip
+            sudo apt-get clean
+            rm -rf ~/.cache/pip
             python3 -m pip install --no-cache-dir -r requirements.txt
             sudo systemctl restart tradingbot
             echo "✅ Bot deployed and service restarted"


### PR DESCRIPTION
## Summary
- clean apt and pip caches on the droplet before installing dependencies
- only install production requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6849acff54e08330824a35a2b6b88559