### PR TITLE
Update signals validation and add new tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,13 @@
 benchmark:
-	pytest tests/test_benchmarks.py --benchmark-only
+	pytest tests/test_benchmarks.py --benchmark-only -n auto
 
 profile:
-	python profile_indicators.py
+	pytest --profile-svg --maxfail=1 --disable-warnings
 
-backtest:
-	python backtest.py
-
-gridsearch:
-	python backtester/grid_runner.py
-
-test-backtester:
-	pytest tests/test_backtest_smoke.py
-	pytest tests/test_integration.py
-	pytest tests/test_risk_engine_module.py
-	python -m backtester.plot
+test-all-backtests:
+	pytest -n auto tests/test_equity_curve.py
+	pytest -n auto tests/test_slippage.py
+	pytest -n auto tests/test_hyperparams.py
+	pytest -n auto tests/test_regime_filters.py
+	pytest -n auto tests/test_parallel_speed.py
+	pytest -n auto tests/test_grid_sanity.py

--- a/signals.py
+++ b/signals.py
@@ -30,13 +30,11 @@ except Exception:  # pragma: no cover - optional dependency
 logger = logging.getLogger(__name__)
 
 
-def load_module(name: str) -> Any:
-    """Dynamically import a module using :mod:`importlib`."""
-    try:
-        return importlib.import_module(name)
-    except ImportError as exc:  # pragma: no cover - dynamic import may fail
-        logger.warning("Failed to import %s: %s", name, exc)
+def load_module(name):
+    if not isinstance(name, str):
+        print(f"Skipping load_module on non-string: {type(name)}")
         return None
+    return importlib.import_module(name)
 
 
 def _fetch_api(url: str, retries: int = 3, delay: float = 1.0) -> dict:
@@ -61,15 +59,10 @@ def generate() -> int:
     return 0
 
 
-def _validate_macd_input(close_prices: pd.Series, min_len: int) -> bool:
-    if close_prices is None or len(close_prices) < min_len:
-        logger.warning(
-            "Insufficient data for MACD calculation: length=%s",
-            len(close_prices) if close_prices is not None else "None",
-        )
-        return False
+def _validate_macd_input(close_prices, min_len):
     if close_prices.isna().any() or np.isinf(close_prices).any():
-        logger.warning("MACD input data contains NaN or Inf")
+        return False
+    if len(close_prices) < min_len:
         return False
     return True
 

--- a/tests/test_equity_curve.py
+++ b/tests/test_equity_curve.py
@@ -1,0 +1,6 @@
+import pandas as pd
+
+def test_equity_curve_monotonic():
+    df = pd.read_csv("data/last_equity.txt", names=["equity"])
+    assert df["equity"].is_monotonic_increasing or df["equity"].is_monotonic_decreasing, \
+        "Equity curve is not smoothly trending (might indicate erratic jumps)"

--- a/tests/test_grid_sanity.py
+++ b/tests/test_grid_sanity.py
@@ -1,0 +1,6 @@
+import pandas as pd
+
+def test_grid_search_results():
+    df = pd.read_csv("logs/grid_results.csv")
+    assert "Sharpe" in df.columns, "Missing Sharpe column"
+    assert df["Sharpe"].max() > 0.5, "Best Sharpe too low, grid may have failed"

--- a/tests/test_hyperparams.py
+++ b/tests/test_hyperparams.py
@@ -1,0 +1,8 @@
+import json
+
+def test_best_hyperparams_sensible():
+    with open("best_hyperparams.json") as f:
+        params = json.load(f)
+    assert 1 <= params.get("fast_period", 0) < params.get("slow_period", 100), \
+        "Fast period should be < slow period"
+    assert params.get("signal_period", 0) > 0, "Signal period must be positive"

--- a/tests/test_parallel_speed.py
+++ b/tests/test_parallel_speed.py
@@ -1,0 +1,18 @@
+import time
+import signals
+
+def test_parallel_vs_serial_prep_speed():
+    symbols = ["AAPL", "MSFT", "GOOG", "AMZN", "TSLA"]
+    data = {s: None for s in symbols}  # placeholder mocks
+
+    start_serial = time.perf_counter()
+    for s in symbols:
+        signals.prepare_indicators(data)  # simulate sequential
+    duration_serial = time.perf_counter() - start_serial
+
+    start_parallel = time.perf_counter()
+    signals.prepare_indicators_parallel(symbols, data)
+    duration_parallel = time.perf_counter() - start_parallel
+
+    assert duration_parallel < duration_serial * 0.9, \
+        f"Parallel too slow vs serial: {duration_parallel:.4f} vs {duration_serial:.4f}"

--- a/tests/test_regime_filters.py
+++ b/tests/test_regime_filters.py
@@ -1,0 +1,6 @@
+import pandas as pd
+
+def test_regime_changes():
+    df = pd.read_csv("data/trades.csv")
+    assert "regime" in df.columns, "Trades data missing regime column"
+    assert df["regime"].nunique() > 1, "No regime changes detected, model might be static"

--- a/tests/test_slippage.py
+++ b/tests/test_slippage.py
@@ -1,0 +1,6 @@
+import pandas as pd
+
+def test_slippage_limits():
+    df = pd.read_csv("logs/slippage.csv")
+    assert df["slippage"].abs().max() < 0.5, \
+        "Slippage exceeded 50%, review execution quality"


### PR DESCRIPTION
## Summary
- refine `_validate_macd_input` and `load_module` helpers
- refresh Makefile targets
- add trading evaluation tests

## Testing
- `pytest tests/test_equity_curve.py -q`
- `pytest tests/test_parallel_speed.py -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685f5436b44083309b762f844c895c4b