### PR TITLE
Improve logging and error handling

### DIFF
--- a/metrics_logger.py
+++ b/metrics_logger.py
@@ -1,12 +1,16 @@
 import csv
 import os
+import logging
 
 
 def log_metrics(record, filename="metrics/model_performance.csv"):
     os.makedirs(os.path.dirname(filename), exist_ok=True)
     file_exists = os.path.isfile(filename)
-    with open(filename, "a", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=record.keys())
-        if not file_exists:
-            writer.writeheader()
-        writer.writerow(record)
+    try:
+        with open(filename, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=record.keys())
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(record)
+    except OSError as exc:
+        logging.getLogger(__name__).error("Failed to log metrics: %s", exc)

--- a/retrain.py
+++ b/retrain.py
@@ -22,14 +22,14 @@ from lightgbm import LGBMClassifier
 
 import pandas_ta as ta
 
+logger = logging.getLogger(__name__)
+warnings.filterwarnings("ignore", category=FutureWarning)
+
 import config
 
 NEWS_API_KEY = config.NEWS_API_KEY
 if not NEWS_API_KEY:
     logger.warning("NEWS_API_KEY is not set; sentiment features will be zero")
-
-logger = logging.getLogger(__name__)
-warnings.filterwarnings("ignore", category=FutureWarning)
 
 MINUTES_REQUIRED = 31
 MFI_PERIOD = 14


### PR DESCRIPTION
## Summary
- initialize logger earlier in `retrain.py`
- guard metrics logging with try/except
- add environment checks and logging to `server.py`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b9c2e5a648330b9da4b5ee09e9d1d