### PR TITLE
Improve unit test coverage

### DIFF
--- a/tests/test_alpaca_api_module.py
+++ b/tests/test_alpaca_api_module.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import alpaca_api
+
+class DummyAPI:
+    def __init__(self):
+        self.calls = 0
+    def submit_order(self, order_data=None):
+        self.calls += 1
+        if self.calls == 1:
+            return types.SimpleNamespace(status_code=429)
+        return types.SimpleNamespace(id=1)
+
+def make_req():
+    return types.SimpleNamespace(symbol='AAPL', qty=1, side='buy', time_in_force='day')
+
+def test_submit_order_shadow(monkeypatch):
+    api = DummyAPI()
+    monkeypatch.setattr(alpaca_api, 'SHADOW_MODE', True)
+    result = alpaca_api.submit_order(api, make_req())
+    assert result['status'] == 'shadow'
+    assert api.calls == 0
+
+def test_submit_order_rate_limit(monkeypatch):
+    api = DummyAPI()
+    monkeypatch.setattr(alpaca_api, 'SHADOW_MODE', False)
+    monkeypatch.setattr(alpaca_api.requests, 'exceptions', types.SimpleNamespace(HTTPError=Exception), raising=False)
+    sleeps = []
+    monkeypatch.setattr(alpaca_api.time, 'sleep', lambda s: sleeps.append(s))
+    result = alpaca_api.submit_order(api, make_req())
+    assert getattr(result, 'id', None) == 1
+    assert api.calls == 2
+    assert sleeps

--- a/tests/test_logger_module.py
+++ b/tests/test_logger_module.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import logger
+
+
+def test_get_logger_singleton(tmp_path):
+    lg1 = logger.get_logger('test')
+    lg2 = logger.get_logger('test')
+    assert lg1 is lg2
+    assert lg1.handlers

--- a/tests/test_meta_learning_module.py
+++ b/tests/test_meta_learning_module.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+import numpy as np
+import json
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import meta_learning
+
+
+def test_load_weights_missing(tmp_path, caplog):
+    path = tmp_path/'w.csv'
+    arr = meta_learning.load_weights(str(path), default=np.array([1.0, 2.0]))
+    assert arr.tolist() == [1.0, 2.0]
+    assert path.exists()
+
+
+def test_update_weights(tmp_path):
+    w_path = tmp_path/'w.csv'
+    history = tmp_path/'hist.json'
+    np.savetxt(w_path, np.array([0.1,0.2]), delimiter=',')
+    result = meta_learning.update_weights(str(w_path), np.array([0.3,0.4]), {'m':1}, str(history), n_history=2)
+    assert result
+    data = np.loadtxt(w_path, delimiter=',')
+    assert list(data) == [0.3,0.4]
+    hist = json.load(open(history))
+    assert hist
+
+
+def test_update_weights_no_change(tmp_path):
+    w_path = tmp_path/'w.csv'
+    np.savetxt(w_path, np.array([0.1,0.2]), delimiter=',')
+    result = meta_learning.update_weights(str(w_path), np.array([0.1,0.2]), {'m':1})
+    assert not result
+
+def test_load_weights_corrupted(tmp_path):
+    p = tmp_path/'w.csv'
+    p.write_text('bad,data')
+    arr = meta_learning.load_weights(str(p), default=np.array([0.5]))
+    assert arr.tolist() == [0.5]
+
+
+def test_update_weights_history_error(tmp_path):
+    w = tmp_path/'w.csv'
+    h = tmp_path/'hist.json'
+    np.savetxt(w, np.array([0.1]), delimiter=',')
+    h.write_text('{bad json')
+    assert meta_learning.update_weights(str(w), np.array([0.2]), {'m':1}, str(h))
+    assert json.loads(h.read_text())

