### PR TITLE
Refactor logging and add docstrings

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -151,7 +151,11 @@ def get_historical_data(symbol: str, start_date, end_date, timeframe: str) -> pd
             idx = safe_to_datetime(df.index, context=f"{symbol} minute")
         except ValueError as e:
             logger.debug("Raw data for %s: %s", symbol, df.head().to_dict())
-            logger.warning(f"Unexpected index format for {symbol}; skipping | {e}")
+            logger.warning(
+                "Unexpected index format for %s; skipping | %s",
+                symbol,
+                e,
+            )
             return pd.DataFrame()
         df.index = idx
         df["timestamp"] = df.index
@@ -203,7 +207,7 @@ def get_daily_df(symbol: str, start: date, end: date) -> pd.DataFrame:
                 else:
                     raise
         except (APIError, RetryError):
-            logger.info(f"SKIP_NO_PRICE_DATA | {symbol}")
+            logger.info("SKIP_NO_PRICE_DATA | %s", symbol)
             return pd.DataFrame()
     try:
         if isinstance(df.columns, pd.MultiIndex):
@@ -228,7 +232,7 @@ def get_daily_df(symbol: str, start: date, end: date) -> pd.DataFrame:
             idx = safe_to_datetime(df.index, context=f"{symbol} daily")
         except ValueError as e:
             logger.debug("Raw daily data for %s: %s", symbol, df.head().to_dict())
-            logger.warning(f"Invalid date index for {symbol}; skipping. {e}")
+            logger.warning("Invalid date index for %s; skipping. %s", symbol, e)
             return pd.DataFrame()
         logger.debug("%s parsed daily timestamps: %s", symbol, list(idx[:5]))
         df.index = idx
@@ -236,7 +240,10 @@ def get_daily_df(symbol: str, start: date, end: date) -> pd.DataFrame:
 
         return df[["timestamp", "open", "high", "low", "close", "volume"]]
     except KeyError:
-        logger.warning(f"Missing OHLCV columns for {symbol}; returning empty DataFrame")
+        logger.warning(
+            "Missing OHLCV columns for %s; returning empty DataFrame",
+            symbol,
+        )
         return pd.DataFrame()
     except Exception as e:
         snippet = df.head().to_dict() if "df" in locals() and isinstance(df, pd.DataFrame) else "N/A"
@@ -394,7 +401,7 @@ def get_minute_df(symbol: str, start_date: date, end_date: date) -> pd.DataFrame
             idx = safe_to_datetime(df.index, context=f"{symbol} minute")
         except ValueError as e:
             logger.debug("Raw minute data for %s: %s", symbol, df.head().to_dict())
-            logger.warning(f"Invalid minute index for {symbol}; skipping. {e}")
+            logger.warning("Invalid minute index for %s; skipping. %s", symbol, e)
             return pd.DataFrame()
         df.index = idx
 
@@ -443,12 +450,20 @@ def get_minute_df(symbol: str, start_date: date, end_date: date) -> pd.DataFrame
                 idx = safe_to_datetime(df.index, context=f"{symbol} fallback")
             except ValueError as e:
                 logger.debug("Raw fallback data for %s: %s", symbol, df.head().to_dict())
-                logger.warning(f"Invalid fallback index for {symbol}; skipping | {e}")
+                logger.warning(
+                    "Invalid fallback index for %s; skipping | %s",
+                    symbol,
+                    e,
+                )
                 return pd.DataFrame()
             logger.debug("%s fallback raw timestamps: %s", symbol, list(df.index[:5]))
             logger.debug("%s fallback parsed timestamps: %s", symbol, list(idx[:5]))
             df.index = idx
