### PR TITLE
Fix Alpaca streaming import

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -68,7 +68,8 @@ from alpaca.trading.requests import (
 )
 from alpaca.trading.models import Order
 from alpaca.common.exceptions import APIError
-from alpaca.data.stream import Stream
+# Legacy import removed; using alpaca-py trading stream instead
+from alpaca.trading.stream import TradingStream
 # for paper trading
 ALPACA_BASE_URL = 'https://paper-api.alpaca.markets'
 import threading
@@ -1527,11 +1528,11 @@ data_client = StockHistoricalDataClient(API_KEY, SECRET_KEY)
 # WebSocket for order status updates
 # use the new Stream class; explicitly set feed and base_url
 
-stream = Stream(
+# Create a trading stream for order status updates
+stream = TradingStream(
     API_KEY,
     SECRET_KEY,
-    base_url="https://paper-api.alpaca.markets",
-    data_stream_url="wss://paper-data.alpaca.markets/stream",
+    paper=True,
 )
 
 async def on_trade_update(channel, data):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -23,7 +23,7 @@ mods = [
     "alpaca_trade_api",
     "alpaca_trade_api.rest",
     "alpaca.data",
-    "alpaca.data.stream",
+    "alpaca.trading.stream",
     "alpaca.data.historical",
     "alpaca.data.models",
     "alpaca.data.requests",
@@ -50,8 +50,7 @@ for name in mods:
     if name not in sys.modules:
         sys.modules[name] = types.ModuleType(name)
 sys.modules["pipeline"].model_pipeline = lambda *a, **k: None
-sys.modules["alpaca.data"].Stream = object
-sys.modules["alpaca.data.stream"].Stream = object
+sys.modules["alpaca.trading.stream"].TradingStream = object
 
 sys.modules["flask"].Flask = object
 sys.modules["requests"].get = lambda *a, **k: None

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -4,6 +4,10 @@ from pathlib import Path
 import pandas as pd
 import datetime
 import pytest
+import os
+
+os.environ.setdefault("APCA_API_KEY_ID", "dummy")
+os.environ.setdefault("APCA_API_SECRET_KEY", "dummy")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 mods = [
@@ -13,11 +17,14 @@ mods = [
     "alpaca.data.timeframe",
     "alpaca_trade_api.rest",
     "alpaca.common.exceptions",
+    "dotenv",
     "finnhub",
 ]
 for m in mods:
     sys.modules.setdefault(m, types.ModuleType(m))
 sys.modules.setdefault("alpaca_trade_api", types.ModuleType("alpaca_trade_api"))
+sys.modules["dotenv"] = types.ModuleType("dotenv")
+sys.modules["dotenv"].load_dotenv = lambda *a, **k: None
 
 
 class _FakeREST:


### PR DESCRIPTION
## Summary
- swap legacy `Stream` for `TradingStream`
- adjust fake modules in tests for new import
- stub missing env vars and dotenv for data_fetcher tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b28ccb1608330b1c0db0a819e0295