### PR TITLE
Add systemd service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ pip install -r requirements-dev.txt
 pytest
 ```
 
+
+## Systemd Service
+
+A sample service file `ai-trading-scheduler.service` is provided to run the bot using the `start.sh` helper script. This ensures the virtual environment is activated and all dependencies are installed before the bot starts.
+
+To use it:
+
+```bash
+sudo cp ai-trading-scheduler.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now ai-trading-scheduler.service
+```
+
+The service writes logs to `/var/log/ai-trading-scheduler.log`.

--- a/ai-trading-scheduler.service
+++ b/ai-trading-scheduler.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=AI Trading Bot Scheduler & Metrics
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/root/ai-trading-bot
+ExecStart=/root/ai-trading-bot/start.sh
+Restart=always
+RestartSec=5
+StandardOutput=append:/var/log/ai-trading-scheduler.log
+StandardError=append:/var/log/ai-trading-scheduler.log
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,3 +38,17 @@ pip install -r requirements-dev.txt
 pytest
 ```
 
+
+## Systemd Service
+
+A sample service file `ai-trading-scheduler.service` is provided to run the bot using the `start.sh` helper script. This ensures the virtual environment is activated and all dependencies are installed before the bot starts.
+
+To use it:
+
+```bash
+sudo cp ai-trading-scheduler.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now ai-trading-scheduler.service
+```
+
+The service writes logs to `/var/log/ai-trading-scheduler.log`.


### PR DESCRIPTION
## Summary
- add `ai-trading-scheduler.service` to run the bot via `start.sh`
- document how to install the service in README and docs

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a47981c148330898b7bd79126284b