### PR TITLE
Refactor backtest into modular backtester package

### DIFF
--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -8,15 +8,11 @@ import time
 from collections import defaultdict
 from typing import Any, Dict, Optional
 
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
-
 import pandas as pd
 import requests
+from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
+                      wait_exponential)
+
 from alerts import send_slack_alert
 
 logger = logging.getLogger(__name__)

--- a/audit.py
+++ b/audit.py
@@ -3,6 +3,7 @@ import logging
 import os
 import uuid
 from datetime import datetime, timezone
+
 from validate_env import settings
 
 TRADE_LOG_FILE = settings.TRADE_LOG_FILE

--- a/backtester/__init__.py
+++ b/backtester/__init__.py
@@ -1,0 +1,17 @@
+"""Backtester package exposing main interfaces."""
+
+from .core import BacktestResult, load_price_data, run_backtest
+from .grid_runner import optimize_hyperparams, run_grid_search
+from .logger import MetricsLogger
+from .plot import plot_drawdown, plot_equity_curve
+
+__all__ = [
+    "BacktestResult",
+    "run_backtest",
+    "load_price_data",
+    "run_grid_search",
+    "optimize_hyperparams",
+    "MetricsLogger",
+    "plot_equity_curve",
+    "plot_drawdown",
+]

--- a/backtester/config.py
+++ b/backtester/config.py
@@ -1,0 +1,6 @@
+"""Configuration constants for the backtesting framework."""
+
+DEFAULT_FEES = 0.0
+DEFAULT_SLIPPAGE = 0.001
+TRADING_DAYS_PER_YEAR = 252
+CACHE_DIR = "backtest_cache"

