### PR TITLE
Fix IEX default on historical fetch

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -96,7 +96,8 @@ def get_historical_data(
         return _DATA_CLIENT.get_stock_bars(req).df
 
     try:
-        bars = _fetch("sip")
+        # default to IEX-delayed data to avoid SIP subscription errors
+        bars = _fetch("iex")
     except APIError as e:
         if "subscription does not permit querying recent sip data" in str(e).lower():
             try:


### PR DESCRIPTION
## Summary
- avoid SIP permission errors by defaulting to the IEX feed in `get_historical_data`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b09d41c708330b3f7a319d2c636b2