### PR TITLE
Fix tz-aware comparison in health check

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -2155,13 +2155,13 @@ def pre_trade_health_check(
 
         orig_range = isinstance(df.index, pd.RangeIndex)
         if not isinstance(df.index, pd.DatetimeIndex):
-            df.index = pd.to_datetime(df.index, errors="coerce")
+            df.index = pd.to_datetime(df.index, errors="coerce", utc=True)
         if getattr(df.index, "tz", None) is None:
             log_warning("HEALTH_TZ_MISSING", extra={"symbol": sym})
-            df.index = pd.to_datetime(df.index, utc=True).tz_localize(None)
+            df.index = df.index.tz_localize(timezone.utc)
             summary["timezone_issues"].append(sym)
         else:
-            df.index = df.index.tz_convert("UTC").tz_localize(None)
+            df.index = df.index.tz_convert("UTC")
 
         # Require data to be recent
         if not orig_range:


### PR DESCRIPTION
## Summary
- ensure health check timestamps are timezone-aware

## Testing
- `pytest -q` *(fails: Namespace object has no attribute 'runslow')*

------
https://chatgpt.com/codex/tasks/task_e_685d6bac928c8330a9038b4260b9971e