### PR TITLE
Improve logging and robustness

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import os
 from dotenv import load_dotenv
+import logging
 
 ROOT_DIR = Path(__file__).resolve().parent
 ENV_PATH = ROOT_DIR / ".env"
@@ -66,3 +67,17 @@ def validate_alpaca_credentials() -> None:
             "Missing Alpaca credentials. Please set ALPACA_API_KEY, "
             "ALPACA_SECRET_KEY and ALPACA_BASE_URL in your environment"
         )
+
+
+def validate_config() -> None:
+    """Validate required API keys and configuration values."""
+    missing = []
+    if not ALPACA_API_KEY:
+        missing.append("ALPACA_API_KEY")
+    if not ALPACA_SECRET_KEY:
+        missing.append("ALPACA_SECRET_KEY")
+    if not FINNHUB_API_KEY:
+        missing.append("FINNHUB_API_KEY")
+    if missing:
+        logging.getLogger(__name__).error("Missing config values: %s", missing)
+        raise RuntimeError(f"Missing required configuration values: {missing}")

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -229,6 +229,10 @@ def get_minute_df(symbol: str, start_date: date, end_date: date) -> pd.DataFrame
     """
     import pandas as pd
 
+    # Normalize date inputs
+    start_date = pd.to_datetime(start_date)
+    end_date = pd.to_datetime(end_date)
+
     # Skip network calls when requesting near real-time data outside market hours
     end_check = end_date
     if hasattr(end_check, "date"):

--- a/meta_learning.py
+++ b/meta_learning.py
@@ -3,9 +3,27 @@ import logging
 from datetime import datetime
 from pathlib import Path
 import numpy as np
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
+
+def load_weights(weight_path: str) -> dict[str, float]:
+    """Load signal weights from ``weight_path`` returning a mapping."""
+    p = Path(weight_path)
+    if not p.exists():
+        logger.error("Weight file %s missing; creating default", weight_path)
+        try:
+            p.write_text("signal,weight\n")
+        except Exception as exc:
+            logger.exception("Failed creating default weight file: %s", exc)
+        return {}
+    try:
+        df = pd.read_csv(p)
+        return {row["signal"]: row["weight"] for _, row in df.iterrows()}
+    except Exception as exc:
+        logger.exception("Failed loading signal weights: %s", exc)
+        return {}
 
 def update_weights(weight_path: str, new_weights: np.ndarray, metrics: dict, history_file: str = "metrics.json", n_history: int = 5) -> bool:
     """Update signal weights if changed and persist metric history."""


### PR DESCRIPTION
## Summary
- replace debug prints in `bot.py` with structured logging
- normalize dates in `get_minute_df`
- add robust model load/predict wrappers
- add safe weight loader in meta_learning
- harden order execution and risk engine logging
- validate configuration for missing API keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d86388db88330a5d746898b174b12