### PR TITLE
Fix pip command in workflow

### DIFF
--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools
-          python -m pip install -r requirements.txt -r requirements-dev.txt
+          python3 -m pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
       - name: "Debug: list installed packages"
         run: pip list
       - name: "Debug: verify pandas import"


### PR DESCRIPTION
## Summary
- ensure lint job installs requirements without cache using python3
- revert nightly health-check setup lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3de2670083309e3c81dbd6ad6537