### PR TITLE
Secure Alpaca headers & retry cleanup

### DIFF
--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -31,11 +31,20 @@ SHADOW_MODE = os.getenv("SHADOW_MODE", "0") == "1"
 
 _warn_counts = defaultdict(int)
 
-ALPACA_BASE_URL = "https://api.alpaca.markets"
-HEADERS = {
-    "APCA-API-KEY-ID": "your_key_id",  # Replace with your env var or config loader
-    "APCA-API-SECRET-KEY": "your_secret_key",
-}
+ALPACA_BASE_URL = os.getenv("ALPACA_BASE_URL", "https://api.alpaca.markets")
+
+
+def _build_headers() -> dict:
+    """Return authorization headers constructed from the current environment.
+
+    Secrets are read at call time so that a configuration reload will be
+    respected without keeping credentials in memory longer than necessary.
+    """
+
+    return {
+        "APCA-API-KEY-ID": os.getenv("ALPACA_API_KEY", ""),
+        "APCA-API-SECRET-KEY": os.getenv("ALPACA_SECRET_KEY", ""),
+    }
 
 
 def _warn_limited(key: str, msg: str, *args, limit: int = 3, **kwargs) -> None:
@@ -62,7 +71,7 @@ def alpaca_get(
 
     url = f"{ALPACA_BASE_URL}{endpoint}"
     try:
-        response = requests.get(url, headers=HEADERS, params=params, timeout=10)
+        response = requests.get(url, headers=_build_headers(), params=params, timeout=10)
         response.raise_for_status()
         return response.json()
     except requests.exceptions.RequestException as exc:

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -384,9 +384,6 @@ class ExecutionEngine:
                         f"submit_order failed for {symbol} after retries: {e}"
                     )
                     return None
-            except APIError as e:
-                self.logger.warning(f"APIError placing order for {symbol}: {e}")
-                return None
             except Exception as e:
                 self.logger.exception(f"Unexpected error placing order for {symbol}: {e}")
                 return None


### PR DESCRIPTION
## Summary
- dynamically build Alpaca REST headers from environment
- avoid storing API keys in memory
- simplify order retry logic

## Testing
- `pytest tests/test_alpaca_api_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b3205f208330b01de266feae45fd