### PR TITLE
Update datetime usage and add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+          pip install pytest-cov
+
+      - name: Run tests
+        run: pytest --cov=. --cov-report=xml --cov-fail-under=50
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5

--- a/meta_learning.py
+++ b/meta_learning.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import numpy as np
 
@@ -55,7 +55,7 @@ def update_weights(weight_path: str, new_weights: np.ndarray, metrics: dict, his
     except Exception as e:
         logger.error("Failed to read metric history: %s", e)
         hist = []
-    hist.append({"ts": datetime.utcnow().isoformat(), **metrics})
+    hist.append({"ts": datetime.now(timezone.utc).isoformat(), **metrics})
     hist = hist[-n_history:]
     with open(history_file, "w") as f:
         json.dump(hist, f)


### PR DESCRIPTION
## Summary
- replace `datetime.utcnow` with timezone-aware `datetime.now(timezone.utc)` in meta_learning
- add CI workflow running tests with coverage threshold 50%

## Testing
- `pytest --maxfail=1 -q`
- `pytest --cov=. --cov-fail-under=50` *(fails: Required test coverage of 50% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_684dbf77c7cc8330a67cc9c65b27ddf9