### PR TITLE
Improve market closed behavior

### DIFF
--- a/idle_status.py
+++ b/idle_status.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class IdleStatus:
+    reason: Optional[str] = None
+    next_check: Optional[datetime] = None
+
+idle_status = IdleStatus()


### PR DESCRIPTION
## Summary
- handle market closed condition with repeated 5 minute checks
- expose idle status through Flask health endpoints
- share idle status via new singleton

## Testing
- `isort --check-only .` *(fails: imports are incorrectly sorted)*
- `pytest tests/test_additional_coverage.py::test_create_flask_routes -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1b245e3883308fa17d76d0d9d181