### PR TITLE
Fix droplet deployment workflow

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -73,6 +73,10 @@ jobs:
             exit 0
           fi
           ssh -i droplet_key.pem -o StrictHostKeyChecking=no "$DROPLET_USER@$DROPLET_HOST" <<'EOF'
+          if ! command -v docker >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y docker.io
+          fi
           docker pull my-bot:${{ github.sha }}
           docker stop tradingbot || true
           docker rm tradingbot || true


### PR DESCRIPTION
## Summary
- ensure docker is installed on droplet before pulling image

## Testing
- `black --check .`
- `flake8 . --max-line-length=120 --extend-ignore=E402,E203 --exclude venv,.venv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d2186498833087c994b0f8e469e7