### PR TITLE
Expand tests for indicators and scaling

### DIFF
--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,75 @@
+import types
+import pytest
+
+
+class DummyLock:
+    data = ''
+    def __init__(self, *a, **k):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, exc, val, tb):
+        return False
+    def write(self, s):
+        self.__class__.data = s
+    def read(self):
+        return self.__class__.data
+    def seek(self, *a):
+        pass
+    def truncate(self):
+        pass
+
+
+def setup_ctx():
+    ctx = types.SimpleNamespace(
+        kelly_fraction=0.6,
+        capital_scaler=types.SimpleNamespace(compression_factor=lambda b: 1.0),
+        max_position_dollars=1e9,
+    )
+    return ctx
+
+
+def manual_fractional(balance, price, atr, win_prob, peak):
+    import bot_engine as bot
+    base_frac = 0.6
+    comp = 1.0
+    base_frac *= comp
+    drawdown = (peak - balance) / peak
+    if drawdown > 0.10:
+        frac = 0.3
+    elif drawdown > 0.05:
+        frac = 0.45
+    else:
+        frac = base_frac
+    edge = win_prob - (1 - win_prob) / 1.5
+    kelly = max(edge / 1.5, 0) * frac
+    dollars = kelly * balance
+    raw = dollars / atr
+    cap_pos = (balance * bot.CAPITAL_CAP) / price
+    risk_cap = (balance * bot.DOLLAR_RISK_LIMIT) / atr
+    dollar_cap = 1e9 / price
+    size = int(round(min(raw, cap_pos, risk_cap, dollar_cap, bot.MAX_POSITION_SIZE)))
+    return max(size, 1)
+
+
+def test_fractional_kelly_drawdown(monkeypatch, tmp_path):
+    import sys, types
+    sys.modules.setdefault('schedule', types.ModuleType('schedule'))
+    sys.modules.setdefault('yfinance', types.ModuleType('yfinance'))
+    import bot_engine as bot
+    ctx = setup_ctx()
+    monkeypatch.setattr(bot, 'PEAK_EQUITY_FILE', tmp_path / 'p.txt')
+    monkeypatch.setattr(bot, 'is_high_vol_thr_spy', lambda: False)
+    monkeypatch.setattr(bot.os.path, 'exists', lambda p: False)
+    monkeypatch.setattr(bot, 'portalocker', types.SimpleNamespace(Lock=DummyLock))
+    size1 = bot.fractional_kelly_size(ctx, 10000, 50, 2.0, 0.6)
+    DummyLock.data = str(10600)
+    monkeypatch.setattr(bot.os.path, 'exists', lambda p: True)
+    size2 = bot.fractional_kelly_size(ctx, 10000, 50, 2.0, 0.6)
+    exp1 = manual_fractional(10000,50,2.0,0.6,10000)
+    exp2 = manual_fractional(10000,50,2.0,0.6,10600)
+    assert size1 == exp1
+    assert size2 == exp2
+    assert size2 < size1
+
+

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,6 +1,9 @@
 import numpy as np
 import pandas as pd
 import pytest
+import sys
+import types
+import importlib
 
 np.random.seed(0)
 
@@ -13,3 +16,74 @@ def test_hmm_regime_detection():
     df = pd.DataFrame({"Close": np.random.rand(100) + 100})
     df = detect_market_regime_hmm(df)
     assert "Regime" in df.columns
+
+
+@pytest.fixture
+def sample_df():
+    """Create simple OHLCV data for indicator tests."""
+    n = 30
+    data = {
+        'high': np.linspace(10, 15, n),
+        'low': np.linspace(9, 14, n),
+        'close': np.linspace(9.5, 14.5, n),
+        'volume': np.linspace(100, 130, n)
+    }
+    return pd.DataFrame(data)
+
+
+def test_prepare_indicators_calculates(sample_df, monkeypatch):
+    """Indicators are added using pandas_ta helpers."""
+    import types
+    pta = types.ModuleType('pandas_ta')
+    pta.vwap = lambda h,l,c,v: pd.Series((h+l+c)/3, index=sample_df.index)
+    pta.macd = lambda c, **k: {
+        'MACD_12_26_9': c * 0 + 1.0,
+        'MACDs_12_26_9': c * 0 + 0.5,
+    }
+    pta.kc = lambda h,l,c,length=20: pd.DataFrame({0: c*0+1.0,1:c*0+2.0,2:c*0+3.0})
+    pta.mfi = lambda h,l,c,v,length=14: pd.Series(c*0+5.0, index=sample_df.index)
+    pta.adx = lambda h,l,c,length=14: {
+        'ADX_14': pd.Series(c*0+7.0, index=sample_df.index),
+        'DMP_14': pd.Series(c*0+1.0, index=sample_df.index),
+        'DMN_14': pd.Series(c*0+1.0, index=sample_df.index),
+    }
+    pta.rsi = lambda *a, **k: pd.Series([50.0]*len(sample_df))
+    pta.atr = lambda *a, **k: pd.Series([1.0]*len(sample_df))
+    pta.bbands = lambda *a, **k: {
+        'BBU_20_2.0': pd.Series([1.0]*len(sample_df)),
+        'BBL_20_2.0': pd.Series([1.0]*len(sample_df)),
+        'BBP_20_2.0': pd.Series([1.0]*len(sample_df)),
+    }
+    monkeypatch.setitem(sys.modules, 'pandas_ta', pta)
+    retrain = importlib.import_module('retrain')
+    out = retrain.prepare_indicators(sample_df)
+    assert out['vwap'].iloc[-1] == pytest.approx((sample_df['high']+sample_df['low']+sample_df['close']).iloc[-1]/3)
+    assert out['macd'].iloc[0] == 1.0
+    assert out['kc_upper'].iloc[0] == 3.0
+    assert out['mfi_14'].iloc[0] == 5.0
+    assert out['adx'].iloc[0] == 7.0
+
+
+def test_composite_signal_confidence(monkeypatch):
+    """SignalManager combines weights into final score."""
+    import bot_engine as bot
+    sm = bot.SignalManager()
+    monkeypatch.setattr(sm, 'load_signal_weights', lambda: {})
+    monkeypatch.setattr(bot, 'load_global_signal_performance', lambda: [])
+    monkeypatch.setattr(sm, 'signal_momentum', lambda df, model=None: (1, 0.4, 'momentum'))
+    monkeypatch.setattr(sm, 'signal_mean_reversion', lambda df, model=None: (-1, 0.2, 'mean_reversion'))
+    monkeypatch.setattr(sm, 'signal_ml', lambda df, model=None: (1, 0.6, 'ml'))
+    monkeypatch.setattr(sm, 'signal_sentiment', lambda ctx, ticker, df=None, model=None: (1, 0.1, 'sentiment'))
+    monkeypatch.setattr(sm, 'signal_regime', lambda state, df, model=None: (1, 1.0, 'regime'))
+    monkeypatch.setattr(sm, 'signal_stochrsi', lambda df, model=None: (1, 0.1, 'stochrsi'))
+    monkeypatch.setattr(sm, 'signal_obv', lambda df, model=None: (1, 0.1, 'obv'))
+    monkeypatch.setattr(sm, 'signal_vsa', lambda df, model=None: (1, 0.1, 'vsa'))
+    df = pd.DataFrame({'close': np.linspace(1,2,60)})
+    ctx = types.SimpleNamespace()
+    state = types.SimpleNamespace(current_regime='trending', no_signal_events=0)
+    model = types.SimpleNamespace(predict=lambda x: [1], predict_proba=lambda x: [[0.4,0.6]], feature_names_in_=['rsi','macd','atr','vwap','sma_50','sma_200'])
+    final, conf, label = sm.evaluate(ctx, state, df, 'TST', model)
+    assert final == 1
+    assert conf == pytest.approx(1.0)
+    assert 'ml' in label
+

