### PR TITLE
Improve timestamp ingestion

### DIFF
--- a/retrain.py
+++ b/retrain.py
@@ -202,10 +202,10 @@ def prepare_indicators(df: pd.DataFrame, freq: str = "daily") -> pd.DataFrame:
     else:
         df = df.reset_index().rename(columns={"index": "Date"})
     if "timestamp" in df.columns and df["Date"].dtype == object:
-        idx = safe_to_datetime(df["timestamp"])
+        idx = safe_to_datetime(df["timestamp"], context="retrain timestamp")
     else:
-        idx = safe_to_datetime(df["Date"])
-    if idx is None:
+        idx = safe_to_datetime(df["Date"], context="retrain date")
+    if idx.empty:
         raise ValueError("Invalid date values in dataframe")
     df["Date"] = idx
     df = df.sort_values("Date").set_index("Date")


### PR DESCRIPTION
## Summary
- update timestamp parsing utility for robustness
- use new timestamp helper across data fetching
- adjust retrain data prep
- expand tests for varied timestamp formats

## Testing
- `pytest tests/test_utils_new.py tests/test_utils_extra.py -q`
- `pytest -q` *(fails: ImportError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_6850516b25a48330b86ce93b799b798e