### PR TITLE
Fix CI lint exclusion

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 160
 extend-ignore = E302, E305, E402, E203, E501, F811
-exclude = .github/, __pycache__/
+exclude = .github/, __pycache__/, scripts/

--- a/.github/workflows/ci-and-test.yml
+++ b/.github/workflows/ci-and-test.yml
@@ -30,8 +30,9 @@ jobs:
           flake8 \
             --max-line-length=160 \
             --extend-ignore=E302,E305,E402,E203,E501,F811 \
-            --statistics .
-          mypy .
+            --statistics \
+            --exclude scripts/ .
+          mypy . --exclude scripts/
 
       - name: Pytest
         run: pytest --maxfail=1 --disable-warnings --junitxml=reports/junit.xml --cov=. --cov-report=xml


### PR DESCRIPTION
## Summary
- adjust CI to skip `scripts/` during lint & type-check
- update Flake8 config to exclude `scripts/`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b51a5ab608330847da8cdd70edade