### PR TITLE
Update torch requirement and stub trading client

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -1,4 +1,4 @@
-__all__ = ["main", "pre_trade_health_check"]
+__all__ = ["pre_trade_health_check"]
 
 import asyncio
 import logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,5 @@ alpaca-trade-api>=3.0.0
 
 torch>=2.0
 joblib>=1.3
+torch==2.5.1
+joblib>=1.3

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -93,6 +93,11 @@ class _FakeREST:
 sys.modules["alpaca_trade_api.rest"].REST = _FakeREST
 sys.modules["alpaca_trade_api.rest"].APIError = Exception
 class _DummyTradingClient:
+    def __init__(self, api_key, secret_key, paper=True):
+        self.api_key = api_key
+        self.secret_key = secret_key
+        self.paper = paper
+
     def get_account(self):
         return {"status": "ACTIVE"}
 


### PR DESCRIPTION
## Summary
- append updated torch and joblib constraints
- stub `TradingClient` for `test_bot`
- narrow `bot_engine` exports to only expose `pre_trade_health_check`

## Testing
- `pip install torch==2.5.1 -q >/tmp/pip.log && tail -n 20 /tmp/pip.log`
- `pytest -n auto --disable-warnings` *(fails: FileNotFoundError, AttributeError, KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686481270c088330970bc1d7f90ca44c