### PR TITLE
Add edge tests and profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ pytest --cov
 
 Test coverage should report at least **90%** for a successful run.
 
+To profile coverage for the indicator preparation logic only:
+
+```bash
+pytest --cov=bot_engine --cov-report=term --cov-report=html tests/test_bot_engine*.py
+```
+
+This outputs a terminal summary and an HTML report at `htmlcov/index.html`.
+
 
 ## Systemd Service
 

--- a/scripts/profile_indicators.py
+++ b/scripts/profile_indicators.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3.12
+"""Profile the prepare_indicators function."""
+
+from __future__ import annotations
+
+import cProfile
+import pstats
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from bot_engine import prepare_indicators
+
+
+def generate_dummy_prices(days: int = 365) -> pd.DataFrame:
+    """Generate a dummy OHLCV DataFrame with minute frequency."""
+    minutes = days * 390
+    index = pd.date_range("2023-01-01", periods=minutes, freq="1min")
+    data = {
+        "open": np.random.uniform(100, 200, size=minutes),
+        "high": np.random.uniform(100, 200, size=minutes),
+        "low": np.random.uniform(100, 200, size=minutes),
+        "close": np.random.uniform(100, 200, size=minutes),
+        "volume": np.random.randint(1_000, 10_000, size=minutes),
+    }
+    return pd.DataFrame(data, index=index)
+
+
+def main() -> None:
+    df = generate_dummy_prices()
+    profiler = cProfile.Profile()
+    profiler.enable()
+    prepare_indicators(df.copy())
+    profiler.disable()
+
+    stats = pstats.Stats(profiler).sort_stats("cumtime")
+    logs_dir = Path("logs")
+    logs_dir.mkdir(exist_ok=True)
+    out_file = logs_dir / "prepare_indicators_profile.txt"
+    with out_file.open("w") as f:
+        stats.stream = f
+        stats.print_stats()
+    stats.stream = sys.stdout
+    stats.print_stats(20)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual profiling utility
+    main()

--- a/tests/test_bot_engine.py
+++ b/tests/test_bot_engine.py
@@ -16,7 +16,7 @@ if 'bot_engine' not in sys.modules:
     mod.pd = pd
     mod.np = np
     mod.ta = types.SimpleNamespace(rsi=lambda close, length=14: pd.Series(np.arange(len(close))))
-    exec(compile(ast.Module([func], []), filename='bot_engine_stub', mode='exec'), mod.__dict__)
+    exec(compile(ast.Module([func], []), filename=str(src_path), mode='exec'), mod.__dict__)
     sys.modules['bot_engine'] = mod
 
 from bot_engine import prepare_indicators

--- a/tests/test_bot_engine_edge_cases.py
+++ b/tests/test_bot_engine_edge_cases.py
@@ -1,0 +1,67 @@
+import ast
+import types
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# Build a lightweight bot_engine module exposing only prepare_indicators
+if 'bot_engine' not in sys.modules:
+    src_path = Path(__file__).resolve().parents[1] / 'bot_engine.py'
+    source = src_path.read_text()
+    tree = ast.parse(source)
+    func = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == 'prepare_indicators')
+    mod = types.ModuleType('bot_engine')
+    mod.pd = pd
+    mod.np = np
+    mod.ta = types.SimpleNamespace(
+        rsi=lambda close, length=14: pd.Series(np.arange(len(close)), dtype=float)
+    )
+    exec(compile(ast.Module([func], []), filename=str(src_path), mode='exec'), mod.__dict__)
+    sys.modules['bot_engine'] = mod
+
+from bot_engine import prepare_indicators
+
+
+def test_prepare_indicators_missing_close_column():
+    print('Testing prepare_indicators with missing Close column')
+    df = pd.DataFrame({'open': [1, 2], 'high': [1, 2], 'low': [1, 2]})
+    with pytest.raises(KeyError):
+        prepare_indicators(df)
+
+
+def test_prepare_indicators_non_numeric_close(monkeypatch):
+    print('Testing prepare_indicators with non-numeric Close column')
+    import bot_engine
+
+    def fake_rsi(close, length=14):
+        if not pd.api.types.is_numeric_dtype(close):
+            raise TypeError('close column must be numeric')
+        return pd.Series(np.arange(len(close)), dtype=float)
+
+    monkeypatch.setattr(bot_engine.ta, 'rsi', fake_rsi)
+    df = pd.DataFrame({'open': [1, 2], 'high': [1, 2], 'low': [1, 2], 'close': ['a', 'b']})
+    with pytest.raises(TypeError):
+        prepare_indicators(df)
+
+
+def test_prepare_indicators_empty_dataframe():
+    print('Testing prepare_indicators with empty DataFrame')
+    df = pd.DataFrame()
+    with pytest.raises(KeyError):
+        prepare_indicators(df)
+
+
+def test_prepare_indicators_single_row():
+    print('Testing prepare_indicators with single row DataFrame')
+    df = pd.DataFrame({
+        'open': [100.0],
+        'high': [101.0],
+        'low': [99.0],
+        'close': [100.5],
+        'volume': [1000]
+    })
+    result = prepare_indicators(df.copy())
+    assert result.empty


### PR DESCRIPTION
## Summary
- add coverage command to README
- compile tests with bot_engine path for coverage
- create edge-case tests for `prepare_indicators`
- add a profiling script for indicator performance

## Testing
- `pytest --cov=bot_engine --cov-report=term --cov-report=html tests/test_bot_engine*.py`

------
https://chatgpt.com/codex/tasks/task_e_685dcf6cedc883308784bcd5aadd1306