### PR TITLE
Add integration tests and CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Test & Coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install pytest pytest-cov
+
+    - name: Run tests and coverage (fail if <50%)
+      run: |
+        pytest --cov=. --cov-report=term-missing --cov-report=xml --cov-report=html --cov-fail-under=50
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # AI Trading Bot
+![CI](https://github.com/dmorazzini23/ai-trading-bot/actions/workflows/ci.yml/badge.svg)
+[![codecov](https://codecov.io/gh/dmorazzini23/ai-trading-bot/branch/main/graph/badge.svg)](https://codecov.io/gh/dmorazzini23/ai-trading-bot)
 
 This repository contains a simple trading bot together with a backtesting
 harness for optimizing its tunable hyperparameters.

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -1,0 +1,38 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def test_bot_main_normal(monkeypatch):
+    monkeypatch.setenv("TRADING_MODE", "shadow")
+    with patch("data_fetcher.get_minute_df", return_value=MagicMock()), \
+         patch("alpaca_api.submit_order", return_value={"status": "mocked"}), \
+         patch("signals.generate", return_value=1), \
+         patch("risk_engine.calculate_position_size", return_value=10):
+        import bot
+        assert bot.main() is None or bot.main() is True
+
+
+def test_bot_main_data_fetch_error(monkeypatch):
+    with patch("data_fetcher.get_minute_df", side_effect=Exception("API error")):
+        import bot
+        with pytest.raises(Exception):
+            bot.main()
+
+
+def test_bot_main_signal_nan(monkeypatch):
+    with patch("signals.generate", return_value=float('nan')), \
+         patch("data_fetcher.get_minute_df", return_value=MagicMock()):
+        import bot
+        # Expect bot to handle or skip NaN signal, not crash
+        try:
+            bot.main()
+        except Exception:
+            pytest.fail("Bot should handle NaN signal gracefully")
+
+
+def test_trade_execution_api_timeout(monkeypatch):
+    with patch("alpaca_api.submit_order", side_effect=TimeoutError("Timeout")), \
+         patch("trade_execution.log_order") as mock_log:
+        import trade_execution
+        with pytest.raises(TimeoutError):
+            trade_execution.place_order("AAPL", 5, "buy")


### PR DESCRIPTION
## Summary
- add robust integration tests covering edge cases
- set up coverage workflow uploading results to Codecov
- show CI and coverage badges in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684dc489d25c8330bdf3a5f495f0fb8a