### PR TITLE
Fix UTC timestamp localization error

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -5509,7 +5509,10 @@ def main() -> None:
 
         # --- Market hours check ---
 
-        now_utc = pd.Timestamp.utcnow().tz_localize("UTC")
+        # pd.Timestamp.utcnow() already returns a timezone-aware UTC timestamp,
+        # so calling tz_localize("UTC") would raise an error. Simply use the
+        # timestamp directly to avoid "Cannot localize tz-aware Timestamp".
+        now_utc = pd.Timestamp.utcnow()
         if is_holiday(now_utc):
             logger.warning(
                 f"No NYSE market schedule for {now_utc.date()}; skipping market open/close check."


### PR DESCRIPTION
## Summary
- avoid localizing an already timezone-aware `pd.Timestamp` in `bot_engine`

## Testing
- `run_checks.sh` *(fails: environment missing heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c54446c688330b3adcdea44a5569c