### PR TITLE
Ensure HTTPError use

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -2297,7 +2297,7 @@ def fetch_sentiment(ctx: BotContext, ticker: str) -> float:
     resp = requests.get(url, timeout=10)
     try:
         resp.raise_for_status()
-    except requests.exceptions.HTTPError:
+    except HTTPError:
         if resp.status_code == 429:
             logger.warning(
                 f"fetch_sentiment({ticker}) rate-limited → returning neutral 0.0"


### PR DESCRIPTION
## Summary
- reference imported `HTTPError` directly

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6861f130a9488330a1c300f3df091a98