### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           name: db-backup
           path: backup-*.sql
+          retention-days: 7
 
       - name: Snapshot Droplet
         if: env.DO_API_TOKEN != ''

--- a/.github/workflows/ci-and-test.yml
+++ b/.github/workflows/ci-and-test.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          set -e
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
@@ -38,6 +39,7 @@ jobs:
 
       - name: Lint and format check
         run: |
+          set -e
           pip install flake8 black
           flake8 \
             --max-line-length=160 \
@@ -48,6 +50,7 @@ jobs:
 
       - name: Type check
         run: |
+          set -e
           pip install mypy
           mypy .
 
@@ -59,6 +62,7 @@ jobs:
         with:
           name: junit-report
           path: reports/junit.xml
+          retention-days: 7
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,23 @@ on:
 jobs:
   preflight:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
-    uses: ./.github/workflows/preflight.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required secrets
+        env:
+          DROPLET_HOST: ${{ secrets.DROPLET_HOST }}
+          DROPLET_SSH_KEY: ${{ secrets.DROPLET_SSH_KEY }}
+          DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          set -e
+          for var in DROPLET_HOST DROPLET_SSH_KEY DOCKER_REGISTRY DOCKER_USERNAME DOCKER_PASSWORD; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Missing required secret $var"
+              exit 1
+            fi
+          done
 
   deploy:
     needs: preflight
@@ -81,6 +97,7 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: |
+          set -e
           sentry-cli releases new $IMAGE_TAG
           sentry-cli releases finalize $IMAGE_TAG
 

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -19,6 +19,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
+          set -e
           for var in DROPLET_HOST DROPLET_SSH_KEY DOCKER_REGISTRY DOCKER_USERNAME DOCKER_PASSWORD; do
             if [ -z "${!var}" ]; then
               echo "::error::Missing required secret $var"


### PR DESCRIPTION
## Summary
- check secrets in preflight with set -e
- enforce `set -e` across CI workflow
- retain CI artifacts for a week
- retain backup artifacts for a week
- inline preflight checks in deploy workflow and finalize Sentry release safely

## Testing
- `pip install -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba43b82c0833097c93ba1181a48c8