### PR TITLE
Remove mypy from CI workflow

### DIFF
--- a/.github/workflows/ci-and-test.yml
+++ b/.github/workflows/ci-and-test.yml
@@ -22,17 +22,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install mypy pytest-cov
+          pip install pytest-cov
 
-      - name: Lint & Type-Check
+      - name: Lint
         run: |
-          pip install flake8 mypy
+          pip install flake8
           flake8 \
             --max-line-length=160 \
             --extend-ignore=E302,E305,E402,E203,E501,F811 \
             --statistics \
             --exclude scripts/ .
-          mypy . --exclude scripts/
 
       - name: Pytest
         run: pytest --maxfail=1 --disable-warnings --junitxml=reports/junit.xml --cov=. --cov-report=xml


### PR DESCRIPTION
## Summary
- simplify the CI workflow by removing MyPy
- run only Flake8 during linting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b55827ab8833093c4ac07d4d46d0a