### PR TITLE
Fix env reload and workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,14 +74,20 @@ jobs:
           host: ${{ secrets.DROPLET_HOST }}
           key: ${{ secrets.DROPLET_SSH_KEY }}
           script: |
-            docker pull ${{ secrets.DOCKER_REGISTRY }}/${{ github.repository }}:${{ github.sha }}
+            docker pull ${{ secrets.DOCKER_REGISTRY }}/${{ github.repository }}:${{ env.IMAGE_TAG }}
             docker stop ai-trader || true
             docker rm ai-trader  || true
             docker run -d \
               --name ai-trader \
               --restart always \
               -e BOT_MODE=$BOT_MODE \
-              ${{ secrets.DOCKER_REGISTRY }}/${{ github.repository }}:${{ github.sha }}
+              ${{ secrets.DOCKER_REGISTRY }}/${{ github.repository }}:${{ env.IMAGE_TAG }}
+
+      - name: Debug workspace on failure
+        if: failure()
+        run: |
+          echo "PWD: $(pwd)"
+          ls -al
 
       - name: Health check
         run: |

--- a/bot.py
+++ b/bot.py
@@ -803,11 +803,9 @@ class DataFetcher:
                     print(
                         f">> DEBUG: INSERTING DUMMY DAILY FOR {symbol} ON {end_ts.date().isoformat()}"
                     )
-                    ts = pd.to_datetime(end_ts)
-                    if ts.tzinfo is not None:
-                        ts = ts.tz_convert("UTC")
-                    else:
-                        ts = ts.tz_localize("UTC")
+                    ts = pd.to_datetime(end_ts, utc=True, errors="coerce")
+                    if ts is None:
+                        ts = pd.Timestamp.utcnow()
                     dummy_date = ts
                     df = pd.DataFrame(
                         [
@@ -823,11 +821,9 @@ class DataFetcher:
                     )
             else:
                 print(f">> DEBUG: ALPACA DAILY FETCH ERROR for {symbol}: {repr(e)}")
-                ts2 = pd.to_datetime(end_ts)
-                if ts2.tzinfo is not None:
-                    ts2 = ts2.tz_convert("UTC")
-                else:
-                    ts2 = ts2.tz_localize("UTC")
+                ts2 = pd.to_datetime(end_ts, utc=True, errors="coerce")
+                if ts2 is None:
+                    ts2 = pd.Timestamp.utcnow()
                 dummy_date = ts2
                 df = pd.DataFrame(
                     [{"open": 0.0, "high": 0.0, "low": 0.0, "close": 0.0, "volume": 0}],
@@ -835,11 +831,9 @@ class DataFetcher:
                 )
         except Exception as e:
             print(f">> DEBUG: ALPACA DAILY FETCH EXCEPTION for {symbol}: {repr(e)}")
-            ts = pd.to_datetime(end_ts)
-            if ts.tzinfo is not None:
-                ts = ts.tz_convert("UTC")
-            else:
-                ts = ts.tz_localize("UTC")
+            ts = pd.to_datetime(end_ts, utc=True, errors="coerce")
+            if ts is None:
+                ts = pd.Timestamp.utcnow()
             dummy_date = ts
             df = pd.DataFrame(
                 [{"open": 0.0, "high": 0.0, "low": 0.0, "close": 0.0, "volume": 0}],
@@ -1091,11 +1085,9 @@ def prefetch_daily_data(
                         print(
                             f">> DEBUG: INSERTING DUMMY DAILY FOR {sym} ON {end_date.isoformat()}"
                         )
-                        tsd = pd.to_datetime(end_date)
-                        if tsd.tzinfo is not None:
-                            tsd = tsd.tz_convert("UTC")
-                        else:
-                            tsd = tsd.tz_localize("UTC")
+                        tsd = pd.to_datetime(end_date, utc=True, errors="coerce")
+                        if tsd is None:
+                            tsd = pd.Timestamp.utcnow()
                         dummy_date = tsd
                         dummy_df = pd.DataFrame(
                             [
@@ -1115,11 +1107,9 @@ def prefetch_daily_data(
             print(f">> DEBUG: ALPACA BULK FETCH UNKNOWN ERROR for {symbols}: {repr(e)}")
             daily_dict = {}
             for sym in symbols:
-                t2 = pd.to_datetime(end_date)
-                if t2.tzinfo is not None:
-                    t2 = t2.tz_convert("UTC")
-                else:
-                    t2 = t2.tz_localize("UTC")
+                t2 = pd.to_datetime(end_date, utc=True, errors="coerce")
+                if t2 is None:
+                    t2 = pd.Timestamp.utcnow()
                 dummy_date = t2
                 dummy_df = pd.DataFrame(
                     [{"open": 0.0, "high": 0.0, "low": 0.0, "close": 0.0, "volume": 0}],
@@ -1131,11 +1121,9 @@ def prefetch_daily_data(
         print(f">> DEBUG: ALPACA BULK FETCH EXCEPTION for {symbols}: {repr(e)}")
         daily_dict = {}
         for sym in symbols:
-            t3 = pd.to_datetime(end_date)
-            if t3.tzinfo is not None:
-                t3 = t3.tz_convert("UTC")
-            else:
-                t3 = t3.tz_localize("UTC")
+            t3 = pd.to_datetime(end_date, utc=True, errors="coerce")
+            if t3 is None:
+                t3 = pd.Timestamp.utcnow()
             dummy_date = t3
             dummy_df = pd.DataFrame(
                 [{"open": 0.0, "high": 0.0, "low": 0.0, "close": 0.0, "volume": 0}],

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -68,8 +68,8 @@ def get_historical_data(
 ) -> pd.DataFrame:
     """Fetch historical bars from Alpaca and ensure OHLCV float columns."""
 
-    start_dt = pd.to_datetime(start_date)
-    end_dt = pd.to_datetime(end_date)
+    start_dt = pd.to_datetime(start_date, utc=True, errors="coerce")
+    end_dt = pd.to_datetime(end_date, utc=True, errors="coerce")
 
     tf_map = {
         "1Min": TimeFrame.Minute,

--- a/server.py
+++ b/server.py
@@ -6,6 +6,8 @@ from flask import Flask
 from flask import abort
 from flask import jsonify
 from flask import request
+import os
+from dotenv import load_dotenv
 from config import WEBHOOK_SECRET, WEBHOOK_PORT
 
 app = Flask(__name__)
@@ -25,6 +27,8 @@ def verify_sig(data: bytes, signature: str) -> bool:
 
 @app.route("/github-webhook", methods=["POST"])
 def hook():
+    # Refresh environment variables on each webhook event
+    load_dotenv(dotenv_path=".env", override=True)
     payload = request.get_json(force=True)
     if not payload or "symbol" not in payload or "action" not in payload:
         return jsonify({"error": "Missing fields"}), 400
@@ -37,6 +41,8 @@ def hook():
 
 
 def start():
+    # Reload env vars when starting the Flask server
+    load_dotenv(dotenv_path=".env", override=True)
     app.run(host="0.0.0.0", port=WEBHOOK_PORT)
 
 


### PR DESCRIPTION
## Summary
- reload environment variables on each webhook event
- harden datetime parsing for data fetcher and bot
- ensure deploy workflow uses correct image tag and debug step

## Testing
- `python -m py_compile server.py data_fetcher.py bot.py risk_engine.py trade_execution.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c71e95c948330a97b7d0d8ba3814b