--- a/tests/test_ml_model_extra.py
+++ b/tests/test_ml_model_extra.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pandas as pd
+
+import pytest
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from ml_model import MLModel
+
+
+class DummyPipe:
+    def __init__(self):
+        self.fitted = False
+        self.version = '1'
+
+    def fit(self, X, y):
+        self.fitted = True
+        return self
+
+    def predict(self, X):
+        if not self.fitted:
+            raise ValueError('not fitted')
+        return np.ones(len(X))
+
+
+def make_df():
+    return pd.DataFrame({'a':[1.0,2.0]})
+
+
+def test_validate_errors():
+    model = MLModel(DummyPipe())
+    with pytest.raises(TypeError):
+        model.predict([1,2])
+    df = make_df()
+    df.loc[0,'a'] = np.nan
+    with pytest.raises(ValueError):
+        model.predict(df)
+
+
+def test_fit_and_predict(tmp_path):
+    model = MLModel(DummyPipe())
+    df = make_df()
+    mse = model.fit(df, np.array([0,1]))
+    assert mse >= 0
+    preds = model.predict(df)
+    assert len(preds) == len(df)
+    save_path = model.save(tmp_path/'m.pkl')
+    assert Path(save_path).exists()
+    loaded = MLModel.load(save_path)
+    assert isinstance(loaded.pipeline, DummyPipe)

--- a/tests/test_risk_engine_module.py
+++ b/tests/test_risk_engine_module.py
@@ -1,0 +1,73 @@
+import sys
+from pathlib import Path
+import types
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+for m in ["strategies","strategies.momentum","strategies.mean_reversion"]:
+    sys.modules.pop(m, None)
+sys.modules.pop("risk_engine", None)
+from strategies import TradeSignal
+from risk_engine import RiskEngine
+
+
+class DummyAPI:
+    def __init__(self, equity=100, last=100):
+        self._eq = equity
+        self._last = last
+    def get_account(self):
+        return types.SimpleNamespace(equity=str(self._eq), last_equity=str(self._last))
+
+
+def make_signal():
+    return TradeSignal(symbol='AAPL', side='buy', confidence=1.0, strategy='s')
+
+
+def test_can_trade_limits():
+    eng = RiskEngine()
+    sig = make_signal()
+    eng.asset_limits['equity'] = 0.5
+    eng.exposure['equity'] = 0.6
+    assert not eng.can_trade(sig)
+    eng.exposure['equity'] = 0.1
+    sig.weight = 0.3
+    assert eng.can_trade(sig)
+
+
+def test_register_and_position_size(monkeypatch):
+    eng = RiskEngine()
+    sig = make_signal()
+    eng.asset_limits['equity'] = 1.0
+    eng.strategy_limits['s'] = 1.0
+    qty = eng.position_size(sig, cash=100, price=10)
+    assert qty == 10
+    eng.register_fill(sig)
+    assert eng.exposure['equity'] == sig.weight
+
+
+def test_check_max_drawdown():
+    eng = RiskEngine()
+    api = DummyAPI(equity=90, last=100)
+    ok = eng.check_max_drawdown(api)
+    assert not ok and eng.hard_stop
+
+
+def test_compute_volatility():
+    eng = RiskEngine()
+    arr = np.array([1.0,2.0,3.0])
+    res = eng.compute_volatility(arr)
+    assert 'volatility' in res and res['volatility'] > 0
+    assert eng.compute_volatility(np.array([]))['volatility'] == 0.0
+
+def test_hard_stop_blocks_trading():
+    eng = RiskEngine()
+    eng.hard_stop = True
+    sig = make_signal()
+    assert not eng.can_trade(sig)
+    assert eng.position_size(sig, 100, 10) == 0
+
+
+def test_check_max_drawdown_ok():
+    eng = RiskEngine()
+    api = DummyAPI(equity=105, last=100)
+    assert eng.check_max_drawdown(api)

