### PR TITLE
Fix start script and Alpaca API handlers

### DIFF
--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -73,8 +73,11 @@ def alpaca_get(
 )
 def get_account() -> Optional[Dict[str, Any]]:
     """Return account details or ``None`` on failure."""
-
-    data = alpaca_get("/v2/account")
+    try:
+        data = alpaca_get("/v2/account")
+    except Exception as e:  # pragma: no cover - network issues
+        logger.exception("Error fetching Alpaca account info: %s", e)
+        return None
     if data is None:
         logger.error("Failed to get Alpaca account data")
     return data
@@ -125,7 +128,9 @@ def submit_order(api, req, log: logging.Logger | None = None):
                 exc_info=True,
             )
             if attempt == max_retries:
-                send_slack_alert(f"Failed to submit order after {max_retries} attempts: {e}")
+                send_slack_alert(
+                    f"Failed to submit order after {max_retries} attempts: {e}"
+                )
                 raise
             time.sleep(attempt * 2)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,5 @@ optuna==3.6.1
 # For Python 3.12 wheels:
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.7.1+cpu
+python-dotenv>=0.21.0
 

--- a/start.sh
+++ b/start.sh
@@ -5,10 +5,10 @@ echo "🔁 Starting AI Trading Bot..."
 source ~/.bashrc
 cd ~/ai-trading-bot
 if [ ! -d venv ]; then
-  python3 -m venv venv
+  python3.12 -m venv venv
 fi
 source venv/bin/activate
 pip install --upgrade pip setuptools >/dev/null
 pip install --quiet -r requirements.txt
 gunicorn -w 2 -b 0.0.0.0:${WEBHOOK_PORT:-9000} server:app &
-python3 bot.py
+python3.12 bot.py


### PR DESCRIPTION
## Summary
- update error handling around Alpaca API calls
- switch startup script to python3.12
- add `python-dotenv` requirement
- load env vars early and relax checks
- adjust minute data fetch call

## Testing
- `pip install -r requirements.txt`
- `bash start.sh`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e66ce5b08330b9c926e27eee950e