### PR TITLE
Fix server port, dependency updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,5 @@ optuna==3.6.1
 torch==2.7.1+cpu
 
 gunicorn>=20.1.0
+loguru>=0.7.0
+requests>=2.31.0

--- a/runner.py
+++ b/runner.py
@@ -7,6 +7,7 @@ import time
 
 from bot import main
 from logger import logger
+import requests
 
 _shutdown = False
 
@@ -29,7 +30,11 @@ if __name__ == "__main__":
             if exc.code == 0:
                 break
             logger.error("Bot exited with code %s", exc.code)
+        except requests.exceptions.RequestException as e:
+            logger.error(f"API request failed: {e}")
+            raise
         except Exception as exc:  # pragma: no cover - safety
-            logger.exception("Unhandled exception in bot: %s", exc)
+            logger.error(f"Unexpected error: {exc}")
+            raise
         if not _shutdown:
             time.sleep(5)


### PR DESCRIPTION
## Summary
- add `loguru` and new `requests` pin to requirements
- improve Flask server port handling and reuse port in tests
- tighten error handling in Alpaca API and runner

## Testing
- `pip install -r requirements.txt`
- `python server.py` twice to verify free port allocation
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68530809e7988330ab793dc843fac5c9