### PR TITLE
Refactor logging and add encoding

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -25,7 +25,7 @@ def log_trade(symbol: str, side: str, qty: int, price: float, result: str, mode:
     }
     try:
         write_header = not os.path.exists(TRADE_LOG_FILE)
-        with open(TRADE_LOG_FILE, "a", newline="") as f:
+        with open(TRADE_LOG_FILE, "a", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=_fields)
             if write_header:
                 writer.writeheader()

--- a/backtest.py
+++ b/backtest.py
@@ -259,7 +259,7 @@ def main():
     best = optimize_hyperparams(None, symbols, data_cfg, param_grid, metric="sharpe")
 
     # Write results
-    with open("best_hyperparams.json", "w") as f:
+    with open("best_hyperparams.json", "w", encoding="utf-8") as f:
         json.dump(best, f, indent=2)
 
     logger.info("Best hyperparameters: %s", best)

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -134,7 +134,7 @@ def get_historical_data(symbol: str, start_date, end_date, timeframe: str) -> pd
     if df.empty:
         logger.critical("NO_DATA_RETURNED_%s", symbol)
         try:
-            with open(HALT_FLAG_PATH, "w") as f:
+            with open(HALT_FLAG_PATH, "w", encoding="utf-8") as f:
                 f.write(f"NO_DATA {symbol} {datetime.now(timezone.utc).isoformat()}")
         except Exception as e:
             logger.error("Failed to write halt flag: %s", e)
@@ -219,7 +219,7 @@ def get_daily_df(symbol: str, start: date, end: date) -> pd.DataFrame:
         if df.empty:
             logger.critical("NO_DATA_RETURNED_%s", symbol)
             try:
-                with open(HALT_FLAG_PATH, "w") as f:
+                with open(HALT_FLAG_PATH, "w", encoding="utf-8") as f:
                     f.write(f"NO_DATA {symbol} {datetime.now(timezone.utc).isoformat()}")
             except Exception as e:
                 logger.error("Failed to write halt flag: %s", e)
@@ -343,7 +343,7 @@ def get_minute_df(symbol: str, start_date: date, end_date: date) -> pd.DataFrame
         if bars is None or not getattr(bars, "df", pd.DataFrame()).size:
             logger.critical("NO_DATA_RETURNED_%s", symbol)
             try:
-                with open(HALT_FLAG_PATH, "w") as f:
+                with open(HALT_FLAG_PATH, "w", encoding="utf-8") as f:
                     f.write(f"NO_DATA {symbol} {datetime.now(timezone.utc).isoformat()}")
             except Exception as e:
                 logger.error("Failed to write halt flag: %s", e)
@@ -392,7 +392,7 @@ def get_minute_df(symbol: str, start_date: date, end_date: date) -> pd.DataFrame
         if df.empty:
             logger.critical("NO_DATA_RETURNED_%s", symbol)
             try:
-                with open(HALT_FLAG_PATH, "w") as f:
+                with open(HALT_FLAG_PATH, "w", encoding="utf-8") as f:
                     f.write(f"NO_DATA {symbol} {datetime.now(timezone.utc).isoformat()}")
             except Exception as e:
                 logger.error("Failed to write halt flag: %s", e)
@@ -441,7 +441,7 @@ def get_minute_df(symbol: str, start_date: date, end_date: date) -> pd.DataFrame
             if df.empty:
                 logger.critical("NO_DATA_RETURNED_%s", symbol)
                 try:
-                    with open(HALT_FLAG_PATH, "w") as f:
+                    with open(HALT_FLAG_PATH, "w", encoding="utf-8") as f:
                         f.write(f"NO_DATA {symbol} {datetime.now(timezone.utc).isoformat()}")
                 except Exception as e:
                     logger.error("Failed to write halt flag: %s", e)

--- a/runner.py
+++ b/runner.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import signal
 import time
 
-from bot import main
 import logging
-logger = logging.getLogger(__name__)
 import requests
+
+from bot import main
+
+logger = logging.getLogger(__name__)
 
 _shutdown = False
 
 
 def _handle_signal(signum: int, _unused_frame) -> None:
+    """Handle termination signals and set shutdown flag."""
     global _shutdown
     logger.info("Received signal %s, shutting down", signum)
     _shutdown = True
@@ -34,7 +37,7 @@ if __name__ == "__main__":
         except requests.exceptions.RequestException as e:
             logger.exception("API request failed", exc_info=e)
             raise
