### PR TITLE
Final cleanup: document stuck order safeguards, refine logs

### DIFF
--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -1,4 +1,10 @@
-"""Lightweight Alpaca REST helpers with retry and validation."""
+"""Lightweight Alpaca REST helpers with retry and validation.
+
+Orders submitted via :func:`submit_order` are recorded in ``pending_orders``.
+The :func:`check_stuck_orders` task periodically scans this registry and will
+cancel and resubmit any order that remains in ``PENDING_NEW`` for over
+60 seconds to guard against missed status updates.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- clarify stuck order safeguards in `alpaca_api`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6862b4c0e3e48330b1784bd5eb754e1c