### PR TITLE
Improve logging & datetime handling

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -806,8 +806,12 @@ class DataFetcher:
         except APIError as e:
             err_msg = str(e).lower()
             if "subscription does not permit querying recent sip data" in err_msg:
-                print(f">> DEBUG: ALPACA SUBSCRIPTION ERROR for {symbol}: {repr(e)}")
-                print(f">> DEBUG: ATTEMPTING IEX-DELAYERED DATA FOR {symbol}")
+                logger.warning(
+                    f"ALPACA SUBSCRIPTION ERROR for {symbol}: {repr(e)}"
+                )
+                logger.info(
+                    f"ATTEMPTING IEX-DELAYERED DATA FOR {symbol}"
+                )
                 try:
                     req.feed = "iex"
                     df_iex = client.get_stock_bars(req).df
@@ -826,9 +830,11 @@ class DataFetcher:
                     df_iex.index = idx
                     df = df_iex.rename(columns=lambda c: c.lower())
                 except Exception as iex_err:
-                    print(f">> DEBUG: ALPACA IEX ERROR for {symbol}: {repr(iex_err)}")
-                    print(
-                        f">> DEBUG: INSERTING DUMMY DAILY FOR {symbol} ON {end_ts.date().isoformat()}"
+                    logger.warning(
+                        f"ALPACA IEX ERROR for {symbol}: {repr(iex_err)}"
+                    )
+                    logger.info(
+                        f"INSERTING DUMMY DAILY FOR {symbol} ON {end_ts.date().isoformat()}"
                     )
                     ts = pd.to_datetime(end_ts, utc=True, errors="coerce")
                     if ts is None:
@@ -847,7 +853,9 @@ class DataFetcher:
                         index=[dummy_date],
                     )
             else:
-                print(f">> DEBUG: ALPACA DAILY FETCH ERROR for {symbol}: {repr(e)}")
+                logger.warning(
+                    f"ALPACA DAILY FETCH ERROR for {symbol}: {repr(e)}"
+                )
                 ts2 = pd.to_datetime(end_ts, utc=True, errors="coerce")
                 if ts2 is None:
                     ts2 = pd.Timestamp.utcnow()
@@ -857,7 +865,9 @@ class DataFetcher:
                     index=[dummy_date],
                 )
         except Exception as e:
-            print(f">> DEBUG: ALPACA DAILY FETCH EXCEPTION for {symbol}: {repr(e)}")
+            logger.warning(
+                f"ALPACA DAILY FETCH EXCEPTION for {symbol}: {repr(e)}"
+            )
             ts = pd.to_datetime(end_ts, utc=True, errors="coerce")
             if ts is None:
                 ts = pd.Timestamp.utcnow()
@@ -926,8 +936,12 @@ class DataFetcher:
                 "subscription does not permit querying recent sip data"
                 in err_msg.lower()
             ):
-                print(f">> DEBUG: ALPACA SUBSCRIPTION ERROR for {symbol}: {repr(e)}")
-                print(f">> DEBUG: ATTEMPTING IEX-DELAYERED DATA FOR {symbol}")
+                logger.warning(
+                    f"ALPACA SUBSCRIPTION ERROR for {symbol}: {repr(e)}"
+                )
+                logger.info(
+                    f"ATTEMPTING IEX-DELAYERED DATA FOR {symbol}"
+                )
                 try:
                     req.feed = "iex"
                     df_iex = client.get_stock_bars(req).df
@@ -951,14 +965,20 @@ class DataFetcher:
                             ["open", "high", "low", "close", "volume"]
                         ]
                 except Exception as iex_err:
-                    print(f">> DEBUG: ALPACA IEX ERROR for {symbol}: {repr(iex_err)}")
-                    print(f">> DEBUG: NO ALTERNATIVE MINUTE DATA FOR {symbol}")
+                    logger.warning(
+                        f"ALPACA IEX ERROR for {symbol}: {repr(iex_err)}"
+                    )
+                    logger.info(f"NO ALTERNATIVE MINUTE DATA FOR {symbol}")
                     df = pd.DataFrame()
             else:
-                print(f">> DEBUG: ALPACA MINUTE FETCH ERROR for {symbol}: {repr(e)}")
+                logger.warning(
+                    f"ALPACA MINUTE FETCH ERROR for {symbol}: {repr(e)}"
+                )
                 df = pd.DataFrame()
         except Exception as e:
-            print(f">> DEBUG: ALPACA MINUTE FETCH ERROR for {symbol}: {repr(e)}")
+            logger.warning(
+                f"ALPACA MINUTE FETCH ERROR for {symbol}: {repr(e)}"
+            )
             df = pd.DataFrame()
 
         with cache_lock:
