### PR TITLE
Update Makefile and pytest options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 benchmark:
-	pytest tests/test_benchmarks.py --benchmark-only -n auto
+	pytest tests/test_benchmarks.py --benchmark-only --benchmark-save=latest
 
 profile:
-	pytest --profile-svg --maxfail=1 --disable-warnings
+	python profile_indicators.py
 
 test-all-backtests:
-	pytest -n auto tests/test_equity_curve.py
-	pytest -n auto tests/test_slippage.py
-	pytest -n auto tests/test_hyperparams.py
-	pytest -n auto tests/test_regime_filters.py
-	pytest -n auto tests/test_parallel_speed.py
-	pytest -n auto tests/test_grid_sanity.py
+	pytest tests/test_equity_curve.py
+	pytest tests/test_slippage.py
+	pytest tests/test_hyperparams.py
+	pytest tests/test_regime_filters.py
+	pytest tests/test_parallel_speed.py
+	pytest tests/test_grid_sanity.py
+
+coverage:
+	pytest --cov=. --cov-report=html
+
+compare-benchmarks:
+	pytest-benchmark compare latest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
+timeout = 10
+addopts = --strict-markers --tb=short
 markers =
-    smoke
-    slow: marks tests as slow (deselect with '-m "not slow"')
-python_files = tests/test_*.py tests/slow/test_*.py
-[run]
-branch = True
+    benchmark
+    slow


### PR DESCRIPTION
## Summary
- update benchmark and profiling targets in Makefile
- add coverage and benchmark comparison targets
- simplify pytest settings

## Testing
- `od -c Makefile | head`


------
https://chatgpt.com/codex/tasks/task_e_685f553808a48330a947e3e0e1e1bf22