### PR TITLE
Advanced risk and signal updates

### DIFF
--- a/risk_engine.py
+++ b/risk_engine.py
@@ -189,6 +189,24 @@ class RiskEngine:
         return {"volatility": vol}
 
 
+def dynamic_position_size(capital: float, volatility: float, drawdown: float) -> float:
+    """Return position size using volatility and drawdown aware Kelly fraction.
+
+    The base Kelly fraction of ``0.5 / volatility`` is throttled by current
+    drawdown. When drawdown exceeds 10% the fraction is scaled down by 50%.
+    """
+
+    if capital <= 0:
+        return 0.0
+
+    vol = max(volatility, 1e-6)
+    kelly_fraction = 0.5 / vol
+    if drawdown > 0.1:
+        kelly_fraction *= 0.5
+    kelly_fraction = min(max(kelly_fraction, 0.0), 1.0)
+    return capital * kelly_fraction
+
+
 def calculate_position_size(*args, **kwargs) -> int:
     """Convenience wrapper supporting simple and advanced usage."""
     engine = RiskEngine()

--- a/tests/test_enhanced_signals.py
+++ b/tests/test_enhanced_signals.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pandas as pd
+
+import risk_engine
+import signals
+
+
+def test_dynamic_position_size_scaling():
+    s1 = risk_engine.dynamic_position_size(10000, volatility=0.02, drawdown=0.05)
+    s2 = risk_engine.dynamic_position_size(10000, volatility=0.02, drawdown=0.15)
+    assert s2 < s1 and s1 > 0
+
+
+def test_signal_matrix_and_vote():
+    close = np.linspace(100, 105, 30)
+    df = pd.DataFrame({
+        "close": close,
+        "high": close * 1.01,
+        "low": close * 0.99,
+    })
+    matrix = signals.compute_signal_matrix(df)
+    assert not matrix.empty
+    vote = signals.ensemble_vote_signals(matrix)
+    assert len(vote) == len(matrix)
+
+
+def test_classify_regime_basic():
+    df = pd.DataFrame({"close": np.linspace(100, 120, 40)})
+    regime = signals.classify_regime(df)
+    assert regime.iloc[-1] in {"trend", "mean_revert"}

--- a/trade_logic.py
+++ b/trade_logic.py
@@ -1,5 +1,21 @@
 # AI-AGENT-REF: basic trade utilities
 
+import random
+
 def compute_order_price(symbol_data):
     raw_price = extract_price(symbol_data)
-    return max(raw_price, 1e-3)  # avoid non-positive prices
+    price = max(raw_price, 1e-3)
+    _, slipped = simulate_execution(price, 1)
+    return slipped
+
+
+def simulate_execution(price: float, qty: int) -> tuple[int, float]:
+    """Return filled quantity and price after slippage and partial fill."""
+
+    if qty <= 0 or price <= 0:
+        return 0, price
+    slippage = random.uniform(-0.0002, 0.0002)
+    fill_price = price * (1 + slippage)
+    fill_ratio = random.uniform(0.9, 1.0)
+    filled_qty = max(1, int(qty * fill_ratio))
+    return filled_qty, fill_price


### PR DESCRIPTION
## Summary
- add Kelly-style `dynamic_position_size`
- generate rolling z-score matrices and ensemble votes
- classify trend/mean‐revert regimes
- simulate partial fills with slippage
- log rolling Sharpe/Sortino and exposure metrics
- extend main summary and add regression tests

## Testing
- `pip install numpy pandas pyarrow pandas_ta`
- `pip install yfinance python-dotenv tenacity pytest pytest-xdist`
- `pytest -n auto --disable-warnings` *(fails: AttributeError due to missing packages)*
- `python backtest.py` *(fails: ModuleNotFoundError: 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_686589cd17f88330a59126a1e0881969