### PR TITLE
Add global uncaught exception handlers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,17 +1,16 @@
 from logger import setup_logging
 import config
 
+import sys
+import traceback
+from alerting import send_slack_alert
+import logging
+import os
+import sentry_sdk
+
 setup_logging()
 
 config.validate_env_vars()
-
-import os
-import sys
-import logging
-import traceback
-import sentry_sdk
-
-from alerting import send_slack_alert
 
 sentry_sdk.init(
     dsn=os.getenv("SENTRY_DSN"),

--- a/server.py
+++ b/server.py
@@ -4,6 +4,9 @@ import os
 import socket
 import subprocess
 from typing import Any
+import sys
+import traceback
+import logging
 
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -27,14 +30,9 @@ sentry_sdk.init(
 app = Flask(__name__)
 
 import config
-import logging
 logger = logging.getLogger(__name__)
 
 setup_logging()
-
-import sys
-import traceback
-
 
 def handle_exception(exc_type, exc_value, exc_traceback):
     if issubclass(exc_type, KeyboardInterrupt):


### PR DESCRIPTION
## Summary
- standardize imports in bot and server
- move global exception handlers higher in files

## Testing
- `bash run_checks.sh` *(fails: E303 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685383a390d883309d642db2a89c9847