--- a/tests/test_trade_logic.py
+++ b/tests/test_trade_logic.py
@@ -1,0 +1,53 @@
+import types
+import pandas as pd
+import numpy as np
+
+
+def test_trade_logic_end_to_end(monkeypatch, caplog):
+    import sys, types as t
+    sys.modules.setdefault('schedule', t.ModuleType('schedule'))
+    sys.modules.setdefault('yfinance', t.ModuleType('yfinance'))
+    import bot_engine as bot
+    df = pd.DataFrame({
+        'close': np.linspace(1,5,30),
+        'high': np.linspace(1,5,30),
+        'low': np.linspace(1,5,30),
+        'volume': np.arange(30)+1,
+        'macd': 0.1,
+        'macds':0.1,
+        'atr':0.5,
+        'vwap':1.0
+    })
+    monkeypatch.setattr(bot, '_fetch_feature_data', lambda ctx, st, sym: (df, df, None))
+    sm = bot.SignalManager()
+    monkeypatch.setattr(sm, 'evaluate', lambda ctx, st, df, sym, model: (1.0, 0.8, 'test'))
+    monkeypatch.setattr(bot, 'signal_manager', sm)
+    monkeypatch.setattr(bot, 'pre_trade_checks', lambda *a, **k: True)
+    monkeypatch.setattr(bot, '_current_position_qty', lambda *a, **k: 0)
+    monkeypatch.setattr(bot, '_recent_rebalance_flag', lambda *a, **k: False)
+    called = {}
+    def dummy_enter(ctx, state, symbol, bal, feat_df, score, conf, strat):
+        called['qty'] = int(bal * 0.01)
+        return True
+    monkeypatch.setattr(bot, '_enter_long', dummy_enter)
+    ctx = types.SimpleNamespace(
+        api=types.SimpleNamespace(get_account=lambda: types.SimpleNamespace(cash='10000', buying_power='10000')),
+        data_fetcher=types.SimpleNamespace(get_daily_df=lambda c,s: df),
+        trade_logger=types.SimpleNamespace(log_entry=lambda *a, **k: None),
+        risk_engine=bot.RiskEngine(),
+        portfolio_weights={'TST':0.01},
+        stop_targets={},
+        take_profit_targets={},
+        rebalance_buys={},
+        max_position_dollars=1e6,
+        params={},
+        capital_scaler=bot.CapitalScalingEngine(),
+        market_open=bot.MARKET_OPEN,
+        market_close=bot.MARKET_CLOSE,
+    )
+    state = types.SimpleNamespace(trade_cooldowns={}, last_trade_direction={}, long_positions=set(), short_positions=set(), position_cache={}, no_signal_events=0)
+    caplog.set_level('INFO')
+    assert bot.trade_logic(ctx, state, 'TST', 10000, model=None, regime_ok=True)
+    assert called.get('qty') == 100
+    assert 'PROCESSING_SYMBOL' in caplog.text
+


### PR DESCRIPTION
## Summary
- add indicator calculation tests for ADX, MACD histogram, Keltner, MFI, and VWAP
- cover SignalManager composite confidence logic
- verify fractional Kelly sizing with drawdown
- basic trade logic integration test

## Testing
- `pytest tests/test_signals.py tests/test_risk.py tests/test_trade_logic.py -n auto --disable-warnings` *(fails: ModuleNotFoundError: schedule)*

------
https://chatgpt.com/codex/tasks/task_e_68659081d8448330bf31052eeb00f034