### PR TITLE
Improve server startup with gunicorn and health checks

### DIFF
--- a/logger_rotator.py
+++ b/logger_rotator.py
@@ -1,6 +1,5 @@
 """Deprecated helper for creating rotating log handlers."""
 
-import os
 from logging.handlers import RotatingFileHandler
 
 

--- a/server.py
+++ b/server.py
@@ -1,9 +1,10 @@
 import hmac
 import logging
 import os
-import socket
+import signal
 import subprocess
 import sys
+import threading
 import traceback
 from typing import Any
 
@@ -24,6 +25,17 @@ logger = logging.getLogger(__name__)
 
 setup_logging()
 
+_shutdown = threading.Event()
+
+
+def _handle_shutdown(signum: int, _unused_frame) -> None:
+    logger.info("Received signal %s, shutting down", signum)
+    _shutdown.set()
+
+
+signal.signal(signal.SIGTERM, _handle_shutdown)
+signal.signal(signal.SIGINT, _handle_shutdown)
+
 def handle_exception(exc_type, exc_value, exc_traceback):
     if issubclass(exc_type, KeyboardInterrupt):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
@@ -38,15 +50,6 @@ sys.excepthook = handle_exception
 if not config.WEBHOOK_SECRET:
     logger.error("WEBHOOK_SECRET must be set")
     raise RuntimeError("WEBHOOK_SECRET must be set")
-
-def check_port_available(port: int) -> bool:
-    """Return ``True`` if ``port`` can be bound."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        try:
-            s.bind(("", port))
-            return True
-        except OSError:
-            return False
 
 
 def verify_sig(payload: bytes, signature_header: str, secret: bytes) -> bool:
@@ -85,7 +88,9 @@ def create_app(cfg: Any = config) -> Flask:
 
     @app.route("/healthz", methods=["GET"])
     def healthz() -> Any:
-        return jsonify(status="ok")
+        from flask import Response
+
+        return Response("OK", status=200)
 
     return app
 
@@ -94,11 +99,17 @@ app = create_app()
 
 
 if __name__ == "__main__":
-    # Disable Flask's reloader so no extra watcher process is spawned.
     flask_port = int(os.getenv("FLASK_PORT", "9000"))
-    # If the port was not set, ensure the env var is populated for consistency
     os.environ.setdefault("FLASK_PORT", str(flask_port))
-    if not check_port_available(flask_port):
-        raise RuntimeError(f"Port {flask_port} is already in use")
     os.environ["WEBHOOK_PORT"] = str(flask_port)
-    app.run(host="0.0.0.0", port=flask_port, debug=False, use_reloader=False)
+    from gunicorn.app.wsgiapp import run
+
+    sys.argv = [
+        "gunicorn",
+        "-w",
+        "4",
+        "-b",
+        f"0.0.0.0:{flask_port}",
+        "server:app",
+    ]
+    run()

--- a/start.sh
+++ b/start.sh
@@ -35,7 +35,17 @@ fi
 # Optionally launch the Flask server in the background if server.py exists
 if [ -f server.py ]; then
   echo "🌐 Launching Flask server..."
-  python -u server.py &
+  FLASK_PORT=${FLASK_PORT:-9000}
+
+  if lsof -ti tcp:"$FLASK_PORT" >/dev/null; then
+    echo "🔪 Port $FLASK_PORT in use, terminating existing processes..."
+    lsof -ti tcp:"$FLASK_PORT" | xargs -r kill -TERM || true
+    sleep 2
+    lsof -ti tcp:"$FLASK_PORT" | xargs -r kill -KILL 2>/dev/null || true
+  fi
+
+  gunicorn -w 4 -b 0.0.0.0:"$FLASK_PORT" \
+    --access-logfile - --error-logfile - server:app &
 else
   echo "⚠️ server.py not found; skipping HTTP server"
 fi


### PR DESCRIPTION
## Summary
- update startup script to use gunicorn and free port before launching
- add signal handlers and `/healthz` route returning `OK`
- clean up deprecated logger helper import

## Testing
- `flake8`
- `isort --check-only .`
- `pylint $(git ls-files '*.py' | grep -v '^tests/' | tr '\n' ' ')`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_68557e26f1bc83309fa90722ecc11165