### PR TITLE
Improve test stability and slow test management

### DIFF
--- a/tests/alias/test_main_alias.py
+++ b/tests/alias/test_main_alias.py
@@ -1,3 +1,4 @@
+# This test modifies sys.modules and should be run serially. Use: pytest -n0 tests/alias/test_main_alias.py
 import importlib
 import runpy
 import types
@@ -14,11 +15,15 @@ def test_main_aliases(monkeypatch):
     run_mod.main = lambda: "main"
     run_mod.__spec__ = importlib.util.spec_from_loader("run", loader=None)
     monkeypatch.setitem(sys.modules, "run", run_mod)
-    monkeypatch.setattr(importlib, "reload", lambda mod: mod)
-    import main as main_mod
-    main_mod = reload_module(main_mod)
-    assert main_mod.create_flask_app() == "app"
-    assert main_mod.main() == "main"
+    original_reload = importlib.reload
+    importlib.reload = lambda mod: mod
+    try:
+        import main as main_mod
+        main_mod = reload_module(main_mod)
+        assert main_mod.create_flask_app() == "app"
+        assert main_mod.main() == "main"
+    finally:
+        importlib.reload = original_reload
 
 
 def test_main_executes_run(monkeypatch):
@@ -31,6 +36,10 @@ def test_main_executes_run(monkeypatch):
     run_mod.validate_environment = lambda: None
     run_mod.__spec__ = importlib.util.spec_from_loader("run", loader=None)
     monkeypatch.setitem(sys.modules, "run", run_mod)
-    monkeypatch.setattr(importlib, "reload", lambda mod: mod)
-    runpy.run_module("main", run_name="__main__")
+    original_reload = importlib.reload
+    importlib.reload = lambda mod: mod
+    try:
+        runpy.run_module("main", run_name="__main__")
+    finally:
+        importlib.reload = original_reload
     assert called == [True]

--- a/tests/slow/conftest.py
+++ b/tests/slow/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--runslow", action="store_true", help="Run slow tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)


### PR DESCRIPTION
## Summary
- tag heavy meta-learning tests as slow via a new plugin
- move main alias tests to an isolated folder
- harden RotatingFileHandler fallback test

## Testing
- `pytest -q tests/alias/test_main_alias.py -vv`
- `pytest -q tests/test_logger.py::test_get_rotating_handler_fallback -vv`
- `pytest -q tests/slow/test_meta_learning_heavy.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_685d683763ac8330a769352cd9ad5949