### PR TITLE
Handle missing indicators per symbol

### DIFF
--- a/tests/slow/conftest.py
+++ b/tests/slow/conftest.py
@@ -10,8 +10,12 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        return
+    try:
+        if config.getoption("--runslow"):
+            return
+    except ValueError:
+        # Option not registered when this conftest is loaded
+        pass
     skip_slow = pytest.mark.skip(reason="need --runslow option to run")
     for item in items:
         if "slow" in item.keywords:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,14 @@
 import os
 import socket
+import sys
 import types
-from datetime import datetime, date, timezone
+from datetime import date, datetime, timezone
 
 import numpy as np
 import pandas as pd
 import pytest
-import utils
 
+import utils
 
 # Basic utils behaviour
 


### PR DESCRIPTION
## Summary
- improve `BotContext` dataclass with a logger attribute
- allow `prepare_indicators` to skip symbols with too few indicators
- log indicator issues when computing features
- update feature data fetcher to respect skipped frames
- patch tests to avoid crashes when `--runslow` option is absent
- fix missing import in tests

## Testing
- `flake8 bot_engine.py tests/slow/conftest.py tests/test_utils.py`
- `pylint bot_engine.py tests/slow/conftest.py tests/test_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_685d7b58f56c83308202b36c5f88fa66