### PR TITLE
Add market hours check

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -4707,6 +4707,18 @@ if __name__ == "__main__":
     try:
         logger.info(">>> BOT __main__ ENTERED – starting up")
 
+        # --- Market hours check ---
+        import pandas_market_calendars as mcal
+        from datetime import datetime, timezone
+
+        nyse = mcal.get_calendar('NYSE')
+        now_utc = datetime.now(timezone.utc)
+        market_open = nyse.open_at_time(now_utc)
+
+        if not market_open:
+            logger.info("Market is closed. Skipping minute-data operations and retraining.")
+            sys.exit(0)
+
         # Try to start Prometheus metrics server; if port is already in use, log and continue
         try:
             start_http_server(9200)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandas_ta>=0.3.14b0
 requests>=2.27.1
 beautifulsoup4>=4.11.1
 flask>=2.1.0
-pandas_market_calendars>=4.1.4
+pandas_market_calendars>=4.3.0
 schedule>=1.1.0
 # removed: alpaca-trade-api (not compatible with Python 3.12)
 portalocker>=2.7.0


### PR DESCRIPTION
## Summary
- skip minute operations and retraining when NYSE is closed
- update pandas_market_calendars version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c9708423483308ca8a4a52e54f9b2