### PR TITLE
Fix alert throttling unit test

### DIFF
--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -13,12 +13,13 @@ def test_alert_throttling(monkeypatch):
     monkeypatch.setattr(alerts, "SLACK_WEBHOOK", "http://example.com")
     monkeypatch.setattr(alerts.requests, "post", lambda *a, **k: sent.append(k))
     monkeypatch.setattr(alerts, "_last_sent", {}, raising=False)
+    monkeypatch.setattr(alerts, "THROTTLE_SEC", 0.1, raising=False)
 
-    alerts.send_slack_alert("msg", key="err", throttle_sec=0.1)
-    alerts.send_slack_alert("msg", key="err", throttle_sec=0.1)
+    alerts.send_slack_alert("msg", key="err")
+    alerts.send_slack_alert("msg", key="err")
     assert len(sent) == 1
 
-    time.sleep(0.1)
+    time.sleep(alerts.THROTTLE_SEC)
 
-    alerts.send_slack_alert("msg", key="err", throttle_sec=0.1)
+    alerts.send_slack_alert("msg", key="err")
     assert len(sent) == 2


### PR DESCRIPTION
## Summary
- avoid timeouts in alert throttling test by monkeypatching `THROTTLE_SEC`

## Testing
- `pytest tests/test_alerts.py::test_alert_throttling -vv`

------
https://chatgpt.com/codex/tasks/task_e_68573481a194833097d048fa8ac3a97a