-        except Exception as exc:  # pragma: no cover - safety
+        except Exception as exc:  # TODO: narrow exception type
             logger.exception("Unexpected error", exc_info=exc)
             raise
         if not _shutdown:

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -29,7 +29,7 @@ try:
     from alpaca.trading.enums import OrderSide, TimeInForce
     from alpaca.trading.models import Order
     from alpaca.trading.requests import LimitOrderRequest, MarketOrderRequest
-except Exception:  # pragma: no cover - allow running without Alpaca SDK
+except Exception:  # TODO: narrow exception type
     TradingClient = object
 
     class MarketOrderRequest(dict):
@@ -75,7 +75,7 @@ except Exception:  # pragma: no cover - allow running without Alpaca SDK
 
 try:
     from alpaca_api import submit_order
-except Exception:  # pragma: no cover - allow running without Alpaca API config
+except Exception:  # TODO: narrow exception type
 
     def submit_order(*args, **kwargs):
         raise RuntimeError("Alpaca API unavailable")
@@ -131,7 +131,7 @@ class ExecutionEngine:
         if not os.path.exists(self.slippage_path):
             # Protect file creation in case the logs directory is unwritable
             try:
-                with open(self.slippage_path, "w", newline="") as f:
+                with open(self.slippage_path, "w", newline="", encoding="utf-8") as f:
                     csv.writer(f).writerow(
                         [
                             "timestamp",
@@ -169,7 +169,7 @@ class ExecutionEngine:
             return True
         try:
             acct = api.get_account()
-        except Exception as exc:  # pragma: no cover - api may be stubbed
+        except Exception as exc:  # TODO: narrow exception type
             self.logger.error("Error fetching account information: %s", exc)
             return False
         need = qty * price
@@ -186,7 +186,7 @@ class ExecutionEngine:
         try:
             pos = api.get_position(symbol)
             return float(getattr(pos, "qty", 0))
-        except Exception as exc:  # pragma: no cover - position may not exist
+        except Exception as exc:  # TODO: narrow exception type
             self.logger.error("No position for %s: %s", symbol, exc)
             return 0.0
 
@@ -320,7 +320,7 @@ class ExecutionEngine:
         slip = ((actual - expected) * 100) if expected else 0.0
         try:
             # File I/O may fail; handle gracefully
-            with open(self.slippage_path, "a", newline="") as f:
+            with open(self.slippage_path, "a", newline="", encoding="utf-8") as f:
                 csv.writer(f).writerow(
                     [
                         datetime.now(timezone.utc).isoformat(),
@@ -403,7 +403,7 @@ class ExecutionEngine:
                         e,
                     )
                     return None
-            except Exception as exc:
+            except Exception as exc:  # TODO: narrow exception type
                 self.logger.exception(
                     "Unexpected error placing order for %s: %s",
                     symbol,

--- a/utils.py
+++ b/utils.py
@@ -33,7 +33,7 @@ def log_warning(
     if extra is None:
         extra = {}
     if exc is not None:
-        logger.warning(f"{msg}: {exc}", extra=extra, exc_info=True)
+        logger.warning("%s: %s", msg, exc, extra=extra, exc_info=True)
     else:
         logger.warning(msg, extra=extra)
 
@@ -111,7 +111,7 @@ def is_market_open(now: dt.datetime | None = None) -> bool:
         market_close = sched.iloc[0]["market_close"].tz_convert(EASTERN_TZ).time()
         current = check_time.time()
         return market_open <= current <= market_close
-    except Exception as e:
+    except Exception as e:  # TODO: narrow exception type
         logger.debug("market calendar unavailable: %s", e)
         # Fallback to simple weekday/time check when calendar unavailable
         now_et = (now or dt.datetime.now(tz=EASTERN_TZ)).astimezone(EASTERN_TZ)
@@ -339,5 +339,5 @@ def get_ohlcv_columns(df):
             get_close_column(df),
             get_volume_column(df),
         ]
-    except Exception:
+    except Exception:  # TODO: narrow exception type
         return []


### PR DESCRIPTION
## Summary
- use UTF-8 encoding on file writes
- fix logger formatting and add TODO for exception handling
- reorder imports and document signal handler
- update slippage log writes
- adjust utilities logging

## Testing
- `bash run_checks.sh` *(fails: Building wheel for peewee finished with status 'canceled')*

------
https://chatgpt.com/codex/tasks/task_e_6858daf7027883309bd517125801183d