### PR TITLE
Dynamic exposure and cooldown enhancements

### DIFF
--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -1,6 +1,7 @@
 """Mean reversion trading strategy implementation."""
 
 import logging
+import os
 from typing import List
 
 import pandas as pd
@@ -16,9 +17,10 @@ class MeanReversionStrategy(Strategy):
 
     name = "mean_reversion"
 
-    def __init__(self, lookback: int = 20, z: float = 2.0) -> None:
+    def __init__(self, lookback: int = 20, z: float | None = None) -> None:
         self.lookback = lookback
-        self.z = z
+        thresh = float(os.getenv("MEAN_REVERT_THRESHOLD", 0.75))
+        self.z = thresh if z is None else z
 
     def generate(self, ctx) -> List[TradeSignal]:
         signals: List[TradeSignal] = []


### PR DESCRIPTION
## Summary
- add dynamic exposure cap logic in `RiskEngine`
- tune reversal protection and cooldown logic in `StrategyAllocator`
- clip ML signal scores and scale confidence in `meta_learning`
- parametrize mean reversion threshold via env var
- log post-run trade summaries in `main`

## Testing
- `pytest -c /tmp/pytest_noxdist.ini` *(fails: 66 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686582fe1654833080d9eb83b9fcf8c3