### PR TITLE
Switch to alpaca-py SDK

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -22,7 +22,7 @@ BACKTEST_WINDOW_DAYS = 365
 import pandas as pd
 import numpy as np
 from data_fetcher import get_historical_data, DataFetchError
-from alpaca_trade_api.rest import APIError
+from alpaca.common.exceptions import APIError
 from tenacity import RetryError
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ beautifulsoup4>=4.11.1
 flask>=2.1.0
 pandas_market_calendars>=4.1.4
 schedule>=1.1.0
+# removed: alpaca-trade-api (not compatible with Python 3.12)
 portalocker>=2.7.0
 alpaca-py>=0.40.1        # new official SDK
 scikit-learn==1.6.1
@@ -22,7 +23,6 @@ finnhub-python>=0.4.0
 xgboost>=1.7.6
 lightgbm>=4.0.0
 pytz
-alpaca-trade-api==2.3.0  # last 2.x release supporting get_order_by_client_order_id
 pytest
 flake8
 black

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -28,6 +28,7 @@ mods = [
     "alpaca.data.models",
     "alpaca.data.requests",
     "alpaca.data.timeframe",
+    "alpaca.common.exceptions",
     "sklearn.ensemble",
     "sklearn.linear_model",
     "sklearn.decomposition",
@@ -59,6 +60,7 @@ sys.modules["urllib3"] = types.ModuleType("urllib3")
 sys.modules["urllib3"].exceptions = types.SimpleNamespace(HTTPError=Exception)
 sys.modules["alpaca_trade_api"].REST = object
 sys.modules["alpaca_trade_api"].APIError = Exception
+sys.modules["alpaca.common.exceptions"].APIError = Exception
 sys.modules["sklearn.ensemble"].RandomForestClassifier = object
 sys.modules["sklearn.linear_model"].Ridge = object
 sys.modules["sklearn.linear_model"].BayesianRidge = object

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -25,7 +25,7 @@ from alpaca.trading.requests import LimitOrderRequest
 from alpaca.trading.requests import MarketOrderRequest
 from alpaca.trading.enums import OrderSide, TimeInForce
 from alpaca.trading.models import Order
-from alpaca_trade_api.rest import APIError
+from alpaca.common.exceptions import APIError
 from alpaca.data.models import Quote
 from alpaca.data.requests import StockLatestQuoteRequest
 


### PR DESCRIPTION
## Summary
- update dependencies to use `alpaca-py`
- refactor trading code to use `TradingClient`/`StockHistoricalDataClient`
- update modules importing `alpaca_trade_api`
- adjust tests for new SDK

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2506018483308c0443371e493dae