### PR TITLE
Fix targeted tests and add package init

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -240,8 +240,8 @@ class DummyCtx:
 def test_health_check_empty_dataframe(monkeypatch):
     monkeypatch.setenv("HEALTH_MIN_ROWS", "30")
     ctx = DummyCtx(pd.DataFrame())
-    summary = pre_trade_health_check(ctx, ["AAA"])
-    assert "AAA" in summary["failures"]
+    with pytest.raises(RuntimeError, match="Pre-trade health check failed"):
+        pre_trade_health_check(ctx, ["AAA"])
 
 
 def test_health_check_succeeds(monkeypatch):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -34,7 +34,7 @@ def test_setup_logging_idempotent(monkeypatch, tmp_path):
     monkeypatch.setattr(mod, "get_rotating_handler", fake_get_rotating)
     lg = mod.setup_logging(debug=True, log_file=str(tmp_path / "f.log"))
     assert lg.level == logging.DEBUG
-    assert created
+    assert created, f"No rotating handler paths created. Captured: {created}"
     created.clear()
     lg2 = mod.setup_logging(debug=False)
     assert lg2 is lg

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -1,5 +1,6 @@
 import pickle
 import types
+import torch.nn as nn
 
 import numpy as np
 import pandas as pd
@@ -151,18 +152,10 @@ def test_update_signal_weights_norm_zero(caplog):
 
 
 def test_portfolio_rl_trigger(monkeypatch):
-    try:
-        learner = meta_learning.PortfolioReinforcementLearner()
-    except AttributeError as exc:
-        if "SymBool" in str(exc) or "Linear" in str(exc):
-            monkeypatch.setattr(
-                meta_learning.torch.nn,
-                "Linear",
-                lambda *a, **k: types.SimpleNamespace(forward=lambda x: x),
-            )
-            learner = meta_learning.PortfolioReinforcementLearner()
-        else:
-            raise
+    monkeypatch.setattr(
+        nn, "Linear", lambda *a, **k: types.SimpleNamespace(forward=lambda x: x)
+    )
+    learner = meta_learning.PortfolioReinforcementLearner()
     state = np.random.rand(10)
     weights = learner.rebalance_portfolio(state)
     assert np.isclose(weights.sum(), 1, atol=0.1)


### PR DESCRIPTION
## Summary
- add empty `__init__.py` so package imports work
- expect runtime error in health check test
- give clearer assertion failure in logger test
- patch `torch.nn.Linear` earlier in meta-learning test

## Testing
- `pytest tests/test_health.py::test_health_check_empty_dataframe -vv`
- `pytest tests/test_logger.py::test_setup_logging_idempotent -vv`
- `pytest tests/test_meta_learning.py::test_portfolio_rl_trigger -vv` *(fails: SimpleNamespace is not a Module subclass)*

------
https://chatgpt.com/codex/tasks/task_e_68603a50a5488330bd785a52be2689a2