### PR TITLE
Add test docstrings and fix long lines

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -80,7 +80,8 @@ _DEFAULT_FEED = ALPACA_DATA_FEED or "iex"
 
 
 class DataFetchError(Exception):
-    pass
+    """Raised when a data request fails after all retries."""
+
 
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))

--- a/predict.py
+++ b/predict.py
@@ -25,7 +25,10 @@ def fetch_sentiment(symbol: str) -> float:
     if not config.NEWS_API_KEY:
         return 0.0
     try:
-        url = f"https://newsapi.org/v2/everything?q={symbol}&pageSize=5&sortBy=publishedAt&apiKey={config.NEWS_API_KEY}"
+        url = (
+            "https://newsapi.org/v2/everything?q="
+            f"{symbol}&pageSize=5&sortBy=publishedAt&apiKey={config.NEWS_API_KEY}"
+        )
         resp = requests.get(url, timeout=10)
         resp.raise_for_status()
         arts = resp.json().get("articles", [])

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -24,6 +24,7 @@ import slippage
 
 
 def test_send_slack_alert(monkeypatch):
+    """Slack alert helper should post messages using requests."""
     messages = []
     monkeypatch.setattr(alerts, "SLACK_WEBHOOK", "http://example.com")
 
@@ -36,6 +37,7 @@ def test_send_slack_alert(monkeypatch):
 
 
 def test_submit_order_shadow(monkeypatch):
+    """submit_order returns a shadow status when SHADOW_MODE is enabled."""
     class DummyAPI:
         def submit_order(self, order_data=None):
             raise AssertionError("should not call in shadow")
@@ -51,6 +53,7 @@ def test_submit_order_shadow(monkeypatch):
 
 
 def test_monitor_slippage_alert(monkeypatch):
+    """An alert is sent when slippage exceeds the threshold."""
     alerts_sent = []
     monkeypatch.setattr(slippage, "SLIPPAGE_THRESHOLD", 0.001)
     monkeypatch.setattr(slippage, "send_slack_alert", lambda m: alerts_sent.append(m))
@@ -59,6 +62,7 @@ def test_monitor_slippage_alert(monkeypatch):
 
 
 def test_maybe_rebalance(monkeypatch):
+    """maybe_rebalance triggers a rebalance after the interval."""
     calls = []
     monkeypatch.setattr(rebalancer, "REBALANCE_INTERVAL_MIN", 0)
     monkeypatch.setattr(rebalancer, "rebalance_portfolio", lambda ctx: calls.append(ctx))

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -8,6 +8,7 @@ import alerts
 
 
 def test_alert_throttling(monkeypatch):
+    """Verify repeated alerts are rate limited."""
     sent = []
     monkeypatch.setattr(alerts, "SLACK_WEBHOOK", "http://example.com")
     monkeypatch.setattr(alerts.requests, "post", lambda *a, **k: sent.append(k))

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -177,7 +177,11 @@ class _CapScaler:
 
 sys.modules["capital_scaling"].CapitalScalingEngine = _CapScaler
 if "pandas_market_calendars" in sys.modules:
-    sys.modules["pandas_market_calendars"].get_calendar = lambda *a, **k: types.SimpleNamespace(schedule=lambda *a, **k: pd.DataFrame())
+    sys.modules["pandas_market_calendars"].get_calendar = (
+        lambda *a, **k: types.SimpleNamespace(
+            schedule=lambda *a, **k: pd.DataFrame()
+        )
+    )
 if "pandas_ta" in sys.modules:
     sys.modules["pandas_ta"].atr = lambda *a, **k: pd.Series([0])
     sys.modules["pandas_ta"].rsi = lambda *a, **k: pd.Series([0])
@@ -188,6 +192,7 @@ bot = pytest.importorskip("bot")
 
 
 def test_screen_candidates_empty(monkeypatch):
