### PR TITLE
Refactor imports for requests

### DIFF
--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 import requests
+from requests.sessions import Session
 from requests.exceptions import HTTPError
 from alpaca.trading.stream import TradingStream
 from tenacity import (retry, retry_if_exception_type, stop_after_attempt,

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -158,6 +158,7 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 
 import portalocker
 import requests
+from requests.sessions import Session
 import schedule
 import yfinance as yf
 # Alpaca v3 SDK imports


### PR DESCRIPTION
## Summary
- adjust imports to guard against `requests` shadowing in `bot_engine` and `alpaca_api`

## Testing
- `pytest -n auto --disable-warnings` *(fails: 20 failed, 212 passed, 3 skipped, 1 xfailed, 11 warnings, 10 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861f2fe0ea88330af68c5723c6e80e1