### PR TITLE
Fix order lookup and streaming

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ finnhub-python>=0.4.0
 xgboost>=1.7.6
 lightgbm>=4.0.0
 pytz
-alpaca-trade-api
+alpaca-trade-api>=3.0.0
 pytest
 flake8
 black


### PR DESCRIPTION
## Summary
- subscribe to Alpaca trade update stream with new API
- query order status using `get_order(order_id=...)`
- pin alpaca-trade-api >=3.0.0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b12c6a430833083e7d78077f09ecf