### PR TITLE
Add tests for improved coverage

### DIFF
--- a/tests/test_alerting_new.py
+++ b/tests/test_alerting_new.py
@@ -1,0 +1,28 @@
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+import alerting
+
+
+def test_send_slack_no_webhook(monkeypatch, caplog):
+    """Warning is logged when webhook is missing."""
+    monkeypatch.setattr(alerting.settings, "SLACK_WEBHOOK", "", raising=False)
+    caplog.set_level("WARNING")
+    alerting.send_slack_alert("msg")
+    assert "SLACK_WEBHOOK not set" in caplog.text
+
+
+def test_send_slack_success(monkeypatch):
+    """Slack POST request is issued when webhook exists."""
+    called = {}
+    def fake_post(url, json, timeout):
+        called['url'] = url
+        called['json'] = json
+        called['timeout'] = timeout
+    monkeypatch.setattr(alerting.settings, "SLACK_WEBHOOK", "http://hook", raising=False)
+    monkeypatch.setattr(alerting.requests, "post", fake_post)
+    alerting.send_slack_alert("hello")
+    assert called['url'] == "http://hook" and called['json']['text'] == "hello"

--- a/tests/test_config_additional.py
+++ b/tests/test_config_additional.py
@@ -1,0 +1,38 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+import config
+
+
+def test_get_env_required_missing(monkeypatch):
+    """get_env raises when required variable is absent."""
+    with pytest.raises(RuntimeError):
+        config.get_env("FOO_BAR_MISSING", required=True)
+
+
+def test_require_env_vars_failure(monkeypatch, caplog):
+    """_require_env_vars logs and raises for missing keys."""
+    caplog.set_level("CRITICAL")
+    with pytest.raises(RuntimeError):
+        config._require_env_vars("NEEDED_VAR")
+    assert "Missing required environment variables" in caplog.text
+
+
+def test_validate_environment_failure(monkeypatch):
+    """validate_environment raises when vars missing."""
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        config.validate_environment()
+
+
+def test_validate_alpaca_credentials_missing(monkeypatch):
+    """validate_alpaca_credentials raises when credentials absent."""
+    monkeypatch.setattr(config, "ALPACA_API_KEY", "", raising=False)
+    monkeypatch.setattr(config, "ALPACA_SECRET_KEY", "", raising=False)
+    monkeypatch.setattr(config, "ALPACA_BASE_URL", "", raising=False)
+    with pytest.raises(RuntimeError):
+        config.validate_alpaca_credentials()

--- a/tests/test_logger_file.py
+++ b/tests/test_logger_file.py
@@ -1,0 +1,20 @@
+import logging
+
+import logger
+
+
+def test_setup_logging_with_file(monkeypatch, tmp_path):
+    """File handler is added when log_file is provided."""
+    logger._configured = False
+    fake = logging.NullHandler()
+
+    def fake_makedirs(path, exist_ok=False):
+        pass
+
+    monkeypatch.setattr(logger.os, "makedirs", fake_makedirs)
+    monkeypatch.setattr(logger, "RotatingFileHandler", lambda *a, **k: fake)
+
+    log_file = tmp_path / "x" / "app.log"
+    logger.setup_logging(log_file=str(log_file))
+    root = logging.getLogger()
+    assert fake in root.handlers

--- a/tests/test_main_extended2.py
+++ b/tests/test_main_extended2.py
@@ -1,0 +1,75 @@
+import logging
+import types
+import sys
+
+import pytest
+
+flask_mod = types.ModuleType("flask")
+class Flask:
+    def __init__(self, *a, **k):
+        pass
+    def route(self, *a, **k):
+        def deco(f):
+            return f
+        return deco
+    def run(self, *a, **k):
+        pass
+flask_mod.Flask = Flask
+flask_mod.jsonify = lambda *a, **k: {}
+sys.modules["flask"] = flask_mod
+import main
+
+
+def test_run_flask_app(monkeypatch):
+    """Flask app is run with provided port."""
+    called = {}
+    class App:
+        def run(self, host, port):
+            called['args'] = (host, port)
+    monkeypatch.setattr(main, 'create_flask_app', lambda: App())
+    main.run_flask_app(1234)
+    assert called['args'] == ('0.0.0.0', 1234)
+
+
+def test_run_bot_missing_exec(monkeypatch):
+    """run_bot raises when python executable missing."""
+    monkeypatch.setattr(main.os.path, 'isfile', lambda p: False)
+    with pytest.raises(RuntimeError):
+        main.run_bot('/venv', 'bot.py')
+
+
+def test_run_bot_success(monkeypatch):
+    """Subprocess is invoked when executable exists."""
+    monkeypatch.setattr(main.os.path, 'isfile', lambda p: True)
+    class P:
+        def wait(self):
+            return 7
+    popen_args = {}
+    def fake_popen(cmd, stdout=None, stderr=None, env=None):
+        popen_args['cmd'] = cmd
+        return P()
+    monkeypatch.setattr(main.subprocess, 'Popen', fake_popen)
+    ret = main.run_bot('/v', 's.py')
+    assert ret == 7
+    assert popen_args['cmd'][0] == '/v/bin/python3.12'
+
+
+def test_validate_environment_missing(monkeypatch):
+    """validate_environment errors when secret missing."""
+    monkeypatch.setattr(main.config, 'WEBHOOK_SECRET', '', raising=False)
+    with pytest.raises(RuntimeError):
+        main.validate_environment()
+
+
+def test_main_bot_only(monkeypatch):
+    """main runs bot and exits with its return code."""
+    monkeypatch.setattr(sys, 'argv', ['main.py', '--bot-only'])
+    monkeypatch.setattr(main, 'run_bot', lambda v, s: 5)
+    monkeypatch.setattr(main, 'run_flask_app', lambda port: None)
+    monkeypatch.setattr(main, 'setup_logging', lambda *a, **k: logging.getLogger('t'))
+    monkeypatch.setattr(main, 'load_dotenv', lambda *a, **k: None)
+    monkeypatch.setattr(main, 'validate_environment', lambda: None)
+    exits = []
+    monkeypatch.setattr(sys, 'exit', lambda code=0: exits.append(code))
+    main.main()
+    assert exits == [5]

