### PR TITLE
Improve health check diagnostics

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -2114,15 +2114,12 @@ def pre_trade_health_check(
                     rows,
                     min_rows,
                 )
-                logger.debug(
-                    "Shape: %s | Columns: %s",
-                    df.shape,
-                    df.columns.tolist(),
-                )
+                logger.debug("Shape: %s", df.shape)
+                logger.debug("Columns: %s", df.columns.tolist())
                 logger.debug("Preview:\n%s", df.head(3))
                 if rows == 0:
                     logger.critical(
-                        "HEALTH_FAILURE: empty DataFrame received",
+                        "HEALTH_FAILURE: empty dataset loaded",
                         extra={"symbol": sym},
                     )
                 summary["insufficient_rows"].append(sym)

--- a/utils.py
+++ b/utils.py
@@ -227,10 +227,11 @@ def health_check(df: pd.DataFrame | None, resolution: str) -> bool:
             rows,
             min_rows,
         )
-        logger.debug("Shape: %s | Columns: %s", df.shape, df.columns.tolist())
+        logger.debug("Shape: %s", df.shape)
+        logger.debug("Columns: %s", df.columns.tolist())
         logger.debug("Preview:\n%s", df.head(3))
         if rows == 0:
-            logger.critical("HEALTH_FAILURE: empty DataFrame received")
+            logger.critical("HEALTH_FAILURE: empty dataset loaded")
         return False
 
     logger.info("HEALTH_ROW_CHECK_PASSED: received %d rows", rows)


### PR DESCRIPTION
## Summary
- log detailed diagnostics when dataset rows are insufficient
- use `HEALTH_MIN_ROWS` env var and warn if empty dataset loaded

## Testing
- `pytest tests/test_health.py -q` *(fails: ModuleNotFoundError: No module named 'pandas_market_calendars')*

------
https://chatgpt.com/codex/tasks/task_e_685c4946d2dc8330a1c7f141c1b68616