### PR TITLE
Fix Alpaca stream usage and add order safeguards

### DIFF
--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -277,7 +277,7 @@ async def start_trade_updates_stream(api_key: str, secret_key: str, api, state=N
     async def handle_async_trade_update(ev):
         handle_trade_update(ev, state)
 
-    await stream.subscribe_trade_updates(handle_async_trade_update)
+    stream.subscribe_trade_updates(handle_async_trade_update)
     logger.info("\u2705 Subscribed to Alpaca trade updates stream.")
     asyncio.create_task(check_stuck_orders(api))
     await stream.run()


### PR DESCRIPTION
## Summary
- fix awaiting trade update subscription that caused TypeError
- ensure trade cooldown and direction dicts exist before processing symbols
- record cooldown and trade direction immediately after submitting orders
- warn when orders stay pending too long

## Testing
- `./run_checks.sh` *(fails: pip install packages blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685eea63df4c8330a11075624f1aeee0