### PR TITLE
Fix disk usage in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,8 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             python3 -m pip install --upgrade pip
-            python3 -m pip install -r requirements.txt -r requirements-dev.txt
+            python3 -m pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+            python3 -m pip cache purge
             python3 -m pytest --maxfail=1 --disable-warnings -q
             # restart your service
             sudo systemctl restart ai-trading-scheduler


### PR DESCRIPTION
## Summary
- avoid pip cache filling the disk when installing deps on the droplet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c02428b4833097a5782348a30985