### PR TITLE
Fix nested asyncio.run in Alpaca stream

### DIFF
--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -280,5 +280,6 @@ async def start_trade_updates_stream(api_key: str, secret_key: str, api, state=N
     stream.subscribe_trade_updates(handle_async_trade_update)
     logger.info("\u2705 Subscribed to Alpaca trade updates stream.")
     asyncio.create_task(check_stuck_orders(api))
-    await stream.run()
+    # Avoid nested asyncio.run inside TradingStream.run()
+    await stream._run_forever()
 


### PR DESCRIPTION
## Summary
- avoid nested asyncio.run in trading stream

## Testing
- `pytest tests/test_alpaca_api_module.py::test_submit_order_shadow -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ef13b8eac8330b41f53a706669415