### PR TITLE
Add yfinance data fetching for backtester

### DIFF
--- a/backtester/grid_runner.py
+++ b/backtester/grid_runner.py
@@ -8,9 +8,9 @@ Example:
 from __future__ import annotations
 
 import logging
+import os
 from itertools import product
 from multiprocessing import Pool, cpu_count
-import os
 from typing import Any, Iterable
 
 from .core import BacktestResult, run_backtest


### PR DESCRIPTION
## Summary
- use `yfinance` to fetch daily data if local CSV is missing
- validate OHLCV columns and log when data is downloaded or loaded
- adjust import ordering per `isort`

## Testing
- `flake8 backtest.py backtester/grid_runner.py`
- `pytest -k backtest_smoke -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `./run_checks.sh` *(fails at pylint stage)*

------
https://chatgpt.com/codex/tasks/task_e_685f1023e1ac8330801f8800eb16fae5