### PR TITLE
Fix MACD checks and upgrade requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,28 +4,25 @@ PyYAML==6.0.1             # ensure a wheel install
 
 tenacity==8.2.2
 ratelimit==2.2.1
-numpy>=1.25.2,<2.0
-pandas>=2.0.3,<3.0
-pandas>=1.5.0
+numpy>=1.24
+pandas>=1.5.3
 pandas_ta==0.3.14b0
 requests>=2.31.0,<3.0
-requests>=2.28.0
 beautifulsoup4>=4.11.1
 flask>=2.2,<3.0
 pandas_market_calendars>=4.3.0
 schedule>=1.1.0
 portalocker==2.7.0
 alpaca-py==0.40.1
-scikit-learn==1.6.1
+scikit-learn>=1.2
 joblib==1.3.2
-python-dotenv==1.0.1
+python-dotenv>=1.0.0
 sentry-sdk==1.39.1
 prometheus-client==0.17.1
 finnhub-python>=2.4.0
 lightgbm>=4.2.1
 pybreaker==1.0.0
 tzlocal==4.3
-python-dotenv>=0.21.0
 pytz>=2023.3
 # pin setuptools to avoid pandas_ta/pkg_resources deprecation warnings
 setuptools>=69,<80


### PR DESCRIPTION
## Summary
- handle None results from MACD indicator
- warn when regime MACD fails
- update dependencies for Python 3.12

## Testing
- `pip install -r requirements.txt`
- `flake8 .`
- `pytest -q` *(fails: RuntimeError in integration tests)*
- `python bot.py --mode balanced --paper` *(terminated after start)*


------
https://chatgpt.com/codex/tasks/task_e_6851e2b0d1b0833086fc36ee45930a18