--- a/backtester/core.py
+++ b/backtester/core.py
@@ -1,0 +1,152 @@
+"""Core backtesting logic and utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+from alpaca.common.exceptions import APIError
+from tenacity import RetryError
+
+from data_fetcher import DataFetchError, get_historical_data
+
+from .config import CACHE_DIR, DEFAULT_SLIPPAGE, TRADING_DAYS_PER_YEAR
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BacktestResult:
+    """Container for backtest results."""
+
+    equity: pd.Series
+    cumulative_return: float
+    sharpe_ratio: float
+    max_drawdown: float
+
+    @property
+    def net_pnl(self) -> float:
+        if self.equity.empty:
+            return 0.0
+        return float(self.equity.iloc[-1] - self.equity.iloc[0])
+
+    def to_dict(self) -> dict:
+        return {
+            "cumulative_return": self.cumulative_return,
+            "sharpe_ratio": self.sharpe_ratio,
+            "max_drawdown": self.max_drawdown,
+            "net_pnl": self.net_pnl,
+        }
+
+
+def load_price_data(symbol: str, start: str, end: str) -> pd.DataFrame:
+    """Load or fetch daily data for ``symbol`` between ``start`` and ``end``."""
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    cache_fname = os.path.join(CACHE_DIR, f"cache_{symbol}_{start}_{end}.csv")
+    if os.path.exists(cache_fname):
+        try:
+            return pd.read_csv(cache_fname, index_col=0, parse_dates=True)
+        except (OSError, pd.errors.ParserError, ValueError):
+            try:
+                os.remove(cache_fname)
+            except OSError:
+                pass
+
+    df_final = pd.DataFrame()
+    for attempt in range(1, 4):
+        try:
+            df_final = get_historical_data(
+                symbol,
+                datetime.fromisoformat(start).date(),
+                datetime.fromisoformat(end).date(),
+                "1Day",
+            )
+            break
+        except (APIError, DataFetchError, RetryError) as exc:
+            if attempt < 3:
+                logger.warning(
+                    "Failed to fetch %s (attempt %s/3): %s – sleeping 2s",
+                    symbol,
+                    attempt,
+                    exc,
+                )
+                time.sleep(2)
+            else:
+                logger.error("Final attempt failed for %s", symbol)
+    try:
+        df_final.to_csv(cache_fname)
+    except OSError:
+        pass
+    time.sleep(1)
+    return df_final
+
+
+def run_backtest(
+    symbols: list[str],
+    start: str,
+    end: str,
+    params: dict[str, float],
+) -> BacktestResult:
+    """Execute a simple backtest over daily bars."""
+    data: dict[str, pd.DataFrame] = {}
+    for sym in symbols:
+        df_sym = load_price_data(sym, start, end)
+        if not df_sym.empty:
+            df_sym["ret"] = df_sym["Close"].pct_change(fill_method=None).fillna(0)
+        data[sym] = df_sym
+
+    cash = 100000.0
+    positions = {s: 0 for s in symbols}
+    entry_price = {s: 0.0 for s in symbols}
+    peak_price = {s: 0.0 for s in symbols}
+    portfolio: list[float] = []
+
+    dates = pd.date_range(start, end, freq="B")
+    for d in dates:
+        for sym, df in data.items():
+            if d not in df.index:
+                continue
+            price = df.loc[d, "Open"]
+            ret = df.loc[d, "ret"]
+            if positions[sym] == 0:
+                if (not np.isnan(ret)) and ret > params["BUY_THRESHOLD"] and cash > 0:
+                    qty = int((cash * params["SCALING_FACTOR"]) / price)
+                    if qty > 0:
+                        cost = qty * price * (1 + params.get("LIMIT_ORDER_SLIPPAGE", DEFAULT_SLIPPAGE))
+                        cash -= cost
+                        positions[sym] += qty
+                        entry_price[sym] = price
+                        peak_price[sym] = price
+            else:
+                peak_price[sym] = max(peak_price[sym], price)
+                drawdown = (price - peak_price[sym]) / peak_price[sym]
+                gain = (price - entry_price[sym]) / entry_price[sym]
+                if gain >= params["TAKE_PROFIT_FACTOR"] or abs(drawdown) >= params["TRAILING_FACTOR"]:
+                    cash += positions[sym] * price * (1 - params.get("LIMIT_ORDER_SLIPPAGE", DEFAULT_SLIPPAGE))
+                    positions[sym] = 0
+                    entry_price[sym] = 0
+                    peak_price[sym] = 0
+        total_value = cash
+        for sym, df in data.items():
+            if d in df.index:
+                total_value += positions[sym] * df.loc[d, "Close"]
+        portfolio.append(total_value)
+
+    equity = pd.Series(portfolio, index=dates)
+    if equity.empty:
+        return BacktestResult(equity, 0.0, float("nan"), 0.0)
+
+    pct = equity.pct_change(fill_method=None).dropna()
+    if pct.empty or pct.std() == 0:
+        sharpe = float("nan")
+    else:
+        sharpe = (pct.mean() / pct.std()) * np.sqrt(TRADING_DAYS_PER_YEAR)
+
+    cumulative_return = equity.iloc[-1] / equity.iloc[0] - 1
+    drawdown = ((equity / equity.cummax()) - 1).min()
+    return BacktestResult(equity, float(cumulative_return), float(sharpe), abs(float(drawdown)))

--- a/backtester/grid_runner.py
+++ b/backtester/grid_runner.py
@@ -1,0 +1,70 @@
+"""Utilities for running parameter grid searches in parallel.
+
+Example:
+    >>> param_list = [{"BUY_THRESHOLD": 0.2}, {"BUY_THRESHOLD": 0.3}]
+    >>> run_grid_search(param_list, ["AAPL"], "2024-01-01", "2024-02-01")
+"""
+
+from __future__ import annotations
+
+import logging
+from itertools import product
+from multiprocessing import Pool, cpu_count
+from typing import Any, Iterable
+
+from .core import BacktestResult, run_backtest
+
+logger = logging.getLogger(__name__)
+
+
+def _run(params_symbols_start_end: tuple[dict[str, float], list[str], str, str]):
+    params, symbols, start, end = params_symbols_start_end
+    res = run_backtest(symbols, start, end, params)
+    return params, res
+
+
+def run_grid_search(
+    param_list: Iterable[dict[str, float]],
+    symbols: list[str],
+    start: str,
+    end: str,
+    metric: str = "sharpe_ratio",
+    top_n: int = 3,
+) -> list[tuple[dict[str, float], BacktestResult]]:
+    """Run a grid search over ``param_list`` in parallel."""
+    tasks = [(p, symbols, start, end) for p in param_list]
+    workers = min(len(tasks), cpu_count() or 1)
+    with Pool(processes=workers) as pool:
+        results = pool.map(_run, tasks)
+
+    sort_key = {
+        "sharpe_ratio": lambda pr: pr[1].sharpe_ratio,
+        "cumulative_return": lambda pr: pr[1].cumulative_return,
+        "net_pnl": lambda pr: pr[1].net_pnl,
+    }.get(metric, lambda pr: pr[1].sharpe_ratio)
+    ranked = sorted(results, key=sort_key, reverse=True)
+    return ranked[:top_n]
+
+
+def optimize_hyperparams(
+    symbols: list[str],
+    backtest_data: dict[str, Any],
+    param_grid: dict[str, Iterable[float]],
+    metric: str = "sharpe_ratio",
+) -> dict[str, float]:
+    """Grid search returning the best parameter set by ``metric``."""
+    keys = list(param_grid.keys())
+    combos = [dict(zip(keys, vals)) for vals in product(*param_grid.values())]
+    ranked = run_grid_search(combos, symbols, backtest_data["start"], backtest_data["end"], metric=metric, top_n=1)
+    if ranked:
+        best_params, best_res = ranked[0]
+        logger.info(
+            "Selected config with %s=%.4f", metric, getattr(best_res, metric, float("nan"))
+        )
+        return best_params
+    logger.warning("No results returned from grid search")
+    return {}
+
+
+__all__ = ["run_grid_search", "optimize_hyperparams"]
+

--- a/backtester/logger.py
+++ b/backtester/logger.py
@@ -1,0 +1,50 @@
+"""Metric logging utilities for backtests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+import pandas as pd
+
+
+class MetricsLogger:
+    """Collects metrics from backtest runs and writes them to disk."""
+
+    def __init__(self, path: str | None = None) -> None:
+        self.path = path
+        self.records: list[Dict[str, Any]] = []
+        self.logger = logging.getLogger(__name__)
+
+    def log_run(self, params: Dict[str, Any], result) -> None:
+        """Record a run's parameters and resulting metrics."""
+        cfg_hash = hashlib.md5(json.dumps(params, sort_keys=True).encode()).hexdigest()
+        rec = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "params": params,
+            "config_hash": cfg_hash,
+            "cumulative_return": result.cumulative_return,
+            "sharpe_ratio": result.sharpe_ratio,
+            "max_drawdown": result.max_drawdown,
+        }
+        self.records.append(rec)
+        self.logger.info(
+            "Run %s CR=%.4f Sharpe=%.4f DD=%.4f",
+            cfg_hash,
+            rec["cumulative_return"],
+            rec["sharpe_ratio"],
+            rec["max_drawdown"],
+        )
+
+    def flush(self) -> None:
+        """Write accumulated records to ``self.path`` if provided."""
+        if not self.path:
+            return
+        if self.path.endswith(".json"):
+            with open(self.path, "w", encoding="utf-8") as f:
+                json.dump(self.records, f, indent=2)
+        else:
+            pd.DataFrame(self.records).to_csv(self.path, index=False)

