### PR TITLE
Improve datetime validation

### DIFF
--- a/tests/test_data_fetcher_datetime.py
+++ b/tests/test_data_fetcher_datetime.py
@@ -1,0 +1,38 @@
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import data_fetcher
+
+
+@pytest.mark.parametrize("value,expected", [
+    (
+        datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+        datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+    ),
+    ("2024-01-01", datetime(2024, 1, 1, 0, 0)),
+    ("2024-01-01 05:30:00", datetime(2024, 1, 1, 5, 30, 0)),
+    ("20240101", datetime(2024, 1, 1, 0, 0)),
+    ("2024-01-01T12:00:00Z", datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)),
+])
+def test_ensure_datetime_valid(value, expected):
+    result = data_fetcher.ensure_datetime(value)
+    assert result == expected
+
+
+def test_ensure_datetime_none():
+    with pytest.raises(ValueError):
+        data_fetcher.ensure_datetime(None)
+
+
+def test_ensure_datetime_empty_str():
+    with pytest.raises(ValueError):
+        data_fetcher.ensure_datetime("")
+
+
+def test_ensure_datetime_invalid_str():
+    with pytest.raises(ValueError):
+        data_fetcher.ensure_datetime("notadate")


### PR DESCRIPTION
## Summary
- expand `ensure_datetime` to handle string inputs and raise errors for `None`
- add validation for date parameters in data fetcher functions
- unit tests for `ensure_datetime`

## Testing
- `pytest tests/test_data_fetcher_datetime.py -q`
- `./run_checks.sh` *(fails: E501 line too long in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_6859728702408330bed818571e26daaa