### PR TITLE
Update signal generation and backtester

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -12,24 +12,11 @@ logger = logging.getLogger(__name__)
 _fields = ["id", "timestamp", "symbol", "side", "qty", "price", "mode", "result"]
 
 
-def log_trade(symbol: str, side: str, qty: int, price: float, result: str, mode: str) -> None:
-    """Append trade details to the trade log CSV."""
-    row = {
-        "id": str(uuid.uuid4()),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "symbol": symbol,
-        "side": side,
-        "qty": qty,
-        "price": price,
-        "mode": mode,
-        "result": result,
-    }
-    try:
-        write_header = not os.path.exists(TRADE_LOG_FILE)
-        with open(TRADE_LOG_FILE, "a", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=_fields)
-            if write_header:
-                writer.writeheader()
-            writer.writerow(row)
-    except Exception as exc:  # pragma: no cover - I/O issues
-        logger.error("Failed to log trade: %s", exc)
+def log_trade(self, trade):
+    # AI-AGENT-REF: track trades and enforce drawdown limit
+    self.trades.append(trade)
+    total_pnl = sum([t['pnl'] for t in self.trades])
+    if total_pnl < -0.1 * self.starting_capital:
+        print('🚨 Max drawdown hit. Trading halted.')
+        raise SystemExit
+

--- a/capital_scaling.py
+++ b/capital_scaling.py
@@ -15,8 +15,13 @@ class CapitalScalingEngine:
         self.params = params or {}
         self.scaler = _CapScaler()
 
-    def scale_position(self, value):
-        return self.scaler.scale_position(value)
+    def scale_position(self, portfolio_value, volatility, drawdown):
+        # AI-AGENT-REF: dynamic position sizing with volatility and drawdown
+        base_fraction = 0.05  # starting Kelly fraction
+        adjusted_fraction = base_fraction * (1 - min(drawdown/0.2, 1))
+        adjusted_fraction /= max(volatility, 0.01)
+        position_size = portfolio_value * adjusted_fraction
+        return max(position_size, 0)
 
     def update(self, ctx, equity_init):
         # Placeholder for future scaling logic


### PR DESCRIPTION
## Summary
- improve momentum signal generation and add ATR stop helper
- implement volatility-aware position scaling
- overhaul backtester logic
- adjust trade audit for drawdown exit

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686588720cbc833092114f1072271200