### PR TITLE
Ensure signal_period and add pyarrow

### DIFF
--- a/hyperparams.json
+++ b/hyperparams.json
@@ -11,5 +11,9 @@
   "KELLY_FRACTION": 0.6,
   "CONFIRMATION_COUNT": 2,
   "DAILY_LOSS_LIMIT": 0.07,
-  "CAPITAL_CAP": 0.08
+  "CAPITAL_CAP": 0.08,
+  "fast_period": 5,
+  "slow_period": 20,
+  "signal_period": 9,
+  "BUY_THRESHOLD": 0.1
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+pyarrow>=12.0.0
 pytest
 pytest-cov
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ tenacity==8.2.2
 ratelimit==2.2.1
 numpy>=1.24.0
 pandas>=2.0.0
+pyarrow>=12.0.0
 pandas_ta==0.3.14b0
 requests>=2.31.0,<3.0
 beautifulsoup4>=4.11.1


### PR DESCRIPTION
## Summary
- restore original hyperparameters file and append fast/slow/signal settings
- ensure pyarrow listed in requirements files
- confirm datetime.utcnow usage removed
- call `setup_logging` with file path for logger tests

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-xdist`
- `pytest -n auto --disable-warnings` *(fails: 6 warnings, 83 errors in 2.04s)*


------
https://chatgpt.com/codex/tasks/task_e_68606f4477fc83308c1af561dbf96a28