### PR TITLE
Fix imports and tests

### DIFF
--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -152,9 +152,11 @@ def test_update_signal_weights_norm_zero(caplog):
 
 
 def test_portfolio_rl_trigger(monkeypatch):
-    monkeypatch.setattr(
-        nn, "Linear", lambda *a, **k: types.SimpleNamespace(forward=lambda x: x)
-    )
+    class DummyModule(nn.Module):
+        def forward(self, x):
+            return x
+
+    monkeypatch.setattr(nn, "Linear", lambda *a, **k: DummyModule())
     learner = meta_learning.PortfolioReinforcementLearner()
     state = np.random.rand(10)
     weights = learner.rebalance_portfolio(state)


### PR DESCRIPTION
## Summary
- add top-level APIs for health helpers
- simplify market/time util behavior
- use dummy module in `test_portfolio_rl_trigger`

## Testing
- `pytest -o addopts='' tests/test_health.py tests/test_integration_robust.py tests/test_parallel_speed.py tests/test_meta_learning.py` *(fails: ImportError: cannot import name 'SGDRegressor' from 'sklearn.linear_model')*

------
https://chatgpt.com/codex/tasks/task_e_68604c807b188330932f68c9f9081fd3