### PR TITLE
Fix droplet deploy path

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -3,7 +3,7 @@ set -e
 
 # ——— Your droplet’s SSH info ———
 SERVER="root@143.110.157.152"
-APP_DIR="/root/ai_trading_bot"
+APP_DIR="/root/ai-trading-bot"
 BRANCH="main"
 
 echo "Deploying branch '$BRANCH' to $SERVER:$APP_DIR …"

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 echo "🔁 Starting AI Trading Bot..."
 source ~/.bashrc
-cd ~/AI_TRADING_BOT
+cd ~/ai-trading-bot
 if [ ! -d venv ]; then
   python3 -m venv venv
 fi


### PR DESCRIPTION
## Summary
- revert pandas_ta stub
- use consistent `/root/ai-trading-bot` path in deploy/start scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a19ff37348330818718f9f2bae819