### PR TITLE
Improve health check logs

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -20,19 +20,21 @@ class DummyCtx:
         self.api = DummyAPI()
 
 
-def test_health_check_empty_dataframe_raises():
+def test_health_check_empty_dataframe_raises(monkeypatch):
+    monkeypatch.setenv("HEALTH_MIN_ROWS", "30")
     ctx = DummyCtx(pd.DataFrame())
     with pytest.raises(RuntimeError):
         pre_trade_health_check(ctx, ["AAA"])
 
 
-def test_health_check_succeeds():
+def test_health_check_succeeds(monkeypatch):
+    monkeypatch.setenv("HEALTH_MIN_ROWS", "30")
     df = pd.DataFrame({
-        "open": [1]*30,
-        "high": [1]*30,
-        "low": [1]*30,
-        "close": [1]*30,
-        "volume": [1]*30,
+        "open": [1] * 30,
+        "high": [1] * 30,
+        "low": [1] * 30,
+        "close": [1] * 30,
+        "volume": [1] * 30,
     })
     ctx = DummyCtx(df)
     pre_trade_health_check(ctx, ["AAA"])


### PR DESCRIPTION
## Summary
- add `HEALTH_MIN_ROWS` env var with default 100
- improve health_check logging and add DF preview
- update pre_trade_health_check with new logging and variable
- adjust unit test to set env var

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `bash run_checks.sh` *(failed to complete due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685c40b4d2b083308a919f026eff469b