### PR TITLE
Fix indicator handling and improve env checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pybreaker==1.0.0
 tzlocal==4.3
 # pin setuptools to avoid pandas_ta/pkg_resources deprecation warnings
 setuptools>=69,<80
-yfinance==0.2.36
+yfinance>=0.2.18
 urllib3>=1.26,<2.0
 statsmodels==0.14.1
 transformers==4.35.2

--- a/signals.py
+++ b/signals.py
@@ -1,5 +1,38 @@
 """Simple signal generation module for tests."""
 
+import importlib
+import logging
+import time
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def load_module(name: str) -> Any:
+    """Dynamically import a module using :mod:`importlib`."""
+    try:
+        return importlib.import_module(name)
+    except Exception as exc:  # pragma: no cover - dynamic import may fail
+        logger.warning("Failed to import %s: %s", name, exc)
+        return None
+
+
+def _fetch_api(url: str, retries: int = 3, delay: float = 1.0) -> dict:
+    """Fetch JSON from an API with simple retry logic."""
+    for attempt in range(1, retries + 1):
+        try:
+            resp = requests.get(url, timeout=5)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:  # pragma: no cover - network may be mocked
+            logger.warning(
+                "API request failed (%s/%s): %s", attempt, retries, exc
+            )
+            time.sleep(delay)
+    return {}
+
 
 def generate(ctx=None):
     return 0


### PR DESCRIPTION
## Summary
- add early environment variable validation in `bot.py`
- guard MACD indicator calculation against None returns
- catch indicator calculation errors when preparing data
- switch to `importlib` and add retry helper in `signals`
- relax yfinance requirement version

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851adf5049c833092b92df92c6995d6