### PR TITLE
Improve ML validation and slack alerts

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -1,18 +1,45 @@
+"""Alert utilities with throttling support."""
+
 import logging
+import time
+from threading import Lock
 import requests
 
 from config import get_env
 
 SLACK_WEBHOOK = get_env("SLACK_WEBHOOK")
 
+_alert_lock = Lock()
+_last_sent = {}
+THROTTLE_SEC = 30
+
 logger = logging.getLogger(__name__)
 
 
-def send_slack_alert(message: str) -> None:
-    """Send a Slack alert if ``SLACK_WEBHOOK`` is configured."""
-    if SLACK_WEBHOOK:
-        try:
-            requests.post(SLACK_WEBHOOK, json={"text": message}, timeout=5)
-        except Exception as exc:  # pragma: no cover - network issues
-            logger.error("Failed to send Slack alert: %s", exc)
+def send_slack_alert(message: str, *, key: str | None = None) -> None:
+    """Send a Slack alert with basic throttling.
+
+    Parameters
+    ----------
+    message : str
+        Text to send.
+    key : str, optional
+        Distinct alert type for throttling. Defaults to ``message``.
+    """
+    if not SLACK_WEBHOOK:
+        return
+
+    ident = key or message
+    now = time.monotonic()
+    with _alert_lock:
+        last = _last_sent.get(ident, 0.0)
+        if now - last < THROTTLE_SEC:
+            logger.info("Alert throttled: %s", ident)
+            return
+        _last_sent[ident] = now
+
+    try:
+        requests.post(SLACK_WEBHOOK, json={"text": message}, timeout=5)
+    except Exception as exc:  # pragma: no cover - network issues
+        logger.error("Failed to send Slack alert: %s", exc)
 

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,0 +1,19 @@
+import types
+import time
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import alerts
+
+
+def test_alert_throttling(monkeypatch):
+    sent = []
+    monkeypatch.setattr(alerts, "SLACK_WEBHOOK", "http://example.com")
+    monkeypatch.setattr(alerts.requests, "post", lambda *a, **k: sent.append(k))
+    alerts.send_slack_alert("msg", key="err")
+    alerts.send_slack_alert("msg", key="err")
+    assert len(sent) == 1
+    time.sleep(alerts.THROTTLE_SEC)
+    alerts.send_slack_alert("msg", key="err")
+    assert len(sent) == 2

--- a/tests/test_ml_model_validation.py
+++ b/tests/test_ml_model_validation.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+import pandas as pd
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from ml_model import MLModel
+
+
+class DummyPipe:
+    def fit(self, X, y):
+        return self
+
+    def predict(self, X):
+        return np.zeros(len(X))
+
+
+def test_predict_validation(monkeypatch):
+    model = MLModel(DummyPipe())
+    df = pd.DataFrame({'a': [1.0, float('nan')]})
+    try:
+        model.predict(df)
+    except ValueError:
+        pass
+    else:
+        assert False, "Expected ValueError"


### PR DESCRIPTION
## Summary
- throttle Slack alerts to one per 30s and allow keyed alerts
- validate ML inputs and log model hash on load
- test new alert throttle behaviour
- ensure MLModel rejects NaN inputs

## Testing
- `pip install -q -r requirements-test.txt`
- `pip install -q joblib`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684db2ab38848330aabed11b50ab6019