### PR TITLE
Add moving average crossover strategy

### DIFF
--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -1,11 +1,13 @@
 from strategies.base import Strategy, TradeSignal, asset_class_for
 from strategies.mean_reversion import MeanReversionStrategy
 from strategies.momentum import MomentumStrategy
+from strategies.moving_average_crossover import MovingAverageCrossoverStrategy
 
 __all__ = (
     "Strategy",
     "TradeSignal",
     "MomentumStrategy",
     "MeanReversionStrategy",
+    "MovingAverageCrossoverStrategy",
     "asset_class_for",
 )

--- a/strategies/moving_average_crossover.py
+++ b/strategies/moving_average_crossover.py
@@ -1,0 +1,54 @@
+"""Moving average crossover trading strategy implementation."""
+
+import logging
+from typing import List
+
+import pandas as pd
+
+from strategies.base import Strategy, TradeSignal, asset_class_for
+
+logger = logging.getLogger(__name__)
+
+
+class MovingAverageCrossoverStrategy(Strategy):
+    """Generate buy or sell signals based on SMA crossovers."""
+
+    name = "moving_average_crossover"
+
+    def __init__(self, short: int = 20, long: int = 50) -> None:
+        self.short = short
+        self.long = long
+
+    def generate(self, ctx) -> List[TradeSignal]:
+        signals: List[TradeSignal] = []
+        tickers = getattr(ctx, "tickers", [])
+        for sym in tickers:
+            df = ctx.data_fetcher.get_daily_df(ctx, sym)
+            if df is None or df.empty or len(df) < self.long:
+                logger.warning(
+                    "Insufficient data for %s; need >=%d rows",
+                    sym,
+                    self.long,
+                )
+                continue
+            short_ma = df["close"].rolling(self.short).mean().iloc[-1]
+            long_ma = df["close"].rolling(self.long).mean().iloc[-1]
+            if pd.isna(short_ma) or pd.isna(long_ma):
+                continue
+            if short_ma > long_ma:
+                side = "buy"
+            elif short_ma < long_ma:
+                side = "sell"
+            else:
+                continue
+            confidence = abs(short_ma - long_ma) / long_ma
+            signals.append(
+                TradeSignal(
+                    symbol=sym,
+                    side=side,
+                    confidence=float(confidence),
+                    strategy=self.name,
+                    asset_class=asset_class_for(sym),
+                )
+            )
+        return signals

--- a/tests/test_moving_average_crossover_extra.py
+++ b/tests/test_moving_average_crossover_extra.py
@@ -1,0 +1,35 @@
+"""Tests for moving average crossover strategy."""
+
+import pandas as pd
+from strategies.moving_average_crossover import MovingAverageCrossoverStrategy
+
+
+class DummyFetcher:
+    def __init__(self, df):
+        self.df = df
+
+    def get_daily_df(self, ctx, sym):
+        return self.df
+
+
+class Ctx:
+    def __init__(self, df):
+        self.tickers = ["A"]
+        self.data_fetcher = DummyFetcher(df)
+
+
+def test_generate_insufficient_data(caplog):
+    df = pd.DataFrame({"close": [1, 2]})
+    ctx = Ctx(df)
+    strat = MovingAverageCrossoverStrategy(short=3, long=5)
+    caplog.set_level("WARNING")
+    assert strat.generate(ctx) == []
+    assert "Insufficient data" in caplog.text
+
+
+def test_generate_buy_signal():
+    df = pd.DataFrame({"close": [1, 2, 3, 4, 5, 6]})
+    ctx = Ctx(df)
+    strat = MovingAverageCrossoverStrategy(short=2, long=3)
+    signals = strat.generate(ctx)
+    assert signals and signals[0].side == "buy"

--- a/tests/test_strategies_module.py
+++ b/tests/test_strategies_module.py
@@ -4,10 +4,20 @@ from pathlib import Path
 import pandas as pd
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-for m in ["strategies", "strategies.momentum", "strategies.mean_reversion"]:
+for m in [
+    "strategies",
+    "strategies.momentum",
+    "strategies.mean_reversion",
+    "strategies.moving_average_crossover",
+]:
     sys.modules.pop(m, None)
 
-from strategies import MeanReversionStrategy, MomentumStrategy, asset_class_for
+from strategies import (
+    MeanReversionStrategy,
+    MomentumStrategy,
+    MovingAverageCrossoverStrategy,
+    asset_class_for,
+)
 
 
 class DummyFetcher:


### PR DESCRIPTION
## Summary
- implement new MovingAverageCrossoverStrategy
- expose new strategy in strategies module
- add tests for crossover strategy
- update module tests

## Testing
- `bash run_checks.sh` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_685963b1c41c8330b9abeee812c1ce30