### PR TITLE
Improve meta learner and indicator robustness

### DIFF
--- a/meta_learning.py
+++ b/meta_learning.py
@@ -1,9 +1,16 @@
+"""Utility helpers for meta-learning weight management."""
+
+from __future__ import annotations
+
 import json
 import logging
+import pickle
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Optional
 
 import numpy as np
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +77,120 @@ def update_weights(
     return True
 
 
-def retrain_meta_learner(*args, **kwargs) -> bool:
-    """Stub retrain_meta_learner for optional import."""
-    logger.warning("retrain_meta_learner stub invoked; implementation missing")
-    return False
+def save_model_checkpoint(model: Any, filepath: str) -> None:
+    """Serialize ``model`` to ``filepath`` using :mod:`pickle`."""
+    try:
+        with open(filepath, "wb") as f:
+            pickle.dump(model, f)
+        logger.info("MODEL_CHECKPOINT_SAVED", extra={"path": filepath})
+    except Exception as exc:  # pragma: no cover - unexpected I/O
+        logger.error("Failed to save model checkpoint: %s", exc, exc_info=True)
+
+
+def load_model_checkpoint(filepath: str) -> Optional[Any]:
+    """Load a model from ``filepath`` previously saved with ``save_model_checkpoint``."""
+    if not Path(filepath).exists():
+        logger.warning("Checkpoint file missing: %s", filepath)
+        return None
+    try:
+        with open(filepath, "rb") as f:
+            model = pickle.load(f)
+        logger.info("MODEL_CHECKPOINT_LOADED", extra={"path": filepath})
+        return model
+    except Exception as exc:  # pragma: no cover - unexpected I/O
+        logger.error("Failed to load model checkpoint: %s", exc, exc_info=True)
+        return None
+
+
+def retrain_meta_learner(
+    trade_log_path: str = "trades.csv",
+    model_path: str = "meta_model.pkl",
+    history_path: str = "meta_retrain_history.pkl",
+    min_samples: int = 20,
+) -> bool:
+    """Retrain the meta-learner model from trade logs.
+
+    Parameters
+    ----------
+    trade_log_path : str
+        CSV file containing historical trades.
+    model_path : str
+        Destination to write the trained model pickle.
+    history_path : str
+        Path to a pickle file storing retrain metrics history.
+    min_samples : int
+        Minimum number of samples required to train.
+
+    Returns
+    -------
+    bool
+        ``True`` if retraining succeeded and the checkpoint was written.
+    """
+
+    logger.info(
+        "META_RETRAIN_START",
+        extra={"trade_log": trade_log_path, "model_path": model_path},
+    )
+
+    if not Path(trade_log_path).exists():
+        logger.error("Training data not found: %s", trade_log_path)
+        return False
+    try:
+        df = pd.read_csv(trade_log_path)
+    except Exception as exc:  # pragma: no cover - I/O failures
+        logger.error("Failed reading trade log: %s", exc, exc_info=True)
+        return False
+
+    df = df.dropna(subset=["entry_price", "exit_price", "signal_tags", "side"])
+    if len(df) < min_samples:
+        logger.warning(
+            "META_RETRAIN_INSUFFICIENT_DATA", extra={"rows": len(df)}
+        )
+        return False
+
+    df["pnl"] = (df["exit_price"] - df["entry_price"]) * df["side"].map(
+        {"buy": 1, "sell": -1}
+    )
+    df["outcome"] = (df["pnl"] > 0).astype(int)
+
+    tags = sorted({t for row in df["signal_tags"] for t in str(row).split("+")})
+    X = np.array(
+        [[int(t in str(row).split("+")) for t in tags] for row in df["signal_tags"]]
+    )
+    y = df["outcome"].values
+    sample_w = df["pnl"].abs() + 1e-3
+
+    from sklearn.linear_model import Ridge
+
+    model = Ridge(alpha=1.0, fit_intercept=True)
+    try:
+        model.fit(X, y, sample_weight=sample_w)
+    except Exception as exc:  # pragma: no cover - sklearn failure
+        logger.error("Meta-learner training failed: %s", exc, exc_info=True)
+        return False
+
+    save_model_checkpoint(model, model_path)
+
+    metrics = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "samples": len(y),
+        "model_path": model_path,
+    }
+    hist: list[dict[str, Any]] = []
+    if Path(history_path).exists():
+        loaded = load_model_checkpoint(history_path)
+        if isinstance(loaded, list):
+            hist = loaded
+    hist.append(metrics)
+    hist = hist[-5:]
+    try:
+        with open(history_path, "wb") as f:
+            pickle.dump(hist, f)
+    except Exception as exc:  # pragma: no cover - unexpected I/O
+        logger.error("Failed to update retrain history: %s", exc, exc_info=True)
+
+    logger.info(
+        "META_RETRAIN_SUCCESS",
+        extra={"samples": len(y), "model": model_path},
+    )
+    return True

--- a/signals.py
+++ b/signals.py
@@ -6,6 +6,7 @@ import time
 from typing import Any, Optional
 
 import pandas as pd
+import numpy as np
 import requests
 
 logger = logging.getLogger(__name__)
@@ -66,11 +67,15 @@ def calculate_macd(
     """
 
     try:
-        if close_prices is None or len(close_prices) < slow_period:
+        min_len = slow_period + signal_period
+        if close_prices is None or len(close_prices) < min_len:
             logger.warning(
-                "Insufficient data for MACD calculation: data length %d",
-                len(close_prices) if close_prices is not None else 0,
+                "Insufficient data for MACD calculation: length=%s",
+                len(close_prices) if close_prices is not None else "None",
             )
+            return None
+        if close_prices.isna().any() or np.isinf(close_prices).any():
+            logger.warning("MACD input data contains NaN or Inf")
             return None
 
         fast_ema = close_prices.ewm(span=fast_period, adjust=False).mean()


### PR DESCRIPTION
## Summary
- implement full `retrain_meta_learner` with pickle checkpointing and history
- harden MACD calculation and use it in regime features
- validate ADV inputs and enhance order status logging
- extend pre-trade health checks for invalid data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851bab09dbc8330822d3056e6416b6e