### PR TITLE
Improve logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,16 @@ Key environment variables include:
 
 All logs are written to standard output so they can be captured by the
 systemd journal or Docker logs. Set `SLACK_WEBHOOK` in your environment to
-enable Slack alerts for critical errors.
+enable Slack alerts for critical errors. Configure logging once at startup:
+
+```python
+from logger import setup_logging
+import logging
+
+setup_logging()  # clears existing handlers and logs to stdout
+logger = logging.getLogger(__name__)
+logger.info("Bot starting up")
+```
 
 ### Running the Bot
 
@@ -102,7 +111,7 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now ai-trading-scheduler.service
 ```
 
-The service writes logs to `/var/log/ai-trading-scheduler.log`.
+Logs are written to stdout and captured by the systemd journal.
 
 ## Daily Retraining
 

--- a/logger_rotator.py
+++ b/logger_rotator.py
@@ -1,7 +1,7 @@
-"""Helper for creating rotating log handlers."""
+"""Deprecated helper for creating rotating log handlers."""
 
-from logging.handlers import RotatingFileHandler
 import os
+from logging.handlers import RotatingFileHandler
 
 
 def get_rotating_handler(
@@ -11,15 +11,10 @@ def get_rotating_handler(
 ) -> RotatingFileHandler:
     """Return a configured :class:`RotatingFileHandler`.
 
-    Parameters
-    ----------
-    path : str
-        File to write logs to.
-    max_bytes : int, optional
-        Maximum size of each log file before rotation. Defaults to ``10_000_000``.
-    backup_count : int, optional
-        Number of rotated log files to keep. Defaults to ``5``.
+    .. deprecated:: 1.0
+       File based logging is disabled; logs should be captured via ``stdout``.
     """
 
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    return RotatingFileHandler(path, maxBytes=max_bytes, backupCount=backup_count)
+    raise NotImplementedError(
+        "File logging is disabled; use centralized stdout logging instead"
+    )

--- a/tests/test_logger_rotator_smoke.py
+++ b/tests/test_logger_rotator_smoke.py
@@ -13,16 +13,6 @@ def force_coverage(mod):
 
 @pytest.mark.smoke
 def test_get_rotating_handler(monkeypatch):
-    created = {}
-
-    class Dummy:
-        def __init__(self, path, maxBytes=0, backupCount=0):
-            created["path"] = path
-            created["maxBytes"] = maxBytes
-            created["backupCount"] = backupCount
-
-    monkeypatch.setattr(logger_rotator, "RotatingFileHandler", Dummy)
-    handler = logger_rotator.get_rotating_handler("foo.log", max_bytes=1, backup_count=2)
-    assert isinstance(handler, Dummy)
-    assert created["path"] == "foo.log"
+    with pytest.raises(NotImplementedError):
+        logger_rotator.get_rotating_handler("foo.log", max_bytes=1, backup_count=2)
     force_coverage(logger_rotator)

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -125,8 +125,8 @@ class ExecutionEngine:
         self.ctx = ctx
         # Trading client from the new Alpaca SDK
         self.api: TradingClient = ctx.api
-        self.logger = logging.getLogger("execution")
-        self.logger.setLevel(logging.INFO)
+        # Use module-level logger so configuration is centralized
+        self.logger = logging.getLogger(__name__)
         self.slippage_path = os.path.join(os.path.dirname(__file__), "logs", "slippage.csv")
         if not os.path.exists(self.slippage_path):
             # Protect file creation in case the logs directory is unwritable


### PR DESCRIPTION
## Summary
- centralize logging setup with optional debug mode
- disable rotating file handler usage
- update trade execution engine to use module logger
- document stdout logging in README
- adjust logger rotator test for deprecation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d5c7e5e08330812194120d49cbcd