### PR TITLE
Enhanced safety checks and logging

### DIFF
--- a/trade_execution.py
+++ b/trade_execution.py
@@ -269,8 +269,12 @@ class ExecutionEngine:
                     )
                     try:
                         order = api.submit_order(order_data=order_req)
+                        self.logger.info(f"Order submit response for {symbol}: {order}")
                     except Exception as e:
-                        self.logger.error(f"Order failed for {symbol}: {e}")
+                        self.logger.error(
+                            f"Order submission failed for {symbol}: {e}",
+                            exc_info=True,
+                        )
                         break
                     break
                 except (APIError, TimeoutError) as e:


### PR DESCRIPTION
## Summary
- validate API key existence on startup
- log invalid order sizes in execute_entry/exit
- add detailed validation in `run_multi_strategy`
- log order submission responses and errors
- add heartbeat log message for main loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684da618479c8330b07534875d7dd576