--- a/tests/test_mean_reversion_extra.py
+++ b/tests/test_mean_reversion_extra.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from strategies.mean_reversion import MeanReversionStrategy
+
+
+class DummyFetcher:
+    def __init__(self, df):
+        self.df = df
+    def get_daily_df(self, ctx, sym):
+        return self.df
+
+class Ctx:
+    def __init__(self, df):
+        self.tickers = ["A"]
+        self.data_fetcher = DummyFetcher(df)
+
+
+def test_generate_insufficient_data(caplog):
+    """Insufficient history skips generation."""
+    df = pd.DataFrame({"close": [1, 2]})
+    ctx = Ctx(df)
+    strat = MeanReversionStrategy(lookback=5)
+    caplog.set_level('WARNING')
+    assert strat.generate(ctx) == []
+    assert "insufficient" in caplog.text
+
+
+def test_generate_invalid_stats(caplog):
+    """Invalid rolling statistics skip generation."""
+    df = pd.DataFrame({"close": [1]*10})
+    ctx = Ctx(df)
+    strat = MeanReversionStrategy(lookback=3)
+    caplog.set_level('WARNING')
+    ctx.data_fetcher.df["close"][-1] = float('nan')
+    assert strat.generate(ctx) == []
+    assert "invalid rolling" in caplog.text
+
+

--- a/tests/test_meta_learning_additional.py
+++ b/tests/test_meta_learning_additional.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+import numpy as np
+import types
+import sklearn.linear_model
+import sys
+
+import meta_learning
+
+
+def test_load_weights_save_fail(monkeypatch, tmp_path, caplog):
+    """Failure to write default weights is logged and default returned."""
+    p = tmp_path / "w.csv"
+    monkeypatch.setattr(meta_learning.Path, "exists", lambda self: False)
+    def fail(*a, **k):
+        raise IOError("fail")
+    monkeypatch.setattr(meta_learning.np, "savetxt", fail)
+    caplog.set_level("ERROR")
+    arr = meta_learning.load_weights(str(p), default=np.array([1.0]))
+    assert arr.tolist() == [1.0]
+    assert "Failed initializing" in caplog.text
+
+
+def test_update_signal_weights_edge_cases():
+    """Handles empty weights and zero performance."""
+    assert meta_learning.update_signal_weights({}, {}) is None
+    w = {"a": 1.0}
+    perf = {"a": 0.0}
+    assert meta_learning.update_signal_weights(w, perf) == w
+
+
+def test_save_and_load_checkpoint(tmp_path):
+    """Model checkpoints can be saved and loaded."""
+    path = tmp_path / "m.pkl"
+    meta_learning.save_model_checkpoint({"x": 1}, str(path))
+    obj = meta_learning.load_model_checkpoint(str(path))
+    assert obj == {"x": 1}
+
+
+def test_retrain_meta_learner(monkeypatch, tmp_path):
+    """Meta learner retrains with small dataset."""
+    data = Path(tmp_path / "trades.csv")
+    df = meta_learning.pd.DataFrame({
+        "entry_price": [1, 2],
+        "exit_price": [2, 3],
+        "signal_tags": ["a", "b"],
+        "side": ["buy", "sell"],
+    })
+    df.to_csv(data, index=False)
+    monkeypatch.setattr(meta_learning, "save_model_checkpoint", lambda *a, **k: None)
+    monkeypatch.setattr(meta_learning, "load_model_checkpoint", lambda *a, **k: [])
+    monkeypatch.setattr(sklearn.linear_model, "Ridge", lambda *a, **k: types.SimpleNamespace(fit=lambda X,y, sample_weight=None: None, predict=lambda X:[0]*len(X)))
+    ok = meta_learning.retrain_meta_learner(str(data), str(tmp_path/"m.pkl"), str(tmp_path/"hist.pkl"), min_samples=1)
+    assert ok
+
+
+def test_optimize_signals(monkeypatch):
+    """optimize_signals uses model predictions when available."""
+    m = types.SimpleNamespace(predict=lambda X: [1,2,3])
+    data = [1,2,3]
+    assert meta_learning.optimize_signals(data, types.SimpleNamespace(MODEL_PATH=""), model=m) == [1,2,3]
+    monkeypatch.setattr(meta_learning, "load_model_checkpoint", lambda path: None)
+    assert meta_learning.optimize_signals(data, types.SimpleNamespace(MODEL_PATH=""), model=None) == data

