### PR TITLE
Fix Alpaca import issues and update tests

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -94,8 +94,16 @@ import yfinance as yf
 from alpaca.common.exceptions import APIError
 # Alpaca v3 SDK imports
 from alpaca.trading.client import TradingClient
-from alpaca.trading.enums import (OrderSide, OrderStatus, QueryOrderStatus,
-                                  TimeInForce)
+from alpaca.trading.enums import OrderSide, QueryOrderStatus, TimeInForce
+try:
+    from alpaca.trading.enums import OrderStatus
+except Exception:  # pragma: no cover - older alpaca-trade-api
+    from enum import Enum
+
+    class OrderStatus(str, Enum):
+        """Fallback enumeration for pre-v3 Alpaca SDKs."""
+
+        PENDING_NEW = "pending_new"
 from alpaca.trading.models import Order
 from alpaca.trading.requests import (GetOrdersRequest, LimitOrderRequest,
                                      MarketOrderRequest)

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -3,6 +3,7 @@ import types
 from pathlib import Path
 
 import pytest
+import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -49,9 +50,27 @@ for name in mods:
 sys.modules["pipeline"].model_pipeline = lambda *a, **k: None
 sys.modules["alpaca.trading.stream"].TradingStream = object
 
-sys.modules["flask"].Flask = object
+class _Flask:
+    def __init__(self, *a, **k):
+        pass
+
+    def route(self, *a, **k):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    def run(self, *a, **k):
+        pass
+
+sys.modules["flask"].Flask = _Flask
 sys.modules["requests"].get = lambda *a, **k: None
-sys.modules["requests"].exceptions = types.SimpleNamespace(RequestException=Exception)
+exc_mod = types.ModuleType("requests.exceptions")
+exc_mod.HTTPError = Exception
+exc_mod.RequestException = Exception
+sys.modules["requests"].exceptions = exc_mod
+sys.modules["requests.exceptions"] = exc_mod
+sys.modules["requests"].RequestException = Exception
 sys.modules["urllib3"] = types.ModuleType("urllib3")
 sys.modules["urllib3"].exceptions = types.SimpleNamespace(HTTPError=Exception)
 sys.modules["alpaca_trade_api"].REST = object
@@ -71,7 +90,19 @@ class _FakeREST:
 
 sys.modules["alpaca_trade_api.rest"].REST = _FakeREST
 sys.modules["alpaca_trade_api.rest"].APIError = Exception
-sys.modules["alpaca.trading.client"].TradingClient = object
+class _DummyTradingClient:
+    def __init__(self, *a, **k):
+        pass
+
+sys.modules["alpaca.trading.client"].TradingClient = _DummyTradingClient
+class _DummyStream:
+    def __init__(self, *a, **k):
+        pass
+
+    def subscribe_trade_updates(self, *a, **k):
+        pass
+
+sys.modules["alpaca.trading.stream"].TradingStream = _DummyStream
 sys.modules["alpaca.trading.enums"].OrderSide = object
 sys.modules["alpaca.trading.enums"].TimeInForce = object
 sys.modules["alpaca.trading.enums"].QueryOrderStatus = object
@@ -79,17 +110,79 @@ sys.modules["alpaca.trading.requests"].GetOrdersRequest = object
 sys.modules["alpaca.trading.requests"].MarketOrderRequest = object
 sys.modules["alpaca.trading.requests"].LimitOrderRequest = object
 sys.modules["alpaca.trading.models"].Order = object
-sys.modules["alpaca.data.historical"].StockHistoricalDataClient = object
 sys.modules["alpaca.data.models"].Quote = object
