### PR TITLE
Fix exports and stabilize tests

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -132,12 +132,11 @@ import pandas as pd
 import pandas_market_calendars as mcal
 import pandas_ta as ta
 
-if not hasattr(ta, "ichimoku"):
-
-    def _ichimoku_placeholder(*a, **k):
-        return pd.DataFrame(), pd.DataFrame()
-
-    ta.ichimoku = _ichimoku_placeholder
+ta.ichimoku = (
+    ta.ichimoku
+    if hasattr(ta, "ichimoku")
+    else lambda *a, **k: (pd.DataFrame(), {})
+)
 
 NY = mcal.get_calendar("NYSE")
 MARKET_SCHEDULE = NY.schedule(start_date="2020-01-01", end_date="2030-12-31")

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -8,6 +8,9 @@ import pandas as pd
 def test_ichimoku_indicator_returns_dataframe(monkeypatch):
     import bot_engine as bot
 
+    if not hasattr(bot.ta, "ichimoku"):
+        setattr(bot.ta, "ichimoku", lambda *a, **k: (pd.DataFrame(), {}))
+
     # Patch pandas_ta.ichimoku to return a tuple (DataFrame, params)
     ich_df = pd.DataFrame({"ITS_9": [1.0], "IKS_26": [1.0]})
     monkeypatch.setattr(bot.ta, "ichimoku", lambda *a, **k: (ich_df, {"foo": 1}))
@@ -22,6 +25,8 @@ def test_ichimoku_indicator_returns_dataframe(monkeypatch):
 
 def test_compute_ichimoku_returns_df_pair(monkeypatch):
     import bot_engine as bot
+    if not hasattr(bot.ta, "ichimoku"):
+        setattr(bot.ta, "ichimoku", lambda *a, **k: (pd.DataFrame(), {}))
     ich_df = pd.DataFrame({"ITS_9": [1.0]})
     signal_df = pd.DataFrame({"ITSs_9": [1.0]})
     monkeypatch.setattr(bot.ta, "ichimoku", lambda *a, **k: (ich_df, signal_df))


### PR DESCRIPTION
## Summary
- ensure `pandas_ta.ichimoku` placeholder exists
- allow indicators test to add placeholder if missing
- keep logger level explicit

## Testing
- `pytest tests/test_health.py tests/test_integration_robust.py tests/test_indicators.py tests/test_logger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6860628d13f083309d4b524707fc31e9