### PR TITLE
Fix metrics file I/O

### DIFF
--- a/metrics_logger.py
+++ b/metrics_logger.py
@@ -1,12 +1,22 @@
 import csv
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def log_metrics(record, filename="metrics/model_performance.csv"):
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
-    file_exists = os.path.isfile(filename)
-    with open(filename, "a", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=record.keys())
-        if not file_exists:
-            writer.writeheader()
-        writer.writerow(record)
+    """Append a metrics record to the CSV file."""
+
+    # Protect file operations so metrics logging can't crash the bot
+    try:
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        file_exists = os.path.isfile(filename)
+        with open(filename, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=record.keys())
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(record)
+    except Exception as e:  # pragma: no cover - best effort logging
+        # Log exception and continue to avoid silent failure
+        logger.warning(f"Failed to update metrics file {filename}: {e}")


### PR DESCRIPTION
## Summary
- guard metrics CSV writing with try/except
- add logging for any failures

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b9979ee0c8330b372727d65113a23