### PR TITLE
Adjust scheduler start and refine unit tests

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -5991,14 +5991,10 @@ def health_check(df: pd.DataFrame, resolution: str) -> bool:
 
 
 if __name__ == "__main__":
-    # One-time startup: loads model, runs initial health check & schedules all jobs
+    from bot import main
     main()
-
-    # Then run only pending scheduled jobs in a tight loop
     import time
-
     import schedule
-
     while True:
         schedule.run_pending()
         time.sleep(config.SCHEDULER_SLEEP_SECONDS)

--- a/tests/test_bot_engine_unit.py
+++ b/tests/test_bot_engine_unit.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import pytest
+import joblib
 
 # Build lightweight module exposing unit-testable functions from bot_engine
 SRC_PATH = Path(__file__).resolve().parents[1] / "bot_engine.py"
@@ -117,6 +118,7 @@ def test_run_trading_cycle_integration(monkeypatch):
 def test_load_model_single(tmp_path):
     path = tmp_path / "m.pkl"
     joblib.dump({"a": 1}, path)
+    assert joblib.load(path) == {"a": 1}
     model = MOD.load_model(str(path))
     assert isinstance(model, dict)
 


### PR DESCRIPTION
## Summary
- invoke bot.main when running bot_engine directly
- exercise joblib usage in unit tests

## Testing
- `pytest -q -c /dev/null tests/test_bot_engine_unit.py`

------
https://chatgpt.com/codex/tasks/task_e_68600c6b078c8330ade9c71aee3abf53