### PR TITLE
Add tests for prepare_indicators edge cases

### DIFF
--- a/tests/test_bot_engine.py
+++ b/tests/test_bot_engine.py
@@ -39,3 +39,43 @@ def test_prepare_indicators_creates_required_columns():
 
     assert isinstance(result, pd.DataFrame)
     assert not result.empty
+
+
+def test_prepare_indicators_insufficient_data():
+    """prepare_indicators should return an empty DataFrame when there is
+    insufficient historical data for rolling calculations."""
+
+    df = pd.DataFrame({
+        'open': np.random.uniform(100, 200, 5),
+        'high': np.random.uniform(100, 200, 5),
+        'low': np.random.uniform(100, 200, 5),
+        'close': np.random.uniform(100, 200, 5),
+        'volume': np.random.randint(1_000_000, 5_000_000, 5),
+    })
+
+    result = prepare_indicators(df.copy())
+
+    assert result.empty or result.shape[0] == 0
+
+
+def test_prepare_indicators_all_nan_columns():
+    """prepare_indicators should drop all rows when input columns are entirely NaN."""
+
+    df = pd.DataFrame({
+        'open': [np.nan] * 30,
+        'high': [np.nan] * 30,
+        'low': [np.nan] * 30,
+        'close': [np.nan] * 30,
+        'volume': [np.nan] * 30,
+    })
+
+    import bot_engine
+
+    original_rsi = bot_engine.ta.rsi
+    bot_engine.ta.rsi = lambda close, length=14: pd.Series([np.nan] * len(close))
+    try:
+        result = prepare_indicators(df.copy())
+    finally:
+        bot_engine.ta.rsi = original_rsi
+
+    assert result.empty or result.shape[0] == 0


### PR DESCRIPTION
## Summary
- extend `tests/test_bot_engine.py` with two edge case tests for `prepare_indicators`
- cover insufficient data and all-NaN input scenarios

## Testing
- `pytest tests/test_bot_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685dabb7d54083309d5c010a4d49639c