### PR TITLE
Fix Hypothesis compatibility by replacing SimpleNamespace mocks

### DIFF
--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -220,7 +220,9 @@ def test_risk_engine_branches(monkeypatch):
 
 def test_runner_main_loop(monkeypatch):
     """Runner exits on SystemExit 0 from bot.main."""
-    sys.modules['bot'] = types.SimpleNamespace(main=lambda: (_ for _ in ()).throw(SystemExit(0)))
+    bot_mod = types.ModuleType('bot')
+    bot_mod.main = lambda: (_ for _ in ()).throw(SystemExit(0))
+    sys.modules['bot'] = bot_mod
     module = runpy.run_module("runner", run_name="__main__")
 
 

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -10,7 +10,9 @@ os.environ.setdefault("ALPACA_API_KEY", "dummy")
 os.environ.setdefault("ALPACA_SECRET_KEY", "dummy")
 
 # stub missing deps
-sys.modules.setdefault("requests", types.SimpleNamespace(post=lambda *a, **k: None))
+req_mod = types.ModuleType("requests")
+req_mod.post = lambda *a, **k: None
+sys.modules.setdefault("requests", req_mod)
 for _m in ["dotenv"]:
     mod = types.ModuleType(_m)
     if _m == "dotenv":


### PR DESCRIPTION
## Summary
- replace `SimpleNamespace` module mocks with `ModuleType`
- update tests to use new mocks

## Testing
- `pytest tests/test_property_based.py --hypothesis-seed=35177355968241738207467288160334516358`

------
https://chatgpt.com/codex/tasks/task_e_685ca3788c848330a18d14ada5bbdb2d