### PR TITLE
Optimize indicators and mean reversion strategy

### DIFF
--- a/features.py
+++ b/features.py
@@ -1,29 +1,26 @@
 import pandas as pd
 import numpy as np
 import logging
+from indicators import ema, atr
 
 logger = logging.getLogger(__name__)
 
 
 def compute_macd(df: pd.DataFrame) -> pd.DataFrame:
-    df['ema12'] = df['close'].ewm(span=12, adjust=False).mean()
-    df['ema26'] = df['close'].ewm(span=26, adjust=False).mean()
+    close = tuple(df['close'].astype(float))
+    df['ema12'] = ema(close, 12)
+    df['ema26'] = ema(close, 26)
     df['macd'] = df['ema12'] - df['ema26']
     return df
 
 
 def compute_macds(df: pd.DataFrame) -> pd.DataFrame:
-    df['macds'] = df['macd'].ewm(span=9, adjust=False).mean()
+    df['macds'] = ema(tuple(df['macd'].astype(float)), 9)
     return df
 
 
 def compute_atr(df: pd.DataFrame, period: int = 14) -> pd.DataFrame:
-    high_low = df['high'] - df['low']
-    high_close = np.abs(df['high'] - df['close'].shift())
-    low_close = np.abs(df['low'] - df['close'].shift())
-    ranges = pd.concat([high_low, high_close, low_close], axis=1)
-    true_range = ranges.max(axis=1)
-    df['atr'] = true_range.rolling(window=period).mean()
+    df['atr'] = atr(df['high'], df['low'], df['close'], period)
     return df
 
 

--- a/profile_indicators.py
+++ b/profile_indicators.py
@@ -19,11 +19,11 @@ def profile(func, *args, **kwargs):
 def run_profiles():
     timings = []
     df = pd.DataFrame({
-        'open': np.random.random(500_000) * 100,
-        'high': np.random.random(500_000) * 100,
-        'low': np.random.random(500_000) * 100,
-        'close': np.random.random(500_000) * 100,
-        'volume': np.random.randint(1000, 10000, size=500_000)
+        'open': np.random.random(100_000) * 100,
+        'high': np.random.random(100_000) * 100,
+        'low': np.random.random(100_000) * 100,
+        'close': np.random.random(100_000) * 100,
+        'volume': np.random.randint(1000, 10000, size=100_000)
     })
 
     modules = [signals, indicators]

--- a/slippage.py
+++ b/slippage.py
@@ -2,6 +2,7 @@ import logging
 
 from alerts import send_slack_alert
 from validate_env import settings
+from metrics_logger import log_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +13,7 @@ def monitor_slippage(expected: float | None, actual: float, symbol: str) -> None
     """Check slippage and send alert when above threshold."""
     if expected:
         pct = abs(actual - expected) / expected
+        log_metrics({"symbol": symbol, "slippage_pct": pct}, filename="metrics/slippage.csv")
         if pct > SLIPPAGE_THRESHOLD:
             msg = f"High slippage {pct:.2%} on {symbol}"
             logger.warning(msg)


### PR DESCRIPTION
## Summary
- implement vectorized indicator helpers
- standardize feature calculations using new indicators
- enhance signal matrix generation and mean reversion strategy
- log slippage metrics
- streamline indicator profiling script

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68658e434ff0833084083e067ed64e5c