### PR TITLE
Add column checks and CLI args

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -40,25 +40,27 @@ def main() -> None:
     parser.add_argument(
         "--symbols",
         required=False,
-        default="AAPL,MSFT,SPY",
-        help="Comma separated symbols (default: AAPL,MSFT,SPY)",
+        help="Comma separated symbols",
     )
     parser.add_argument(
         "--start",
         required=False,
-        default=str(default_start),
-        help=f"Backtest start date YYYY-MM-DD (default: {default_start})",
+        help="Backtest start date YYYY-MM-DD",
     )
     parser.add_argument(
         "--end",
         required=False,
-        default=str(default_end),
-        help=f"Backtest end date YYYY-MM-DD (default: {default_end})",
+        help="Backtest end date YYYY-MM-DD",
     )
     parser.add_argument("--mode", choices=["grid"], default="grid")
     args = parser.parse_args()
 
-    symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    start = args.start or str(default_start)
+    end = args.end or str(default_end)
+    if args.symbols:
+        symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    else:
+        symbols = ["AAPL", "MSFT"]
     param_grid = {
         "BUY_THRESHOLD": [0.15, 0.2, 0.25],
         "TRAILING_FACTOR": [1.0, 1.2, 1.5],
@@ -67,12 +69,12 @@ def main() -> None:
         "LIMIT_ORDER_SLIPPAGE": [0.001, 0.005],
     }
 
-    data_cfg = {"start": args.start, "end": args.end}
+    data_cfg = {"start": start, "end": end}
     logger.info(
         "Starting grid search over %s symbols from %s to %s",
         len(symbols),
-        args.start,
-        args.end,
+        start,
+        end,
     )
     best = optimize_hyperparams_wrapper(None, symbols, data_cfg, param_grid, metric="sharpe_ratio")
 

--- a/backtester/core.py
+++ b/backtester/core.py
@@ -94,8 +94,13 @@ def run_backtest(
 ) -> BacktestResult:
     """Execute a simple backtest over daily bars."""
     data: dict[str, pd.DataFrame] = {}
+    required_cols = {"Open", "High", "Low", "Close", "Volume"}
     for sym in symbols:
         df_sym = load_price_data(sym, start, end)
+        missing = required_cols - set(df_sym.columns)
+        if missing:
+            logger.warning("Missing required columns for %s: %s", sym, missing)
+            continue
         if not df_sym.empty:
             df_sym["ret"] = df_sym["Close"].pct_change(fill_method=None).fillna(0)
         data[sym] = df_sym

--- a/tests/test_bot_engine.py
+++ b/tests/test_bot_engine.py
@@ -1,6 +1,6 @@
 import ast
-import types
 import sys
+import types
 from pathlib import Path
 
 import numpy as np


### PR DESCRIPTION
## Summary
- ensure backtester skips symbols missing OHLCV columns
- support `--symbols`, `--start`, and `--end` CLI arguments
- fix import order in tests for isort compliance

## Testing
- `./run_checks.sh` *(fails: pylint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685dd020216c8330a5a0cf10e85c8c47