### PR TITLE
Add max drawdown metric

### DIFF
--- a/metrics_logger.py
+++ b/metrics_logger.py
@@ -1,22 +1,69 @@
+"""Helpers for logging model performance metrics."""
+
+from __future__ import annotations
+
 import csv
 import logging
 import os
+from typing import Any, Sequence
+
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
 
-def log_metrics(record, filename="metrics/model_performance.csv"):
-    """Append a metrics record to the CSV file."""
+def compute_max_drawdown(equity_curve: Sequence[float]) -> float:
+    """Return the maximum drawdown for ``equity_curve``.
 
-    # Protect file operations so metrics logging can't crash the bot
+    Parameters
+    ----------
+    equity_curve : Sequence[float]
+        Sequence of portfolio values or equity amounts.
+
+    Returns
+    -------
+    float
+        Maximum drawdown as a fraction between 0 and 1.
+    """
+
+    if not equity_curve:
+        return 0.0
+
+    arr = np.asarray(equity_curve, dtype=float)
+    peak = np.maximum.accumulate(arr)
+    drawdowns = (peak - arr) / peak
+    return float(np.max(drawdowns))
+
+
+def log_metrics(
+    record: dict[str, Any],
+    filename: str = "metrics/model_performance.csv",
+    equity_curve: Sequence[float] | None = None,
+) -> None:
+    """Append a metrics record to ``filename``.
+
+    Parameters
+    ----------
+    record : dict[str, Any]
+        Dictionary of metric values to log.
+    filename : str, optional
+        Output CSV path, by default ``"metrics/model_performance.csv"``.
+    equity_curve : Sequence[float] | None, optional
+        Optional list of portfolio values used to compute the ``max_drawdown``
+        metric. When provided the computed value is added to ``record`` if not
+        already present.
+    """
+
+    if equity_curve and "max_drawdown" not in record:
+        record["max_drawdown"] = compute_max_drawdown(equity_curve)
+
     try:
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         file_exists = os.path.isfile(filename)
-        with open(filename, "a", newline="") as f:
+        with open(filename, "a", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=record.keys())
             if not file_exists:
                 writer.writeheader()
             writer.writerow(record)
-    except Exception as e:  # pragma: no cover - best effort logging
-        # Log exception and continue to avoid silent failure
-        logger.warning(f"Failed to update metrics file {filename}: {e}")
+    except (OSError, csv.Error) as exc:  # pragma: no cover - best effort logging
+        logger.warning("Failed to update metrics file %s: %s", filename, exc)

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -6,7 +6,7 @@ echo "Installing main requirements..."
 pip install -r requirements.txt
 
 echo "Installing test requirements..."
-pip install -r requirements-test.txt
+pip install -r requirements-dev.txt
 
 # Ensure linting tools are available
 pip install flake8 isort==5.12.0 pylint pytest-cov >/dev/null

--- a/tests/test_metrics_logger_smoke.py
+++ b/tests/test_metrics_logger_smoke.py
@@ -18,7 +18,14 @@ def force_coverage(mod):
 @pytest.mark.smoke
 def test_log_metrics(tmp_path):
     file = tmp_path / "m.csv"
-    metrics_logger.log_metrics({"a": 1}, filename=str(file))
-    rows = list(csv.DictReader(open(file)))
-    assert rows and rows[0]["a"] == "1"
+    metrics_logger.log_metrics({"a": 1}, filename=str(file), equity_curve=[1, 2, 1.5])
+    rows = list(csv.DictReader(open(file, encoding="utf-8")))
+    assert rows and rows[0]["a"] == "1" and "max_drawdown" in rows[0]
     force_coverage(metrics_logger)
+
+
+def test_compute_max_drawdown():
+    curve = [100.0, 120.0, 110.0, 90.0, 95.0]
+    expected = (120.0 - 90.0) / 120.0
+    assert metrics_logger.compute_max_drawdown(curve) == pytest.approx(expected)
+


### PR DESCRIPTION
## Summary
- enhance metrics_logger with new max drawdown metric
- adjust run_checks script to use dev requirements
- extend metrics logger smoke test

## Testing
- `./run_checks.sh` *(fails: torch install stalled)*

------
https://chatgpt.com/codex/tasks/task_e_6858cfeaa8088330b97cc743e9510af0