### PR TITLE
Fix ImportError for TransformerMixin

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -43,9 +43,26 @@ else:
 
     base = ModuleType("sklearn.base")
 
-    class BaseEstimator: ...
+    class BaseEstimator:
+        """Minimal stand-in for :class:`sklearn.base.BaseEstimator`."""
+
+        def get_params(self, deep: bool = True):
+            return {}
+
+        def set_params(self, **params):
+            return self
+
+    class TransformerMixin:
+        """Lightweight version of :class:`sklearn.base.TransformerMixin`."""
+
+        def fit(self, X, y=None):
+            return self
+
+        def transform(self, X):
+            return X
 
     base.BaseEstimator = BaseEstimator
+    base.TransformerMixin = TransformerMixin
     base.clone = lambda est: est
 
     linear_model = ModuleType("sklearn.linear_model")


### PR DESCRIPTION
## Summary
- expand sklearn stub to include `TransformerMixin`

## Testing
- `./run_checks.sh` *(fails: download heavy packages)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685c364cc324833081a4e074d1b3544f