+    """screen_candidates returns an empty list when none pass."""
     monkeypatch.setattr(bot, "load_tickers", lambda path=bot.TICKERS_FILE: ["AAA"])
     monkeypatch.setattr(bot, "screen_universe", lambda candidates, ctx: [])
     assert bot.screen_candidates() == []

--- a/tests/test_bot_extended.py
+++ b/tests/test_bot_extended.py
@@ -62,7 +62,11 @@ if "capital_scaling" in sys.modules:
 
 sys.modules.setdefault("yfinance", types.ModuleType("yfinance"))
 if "pandas_market_calendars" in sys.modules:
-    sys.modules["pandas_market_calendars"].get_calendar = lambda *a, **k: types.SimpleNamespace(schedule=lambda *a, **k: pd.DataFrame())
+    sys.modules["pandas_market_calendars"].get_calendar = (
+        lambda *a, **k: types.SimpleNamespace(
+            schedule=lambda *a, **k: pd.DataFrame()
+        )
+    )
 if "pandas_ta" in sys.modules:
     sys.modules["pandas_ta"].atr = lambda *a, **k: pd.Series([0])
     sys.modules["pandas_ta"].rsi = lambda *a, **k: pd.Series([0])
@@ -194,11 +198,13 @@ import bot
 
 
 def test_compute_time_range():
+    """compute_time_range should span the requested minutes."""
     start, end = bot.compute_time_range(5)
     assert (end - start).total_seconds() == 300
 
 
 def test_get_latest_close_edge_cases():
+    """get_latest_close handles missing data gracefully."""
     assert bot.get_latest_close(pd.DataFrame()) == 0.0
     assert bot.get_latest_close(None) == 0.0
     df = pd.DataFrame({"close": [1.5]}, index=[pd.Timestamp("2024-01-01")])
@@ -206,12 +212,14 @@ def test_get_latest_close_edge_cases():
 
 
 def test_fetch_minute_df_safe_market_closed(monkeypatch):
+    """No data is returned when the market is closed."""
     monkeypatch.setattr(bot, "market_is_open", lambda now=None: False)
     result = bot.fetch_minute_df_safe("AAPL")
     assert result.empty
 
 
 def test_fetch_minute_df_safe_open(monkeypatch):
+    """DataFrame is returned when the market is open."""
     monkeypatch.setattr(bot, "market_is_open", lambda now=None: True)
     df = pd.DataFrame({"close": [1]}, index=[pd.Timestamp("2024-01-01")])
     monkeypatch.setattr(bot, "get_minute_df", lambda symbol, start_date, end_date: df)

