### PR TITLE
Fix exports for strategy allocator and trade execution

### DIFF
--- a/strategy_allocator.py
+++ b/strategy_allocator.py
@@ -77,3 +77,6 @@ class StrategyAllocator:
             )
 
         return results
+
+
+__all__ = ["StrategyAllocator"]


### PR DESCRIPTION
## Summary
- export `StrategyAllocator` symbol in `strategy_allocator`
- ensure `log_order` stub and exports in `trade_execution`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684df88d8690833097eee929d209d3eb