-            logger.info(f"Falling back to daily bars for {symbol} ({len(df)} rows)")
+            logger.info(
+                "Falling back to daily bars for %s (%s rows)",
+                symbol,
+                len(df),
+            )
             _MINUTE_CACHE[symbol] = (df, pd.Timestamp.utcnow())
             logger.info(
                 "MINUTE_FETCHED",

--- a/logger.py
+++ b/logger.py
@@ -54,9 +54,10 @@ def setup_logging(debug: bool = False, log_file: str | None = None) -> None:
     for h in handlers:
         logger.addHandler(h)
 
+    file_part = " with file %s" % log_file if log_file else ""
     logger.info(
         "Logging initialized%s (level %s)",
-        f" with file {log_file}" if log_file else "",
+        file_part,
         logging.getLevelName(level),
     )
     _configured = True

--- a/meta_learning.py
+++ b/meta_learning.py
@@ -61,7 +61,7 @@ def update_weights(
         return False
     try:
         if Path(history_file).exists():
-            with open(history_file) as f:
+            with open(history_file, encoding="utf-8") as f:
                 hist = json.load(f)
         else:
             hist = []
@@ -70,7 +70,7 @@ def update_weights(
         hist = []
     hist.append({"ts": datetime.now(timezone.utc).isoformat(), **metrics})
     hist = hist[-n_history:]
-    with open(history_file, "w") as f:
+    with open(history_file, "w", encoding="utf-8") as f:
         json.dump(hist, f)
     logger.info("META_METRICS", extra={"recent": hist})
     return True

--- a/predict.py
+++ b/predict.py
@@ -92,7 +92,7 @@ def predict(csv_path: str, freq: str = "intraday") -> tuple[int | None, float | 
             feat = prepare_indicators(df, freq=freq, symbol=symbol)
         else:
             feat = prepare_indicators(df, freq=freq)
-    except Exception:  # TODO: narrow exception type
+    except (TypeError, ValueError, AttributeError):
         feat = prepare_indicators(df, freq=freq)
     if os.path.exists(INACTIVE_FEATURES_FILE):
         try:

--- a/rebalancer.py
+++ b/rebalancer.py
@@ -1,10 +1,12 @@
+"""Portfolio rebalancing utilities."""
+
 import logging
 from datetime import datetime, timedelta, timezone
 
 from alerts import send_slack_alert
+import config
 
 logger = logging.getLogger(__name__)
-import config
 
 REBALANCE_INTERVAL_MIN = int(config.get_env("REBALANCE_INTERVAL_MIN", "1440"))
 

--- a/server.py
+++ b/server.py
@@ -46,7 +46,7 @@ class WebhookPayload(BaseModel):
     action: str
 
 def _handle_shutdown(signum: int, _unused_frame) -> None:
-    logger.info(f"Received signal {signum}, shutting down")
+    logger.info("Received signal %s, shutting down", signum)
     _shutdown.set()
 
 signal.signal(signal.SIGTERM, _handle_shutdown)
@@ -151,6 +151,6 @@ if __name__ == "__main__":
     ]
     try:
         run()
-    except Exception as exc:
+    except Exception as exc:  # TODO: narrow exception type
         logger.exception("Failed to start gunicorn: %s", exc)
         raise

--- a/signals.py
+++ b/signals.py
@@ -163,7 +163,7 @@ def generate_signal(df: pd.DataFrame, column: str) -> pd.Series:
         return pd.Series(dtype=float)
 
     if column not in df.columns:
-        logger.error(f"Required column '{column}' not found in dataframe")
+        logger.error("Required column '%s' not found in dataframe", column)
         return pd.Series(dtype=float)
 
     try:
@@ -171,6 +171,6 @@ def generate_signal(df: pd.DataFrame, column: str) -> pd.Series:
         signal[df[column] > 0] = 1
         signal[df[column] < 0] = -1
         return signal.fillna(0)
-    except Exception as e:
-        logger.error(f"Exception generating signal: {e}", exc_info=True)
+    except Exception as e:  # TODO: narrow exception type
+        logger.error("Exception generating signal: %s", e, exc_info=True)
         return pd.Series(dtype=float)

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -1,3 +1,5 @@
+"""Mean reversion trading strategy implementation."""
+
 import logging
 from typing import List
 
@@ -24,7 +26,11 @@ class MeanReversionStrategy(Strategy):
             df = ctx.data_fetcher.get_daily_df(ctx, sym)
             # Ensure we have data and enough rows before doing rolling calculations
             if df is None or df.empty or len(df) < self.lookback:
-                logger.warning(f"{sym}: insufficient data for lookback {self.lookback}")
+                logger.warning(
+                    "%s: insufficient data for lookback %s",
+                    sym,
+                    self.lookback,
+                )
                 # Skip signal generation when we don't have enough history
                 continue
 
@@ -32,14 +38,14 @@ class MeanReversionStrategy(Strategy):
             sd = df["close"].rolling(self.lookback).std().iloc[-1]
             # Validate rolling mean/std results before computing the z-score
             if pd.isna(ma) or pd.isna(sd) or sd == 0:
-                logger.warning(f"{sym}: invalid rolling statistics")
+                logger.warning("%s: invalid rolling statistics", sym)
                 # Avoid division by zero or propagating NaNs
                 continue
 
             last_close = df["close"].iloc[-1]
             # Guard against NaN closing prices before computing z-score
             if pd.isna(last_close):
-                logger.warning(f"{sym}: last close is NaN")
+                logger.warning("%s: last close is NaN", sym)
                 continue
 
             # Calculate the z-score of the latest close price

--- a/strategies/momentum.py
+++ b/strategies/momentum.py
@@ -1,3 +1,5 @@
+"""Momentum trading strategy implementation."""
+
 import logging
 from typing import List
 


### PR DESCRIPTION
## Summary
- tweak logger initialization
- handle shutdown log in server
- add TODO when catching generic Exception
- narrow prepare_indicators exception
- cleanup log formatting in data fetching
- refine signal generation errors
- add module docs in strategies
- document rebalancer utilities
- specify file encodings

## Testing
- `./run_checks.sh` *(fails: flake8 E501 line length issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6858d75ed7588330aef7d84ae8ae2101