### PR TITLE
Improve prepare_indicators docstring

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -4520,7 +4520,14 @@ def _drop_inactive_features(df: pd.DataFrame) -> None:
 
 
 def prepare_indicators(frame, symbol=None, ctx=None):
-    """Validate and clean indicator columns."""
+    """Validate and clean indicator columns.
+
+    Ensures a minimal set of technical indicators are present. If fewer
+    than eight of the required indicators are available the function
+    returns ``None``. When ``stochrsi`` is missing but ``rsi`` exists it
+    is substituted automatically. Rows where all available indicators are
+    NaN are dropped before returning the cleaned DataFrame.
+    """
     required = [
         "rsi",
         "macd",


### PR DESCRIPTION
## Summary
- document how `prepare_indicators` sanitizes missing indicators

## Testing
- `bash run_checks.sh` *(fails: imports incorrectly sorted)*

------
https://chatgpt.com/codex/tasks/task_e_685d9297fc508330a1814d69a888374b