### PR TITLE
Refactor health check

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,36 @@
+"""Minimal trading entrypoint for ``python -m ai-trading-bot``."""
+
+from __future__ import annotations
+
+import logging
+
+try:
+    from alpaca_trade_api.rest import REST
+except Exception:  # pragma: no cover - optional dependency
+    REST = object  # type: ignore
+
+from utils import pre_trade_health_check
+
+
+def run_trades(symbols: list[str], api: REST) -> None:
+    """Placeholder trade execution logic."""
+    for sym in symbols:
+        logging.info("Executing trade for %s", sym)
+
+
+def main() -> None:
+    """Fetch symbols, run health check, and execute trades."""
+    symbols = ["AAPL", "MSFT"]
+    api = REST()  # type: ignore[arg-type]
+    health = pre_trade_health_check(symbols, api)
+    symbols_to_trade = [s for s, ok in health.items() if ok]
+    if not symbols_to_trade:
+        logging.warning("No symbols passed health check; skipping this cycle")
+    else:
+        run_trades(symbols_to_trade, api)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    logging.basicConfig(level=logging.INFO)
+    main()
+


### PR DESCRIPTION
## Summary
- refactor utils pre_trade_health_check to return per-symbol status instead of exiting
- add minimal __main__ entrypoint demonstrating health check usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6859a66074148330aef2e915f7d5f33a