### PR TITLE
Add robust datetime validation

### DIFF
--- a/tests/test_data_fetcher_datetime.py
+++ b/tests/test_data_fetcher_datetime.py
@@ -1,5 +1,7 @@
 import sys
 from datetime import datetime, timezone
+
+import pandas as pd
 from pathlib import Path
 
 import pytest
@@ -36,3 +38,19 @@ def test_ensure_datetime_empty_str():
 def test_ensure_datetime_invalid_str():
     with pytest.raises(ValueError):
         data_fetcher.ensure_datetime("notadate")
+
+
+def test_ensure_datetime_pandas_timestamp():
+    ts = pd.Timestamp("2024-02-02T15:00:00", tz="UTC")
+    result = data_fetcher.ensure_datetime(ts)
+    assert result == ts.to_pydatetime()
+
+
+def test_ensure_datetime_nat():
+    with pytest.raises(ValueError):
+        data_fetcher.ensure_datetime(pd.NaT)
+
+
+def test_ensure_datetime_bad_type():
+    with pytest.raises(TypeError):
+        data_fetcher.ensure_datetime(123)

--- a/tests/test_data_fetcher_extended.py
+++ b/tests/test_data_fetcher_extended.py
@@ -69,3 +69,11 @@ def test_get_minute_df_missing_columns(monkeypatch):
     data_fetcher._MINUTE_CACHE.clear()
     result = data_fetcher.get_minute_df("AAPL", datetime.date(2024, 1, 1), datetime.date(2024, 1, 1))
     assert result.empty
+
+
+def test_get_minute_df_invalid_inputs(monkeypatch):
+    monkeypatch.setattr(data_fetcher, "is_market_open", lambda: True)
+    with pytest.raises(ValueError):
+        data_fetcher.get_minute_df("AAPL", None, datetime.date.today())
+    with pytest.raises(TypeError):
+        data_fetcher.get_minute_df("AAPL", 123, datetime.date.today())


### PR DESCRIPTION
## Summary
- improve `ensure_datetime` to handle pandas Timestamp and NaT
- validate types for date ranges in Alpaca fetch helpers
- expand tests for datetime edge cases

## Testing
- `pytest tests/test_data_fetcher_datetime.py tests/test_data_fetcher_extended.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68597829ef5c8330a691910904b84d50