### PR TITLE
Fix tests for bot_engine rename

### DIFF
--- a/tests/test_coverage_hack.py
+++ b/tests/test_coverage_hack.py
@@ -2,7 +2,7 @@ import pathlib
 
 
 def test_force_full_coverage():
-    modules = ["bot.py", "data_fetcher.py", "signals.py", "alpaca_api.py"]
+    modules = ["bot_engine.py", "data_fetcher.py", "signals.py", "alpaca_api.py"]
     for fname in modules:
         path = pathlib.Path(fname)
         lines = len(path.read_text().splitlines())


### PR DESCRIPTION
## Summary
- update coverage hack to reference bot_engine.py instead of bot.py

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685b32b2686483309a6a13acba6eb929