@@ -1087,10 +1107,10 @@ def prefetch_daily_data(
     except APIError as e:
         err_msg = str(e).lower()
         if "subscription does not permit querying recent sip data" in err_msg:
-            print(
-                f">> DEBUG: ALPACA SUBSCRIPTION ERROR in bulk for {symbols}: {repr(e)}"
+            logger.warning(
+                f"ALPACA SUBSCRIPTION ERROR in bulk for {symbols}: {repr(e)}"
             )
-            print(f">> DEBUG: ATTEMPTING IEX-DELAYERED BULK FETCH FOR {symbols}")
+            logger.info(f"ATTEMPTING IEX-DELAYERED BULK FETCH FOR {symbols}")
             try:
                 req.feed = "iex"
                 bars_iex = client.get_stock_bars(req).df
@@ -1114,7 +1134,9 @@ def prefetch_daily_data(
                     grouped[sym] = df
                 return grouped
             except Exception as iex_err:
-                print(f">> DEBUG: ALPACA IEX BULK ERROR for {symbols}: {repr(iex_err)}")
+                logger.warning(
+                    f"ALPACA IEX BULK ERROR for {symbols}: {repr(iex_err)}"
+                )
                 daily_dict = {}
                 for sym in symbols:
                     try:
@@ -1137,11 +1159,11 @@ def prefetch_daily_data(
                         df_sym = df_sym.rename(columns=lambda c: c.lower())
                         daily_dict[sym] = df_sym
                     except Exception as indiv_err:
-                        print(
-                            f">> DEBUG: ALPACA IEX ERROR for {sym}: {repr(indiv_err)}"
+                        logger.warning(
+                            f"ALPACA IEX ERROR for {sym}: {repr(indiv_err)}"
                         )
-                        print(
-                            f">> DEBUG: INSERTING DUMMY DAILY FOR {sym} ON {end_date.isoformat()}"
+                        logger.info(
+                            f"INSERTING DUMMY DAILY FOR {sym} ON {end_date.isoformat()}"
                         )
                         tsd = pd.to_datetime(end_date, utc=True, errors="coerce")
                         if tsd is None:
@@ -1162,7 +1184,9 @@ def prefetch_daily_data(
                         daily_dict[sym] = dummy_df
                 return daily_dict
         else:
-            print(f">> DEBUG: ALPACA BULK FETCH UNKNOWN ERROR for {symbols}: {repr(e)}")
+            logger.warning(
+                f"ALPACA BULK FETCH UNKNOWN ERROR for {symbols}: {repr(e)}"
+            )
             daily_dict = {}
             for sym in symbols:
                 t2 = pd.to_datetime(end_date, utc=True, errors="coerce")
@@ -1176,7 +1200,9 @@ def prefetch_daily_data(
                 daily_dict[sym] = dummy_df
             return daily_dict
     except Exception as e:
-        print(f">> DEBUG: ALPACA BULK FETCH EXCEPTION for {symbols}: {repr(e)}")
+        logger.warning(
+            f"ALPACA BULK FETCH EXCEPTION for {symbols}: {repr(e)}"
+        )
         daily_dict = {}
         for sym in symbols:
             t3 = pd.to_datetime(end_date, utc=True, errors="coerce")
@@ -4383,21 +4409,21 @@ def load_or_retrain_daily(ctx: BotContext) -> Any:
             else:
                 try:
                     symbols = load_tickers(TICKERS_FILE)
-                    print(
-                        f">> DEBUG: RETRAINING START for {today_str} on {len(symbols)} tickers..."
+                    logger.info(
+                        f"RETRAINING START for {today_str} on {len(symbols)} tickers..."
                     )
                     valid_symbols = []
                     for symbol in symbols:
                         df_min = fetch_minute_df_safe(ctx, symbol)
                         if df_min is None or df_min.empty:
-                            print(
-                                f">> DEBUG: {symbol} returned no minute data; skipping symbol."
+                            logger.info(
+                                f"{symbol} returned no minute data; skipping symbol."
                             )
                             continue
                         valid_symbols.append(symbol)
                     if not valid_symbols:
-                        print(
-                            ">> WARNING: No symbols returned valid minute data; skipping retraining entirely."
+                        logger.warning(
+                            "No symbols returned valid minute data; skipping retraining entirely."
                         )
                     else:
                         force_train = not os.path.exists(MODEL_PATH)
@@ -4593,7 +4619,7 @@ def run_all_trades_worker(state: BotState, model) -> None:
                     return
                 price_df = fetch_minute_df_safe(ctx, symbol)
                 if price_df.empty or "close" not in price_df.columns:
-                    print(f"INFO SKIP_NO_PRICE_DATA | {symbol}")
+                    logger.info(f"SKIP_NO_PRICE_DATA | {symbol}")
                     return
                 processed.append(symbol)
                 _safe_trade(ctx, symbol, current_cash, model, regime_ok)
@@ -4604,8 +4630,8 @@ def run_all_trades_worker(state: BotState, model) -> None:
             list(executor.map(process_symbol, symbols))
 
         if not processed:
-            print(
-                "WARNING no symbols returned any price data; skipping strategy computation."
+            logger.warning(
+                "No symbols returned any price data; skipping strategy computation."
             )
             return
 

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -228,6 +228,12 @@ def get_minute_df(symbol: str, start_date: date, end_date: date) -> pd.DataFrame
         For network-related failures handled by ``tenacity`` retry.
     """
     import pandas as pd
+    from datetime import datetime, date, timedelta
+
+    if isinstance(start_date, date) and not isinstance(start_date, datetime):
+        start_date = datetime.combine(start_date, datetime.min.time())
+    if isinstance(end_date, date) and not isinstance(end_date, datetime):
+        end_date = datetime.combine(end_date, datetime.max.time())
 
     # Skip network calls when requesting near real-time data outside market hours
     end_check = end_date

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ flask==2.2.5
 pandas_market_calendars>=4.3.0
 schedule>=1.1.0
 # removed: alpaca-trade-api (not compatible with Python 3.12)
+alpaca-trade-api==3.2.0
 portalocker==2.7.0
 alpaca-py==0.40.1        # new official SDK
 scikit-learn==1.6.1


### PR DESCRIPTION
## Summary
- use logger instead of print statements in `bot.py`
- normalize date objects to datetimes in `get_minute_df`
- list `alpaca-trade-api` in requirements

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution found for finnhub-python==0.4.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684d8502ea988330aeac88217cb1ccf0