### PR TITLE
Improve backtest validation and sell logic

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -388,6 +388,22 @@ def get_ohlcv_columns(df):
     return cols
 
 
+REQUIRED_OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume"]
+
+
+def validate_ohlcv(df: pd.DataFrame) -> bool:
+    """Return True if ``df`` contains the required OHLCV columns."""
+
+    if not isinstance(df, pd.DataFrame) or df.empty:
+        logger.error("validate_ohlcv received invalid DataFrame")
+        return False
+    missing = [c for c in REQUIRED_OHLCV_COLS if c not in df.columns]
+    if missing:
+        logger.error("Missing OHLCV columns: %s", missing)
+        return False
+    return True
+
+
 from typing import Dict, List
 
 try:


### PR DESCRIPTION
## Summary
- validate OHLCV data with new util helper
- patch `load_price_data` to check columns
- implement SMA based exits and stop-loss re-entry
- ensure grid search can run serially for tests
- update wrappers to allow monkeypatching

## Testing
- `pytest tests/test_backtest_smoke.py::test_backtest_run_and_optimize -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bot')*

------
https://chatgpt.com/codex/tasks/task_e_685f0bf07b448330ac10e2ff09bbcb46