### PR TITLE
Fix imports and test stubs

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -1,7 +1,4 @@
-__all__ = [
-    "pre_trade_health_check",
-    "main",
-]
+__all__ = ["main", "pre_trade_health_check"]
 
 import asyncio
 import logging

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,5 @@ markers =
     slow
     smoke
 timeout = 10
-addopts = -ra -q --disable-warnings -n auto --benchmark-save=latest --cov=. --cov-report=html
-python_files = tests/*
+addopts = -ra -q --disable-warnings -n auto
+python_files = tests/*.py

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -115,6 +115,7 @@ sys.modules["urllib3"] = types.ModuleType("urllib3")
 sys.modules["urllib3"].exceptions = types.SimpleNamespace(HTTPError=Exception)
 sys.modules["alpaca_trade_api"].REST = object
 sys.modules["alpaca_trade_api"].APIError = Exception
+sys.modules["alpaca_trade_api.rest"].APIError = Exception
 sys.modules["alpaca.common.exceptions"].APIError = Exception
 
 
@@ -135,10 +136,28 @@ class _Req:
 sys.modules["alpaca.trading.requests"].LimitOrderRequest = _Req
 sys.modules["alpaca.trading.requests"].MarketOrderRequest = _Req
 sys.modules["alpaca.trading.requests"].GetOrdersRequest = _Req
-sys.modules["alpaca.trading.enums"].OrderSide = types.SimpleNamespace(BUY="buy", SELL="sell")
-sys.modules["alpaca.trading.enums"].TimeInForce = types.SimpleNamespace(DAY="day")
-sys.modules["alpaca.trading.enums"].QueryOrderStatus = object
-sys.modules["alpaca.trading.enums"].OrderStatus = object
+from enum import Enum
+
+class _Enum(str, Enum):
+    pass
+
+class _OrderSide(_Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+class _TimeInForce(_Enum):
+    DAY = "day"
+
+class _QueryOrderStatus(_Enum):
+    pass
+
+class _OrderStatus(_Enum):
+    pass
+
+sys.modules["alpaca.trading.enums"].OrderSide = _OrderSide
+sys.modules["alpaca.trading.enums"].TimeInForce = _TimeInForce
+sys.modules["alpaca.trading.enums"].QueryOrderStatus = _QueryOrderStatus
+sys.modules["alpaca.trading.enums"].OrderStatus = _OrderStatus
 sys.modules["alpaca.trading.models"].Order = object
 sys.modules["alpaca.trading.stream"] = types.ModuleType("alpaca.trading.stream")
 

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -152,7 +152,12 @@ def test_update_signal_weights_norm_zero(caplog):
 
 
 def test_portfolio_rl_trigger(monkeypatch):
+    import torch
     class FakeLinear(nn.Module):
+        def __init__(self, *a, **k):
+            super().__init__()
+            self.weight = nn.Parameter(torch.tensor([0.0]))
+
         def forward(self, x):
             return x
 


### PR DESCRIPTION
## Summary
- set exported functions in `bot_engine`
- adjust pytest configuration
- improve stubs in integration tests
- tweak portfolio RL test to avoid PyTorch SymBool errors

## Testing
- `make test-all` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest tests/test_health.py::test_health_check_succeeds -q -n0`
- `pytest tests/test_integration_robust.py::test_bot_main_normal -q -n0`
- `pytest tests/test_meta_learning.py::test_portfolio_rl_trigger -q -n0`

------
https://chatgpt.com/codex/tasks/task_e_686058b6a08c83308ee1acf5843328ce