--- a/tests/test_momentum_extra.py
+++ b/tests/test_momentum_extra.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from strategies import momentum
+from strategies.momentum import MomentumStrategy
+
+
+class DummyFetcher:
+    def __init__(self, df):
+        self.df = df
+    def get_daily_df(self, ctx, sym):
+        return self.df
+
+class Ctx:
+    def __init__(self, df):
+        self.tickers = ["A"]
+        self.data_fetcher = DummyFetcher(df)
+
+
+def test_generate_insufficient_data(caplog):
+    df = pd.DataFrame({"close": [1]})
+    ctx = Ctx(df)
+    strat = MomentumStrategy(lookback=2)
+    caplog.set_level('WARNING')
+    assert strat.generate(ctx) == []
+    assert "Insufficient data" in caplog.text
+
+
+def test_generate_ret_nan(monkeypatch):
+    df = pd.DataFrame({"close": [1,2,3,4]})
+    ctx = Ctx(df)
+    strat = MomentumStrategy(lookback=3)
+    ctx.data_fetcher.df.loc[len(df)-1, "close"] = float('nan')
+    monkeypatch.setattr(momentum.pd, "isna", lambda v: True)
+    assert strat.generate(ctx) == []

--- a/tests/test_rebalancer_new.py
+++ b/tests/test_rebalancer_new.py
@@ -1,0 +1,9 @@
+import rebalancer
+
+
+def test_rebalance_portfolio(monkeypatch):
+    """Slack alert is triggered during rebalance."""
+    called = {}
+    monkeypatch.setattr(rebalancer, 'send_slack_alert', lambda msg: called.setdefault('m', msg))
+    rebalancer.rebalance_portfolio(None)
+    assert called['m']

--- a/tests/test_risk_engine_additional.py
+++ b/tests/test_risk_engine_additional.py
@@ -1,0 +1,77 @@
+import types
+
+import numpy as np
+import pytest
+
+import risk_engine
+from strategies import TradeSignal
+
+
+def test_can_trade_invalid_type(caplog):
+    """can_trade rejects non-TradeSignal objects."""
+    eng = risk_engine.RiskEngine()
+    caplog.set_level('ERROR')
+    assert not eng.can_trade(object())
+    assert "invalid signal" in caplog.text
+
+
+def test_register_fill_invalid(caplog):
+    """register_fill ignores invalid types."""
+    eng = risk_engine.RiskEngine()
+    caplog.set_level('ERROR')
+    eng.register_fill(object())
+    assert "invalid signal" in caplog.text
+
+
+def test_check_max_drawdown_exception(monkeypatch):
+    """API errors lead to False return."""
+    class API:
+        def get_account(self):
+            raise RuntimeError('oops')
+    eng = risk_engine.RiskEngine()
+    assert not eng.check_max_drawdown(API())
+
+
+def test_position_size_invalid_signal():
+    """Invalid signal results in zero position."""
+    eng = risk_engine.RiskEngine()
+    assert eng.position_size(object(), 100, 10) == 0
+
+
+def test_position_size_division_error():
+    """Errors during quantity calc return zero."""
+    eng = risk_engine.RiskEngine()
+    sig = TradeSignal(symbol='A', side='buy', confidence=1.0, strategy='s')
+    qty = eng.position_size(sig, cash=100, price=float('nan'))
+    assert qty == 0
+
+
+def test_apply_weight_limits():
+    """Weight adjustments respect caps."""
+    eng = risk_engine.RiskEngine()
+    eng.asset_limits['equity'] = 0.5
+    eng.strategy_limits['s'] = 0.3
+    eng.exposure['equity'] = 0.4
+    sig = TradeSignal(symbol='A', side='buy', confidence=1.0, strategy='s', weight=1.0)
+    w = eng._apply_weight_limits(sig)
+    assert round(w, 1) == 0.1
+
+
+def test_compute_volatility_error(monkeypatch):
+    """Exceptions in std calculation are handled."""
+    eng = risk_engine.RiskEngine()
+    monkeypatch.setattr(risk_engine.np, 'std', lambda arr: (_ for _ in ()).throw(ValueError('bad')))
+    res = eng.compute_volatility(np.array([1.0]))
+    assert res['volatility'] == 0.0
+
+
+def test_calculate_position_size_invalid_args():
+    """Invalid argument patterns raise TypeError."""
+    with pytest.raises(TypeError):
+        risk_engine.calculate_position_size()
+
+
+def test_register_trade_blocked(monkeypatch):
+    """register_trade returns None when trading not allowed."""
+    monkeypatch.setattr(risk_engine, 'CURRENT_TRADES', risk_engine.MAX_TRADES)
+    assert risk_engine.register_trade(1) is None

