### PR TITLE
Fix Slack alert throttling test

### DIFF
--- a/alerts.py
+++ b/alerts.py
@@ -16,7 +16,12 @@ _last_sent = {}
 THROTTLE_SEC = 30
 
 
-def send_slack_alert(message: str, *, key: str | None = None) -> None:
+def send_slack_alert(
+    message: str,
+    *,
+    key: str | None = None,
+    throttle_sec: float | None = None,
+) -> None:
     """Send a Slack alert with basic throttling.
 
     Parameters
@@ -25,7 +30,10 @@ def send_slack_alert(message: str, *, key: str | None = None) -> None:
         Text to send.
     key : str, optional
         Distinct alert type for throttling. Defaults to ``message``.
+    throttle_sec : float | None, optional
+        Custom throttling interval for this call. Defaults to ``THROTTLE_SEC``.
     """
+    throttle = THROTTLE_SEC if throttle_sec is None else throttle_sec
     if not SLACK_WEBHOOK:
         return
 
@@ -33,7 +41,7 @@ def send_slack_alert(message: str, *, key: str | None = None) -> None:
     now = time.monotonic()
     with _alert_lock:
         last = _last_sent.get(ident, 0.0)
-        if now - last < THROTTLE_SEC:
+        if now - last < throttle:
             logger.info("Alert throttled: %s", ident)
             return
         _last_sent[ident] = now

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -12,14 +12,13 @@ def test_alert_throttling(monkeypatch):
     sent = []
     monkeypatch.setattr(alerts, "SLACK_WEBHOOK", "http://example.com")
     monkeypatch.setattr(alerts.requests, "post", lambda *a, **k: sent.append(k))
-    monkeypatch.setattr(alerts, "THROTTLE_SEC", 0.1)
     monkeypatch.setattr(alerts, "_last_sent", {}, raising=False)
 
-    alerts.send_slack_alert("msg", key="err")
-    alerts.send_slack_alert("msg", key="err")
+    alerts.send_slack_alert("msg", key="err", throttle_sec=0.1)
+    alerts.send_slack_alert("msg", key="err", throttle_sec=0.1)
     assert len(sent) == 1
 
-    time.sleep(alerts.THROTTLE_SEC)
+    time.sleep(0.1)
 
-    alerts.send_slack_alert("msg", key="err")
+    alerts.send_slack_alert("msg", key="err", throttle_sec=0.1)
     assert len(sent) == 2


### PR DESCRIPTION
## Summary
- allow passing custom throttle to `send_slack_alert`
- simplify `test_alert_throttling` to use new parameter

## Testing
- `pytest tests/test_alerts.py::test_alert_throttling -vv`

------
https://chatgpt.com/codex/tasks/task_e_685732b29a008330b9245a93f4a732be