### PR TITLE
Guard Sentry init in bot.py

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,11 +12,12 @@ setup_logging()
 
 config.validate_env_vars()
 
-sentry_sdk.init(
-    dsn=os.getenv("SENTRY_DSN"),
-    traces_sample_rate=1.0,
-    environment=os.getenv("BOT_MODE", "production"),
-)
+if not os.environ.get("TESTING"):
+    sentry_sdk.init(
+        dsn=os.getenv("SENTRY_DSN"),
+        traces_sample_rate=1.0,
+        environment=os.getenv("BOT_MODE", "production"),
+    )
 
 
 def handle_exception(exc_type, exc_value, exc_traceback):


### PR DESCRIPTION
## Summary
- initialize Sentry only if not running in testing mode

## Testing
- `bash run_checks.sh` *(fails: flake8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68545c34b3348330814132c1969ed661