### PR TITLE
Improve data parsing robustness

### DIFF
--- a/retrain.py
+++ b/retrain.py
@@ -9,6 +9,7 @@ import warnings
 import pandas as pd
 import numpy as np
 from metrics_logger import log_metrics
+from utils import safe_to_datetime
 
 load_dotenv(dotenv_path=".env", override=True)
 
@@ -197,9 +198,12 @@ def prepare_indicators(df: pd.DataFrame, freq: str = "daily") -> pd.DataFrame:
     else:
         df = df.reset_index().rename(columns={"index": "Date"})
     if "timestamp" in df.columns and df["Date"].dtype == object:
-        df["Date"] = pd.to_datetime(df["timestamp"])
+        idx = safe_to_datetime(df["timestamp"])
     else:
-        df["Date"] = pd.to_datetime(df["Date"])
+        idx = safe_to_datetime(df["Date"])
+    if idx is None:
+        raise ValueError("Invalid date values in dataframe")
+    df["Date"] = idx
     df = df.sort_values("Date").set_index("Date")
 
     # Calculate basic TA indicators


### PR DESCRIPTION
## Summary
- add utility `safe_to_datetime` for validated datetime conversion
- handle invalid indexes in `data_fetcher` and `bot` data pipelines
- use safe date parsing during retraining

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8422f4288330ae267885d01b7597