### PR TITLE
Improve OHLCV data loading

### DIFF
--- a/backtester/__init__.py
+++ b/backtester/__init__.py
@@ -1,6 +1,7 @@
 """Backtester package exposing main interfaces."""
 
 from .core import BacktestResult, load_price_data, run_backtest
+from .data_loader import load_symbol_data
 from .grid_runner import optimize_hyperparams, run_grid_search
 from .logger import MetricsLogger
 from .plot import plot_drawdown, plot_equity_curve
@@ -9,6 +10,7 @@ __all__ = [
     "BacktestResult",
     "run_backtest",
     "load_price_data",
+    "load_symbol_data",
     "run_grid_search",
     "optimize_hyperparams",
     "MetricsLogger",

--- a/backtester/data_loader.py
+++ b/backtester/data_loader.py
@@ -1,0 +1,104 @@
+"""Utilities for loading and repairing cached OHLCV data."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pandas as pd
+from alpaca_trade_api import REST, TimeFrame
+from requests.exceptions import RequestException
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path("data")
+REQUIRED_COLS = ["Open", "High", "Low", "Close", "Volume"]
+
+
+def _get_api() -> REST:
+    """Return an Alpaca REST client using environment variables."""
+    api_key = os.getenv("ALPACA_API_KEY")
+    secret_key = os.getenv("ALPACA_SECRET_KEY")
+    base_url = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+    return REST(api_key, secret_key, base_url)
+
+
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=8))
+def _fetch_from_alpaca(symbol: str, start: datetime, end: datetime) -> pd.DataFrame:
+    """Fetch daily OHLCV bars for ``symbol`` from Alpaca."""
+    api = _get_api()
+    bars = api.get_bars(
+        symbol,
+        TimeFrame.Day,
+        start=start.strftime("%Y-%m-%d"),
+        end=end.strftime("%Y-%m-%d"),
+        adjustment="raw",
+    ).df
+    if bars is None or bars.empty:
+        raise ValueError(f"No data returned for {symbol}")
+    if isinstance(bars.index, pd.MultiIndex):
+        bars = bars.xs(symbol, level=0)
+    df = bars.reset_index()
+    rename_map = {
+        "timestamp": "timestamp",
+        "open": "Open",
+        "high": "High",
+        "low": "Low",
+        "close": "Close",
+        "volume": "Volume",
+    }
+    df = df.rename(columns=rename_map)
+    df = df[[c for c in ["timestamp"] + REQUIRED_COLS if c in df.columns]]
+    missing = [c for c in REQUIRED_COLS if c not in df.columns]
+    if missing:
+        raise ValueError(f"Fetched data missing columns {missing} for {symbol}")
+    return df
+
+
+def _save_csv(df: pd.DataFrame, path: Path) -> None:
+    try:
+        df.to_csv(path, index=False)
+    except OSError as exc:  # pragma: no cover - disk error
+        logger.warning("Failed to cache %s: %s", path, exc)
+
+
+def load_symbol_data(symbol: str, start: datetime | None = None, end: datetime | None = None) -> pd.DataFrame:
+    """Return daily OHLCV data for ``symbol`` with automatic repair and fetch."""
+    DATA_DIR.mkdir(exist_ok=True)
+    csv_path = DATA_DIR / f"{symbol}.csv"
+    df = pd.DataFrame()
+    if csv_path.exists():
+        try:
+            df = pd.read_csv(csv_path)
+            missing = [c for c in REQUIRED_COLS if c not in df.columns]
+            if missing:
+                logger.warning("%s missing columns %s; deleting", csv_path, missing)
+                csv_path.unlink(missing_ok=True)
+                df = pd.DataFrame()
+            else:
+                df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+                df = df.dropna(subset=["timestamp"])
+                return df[["timestamp"] + REQUIRED_COLS]
+        except (OSError, pd.errors.ParserError, ValueError) as exc:
+            logger.error("Failed to read %s: %s", csv_path, exc)
+            try:
+                csv_path.unlink(missing_ok=True)
+                logger.info("Deleted corrupted file %s", csv_path)
+            except OSError:
+                logger.error("Could not delete corrupted file %s", csv_path)
+            df = pd.DataFrame()
+
+    # Determine fetch range
+    end_dt = end or datetime.utcnow()
+    start_dt = start or end_dt - timedelta(days=365 * 2)
+
+    try:
+        df = _fetch_from_alpaca(symbol, start_dt, end_dt)
+    except Exception as exc:
+        logger.error("Data fetch failed for %s: %s", symbol, exc)
+        raise
+    _save_csv(df, csv_path)
+    return df[["timestamp"] + REQUIRED_COLS]

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import types
+
+from pathlib import Path
+
+import backtester.data_loader as data_loader
+
+
+def test_load_symbol_data_repairs_and_fetches(monkeypatch, tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    bad = data_dir / "AAPL.csv"
+    pd.DataFrame({"Open": [1], "High": [2]}).to_csv(bad, index=False)
+
+    monkeypatch.setattr(data_loader, "DATA_DIR", data_dir)
+
+    fake_df = pd.DataFrame(
+        {
+            "timestamp": ["2023-01-01"],
+            "Open": [1.0],
+            "High": [1.0],
+            "Low": [1.0],
+            "Close": [1.0],
+            "Volume": [10],
+        }
+    )
+
+    monkeypatch.setattr(data_loader, "_fetch_from_alpaca", lambda *a, **k: fake_df)
+
+    df = data_loader.load_symbol_data("AAPL")
+    assert set(df.columns) == {"timestamp", "Open", "High", "Low", "Close", "Volume"}
+    saved = pd.read_csv(bad)
+    assert set(saved.columns) == {"timestamp", "Open", "High", "Low", "Close", "Volume"}
+


### PR DESCRIPTION
## Summary
- add a loader that repairs cached CSV data and refetches from Alpaca if needed
- expose `load_symbol_data` via `backtester.__init__`
- test that corrupted data files are repaired and saved correctly

## Testing
- `bash run_checks.sh` *(fails: network restrictions prevent installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685dd368acac8330a2bbd9feedaeca54