### PR TITLE
Handle indicator errors and tuple timestamps

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -190,6 +190,16 @@ def safe_to_datetime(arr, format="%Y-%m-%d %H:%M:%S", utc=True, *, context: str 
     if arr is None:
         return pd.DatetimeIndex([], tz="UTC")
 
+    # if someone passed (symbol, Timestamp), extract the Timestamp
+    if isinstance(arr, tuple) and len(arr) == 2 and isinstance(arr[1], pd.Timestamp):
+        arr = arr[1]
+    elif (
+        isinstance(arr, (list, pd.Index, pd.Series))
+        and len(arr) > 0
+        and isinstance(arr[0], tuple)
+    ):
+        arr = [x[1] if isinstance(x, tuple) and len(x) == 2 else x for x in arr]
+
     try:
         return pd.to_datetime(arr, format=format, utc=utc)
     except (TypeError, ValueError) as exc:


### PR DESCRIPTION
## Summary
- sanitize price columns before PnL math
- dedupe frames and guard MFI/Ichimoku indicator calculations
- allow `safe_to_datetime` to unpack `(symbol, ts)` tuples

## Testing
- `bash run_checks.sh` *(fails: E501 line too long)*
- `pytest -k safe_to_datetime -q` *(fails: Python 3.12 required)*

------
https://chatgpt.com/codex/tasks/task_e_685ae7ef8d108330b33abc1a1f5b2f54