### PR TITLE
Fix exports and imports in bot_engine tests

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -1,9 +1,6 @@
 __all__ = [
     "pre_trade_health_check",
     "main",
-    "market_is_open",
-    "get_latest_close",
-    "compute_time_range",
 ]
 
 import asyncio

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ markers =
     smoke
 timeout = 10
 addopts = -ra -q --disable-warnings -n auto --benchmark-save=latest --cov=. --cov-report=html
+python_files = tests/*

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-from bot_engine import pre_trade_health_check
 
 # Minimal stubs so importing bot_engine succeeds without optional deps
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -218,6 +217,9 @@ sys.modules["torch.nn"] = torch_nn
 torch_optim = types.ModuleType("torch.optim")
 torch_optim.Adam = lambda *a, **k: None
 sys.modules["torch.optim"] = torch_optim
+
+from bot_engine import pre_trade_health_check
+from bot_engine import main
 
 
 class DummyFetcher:

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -152,11 +152,11 @@ def test_update_signal_weights_norm_zero(caplog):
 
 
 def test_portfolio_rl_trigger(monkeypatch):
-    class DummyModule(nn.Module):
+    class FakeLinear(nn.Module):
         def forward(self, x):
             return x
 
-    monkeypatch.setattr(nn, "Linear", lambda *a, **k: DummyModule())
+    monkeypatch.setattr(nn, "Linear", lambda *a, **k: FakeLinear())
     learner = meta_learning.PortfolioReinforcementLearner()
     state = np.random.rand(10)
     weights = learner.rebalance_portfolio(state)


### PR DESCRIPTION
## Summary
- adjust `__all__` in `bot_engine` to expose only `pre_trade_health_check` and `main`
- ensure tests import these functions explicitly
- move test imports after dependency stubs
- fix RL monkeypatch naming
- configure pytest to discover tests in `tests/` directory

## Testing
- `make test-all` *(fails: ImportError from missing optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_6860500ecc6c8330a2c630aeb9a016f9