### PR TITLE
Relax training data row requirement

### DIFF
--- a/retrain.py
+++ b/retrain.py
@@ -379,9 +379,11 @@ def build_feature_label_df(
                     f"[build_feature_label_df] – {sym} returned no minute data; skipping symbol."
                 )
                 continue
-            if raw.shape[0] < MINUTES_REQUIRED:
+            min_required = max(int(MINUTES_REQUIRED * 0.7), 5)
+            if raw.shape[0] < min_required:
                 print(
-                    f"[build_feature_label_df] – skipping {sym}, only {raw.shape[0]} < {MINUTES_REQUIRED}"
+                    f"[build_feature_label_df] – skipping {sym}, only {raw.shape[0]} < {min_required} "
+                    f"(70% of {MINUTES_REQUIRED})"
                 )
                 continue
 


### PR DESCRIPTION
## Summary
- loosen minimum row requirement in `build_feature_label_df`
- keep at least 70% of expected rows to avoid discarding sparse data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0a2c643483308074ffefc6bf641f