-sys.modules["alpaca.data.requests"].StockBarsRequest = object
-sys.modules["alpaca.data.requests"].StockLatestQuoteRequest = object
-sys.modules["alpaca.data.timeframe"].TimeFrame = object
+class _RF:
+    def __init__(self, *a, **k):
+        pass
+
+class _Ridge:
+    def __init__(self, *a, **k):
+        pass
+
+class _BR:
+    def __init__(self, *a, **k):
+        pass
+
+class _PCA:
+    def __init__(self, *a, **k):
+        pass
+
+sys.modules["sklearn.ensemble"].RandomForestClassifier = _RF
+sys.modules["sklearn.linear_model"].Ridge = _Ridge
+sys.modules["sklearn.linear_model"].BayesianRidge = _BR
+sys.modules["sklearn.decomposition"].PCA = _PCA
+class _DummyReq:
+    def __init__(self, *a, **k):
+        pass
+
+sys.modules["alpaca.data.requests"].StockBarsRequest = _DummyReq
+sys.modules["alpaca.data.requests"].StockLatestQuoteRequest = _DummyReq
+class _DummyTimeFrame:
+    Day = object()
+
+sys.modules["alpaca.data.timeframe"].TimeFrame = _DummyTimeFrame
+sys.modules["alpaca.data.timeframe"].TimeFrameUnit = object
 
 sys.modules["bs4"].BeautifulSoup = lambda *a, **k: None
 sys.modules["prometheus_client"].start_http_server = lambda *a, **k: None
 sys.modules["prometheus_client"].Counter = lambda *a, **k: None
 sys.modules["prometheus_client"].Gauge = lambda *a, **k: None
 sys.modules["prometheus_client"].Histogram = lambda *a, **k: None
+sys.modules["metrics_logger"].log_metrics = lambda *a, **k: None
+sys.modules["finnhub"].FinnhubAPIException = Exception
+sys.modules["finnhub"].Client = lambda *a, **k: None
+class _DummyDataClient:
+    def __init__(self, *a, **k):
+        pass
+
+    def get_stock_bars(self, *a, **k):
+        return types.SimpleNamespace(df=pd.DataFrame({"high": [1], "low": [1], "close": [1]}))
+
+sys.modules["alpaca.data.historical"].StockHistoricalDataClient = _DummyDataClient
+sys.modules["strategy_allocator"].StrategyAllocator = object
+class _DummyBreaker:
+    def __init__(self, *a, **k):
+        pass
+
+    def __call__(self, func):
+        return func
+
+sys.modules["pybreaker"].CircuitBreaker = _DummyBreaker
+class _CapScaler:
+    def __init__(self, *a, **k):
+        pass
+
+    def update(self, *a, **k):
+        pass
+
+sys.modules["capital_scaling"].CapitalScalingEngine = _CapScaler
+if "pandas_market_calendars" in sys.modules:
+    sys.modules["pandas_market_calendars"].get_calendar = lambda *a, **k: types.SimpleNamespace(schedule=lambda *a, **k: pd.DataFrame())
+if "pandas_ta" in sys.modules:
+    sys.modules["pandas_ta"].atr = lambda *a, **k: pd.Series([0])
+    sys.modules["pandas_ta"].rsi = lambda *a, **k: pd.Series([0])
+    sys.modules["pandas_ta"].obv = lambda *a, **k: pd.Series([0])
+    sys.modules["pandas_ta"].vwap = lambda *a, **k: pd.Series([0])
 
 bot = pytest.importorskip("bot")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,7 +31,7 @@ def test_end_to_end_pipeline(monkeypatch):
     config.reload_env()
 
     # prepare mock minute data
-    idx = pd.date_range("2024-01-01", periods=2, freq="T", tz="UTC")
+    idx = pd.date_range("2024-01-01", periods=2, freq="min", tz="UTC")
     df = pd.DataFrame(
         {
             "open": [1.0, 1.1],


### PR DESCRIPTION
## Summary
- handle missing `OrderStatus` for newer `alpaca-trade-api`
- patch integration tests to use `min` frequency
- expand mocks in `tests/test_bot.py` so it imports `bot`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `ALPACA_API_KEY=k ALPACA_SECRET_KEY=s FLASK_PORT=1234 python server.py`

------
https://chatgpt.com/codex/tasks/task_e_6853427fabfc83308492fcb5d83b945a