### PR TITLE
Initialize logging in entrypoints

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,7 @@
+from logger import setup_logging
 import config
+
+setup_logging()
 
 config.validate_env_vars()
 

--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+from logger import setup_logging
 import hmac
 import os
 import socket
@@ -12,6 +13,8 @@ load_dotenv(dotenv_path=".env", override=True)
 
 import config
 from logger import logger
+
+setup_logging()
 
 if not config.WEBHOOK_SECRET:
     logger.error("WEBHOOK_SECRET must be set")


### PR DESCRIPTION
## Summary
- configure centralized logging when `bot.py` and `server.py` start

## Testing
- `bash run_checks.sh` *(fails: flake8 violations)*

------
https://chatgpt.com/codex/tasks/task_e_68535a16d5008330b6eda798d945cac8