### PR TITLE
Fix imports for HTTPError

### DIFF
--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -13,8 +13,7 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 import requests
-from requests.sessions import Session
-from requests.exceptions import HTTPError
+from requests import Session, HTTPError
 from alpaca.trading.stream import TradingStream
 from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
                       wait_exponential)

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -158,7 +158,7 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 
 import portalocker
 import requests
-from requests.sessions import Session
+from requests import Session, HTTPError
 import schedule
 import yfinance as yf
 # Alpaca v3 SDK imports
@@ -184,7 +184,6 @@ from alpaca.trading.requests import (GetOrdersRequest, LimitOrderRequest,
 from alpaca.trading.stream import TradingStream
 from bs4 import BeautifulSoup
 from flask import Flask
-from requests.exceptions import HTTPError
 
 from alpaca_api import alpaca_get, start_trade_updates_stream
 from rebalancer import maybe_rebalance

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -38,8 +38,8 @@ logger = logging.getLogger(__name__)
 _rate_limit_lock = threading.Lock()
 try:
     import requests
-    from requests.sessions import Session
-    from requests.exceptions import HTTPError, RequestException
+    from requests import Session, HTTPError
+    from requests.exceptions import RequestException
     import urllib3
 except Exception as e:  # pragma: no cover - allow missing in test env
     logger.warning("Optional dependencies missing: %s", e)


### PR DESCRIPTION
## Summary
- import `HTTPError` directly from `requests`
- clean up session imports in several modules

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6861fa3465788330be8a57062271c8d8