### PR TITLE
Fix timezone comparison in health check

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -2158,10 +2158,10 @@ def pre_trade_health_check(
             df.index = pd.to_datetime(df.index, errors="coerce")
         if getattr(df.index, "tz", None) is None:
             log_warning("HEALTH_TZ_MISSING", extra={"symbol": sym})
-            df.index = pd.to_datetime(df.index, utc=True).tz_localize(None)
+            df.index = pd.to_datetime(df.index, utc=True)
             summary["timezone_issues"].append(sym)
         else:
-            df.index = df.index.tz_convert("UTC").tz_localize(None)
+            df.index = df.index.tz_convert("UTC")
 
         # Require data to be recent
         if not orig_range:

--- a/tests/slow/test_meta_learning_heavy.py
+++ b/tests/slow/test_meta_learning_heavy.py
@@ -1,9 +1,11 @@
 import io
 import types
+
 import pandas as pd
 import pytest
-import sklearn.linear_model
+
 import meta_learning
+import sklearn.linear_model
 
 
 @pytest.mark.slow

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,8 +1,10 @@
 import importlib
 import logging
+
 import pytest
-import logger
 from conftest import reload_module
+
+import logger
 
 
 def test_get_rotating_handler_fallback(monkeypatch, tmp_path, caplog):

--- a/tests/test_main_alias.py
+++ b/tests/test_main_alias.py
@@ -1,7 +1,8 @@
 import importlib
 import runpy
-import types
 import sys
+import types
+
 from conftest import reload_module
 
 

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -1,10 +1,12 @@
 import pickle
 import types
+
 import numpy as np
 import pandas as pd
 import pytest
-import sklearn.linear_model
+
 import meta_learning
+import sklearn.linear_model
 
 
 def test_load_weights_creates_default(tmp_path):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,8 +1,9 @@
-import types
 import runpy
 import sys
-import requests
+import types
+
 import pytest
+import requests
 from conftest import load_runner
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,13 @@
 import os
 import socket
 import types
-from datetime import datetime, date, timezone
+from datetime import date, datetime, timezone
 
 import numpy as np
 import pandas as pd
 import pytest
-import utils
 
+import utils
 
 # Basic utils behaviour
 


### PR DESCRIPTION
## Summary
- ensure timezone aware index handling in `pre_trade_health_check`
- run isort on test modules

## Testing
- `isort --check-only .`
- `pytest --cov=. (fails: ModuleNotFoundError: No module named 'hypothesis')`


------
https://chatgpt.com/codex/tasks/task_e_685d688772908330a851102064314537