### PR TITLE
Fix startup env var checks

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -32,17 +32,18 @@ import csv
 import json
 import logging
 import logging.handlers
+import sys
 
 _REQUIRED_ENV = ["ALPACA_API_KEY", "ALPACA_SECRET_KEY"]
 _missing_env = [v for v in _REQUIRED_ENV if not os.getenv(v)]
 if _missing_env:
-    logging.getLogger(__name__).error(
+    logging.getLogger(__name__).critical(
         "Missing required environment variables: %s", _missing_env
     )
+    sys.exit(1)
 import random
 import re
 import signal
-import sys
 import threading
 import time as pytime
 from argparse import ArgumentParser

--- a/config.py
+++ b/config.py
@@ -11,6 +11,12 @@ ENV_PATH = ROOT_DIR / ".env"
 # should call ``reload_env()`` to refresh values if needed.
 load_dotenv(ENV_PATH)
 
+REQUIRED_ENV_VARS = ["ALPACA_API_KEY", "ALPACA_SECRET_KEY"]
+_missing = [v for v in REQUIRED_ENV_VARS if not os.getenv(v)]
+if _missing:
+    print(f"Error: Missing required environment variables: {_missing}")
+    sys.exit(1)
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,7 +65,6 @@ def _require_env_vars(*keys: str) -> None:
         sys.exit(1)
 
 
-_require_env_vars("APCA_API_KEY_ID", "APCA_API_SECRET_KEY")
 
 ALPACA_API_KEY = get_env("ALPACA_API_KEY") or get_env("APCA_API_KEY_ID")
 ALPACA_SECRET_KEY = get_env("ALPACA_SECRET_KEY") or get_env("APCA_API_SECRET_KEY")

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -8,6 +8,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 os.environ.setdefault("APCA_API_KEY_ID", "dummy")
 os.environ.setdefault("APCA_API_SECRET_KEY", "dummy")
+os.environ.setdefault("ALPACA_API_KEY", "dummy")
+os.environ.setdefault("ALPACA_SECRET_KEY", "dummy")
 
 # stub missing deps
 sys.modules.setdefault("requests", types.SimpleNamespace(post=lambda *a, **k: None))

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -9,6 +9,8 @@ import pytest
 
 os.environ.setdefault("APCA_API_KEY_ID", "dummy")
 os.environ.setdefault("APCA_API_SECRET_KEY", "dummy")
+os.environ.setdefault("ALPACA_API_KEY", "dummy")
+os.environ.setdefault("ALPACA_SECRET_KEY", "dummy")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 mods = [

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,6 +10,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 if "joblib" in sys.modules:
     del sys.modules["joblib"]
 
+os.environ.setdefault("ALPACA_API_KEY", "dummy")
+os.environ.setdefault("ALPACA_SECRET_KEY", "dummy")
 import config
 import data_fetcher
 from ml_model import MLModel

--- a/tests/test_server_smoke.py
+++ b/tests/test_server_smoke.py
@@ -35,6 +35,8 @@ import os
 
 os.environ["WEBHOOK_SECRET"] = "secret"
 os.environ["WEBHOOK_PORT"] = "1"
+os.environ.setdefault("ALPACA_API_KEY", "dummy")
+os.environ.setdefault("ALPACA_SECRET_KEY", "dummy")
 import config
 
 importlib.reload(config)


### PR DESCRIPTION
## Summary
- validate ALPACA credentials early in `config.py`
- exit on missing credentials during bot startup
- update tests to provide ALPACA env vars

## Testing
- `pip install -q -r requirements-test.txt` *(fails: Module downloads blocked)*
- `pytest -q` *(fails: missing joblib)*

------
https://chatgpt.com/codex/tasks/task_e_6850f09b949c833092d14e0678a1c29b