### PR TITLE
Add grid tuner and runtime config

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -12,3 +12,23 @@ def load_data(file: str) -> pd.DataFrame:
     df.fillna(method="ffill", inplace=True)
     df.dropna(inplace=True)
     return df
+
+
+def execute_backtest():
+    """Placeholder backtest executor returning empty metrics."""
+    # AI-AGENT-REF: simplified backtest stub for grid tuning
+    return {}
+
+
+def run_backtest(
+    volume_spike_threshold: float,
+    ml_confidence_threshold: float,
+    pyramid_levels: dict,
+) -> dict:
+    """Run backtest with overridable parameters."""
+    from config import set_runtime_config
+
+    set_runtime_config(volume_spike_threshold, ml_confidence_threshold, pyramid_levels)
+    results = execute_backtest()
+    return results
+

--- a/config.py
+++ b/config.py
@@ -143,6 +143,14 @@ PYRAMID_LEVELS = {
 FORCE_TRADES: bool = False
 """If True, bypasses all pre-trade halts for testing."""
 
+
+def set_runtime_config(volume_thr: float, ml_thr: float, pyramid_levels: dict) -> None:
+    """Override key strategy parameters at runtime."""
+    global VOLUME_SPIKE_THRESHOLD, ML_CONFIDENCE_THRESHOLD, PYRAMID_LEVELS
+    VOLUME_SPIKE_THRESHOLD = volume_thr
+    ML_CONFIDENCE_THRESHOLD = ml_thr
+    PYRAMID_LEVELS = pyramid_levels
+
 # centralize SGDRegressor hyperparameters
 SGD_PARAMS = MappingProxyType(
     {
@@ -198,4 +206,5 @@ __all__ = [
     "ML_CONFIDENCE_THRESHOLD",
     "PYRAMID_LEVELS",
     "FORCE_TRADES",
+    "set_runtime_config",
 ]

--- a/config_server.py
+++ b/config_server.py
@@ -1,0 +1,30 @@
+from flask import Flask, request, jsonify
+from config import set_runtime_config
+
+app = Flask(__name__)
+
+
+@app.route("/update_config", methods=["POST"])
+def update_config():
+    data = request.get_json()
+    volume_thr = float(data.get("volume_spike_threshold", 1.5))
+    ml_thr = float(data.get("ml_confidence_threshold", 0.5))
+    pyramid_levels = data.get(
+        "pyramid_levels",
+        {"high": 0.4, "medium": 0.25, "low": 0.15},
+    )
+
+    set_runtime_config(volume_thr, ml_thr, pyramid_levels)
+    return jsonify(
+        {
+            "status": "updated",
+            "volume_spike_threshold": volume_thr,
+            "ml_confidence_threshold": ml_thr,
+            "pyramid_levels": pyramid_levels,
+        }
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5002)
+

--- a/grid_tuner.py
+++ b/grid_tuner.py
@@ -1,0 +1,32 @@
+import itertools
+from backtester import run_backtest
+from logger import init_logger
+
+logger = init_logger("grid_tuner.log")
+
+
+def grid_search():
+    volume_spike_range = [1.3, 1.5, 1.7]
+    ml_confidence_range = [0.5, 0.6, 0.7]
+    pyramid_configs = [
+        {"high": 0.4, "medium": 0.25, "low": 0.15},
+        {"high": 0.5, "medium": 0.3, "low": 0.2},
+    ]
+
+    results = []
+    for vol_thr, ml_thr, pyr in itertools.product(
+        volume_spike_range, ml_confidence_range, pyramid_configs
+    ):
+        metrics = run_backtest(
+            volume_spike_threshold=vol_thr,
+            ml_confidence_threshold=ml_thr,
+            pyramid_levels=pyr,
+        )
+        logger.info(f"VOL={vol_thr} ML={ml_thr} PYR={pyr} => {metrics}")
+        results.append((vol_thr, ml_thr, pyr, metrics))
+    return results
+
+
+if __name__ == "__main__":
+    grid_search()
+

--- a/logger.py
+++ b/logger.py
@@ -108,6 +108,12 @@ def get_logger(name: str) -> logging.Logger:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["setup_logging", "get_logger", "logger"]
+def init_logger(log_file: str) -> logging.Logger:
+    """Wrapper used by utilities to initialize logging."""
+    # AI-AGENT-REF: provide simple alias for setup_logging
+    return setup_logging(log_file=log_file)
+
+
+__all__ = ["setup_logging", "get_logger", "init_logger", "logger"]
 
 


### PR DESCRIPTION
## Summary
- add `grid_tuner.py` for sweeping parameters
- allow runtime overrides via `set_runtime_config`
- expose a Flask endpoint in `config_server.py`
- add `init_logger` helper
- provide stub `run_backtest` in `backtester.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -n auto --disable-warnings` *(fails: 21 failed, 189 passed, 2 skipped, 1 xfailed, 39 errors)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6862d2631db0833096fa580fce1368fd