### PR TITLE
Update pip install procedure and numpy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ optuna==3.6.1
 torch==2.7.1+cpu
 python-dotenv>=0.21.0
 
+numpy>=1.25.0

--- a/start.sh
+++ b/start.sh
@@ -20,8 +20,8 @@ fi
 # Activate virtualenv
 source venv/bin/activate
 
-# Upgrade pip and install requirements
-pip install --upgrade pip setuptools >/dev/null
-pip install --quiet -r requirements.txt
+# Force-reinstall setuptools, upgrade pip, then install requirements (show errors)
+pip install --upgrade --force-reinstall setuptools pip wheel || exit 1
+pip install -r requirements.txt || exit 1
 gunicorn -w 2 -b 0.0.0.0:${WEBHOOK_PORT:-9000} server:app &
 python3.12 bot.py


### PR DESCRIPTION
## Summary
- append `numpy>=1.25.0` requirement
- reinstall setuptools and install dependencies with verbose output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6852025dc42c8330a5b95b07edcd04af