### PR TITLE
Switch to alpaca-py Stream

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ flask>=2.1.0
 pandas_market_calendars>=4.1.4
 schedule>=1.1.0
 portalocker>=2.7.0
-alpaca-py>=0.40.1
+alpaca-py>=0.40.1        # new official SDK
 scikit-learn==1.6.1
 joblib
 python-dotenv>=0.21.0
@@ -20,7 +20,7 @@ finnhub-python>=0.4.0
 xgboost>=1.7.6
 lightgbm>=4.0.0
 pytz
-alpaca-trade-api>=3.0.0
+alpaca-trade-api==2.4.0
 pytest
 flake8
 black

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -22,6 +22,8 @@ mods = [
     "alpaca.trading.models",
     "alpaca_trade_api",
     "alpaca_trade_api.rest",
+    "alpaca.data",
+    "alpaca.data.stream",
     "alpaca.data.historical",
     "alpaca.data.models",
     "alpaca.data.requests",
@@ -47,6 +49,8 @@ for name in mods:
     if name not in sys.modules:
         sys.modules[name] = types.ModuleType(name)
 sys.modules["pipeline"].model_pipeline = lambda *a, **k: None
+sys.modules["alpaca.data"].Stream = object
+sys.modules["alpaca.data.stream"].Stream = object
 
 sys.modules["flask"].Flask = object
 sys.modules["requests"].get = lambda *a, **k: None


### PR DESCRIPTION
## Summary
- use `Stream` from `alpaca.data`
- adjust trade update handler signature
- update order lookup methods for alpaca-py
- pin `alpaca-trade-api` to 2.4.0 and comment new `alpaca-py` usage
- extend tests for new alpaca modules

## Testing
- `pip install pandas`
- `pip install python-dotenv`
- `pip install tenacity`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b163132148330baddaf3534d74dc4