--- a/backtester/plot.py
+++ b/backtester/plot.py
@@ -1,0 +1,34 @@
+"""Plotting helpers for backtest results."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def plot_equity_curve(equity: pd.Series, output_path: str | None = None):
+    """Plot the equity curve and optionally save to ``output_path``."""
+    fig, ax = plt.subplots()
+    equity.plot(ax=ax)
+    ax.set_title("Equity Curve")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Equity")
+    fig.tight_layout()
+    if output_path:
+        fig.savefig(output_path)
+    return fig
+
+
+def plot_drawdown(equity: pd.Series, output_path: str | None = None):
+    """Plot the drawdown curve."""
+    cummax = equity.cummax()
+    drawdown = (equity - cummax) / cummax
+    fig, ax = plt.subplots()
+    drawdown.plot(ax=ax)
+    ax.set_title("Drawdown")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Drawdown")
+    fig.tight_layout()
+    if output_path:
+        fig.savefig(output_path)
+    return fig

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from dotenv import load_dotenv
+
 from validate_env import settings as env_settings
 
 logger = logging.getLogger(__name__)

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -1,14 +1,13 @@
 import logging
 import random
+import sys
 import threading
 import time as pytime
+import types
 import warnings
 from collections import deque
 from datetime import date, datetime, timedelta, timezone
 from typing import Optional, Sequence
-import types
-
-import sys
 
 # Do not hard fail when running under older Python versions in tests
 if sys.version_info < (3, 12, 3):  # pragma: no cover - compat check
@@ -55,6 +54,7 @@ MINUTES_REQUIRED = 31
 HISTORICAL_START = "2025-06-01"
 HISTORICAL_END = "2025-06-06"
 import logging
+
 warnings.filterwarnings("ignore", category=FutureWarning)
 
 try:
@@ -62,6 +62,7 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     finnhub = types.SimpleNamespace(Client=lambda *a, **k: None)
 import pandas as pd
+
 try:
     from alpaca.common.exceptions import APIError
     from alpaca.data.requests import StockBarsRequest

--- a/logger_rotator.py
+++ b/logger_rotator.py
@@ -1,5 +1,6 @@
 """Utility wrapper exposing logger.get_rotating_handler for tests."""
 from logging import Handler
+
 from logger import get_rotating_handler
 
 __all__ = ["get_rotating_handler"]

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 """Alias to run module for backward compatibility."""
 import importlib
+
 import run as _run
+
 _run = importlib.reload(_run)
 
 create_flask_app = _run.create_flask_app

--- a/meta_learning.py
+++ b/meta_learning.py
@@ -1,15 +1,15 @@
 """Utility helpers for meta-learning weight management."""
 
 import json
+import logging
 import pickle
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional, Dict
+from typing import Any, Dict, Optional
 
 import numpy as np
 import pandas as pd
 
-import logging
 logger = logging.getLogger(__name__)
 
 

--- a/ml_model.py
+++ b/ml_model.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import io
+import logging
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Sequence
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,10 +1,10 @@
 import numpy as np
+
+import config
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.linear_model import SGDRegressor
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
-
-import config
 
 
 class FeatureBuilder(BaseEstimator, TransformerMixin):

--- a/rebalancer.py
+++ b/rebalancer.py
@@ -1,12 +1,12 @@
 """Portfolio rebalancing utilities."""
 
 import logging
-from datetime import datetime, timedelta, timezone
-import time
-
-from alerts import send_slack_alert
-import config
 import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+import config
+from alerts import send_slack_alert
 
 logger = logging.getLogger(__name__)
 

--- a/retrain.py
+++ b/retrain.py
@@ -29,13 +29,13 @@ except ImportError:
     pass
 from datetime import date, datetime, time, timedelta, timezone
 
+import pandas_ta as ta
 import requests
 from lightgbm import LGBMClassifier
+
 from sklearn.model_selection import ParameterSampler, cross_val_score
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import StandardScaler
-
-import pandas_ta as ta
 
 try:
     import optuna

--- a/run.py
+++ b/run.py
@@ -8,13 +8,12 @@ import threading
 from typing import Any
 
 from alpaca_trade_api.rest import APIError  # noqa: F401
-
 from dotenv import load_dotenv
 from flask import Flask, jsonify
-from logger import setup_logging
 
 import config
 from alerting import send_slack_alert
+from logger import setup_logging
 
 
 def create_flask_app() -> Flask:

--- a/server.py
+++ b/server.py
@@ -8,10 +8,9 @@ import threading
 import traceback
 from typing import Any
 
-from pydantic import BaseModel, ValidationError
-
 from dotenv import load_dotenv
 from flask import Flask, abort, jsonify, request
+from pydantic import BaseModel, ValidationError
 
 from alerting import send_slack_alert
 from validate_env import settings
@@ -20,6 +19,7 @@ from validate_env import settings
 load_dotenv(dotenv_path=".env", override=True)
 
 import config
+
 
 # Configure Flask and root logger to integrate with Gunicorn's error logger
 def configure_logging(flask_app: Flask) -> None:

--- a/signals.py
+++ b/signals.py
@@ -1,13 +1,14 @@
 """Simple signal generation module for tests."""
 
 import importlib
+import logging
 import time
 from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
 import requests
-import logging
+
 logger = logging.getLogger(__name__)
 def load_module(name: str) -> Any:
     """Dynamically import a module using :mod:`importlib`."""

--- a/slippage.py
+++ b/slippage.py
@@ -1,4 +1,5 @@
 import logging
+
 from alerts import send_slack_alert
 from validate_env import settings
 

--- a/strategy_allocator.py
+++ b/strategy_allocator.py
@@ -3,6 +3,7 @@ import math
 from typing import Dict, List
 
 from strategies import TradeSignal
+
 logger = logging.getLogger(__name__)
 logger.debug("=== STRATEGY_ALLOCATOR LOADED === %s", __file__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
-from pathlib import Path
-import sys
-from dotenv import load_dotenv
 import os
+import sys
+from pathlib import Path
+
 import pytest
 import urllib3
+from dotenv import load_dotenv
+
 
 def pytest_configure() -> None:
     """Load environment variables for tests."""

--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -1,25 +1,25 @@
-import importlib
-import runpy
-import types
 import builtins
+import importlib
 import logging
-import sys
-from datetime import datetime
+import runpy
 import signal
+import sys
+import types
+from datetime import datetime
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
 
 import alerts
 import config
-import run as main
 import meta_learning
 import ml_model
 import risk_engine
-from strategies.mean_reversion import MeanReversionStrategy
+import run as main
 import utils
 import validate_env
+from strategies.mean_reversion import MeanReversionStrategy
 
 
 def test_alert_no_webhook(monkeypatch):

--- a/tests/test_alerting_new.py
+++ b/tests/test_alerting_new.py
@@ -1,5 +1,5 @@
-import types
 import sys
+import types
 from pathlib import Path
 
 import pytest

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,8 +2,8 @@ import sys
 import types
 from pathlib import Path
 
-import pytest
 import pandas as pd
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 

--- a/tests/test_data_fetcher_datetime.py
+++ b/tests/test_data_fetcher_datetime.py
@@ -1,9 +1,8 @@
 import sys
 from datetime import datetime, timezone
-
-import pandas as pd
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_fetch_and_screen.py
+++ b/tests/test_fetch_and_screen.py
@@ -1,7 +1,9 @@
+import datetime as dt
 import sys
 import types
-import datetime as dt
+
 import pandas as pd
+
 import data_fetcher
 from utils import health_check
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,8 +1,10 @@
 import types
+
 import pandas as pd
 import pytest
 
 from bot_engine import pre_trade_health_check
+
 
 class DummyFetcher:
     def __init__(self, df):

--- a/tests/test_logger_rotator_smoke.py
+++ b/tests/test_logger_rotator_smoke.py
@@ -1,6 +1,6 @@
+import logging
 from pathlib import Path
 
-import logging
 import pytest
 
 import logger_rotator

--- a/tests/test_main_extended2.py
+++ b/tests/test_main_extended2.py
@@ -1,6 +1,6 @@
 import logging
-import types
 import sys
+import types
 
 import pytest
 

--- a/tests/test_main_smoke.py
+++ b/tests/test_main_smoke.py
@@ -25,6 +25,7 @@ os.environ.setdefault("ALPACA_SECRET_KEY", "x")
 
 sys.modules.pop("config", None)
 import config
+
 importlib.reload(config)
 
 sys.modules.pop("run", None)

--- a/tests/test_mean_reversion_extra.py
+++ b/tests/test_mean_reversion_extra.py
@@ -1,4 +1,5 @@
 import pandas as pd
+
 from strategies.mean_reversion import MeanReversionStrategy
 
 

--- a/tests/test_meta_learning_additional.py
+++ b/tests/test_meta_learning_additional.py
@@ -1,11 +1,12 @@
 import json
-from pathlib import Path
-import numpy as np
-import types
-import sklearn.linear_model
 import sys
+import types
+from pathlib import Path
+
+import numpy as np
 
 import meta_learning
+import sklearn.linear_model
 
 
 def test_load_weights_save_fail(monkeypatch, tmp_path, caplog):

--- a/tests/test_momentum_extra.py
+++ b/tests/test_momentum_extra.py
@@ -1,4 +1,5 @@
 import pandas as pd
+
 from strategies import momentum
 from strategies.momentum import MomentumStrategy
 

--- a/tests/test_moving_average_crossover_extra.py
+++ b/tests/test_moving_average_crossover_extra.py
@@ -1,6 +1,7 @@
 """Tests for moving average crossover strategy."""
 
 import pandas as pd
+
 from strategies.moving_average_crossover import MovingAverageCrossoverStrategy
 
 

--- a/tests/test_property_based.py
+++ b/tests/test_property_based.py
@@ -1,14 +1,16 @@
 import sys
 from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
-from hypothesis import given, strategies as st, settings, HealthCheck
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 
 # Ensure project root is on path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-import signals
 import risk_engine
+import signals
 import utils
 
 

--- a/tests/test_runner_additional.py
+++ b/tests/test_runner_additional.py
@@ -1,5 +1,6 @@
 import importlib
 import types
+
 import pytest
 import requests
 

--- a/tests/test_server_smoke.py
+++ b/tests/test_server_smoke.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+
 class _DummyFlask:
     def __init__(self, *a, **k):
         pass

--- a/tests/test_server_validation_payload.py
+++ b/tests/test_server_validation_payload.py
@@ -1,4 +1,5 @@
 import pytest
+
 from server import WebhookPayload
 
 
@@ -24,7 +25,8 @@ def test_hook_invalid_symbol(monkeypatch):
     monkeypatch.setenv("WEBHOOK_SECRET", "x")
     monkeypatch.setenv("ALPACA_API_KEY", "k")
     monkeypatch.setenv("ALPACA_SECRET_KEY", "s")
-    import importlib, sys
+    import importlib
+    import sys
     sys.modules.pop("server", None)
     import server
     importlib.reload(server)

--- a/tests/test_strategies_module.py
+++ b/tests/test_strategies_module.py
@@ -12,12 +12,8 @@ for m in [
 ]:
     sys.modules.pop(m, None)
 
-from strategies import (
-    MeanReversionStrategy,
-    MomentumStrategy,
-    MovingAverageCrossoverStrategy,
-    asset_class_for,
-)
+from strategies import (MeanReversionStrategy, MomentumStrategy,
+                        MovingAverageCrossoverStrategy, asset_class_for)
 
 
 class DummyFetcher:

--- a/tests/test_utils_more.py
+++ b/tests/test_utils_more.py
@@ -1,9 +1,10 @@
-import types
-import sys
-from types import MappingProxyType
-from datetime import datetime, timezone
-import pandas as pd
 import socket
+import sys
+import types
+from datetime import datetime, timezone
+from types import MappingProxyType
+
+import pandas as pd
 import pytest
 
 import utils

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -11,16 +11,10 @@ import warnings
 from datetime import datetime, timezone
 from typing import Any, Optional, Tuple
 
-import pandas as pd
-
 import numpy as np
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-    wait_random,
-)
+import pandas as pd
+from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
+                      wait_exponential, wait_random)
 
 # Updated Alpaca SDK imports
 try:

--- a/validate_env.py
+++ b/validate_env.py
@@ -1,6 +1,7 @@
 """Environment validation using pydantic-settings."""
 
 import logging
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- split backtester logic into a package with core modules
- expose grid search helpers and plotting utilities
- keep backward-compatible wrapper in `backtest.py`
- reorder imports repository-wide via isort

## Testing
- `flake8`
- `isort --check-only .`
- `pylint $(git ls-files '*.py' | grep -v '^tests/' | tr '\n' ' ')`
- `pytest --cov=.`

------
https://chatgpt.com/codex/tasks/task_e_685cbd4fd40c8330b758833aebe0dc18