--- a/tests/test_utils_all_helpers.py
+++ b/tests/test_utils_all_helpers.py
@@ -13,6 +13,8 @@ from utils import (get_close_column, get_datetime_column, get_high_column,
 
 
 def make_df(cols, dtype="float64", values=None):
+    """Return a small DataFrame with columns tailored for testing."""
+
     if values is None:
         values = [1, 2, 3]
     dct = {}
@@ -39,6 +41,7 @@ def make_df(cols, dtype="float64", values=None):
 
 
 def test_ohlcv_variants():
+    """Validate helper functions that identify OHLCV columns."""
     for fn, names in [
         (get_open_column, ["Open", "open", "o"]),
         (get_high_column, ["High", "high", "h"]),
@@ -67,6 +70,7 @@ def test_ohlcv_variants():
 
 
 def test_get_datetime_column_variants():
+    """Ensure datetime column detection handles edge cases."""
     for name in ["Datetime", "datetime", "timestamp", "date"]:
         df = make_df([name])
         df[name] = pd.date_range("2024-01-01", periods=3, freq="D", tz="UTC")
@@ -86,6 +90,7 @@ def test_get_datetime_column_variants():
 
 
 def test_get_symbol_column_variants():
+    """Check detection of symbol column names and uniqueness."""
     for name in ["symbol", "ticker", "SYMBOL"]:
         df = make_df([name])
         assert get_symbol_column(df) == name
@@ -96,6 +101,7 @@ def test_get_symbol_column_variants():
 
 
 def test_get_return_column_variants():
+    """Verify return column detection with valid and null data."""
     for name in ["Return", "ret", "returns"]:
         df = make_df([name])
         assert get_return_column(df) == name
@@ -106,6 +112,7 @@ def test_get_return_column_variants():
 
 
 def test_get_indicator_column():
+    """Test selection of technical indicator columns."""
     df = make_df(["SMA", "ema", "RSI"])
     assert get_indicator_column(df, ["SMA", "EMA"]) == "SMA"
     assert get_indicator_column(df, ["EMA", "ema"]) == "ema"
@@ -113,6 +120,7 @@ def test_get_indicator_column():
 
 
 def test_get_order_column():
+    """Confirm order identifier columns are correctly resolved."""
     df = make_df(["OrderID", "TradeID"])
     assert get_order_column(df, "OrderID") == "OrderID"
     assert get_order_column(df, "TradeID") == "TradeID"

--- a/tests/test_utils_new.py
+++ b/tests/test_utils_new.py
@@ -11,16 +11,19 @@ import utils
 
 
 def test_get_latest_close_normal():
+    """Latest close is returned when present."""
     df = pd.DataFrame({"close": [1.0, 2.0]})
     assert utils.get_latest_close(df) == 2.0
 
 
 def test_get_latest_close_missing():
+    """Default value is used when close column is missing."""
     df = pd.DataFrame({"open": [1.0]})
     assert utils.get_latest_close(df) == 1.0
 
 
 def test_is_market_open_with_calendar(monkeypatch):
+    """Market open helper should use calendar API when available."""
     mod = types.ModuleType("pandas_market_calendars")
 
     class DummyCal:
@@ -39,6 +42,7 @@ def test_is_market_open_with_calendar(monkeypatch):
 
 
 def test_is_market_open_fallback(monkeypatch):
+    """Fallback logic is used when calendar fails."""
     mod = types.ModuleType("pandas_market_calendars")
     mod.get_calendar = lambda name: (_ for _ in ()).throw(Exception("fail"))
     monkeypatch.setitem(sys.modules, "pandas_market_calendars", mod)
@@ -47,6 +51,7 @@ def test_is_market_open_fallback(monkeypatch):
 
 
 def test_ensure_utc_and_convert():
+    """ensure_utc converts naive datetimes and dates."""
     naive = datetime(2024, 1, 1, 12, 0)
     aware = utils.ensure_utc(naive)
     assert aware.tzinfo == timezone.utc
@@ -55,6 +60,7 @@ def test_ensure_utc_and_convert():
 
 
 def test_safe_to_datetime():
+    """safe_to_datetime returns NaT for invalid entries."""
     vals = ["2024-01-01", "2024-01-02"]
     idx = utils.safe_to_datetime(vals)
     assert idx.isna().all()
@@ -63,6 +69,7 @@ def test_safe_to_datetime():
 
 
 def test_safe_to_datetime_various_formats():
+    """Various input formats are handled gracefully."""
     secs = [1700000000, 1700003600]
     ms = [v * 1000 for v in secs]
     idx_s = utils.safe_to_datetime(secs)


### PR DESCRIPTION
## Summary
- document test helper DataFrame factory
- add descriptive docstrings to several tests
- break a few overly long lines
- document `DataFetchError`

## Testing
- `flake8 --max-line-length=120 --select=E501 tests/test_utils_all_helpers.py tests/test_bot_extended.py tests/test_bot.py tests/test_utils_new.py tests/test_alerts.py tests/test_advanced_features.py predict.py data_fetcher.py`
- `pytest -q`
- `python - <<'PY'
import datetime
import data_fetcher
try:
    df = data_fetcher.get_minute_df('AAPL', datetime.date(2024,1,1), datetime.date(2024,1,2))
    print('Result type:', type(df), 'len', len(df))
except Exception as e:
    print('call failed:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68571109e66c8330a0b0b6577dc4c3a1