### PR TITLE
Improve price handling

### DIFF
--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -34,6 +34,7 @@ if "ALPACA_SECRET_KEY" in os.environ:
     os.environ.setdefault("APCA_API_SECRET_KEY", os.environ["ALPACA_SECRET_KEY"])
 
 SHADOW_MODE = os.getenv("SHADOW_MODE", "0") == "1"
+DRY_RUN = os.getenv("DRY_RUN", "false").lower() == "true"
 
 
 _warn_counts = defaultdict(int)
@@ -113,6 +114,17 @@ def get_account() -> Optional[Dict[str, Any]]:
 def submit_order(api, req, log: logging.Logger | None = None):
     """Submit an order with retry and optional shadow mode."""
     log = log or logger
+    if DRY_RUN:
+        log.info(
+            "DRY RUN: would submit order for %s of size %s", 
+            getattr(req, "symbol", ""), 
+            getattr(req, "qty", 0),
+        )
+        return {
+            "status": "dry_run",
+            "symbol": getattr(req, "symbol", ""),
+            "qty": getattr(req, "qty", 0),
+        }
     if SHADOW_MODE:
         log.info(
             "SHADOW_MODE: Would place order: %s %s %s %s %s",

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -3758,6 +3758,13 @@ def _enter_long(
     strat: str,
 ) -> bool:
     current_price = get_latest_close(feat_df)
+    if current_price <= 0:
+        logger.warning(
+            "Aborting trade for %s, invalid price: %.2f",
+            symbol,
+            current_price,
+        )
+        return True
     target_weight = ctx.portfolio_weights.get(symbol, 0.0)
     raw_qty = int(balance * target_weight / current_price) if current_price > 0 else 0
     if raw_qty is None or not np.isfinite(raw_qty) or raw_qty <= 0:
@@ -3818,6 +3825,13 @@ def _enter_short(
     strat: str,
 ) -> bool:
     current_price = get_latest_close(feat_df)
+    if current_price <= 0:
+        logger.warning(
+            "Aborting trade for %s, invalid price: %.2f",
+            symbol,
+            current_price,
+        )
+        return True
     atr = feat_df["atr"].iloc[-1]
     qty = calculate_entry_size(ctx, symbol, current_price, atr, conf)
     try:

--- a/risk_engine.py
+++ b/risk_engine.py
@@ -103,7 +103,7 @@ class RiskEngine:
             return 0
 
         if cash <= 0 or price <= 0:
-            logger.error(
+            logger.warning(
                 "Invalid cash %.2f or price %.2f for position sizing", cash, price
             )
             return 0
@@ -194,6 +194,9 @@ import pandas_ta as ta
 def apply_trailing_atr_stop(df: pd.DataFrame, entry_price: float) -> None:
     """Exit position if price falls below an ATR-based trailing stop."""
     try:
+        if entry_price <= 0:
+            logger.warning("apply_trailing_atr_stop invalid entry price: %.2f", entry_price)
+            return
         atr = df.ta.atr()
         trailing_stop = entry_price - 2 * atr
         price = df["Close"].iloc[-1]

--- a/tests/test_alpaca_api_module.py
+++ b/tests/test_alpaca_api_module.py
@@ -29,6 +29,14 @@ def test_submit_order_shadow(monkeypatch):
     assert api.calls == 0
 
 
+def test_submit_order_dry_run(monkeypatch):
+    api = DummyAPI()
+    monkeypatch.setattr(alpaca_api, "DRY_RUN", True)
+    result = alpaca_api.submit_order(api, make_req())
+    assert result["status"] == "dry_run"
+    assert api.calls == 0
+
+
 def test_submit_order_rate_limit(monkeypatch):
     api = DummyAPI()
     monkeypatch.setattr(alpaca_api, "SHADOW_MODE", False)

--- a/tests/test_utils_new.py
+++ b/tests/test_utils_new.py
@@ -80,3 +80,21 @@ def test_safe_to_datetime_various_formats():
     assert iso.isna().all()
     assert len(utils.safe_to_datetime([])) == 0
     assert utils.safe_to_datetime([float("nan"), None]).isna().all()
+
+
+def test_get_current_price_fallback(monkeypatch):
+    api_mod = types.SimpleNamespace(alpaca_get=lambda url: {"ap": 0})
+    fetch_mod = types.SimpleNamespace(get_daily_df=lambda s, start, end: pd.DataFrame({"close": [2.0]}))
+    monkeypatch.setitem(sys.modules, "alpaca_api", api_mod)
+    monkeypatch.setitem(sys.modules, "data_fetcher", fetch_mod)
+    price = utils.get_current_price("AAPL")
+    assert price == 2.0
+
+
+def test_get_current_price_final_fallback(monkeypatch):
+    api_mod = types.SimpleNamespace(alpaca_get=lambda url: {"ap": 0})
+    fetch_mod = types.SimpleNamespace(get_daily_df=lambda s, start, end: pd.DataFrame())
+    monkeypatch.setitem(sys.modules, "alpaca_api", api_mod)
+    monkeypatch.setitem(sys.modules, "data_fetcher", fetch_mod)
+    price = utils.get_current_price("AAPL")
+    assert price == 0.01

--- a/validate_env.py
+++ b/validate_env.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
     SLIPPAGE_THRESHOLD: float = 0.003
     REBALANCE_INTERVAL_MIN: int = 1440
     SHADOW_MODE: bool = False
+    DRY_RUN: bool = False
     DISABLE_DAILY_RETRAIN: bool = False
     TRADE_LOG_FILE: str = "trades.csv"
     FORCE_TRADES: bool = False


### PR DESCRIPTION
## Summary
- add `get_current_price` with fallbacks
- guard trade entry on invalid prices
- warn when position sizing receives bad prices
- skip ATR stop calc on invalid entry price
- support DRY_RUN in order helper
- test dry-run and price fallbacks

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68642197780083309aa2b5adafd408f5