### PR TITLE
Fix deploy pip upgrade

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip setuptools
           python -m pip install -r requirements.txt -r requirements-dev.txt
       - name: "Debug: list installed packages"
         run: pip list
@@ -103,7 +103,7 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip setuptools
           python -m pip install -r requirements.txt -r requirements-dev.txt
       - name: Run health-check script
         run: |


### PR DESCRIPTION
## Summary
- ensure setuptools is installed during CI deploy steps

## Testing
- `pre-commit run --files .github/workflows/droplet-ci.yml`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a22fc1e5483309079e3ff1da076da