### PR TITLE
Update benchmark scripts

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -5,22 +5,31 @@ import signals
 import indicators
 import pytest
 
-# Generate a large random DataFrame for benchmarking
-# using half a million rows to keep runtime reasonable.
 df = pd.DataFrame({
-    'Open': np.random.random(500_000) * 100,
-    'High': np.random.random(500_000) * 100,
-    'Low': np.random.random(500_000) * 100,
-    'Close': np.random.random(500_000) * 100,
-    'Volume': np.random.randint(1000, 10000, size=500_000)
+    'open': np.random.random(500_000) * 100,
+    'high': np.random.random(500_000) * 100,
+    'low': np.random.random(500_000) * 100,
+    'close': np.random.random(500_000) * 100,
+    'volume': np.random.randint(1000, 10000, size=500_000)
 })
 
-params = []
 modules = [signals, indicators]
+params = []
+
 for module in modules:
     for name, func in inspect.getmembers(module, inspect.isfunction):
+        sig = inspect.signature(func)
+        required_positional = [
+            p for p in sig.parameters.values()
+            if p.default == inspect.Parameter.empty and p.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD
+            )
+        ]
+        if len(required_positional) > 1:
+            print(f"Skipping {module.__name__}.{name} — requires multiple args: {[p.name for p in required_positional]}")
+            continue
         params.append(pytest.param(func, id=f"{module.__name__}.{name}"))
-
 
 @pytest.mark.parametrize("func", params)
 def test_benchmarks(benchmark, func):


### PR DESCRIPTION
## Summary
- update benchmarking test to skip multi-argument functions
- update indicator profiling utility to use same logic

## Testing
- `pytest tests/test_benchmarks.py -q` *(fails: TypeError and AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_685f3337d6c48330bd559dee802edf96