### PR TITLE
Update bot for alpaca sdk changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pandas_market_calendars>=4.1.4
 schedule>=1.1.0
 portalocker>=2.7.0
 alpaca-py>=0.40.1
-scikit-learn
+scikit-learn==1.6.1
 joblib
 python-dotenv>=0.21.0
 sentry-sdk


### PR DESCRIPTION
## Summary
- ignore InconsistentVersionWarning from sklearn
- alias get_order for TradingClient
- use Stream with explicit feed
- run websocket with default topics
- validate loaded models
- pin scikit-learn version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0fb71acc8330b369cf164e068acf