### PR TITLE
Update trading bot for new Alpaca API

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,8 @@ import sys
 import threading
 from typing import Any
 
+from alpaca_trade_api.rest import APIError  # noqa: F401
+
 from dotenv import load_dotenv
 from flask import Flask, jsonify
 from logger import setup_logging


### PR DESCRIPTION
## Summary
- add `calculate_adv` helper and update `_adv_volume`
- refine order status logging in execution engine
- handle insufficient quantity errors gracefully in `safe_submit_order`
- import `APIError` in entrypoint
- implement `pre_trade_health_check` in utils

## Testing
- `./run_checks.sh` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_6859a102e35c8330aaa84890ed1e3066