### PR TITLE
Fix YAML syntax for droplet workflow

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -62,12 +62,12 @@ jobs:
             echo "Skipping deploy, DROPLET_HOST not set"
             exit 0
           fi
-          ssh -i droplet_key.pem -o StrictHostKeyChecking=no "$DROPLET_USER@$DROPLET_HOST" <<EOF
+          ssh -i droplet_key.pem -o StrictHostKeyChecking=no "$DROPLET_USER@$DROPLET_HOST" <<'EOF'
           docker pull my-bot:${{ github.sha }}
           docker stop tradingbot || true
           docker rm tradingbot || true
           docker run -d --name tradingbot --restart always my-bot:${{ github.sha }}
-EOF
+          EOF
 
   nightly-health-check:
     if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
## Summary
- fix indentation for EOF block in droplet CI workflow

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails to complete due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6849c4f99f28833082fbddfe3a3cd0dd