### PR TITLE
Update flake8 ignores and CI linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-max-line-length = 120
-extend-ignore = E302, E305, F811
+max-line-length = 160
+extend-ignore = E302, E305, E402, E203, E501, F811
 exclude = .github/, __pycache__/

--- a/.github/workflows/ci-and-test.yml
+++ b/.github/workflows/ci-and-test.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           pip install flake8 mypy
           flake8 \
-            --max-line-length=120 \
-            --extend-ignore=E302,E305,F811 \
+            --max-line-length=160 \
+            --extend-ignore=E302,E305,E402,E203,E501,F811 \
             --statistics .
           mypy .
 


### PR DESCRIPTION
## Summary
- ignore `E402`, `E203`, and `E501` in flake8 config
- keep CI lint step consistent with flake8 settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4fd618dc8330a815ede0a06fda03