### PR TITLE
Add FORCE_MARKET_OPEN override and warnings filters

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 import logging
+import warnings
+
+# AI-AGENT-REF: suppress noisy external library warnings
+warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence")
+warnings.filterwarnings("ignore", message=".*_register_pytree_node.*")
 
 try:
     from alpaca_trade_api.rest import REST

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -7,6 +7,11 @@ import sys
 import time
 import traceback
 import types
+import warnings
+
+# AI-AGENT-REF: suppress noisy external library warnings
+warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence")
+warnings.filterwarnings("ignore", message=".*_register_pytree_node.*")
 
 # Avoid failing under older Python versions during tests
 if sys.version_info < (3, 12, 3):  # pragma: no cover - compat check
@@ -289,7 +294,12 @@ from utils import portfolio_lock
 
 def market_is_open(now: datetime.datetime | None = None) -> bool:
     """Return True if the market is currently open."""
-    return True
+    if os.getenv("FORCE_MARKET_OPEN", "false").lower() == "true":
+        logger.info(
+            "FORCE_MARKET_OPEN is enabled; overriding market hours checks."
+        )
+        return True
+    return utils_market_open(now)
 
 
 # backward compatibility

--- a/run.py
+++ b/run.py
@@ -6,6 +6,11 @@ import subprocess
 import sys
 import threading
 from typing import Any
+import warnings
+
+# AI-AGENT-REF: suppress noisy external library warnings
+warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence")
+warnings.filterwarnings("ignore", message=".*_register_pytree_node.*")
 
 from alpaca_trade_api.rest import APIError  # noqa: F401
 from dotenv import load_dotenv

--- a/utils.py
+++ b/utils.py
@@ -130,6 +130,11 @@ def get_current_price(symbol: str) -> float:
 
 def is_market_open(now: dt.datetime | None = None) -> bool:
     """Return True if current time is within NYSE trading hours."""
+    if os.getenv("FORCE_MARKET_OPEN", "false").lower() == "true":
+        logger.info(
+            "FORCE_MARKET_OPEN is enabled; overriding market hours checks."
+        )
+        return True
     try:
         import pandas_market_calendars as mcal
 


### PR DESCRIPTION
## Summary
- suppress noisy library warnings at startup
- allow overriding market hours check via `FORCE_MARKET_OPEN`

## Testing
- `pytest -n auto --disable-warnings` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68646ce08b8c8330a04d3233e25be621