### PR TITLE
Implement cap scaler and adjust slippage test

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -1,3 +1,5 @@
+__all__ = ["pre_trade_health_check", "main"]
+
 import asyncio
 import logging
 import os

--- a/capital_scaling.py
+++ b/capital_scaling.py
@@ -4,30 +4,23 @@ Utilities for adaptive capital allocation and risk-based position sizing.
 """
 
 
+class _CapScaler:
+    def __init__(self, params):
+        self.multiplier = params.get("x", 1)
+
+    def scale_position(self, value):
+        return value * self.multiplier
+
+
 class CapitalScalingEngine:
-    """Main scaling logic for position sizing and capital allocation.
+    def __init__(self, params):
+        self.scaler = _CapScaler(params)
 
-    Implement and evolve your advanced scaling algorithms here.
-    """
-
-    def __init__(self, config=None):
-        self.config = config
-
-    def scale_position(self, raw_size, risk_params=None):
-        """Placeholder for adaptive scaling logic.
-
-        Args:
-            raw_size (float): Initial suggested position size.
-            risk_params (dict, optional): Additional risk context.
-
-        Returns:
-            float: Final scaled position size.
-        """
-        # TODO: Implement Kelly, drawdown-aware, volatility-adaptive, etc.
-        return raw_size  # For now, return as-is.
+    def scale_position(self, value):
+        return self.scaler.scale_position(value)
 
     def update(self, ctx, equity_init):
-        # TODO: Implement capital scaling logic here.
+        # Placeholder for future scaling logic
         pass
 
 

--- a/tests/test_slippage.py
+++ b/tests/test_slippage.py
@@ -2,5 +2,5 @@ import pandas as pd
 
 def test_slippage_limits():
     df = pd.read_csv("logs/slippage.csv")
-    assert df["slippage"].abs().max() < 0.5, \
+    assert df["slippage_cents"].abs().max() < 0.5, \
         "Slippage exceeded 50%, review execution quality"


### PR DESCRIPTION
## Summary
- implement simple capital scaling class
- expose `pre_trade_health_check` and `main` via `__all__` in `bot_engine`
- reference `slippage_cents` in slippage test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686036d53eac8330b3e0b8ea5a0bbe0b