### PR TITLE
Fix env var validation and restore tests

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,6 @@
 import config
+config.load_dotenv()
+config.validate_env_vars()
 config.reload_env()
 
 import time

--- a/config.py
+++ b/config.py
@@ -69,7 +69,10 @@ def validate_environment() -> None:
             "Missing required environment variables: " + ", ".join(missing)
         )
 
-validate_environment()
+
+def validate_env_vars() -> None:
+    _require_env_vars("ALPACA_API_KEY", "ALPACA_SECRET_KEY", "ALPACA_BASE_URL")
+
 ALPACA_API_KEY = get_env("ALPACA_API_KEY")
 ALPACA_SECRET_KEY = get_env("ALPACA_SECRET_KEY")
 ALPACA_BASE_URL = get_env("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")

--- a/rebalancer.py
+++ b/rebalancer.py
@@ -2,9 +2,9 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 from alerts import send_slack_alert
-from config import get_env
+import config
 
-REBALANCE_INTERVAL_MIN = int(get_env("REBALANCE_INTERVAL_MIN", "1440"))
+REBALANCE_INTERVAL_MIN = int(config.get_env("REBALANCE_INTERVAL_MIN", "1440"))
 
 logger = logging.getLogger(__name__)
 _last_rebalance = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- remove import-time validation in `config`
- validate env vars only in the `bot` entrypoint
- update rebalancer to import full `config`
- install test dependencies and run tests on Python 3.12

## Testing
- `python3.12 bot.py` *(fails: KeyboardInterrupt during model download)*
- `pytest --maxfail=1 --disable-warnings -q`
- `pytest --cov=. --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6851f2f866988330b913fd33adc043d6