### PR TITLE
Improve Alpaca streaming and stuck order handling

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import sys
@@ -171,7 +172,7 @@ from bs4 import BeautifulSoup
 from flask import Flask
 from requests.exceptions import HTTPError
 
-from alpaca_api import alpaca_get
+from alpaca_api import alpaca_get, start_trade_updates_stream
 from rebalancer import maybe_rebalance
 
 # for paper trading
@@ -5649,7 +5650,9 @@ def main() -> None:
 
         # Start listening for trade updates in a background thread
         threading.Thread(
-            target=stream.run,
+            target=lambda: asyncio.run(
+                start_trade_updates_stream(API_KEY, API_SECRET, trading_client, paper=True)
+            ),
             daemon=True,
         ).start()
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,11 @@
 """Alias to run module for backward compatibility."""
+import asyncio
 import importlib
+import os
 
+from alpaca.trading.client import TradingClient
+
+import alpaca_api
 import run as _run
 
 _run = importlib.reload(_run)
@@ -10,6 +15,17 @@ run_flask_app = _run.run_flask_app
 run_bot = _run.run_bot
 validate_environment = _run.validate_environment
 main = _run.main
+
+
+def start_trade_updates_loop() -> None:
+    """Convenience wrapper to run trade update streaming."""
+    api_key = os.getenv("ALPACA_API_KEY", "")
+    secret = os.getenv("ALPACA_SECRET_KEY", "")
+    paper = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets").startswith("https://paper")
+    client = TradingClient(api_key, secret, paper=paper)
+    asyncio.run(
+        alpaca_api.start_trade_updates_stream(api_key, secret, client, paper=paper)
+    )
 
 if __name__ == "__main__":
     _run.main()


### PR DESCRIPTION
## Summary
- add async trade update streaming and stuck order retries
- expose trade streaming helper in `main.py`
- run streaming loop from `bot_engine`

## Testing
- `./run_checks.sh` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685eb9d3be188330ae610e05f532ac46