### PR TITLE
Fix market hours and port reuse

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -188,6 +188,25 @@ def test_is_market_open_holiday(monkeypatch):
     assert not utils.is_market_open(now)
 
 
+def test_is_market_open_july3_2025(monkeypatch):
+    """July 3, 2025 should be normal hours."""
+    mod = types.ModuleType("pandas_market_calendars")
+
+    class Cal:
+        def schedule(self, start_date=None, end_date=None):
+            return pd.DataFrame(
+                {
+                    "market_open": [pd.Timestamp("2025-07-03 09:30", tz="US/Eastern")],
+                    "market_close": [pd.Timestamp("2025-07-03 13:00", tz="US/Eastern")],
+                }
+            )
+
+    mod.get_calendar = lambda name: Cal()
+    monkeypatch.setitem(sys.modules, "pandas_market_calendars", mod)
+    now = datetime(2025, 7, 3, 11, 55, tzinfo=utils.EASTERN_TZ)
+    assert utils.is_market_open(now)
+
+
 def test_ensure_utc_type_error():
     with pytest.raises(AssertionError):
         utils.ensure_utc(1)


### PR DESCRIPTION
## Summary
- correct July 3 NYSE hours logic
- log detected market hours
- add PID lookup for occupied ports
- retry Flask startup on new port when TEST_MODE is set
- test coverage for market hours and port reuse

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6866d2b97c888330985e890e2f5ccd62