--- a/tests/test_strategies_module.py
+++ b/tests/test_strategies_module.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+for m in ["strategies","strategies.momentum","strategies.mean_reversion"]:
+    sys.modules.pop(m, None)
+
+from strategies import asset_class_for, MomentumStrategy, MeanReversionStrategy
+
+class DummyFetcher:
+    def __init__(self, df):
+        self.df = df
+    def get_daily_df(self, ctx, sym):
+        return self.df
+
+
+class Ctx:
+    def __init__(self, df):
+        self.tickers = ['AAPL']
+        self.data_fetcher = DummyFetcher(df)
+
+
+def test_asset_class_for():
+    assert asset_class_for('EURUSD') == 'forex'
+    assert asset_class_for('BTCUSD') == 'forex'
+    assert asset_class_for('AAPL') == 'equity'
+
+
+def test_momentum_generate():
+    df = pd.DataFrame({'close':[1,2,3,4,5]})
+    ctx = Ctx(df)
+    strat = MomentumStrategy(lookback=2)
+    signals = strat.generate(ctx)
+    assert signals and signals[0].side == 'buy'
+
+
+def test_mean_reversion_generate():
+    df = pd.DataFrame({'close':[1,1,1,1,5]})
+    ctx = Ctx(df)
+    strat = MeanReversionStrategy(lookback=3, z=1.0)
+    signals = strat.generate(ctx)
+    assert signals and signals[0].side == 'sell'

--- a/tests/test_utils_new.py
+++ b/tests/test_utils_new.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+import types
+import pandas as pd
+from datetime import datetime, date, time, timezone
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import utils
+
+
+def test_get_latest_close_normal():
+    df = pd.DataFrame({'close':[1.0, 2.0]})
+    assert utils.get_latest_close(df) == 2.0
+
+
+def test_get_latest_close_missing():
+    df = pd.DataFrame({'open':[1.0]})
+    assert utils.get_latest_close(df) == 1.0
+
+
+def test_is_market_open_with_calendar(monkeypatch):
+    mod = types.ModuleType('pandas_market_calendars')
+    class DummyCal:
+        def schedule(self, start_date=None, end_date=None):
+            return pd.DataFrame({
+                'market_open':[pd.Timestamp('2024-01-02 09:30', tz='US/Eastern')],
+                'market_close':[pd.Timestamp('2024-01-02 16:00', tz='US/Eastern')]
+            })
+    mod.get_calendar = lambda name: DummyCal()
+    monkeypatch.setitem(sys.modules, 'pandas_market_calendars', mod)
+    now = datetime(2024, 1, 2, 10, 0, tzinfo=utils.EASTERN_TZ)
+    assert utils.is_market_open(now)
+
+
+def test_is_market_open_fallback(monkeypatch):
+    mod = types.ModuleType('pandas_market_calendars')
+    mod.get_calendar = lambda name: (_ for _ in ()).throw(Exception('fail'))
+    monkeypatch.setitem(sys.modules, 'pandas_market_calendars', mod)
+    weekend = datetime(2024, 1, 6, 10, 0, tzinfo=utils.EASTERN_TZ)
+    assert not utils.is_market_open(weekend)
+
+
+def test_ensure_utc_and_convert():
+    naive = datetime(2024,1,1,12,0)
+    aware = utils.ensure_utc(naive)
+    assert aware.tzinfo == timezone.utc
+    d = date(2024,1,1)
+    assert utils.ensure_utc(d).tzinfo == timezone.utc
+
+
+def test_safe_to_datetime():
+    vals = ['2024-01-01','2024-01-02']
+    idx = utils.safe_to_datetime(vals)
+    assert list(idx) == [pd.Timestamp('2024-01-01'), pd.Timestamp('2024-01-02')]
+    assert utils.safe_to_datetime(['abc']) is None


### PR DESCRIPTION
## Summary
- add tests for Alpaca API order submission logic
- exercise logger singleton behavior
- cover meta-learning weight utilities
- add ML model fit/predict tests
- test risk engine exposure rules and drawdown logic
- validate strategy generation and utils helpers

## Testing
- `pytest -q`
- `pytest --cov=. --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_684db9877a3c8330878f967f6de9dd5e