### PR TITLE
Refactor trading bot state handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,41 +3,47 @@ import os
 from dotenv import load_dotenv
 
 ROOT_DIR = Path(__file__).resolve().parent
-ENV_PATH = ROOT_DIR / '.env'
+ENV_PATH = ROOT_DIR / ".env"
 load_dotenv(ENV_PATH)
 
-required_env_vars = ['APCA_API_KEY_ID', 'APCA_API_SECRET_KEY']
+from types import MappingProxyType
+
+required_env_vars = ("APCA_API_KEY_ID", "APCA_API_SECRET_KEY")
 missing = [v for v in required_env_vars if v not in os.environ]
 if missing:
     raise RuntimeError(f"Missing required environment variables: {missing}")
 
-ALPACA_API_KEY = os.environ.get('ALPACA_API_KEY') or os.environ.get('APCA_API_KEY_ID')
-ALPACA_SECRET_KEY = os.environ.get('ALPACA_SECRET_KEY') or os.environ.get('APCA_API_SECRET_KEY')
-ALPACA_BASE_URL = os.environ.get('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
-ALPACA_PAPER = 'paper' in ALPACA_BASE_URL.lower()
-FINNHUB_API_KEY = os.environ.get('FINNHUB_API_KEY')
-FUNDAMENTAL_API_KEY = os.environ.get('FUNDAMENTAL_API_KEY')
-NEWS_API_KEY = os.environ.get('NEWS_API_KEY')
-IEX_API_TOKEN = os.environ.get('IEX_API_TOKEN')
-SENTRY_DSN = os.environ.get('SENTRY_DSN')
-BOT_MODE = os.environ.get('BOT_MODE', 'balanced')
-MODEL_PATH = os.environ.get('MODEL_PATH', 'trained_model.pkl')
-HALT_FLAG_PATH = os.environ.get('HALT_FLAG_PATH', 'halt.flag')
-MAX_PORTFOLIO_POSITIONS = int(os.environ.get('MAX_PORTFOLIO_POSITIONS', '20'))
-LIMIT_ORDER_SLIPPAGE = float(os.environ.get('LIMIT_ORDER_SLIPPAGE', '0.005'))
-HEALTHCHECK_PORT = int(os.environ.get('HEALTHCHECK_PORT', '8081'))
-RUN_HEALTHCHECK = os.environ.get('RUN_HEALTHCHECK', '0')
-BUY_THRESHOLD = float(os.environ.get('BUY_THRESHOLD', '0.5'))
-WEBHOOK_SECRET = os.environ.get('WEBHOOK_SECRET', '')
-WEBHOOK_PORT = int(os.environ.get('WEBHOOK_PORT', '9000'))
+ALPACA_API_KEY = os.environ.get("ALPACA_API_KEY") or os.environ.get("APCA_API_KEY_ID")
+ALPACA_SECRET_KEY = os.environ.get("ALPACA_SECRET_KEY") or os.environ.get(
+    "APCA_API_SECRET_KEY"
+)
+ALPACA_BASE_URL = os.environ.get("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+ALPACA_PAPER = "paper" in ALPACA_BASE_URL.lower()
+FINNHUB_API_KEY = os.environ.get("FINNHUB_API_KEY")
+FUNDAMENTAL_API_KEY = os.environ.get("FUNDAMENTAL_API_KEY")
+NEWS_API_KEY = os.environ.get("NEWS_API_KEY")
+IEX_API_TOKEN = os.environ.get("IEX_API_TOKEN")
+SENTRY_DSN = os.environ.get("SENTRY_DSN")
+BOT_MODE = os.environ.get("BOT_MODE", "balanced")
+MODEL_PATH = os.environ.get("MODEL_PATH", "trained_model.pkl")
+HALT_FLAG_PATH = os.environ.get("HALT_FLAG_PATH", "halt.flag")
+MAX_PORTFOLIO_POSITIONS = int(os.environ.get("MAX_PORTFOLIO_POSITIONS", "20"))
+LIMIT_ORDER_SLIPPAGE = float(os.environ.get("LIMIT_ORDER_SLIPPAGE", "0.005"))
+HEALTHCHECK_PORT = int(os.environ.get("HEALTHCHECK_PORT", "8081"))
+RUN_HEALTHCHECK = os.environ.get("RUN_HEALTHCHECK", "0")
+BUY_THRESHOLD = float(os.environ.get("BUY_THRESHOLD", "0.5"))
+WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET", "")
+WEBHOOK_PORT = int(os.environ.get("WEBHOOK_PORT", "9000"))
 
 # centralize SGDRegressor hyperparameters
-SGD_PARAMS = {
-    'loss': 'squared_error',
-    'learning_rate': 'constant',
-    'eta0': 0.01,
-    'penalty': 'l2',
-}
+SGD_PARAMS = MappingProxyType(
+    {
+        "loss": "squared_error",
+        "learning_rate": "constant",
+        "eta0": 0.01,
+        "penalty": "l2",
+    }
+)
 
 
 def validate_alpaca_credentials() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,4 @@ yfinance
 urllib3
 statsmodels
 transformers
+python-dateutil

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -2,10 +2,10 @@ from .base import Strategy, TradeSignal, asset_class_for
 from .momentum import MomentumStrategy
 from .mean_reversion import MeanReversionStrategy
 
-__all__ = [
+__all__ = (
     "Strategy",
     "TradeSignal",
     "MomentumStrategy",
     "MeanReversionStrategy",
     "asset_class_for",
-]
+)


### PR DESCRIPTION
## Summary
- centralize bot mutable state in new `BotState` class
- remove all global state mutations in `bot.py`
- make config and strategies constants immutable
- include `python-dateutil` in requirements

## Testing
- `black -q bot.py config.py strategies/__init__.py`
- `flake8` *(fails: ./retrain.py:29:5: F821 undefined name 'logger')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba91ed0d88330aeff4ec2f19d28a1