### PR TITLE
Fix timezone in market hours check

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -5509,7 +5509,7 @@ def main() -> None:
 
         # --- Market hours check ---
 
-        now_utc = pd.Timestamp.utcnow()
+        now_utc = pd.Timestamp.utcnow().tz_localize("UTC")
         if is_holiday(now_utc):
             logger.warning(
                 f"No NYSE market schedule for {now_utc.date()}; skipping market open/close check."


### PR DESCRIPTION
## Summary
- fix tz-naive vs. tz-aware error on startup by localizing timestamp to UTC before market open check

## Testing
- `./run_checks.sh` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_685c51899fe88330b044eacc87456185