### PR TITLE
Fix Flask routes and refactor bot modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ sentry-sdk==1.39.1
 prometheus-client==0.17.1
 finnhub-python>=2.4.0
 lightgbm>=4.2.1
-pytz==2024.1
 pybreaker==1.0.0
 tzlocal==4.3
 # pin setuptools to avoid pandas_ta/pkg_resources deprecation warnings

--- a/tests/test_server_smoke.py
+++ b/tests/test_server_smoke.py
@@ -49,6 +49,6 @@ def force_coverage(mod):
 
 @pytest.mark.smoke
 def test_verify_sig():
-    sig = hmac.new(server.SECRET, b"x", "sha256").hexdigest()
-    assert server.verify_sig(b"x", f"sha256={sig}")
+    sig = hmac.new(b"secret", b"x", "sha256").hexdigest()
+    assert server.verify_sig(b"x", f"sha256={sig}", b"secret")
     force_coverage(server)


### PR DESCRIPTION
## Summary
- standardize healthcheck routes using `@app.route(..., methods=["GET"])`
- remove unused dependency `pytz`
- refactor large functions in `bot.py` and `trade_execution.py`
- pass config object into server `create_app`
- update tests for new `verify_sig` API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python server.py` *(fails: `WEBHOOK_SECRET must be set`)*
- `python server.py` with `WEBHOOK_SECRET=secret` then `curl http://localhost:9000/health`

------
https://chatgpt.com/codex/tasks/task_e_6850ec4c6bf48330aa92db4c4abd80bc