--- a/tests/test_strategies_base_extra.py
+++ b/tests/test_strategies_base_extra.py
@@ -1,0 +1,11 @@
+from strategies.base import Strategy, asset_class_for
+
+
+def test_asset_class_for_crypto():
+    """Symbols starting with crypto prefixes are labelled crypto."""
+    assert asset_class_for("ETHBTC") == "crypto"
+
+
+def test_strategy_generate_base():
+    """Base Strategy.generate returns empty list."""
+    assert Strategy().generate(None) == []

--- a/tests/test_utils_more.py
+++ b/tests/test_utils_more.py
@@ -1,0 +1,85 @@
+import types
+import sys
+from types import MappingProxyType
+from datetime import datetime, timezone
+import pandas as pd
+import socket
+import pytest
+
+import utils
+
+
+def test_log_warning_with_exception(caplog):
+    caplog.set_level('WARNING')
+    utils.log_warning('hi', exc=ValueError('x'))
+    assert 'hi: x' in caplog.text
+    caplog.clear()
+    utils.log_warning('hi')
+    assert 'hi' in caplog.text
+
+
+def test_callable_lock_methods():
+    lock = utils._CallableLock()
+    assert not lock.locked()
+    lock.acquire()
+    try:
+        assert lock.locked()
+    finally:
+        lock.release()
+    assert not lock.locked()
+
+
+def test_is_market_open_weekday(monkeypatch):
+    mod = types.ModuleType('pandas_market_calendars')
+    mod.get_calendar = lambda name: (_ for _ in ()).throw(Exception('fail'))
+    monkeypatch.setitem(sys.modules, 'pandas_market_calendars', mod)
+    now = datetime(2024, 1, 2, 10, 0, tzinfo=utils.EASTERN_TZ)
+    assert utils.is_market_open(now)
+
+
+def test_ensure_utc_timezone_aware():
+    aware = datetime(2024,1,1,12,0,tzinfo=timezone.utc)
+    assert utils.ensure_utc(aware).tzinfo == timezone.utc
+    with pytest.raises(AssertionError):
+        utils.ensure_utc(123)
+
+
+def test_get_free_port_none(monkeypatch):
+    def fake_socket(*a, **k):
+        class S:
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+            def bind(self, *a): raise OSError
+        return S()
+    monkeypatch.setattr(socket, 'socket', fake_socket)
+    assert utils.get_free_port(9200, 9200) is None
+
+
+def test_to_serializable_mappingproxy():
+    mp = MappingProxyType({'a': 1})
+    assert utils.to_serializable(mp) == {'a': 1}
+    assert utils.to_serializable([mp]) == [{'a': 1}]
+
+
+def test_warn_limited(caplog):
+    caplog.set_level('WARNING')
+    for _ in range(4):
+        utils._warn_limited('k', 'msg')
+    assert "suppressed" in caplog.text
+
+
+def test_safe_to_datetime_none_and_failure(monkeypatch):
+    assert len(utils.safe_to_datetime(None)) == 0
+    def bad(*a, **k):
+        raise TypeError
+    monkeypatch.setattr(utils.pd, 'to_datetime', bad)
+    res = utils.safe_to_datetime(['x'])
+    assert res.isna().all()
+
+
+def test_get_ohlcv_columns_positive():
+    df = pd.DataFrame({
+        'Open':[1], 'High':[1], 'Low':[1], 'Close':[1], 'Volume':[1]
+    })
+    cols = utils.get_ohlcv_columns(df)
+    assert cols == ['Open', 'High', 'Low', 'Close', 'Volume']


### PR DESCRIPTION
## Summary
- add new unit tests targeting missing branches in several modules
- cover logging setup, Slack alerts, config validation, and main routines
- exercise strategy edge cases and risk engine error handling
- ensure utils helpers and meta-learning functions are robust

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857154d7be083308ce4d672f16f690a