### PR TITLE
Pin Cython<3 and wheel to allow PyYAML build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# Ensure PyYAML can build under Python 3.12
+cython<3.0.0
+wheel
+
 structlog>=21.5.0
 tenacity>=8.2.0
 ratelimit>=2.2.1


### PR DESCRIPTION
## Summary
- pin Cython below 3 and include wheel so PyYAML builds on Python 3.12

## Testing
- `pre-commit run --files requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2a3937948330afe57902c42a5cda