### PR TITLE
Fix timezone-aware index comparison

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -2158,7 +2158,7 @@ def pre_trade_health_check(
             df.index = pd.to_datetime(df.index, errors="coerce")
         if getattr(df.index, "tz", None) is None:
             log_warning("HEALTH_TZ_MISSING", extra={"symbol": sym})
-            df.index = pd.to_datetime(df.index).tz_localize("UTC")
+            df.index = pd.to_datetime(df.index, utc=True).tz_localize(None)
             summary["timezone_issues"].append(sym)
         else:
             df.index = df.index.tz_convert("UTC").tz_localize(None)


### PR DESCRIPTION
## Summary
- ensure startup health check uses consistent timezone handling to avoid tz-aware/naive comparison errors

## Testing
- `./run_checks.sh` *(fails: imports not sorted)*

------
https://chatgpt.com/codex/tasks/task_e_685c4f3e00cc83309e5fc6d0a0c0582a