### PR TITLE
Bug fixes for log_trade, port check, and data fetcher

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -12,11 +12,32 @@ logger = logging.getLogger(__name__)
 _fields = ["id", "timestamp", "symbol", "side", "qty", "price", "mode", "result"]
 
 
-def log_trade(self, trade):
-    # AI-AGENT-REF: track trades and enforce drawdown limit
-    self.trades.append(trade)
-    total_pnl = sum([t['pnl'] for t in self.trades])
-    if total_pnl < -0.1 * self.starting_capital:
-        print('🚨 Max drawdown hit. Trading halted.')
-        raise SystemExit
+def log_trade(symbol, qty, side, fill_price, timestamp, extra_info=None):
+    """Persist a trade event to ``TRADE_LOG_FILE`` and log a summary."""
+    # AI-AGENT-REF: new signature for flexible logging
+    logger.info(
+        f"Trade Log | {symbol=} {qty=} {side=} {fill_price=} {timestamp=} {extra_info=}"
+    )
+
+    os.makedirs(os.path.dirname(TRADE_LOG_FILE) or ".", exist_ok=True)
+    exists = os.path.exists(TRADE_LOG_FILE)
+    try:
+        with open(TRADE_LOG_FILE, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=_fields)
+            if not exists:
+                writer.writeheader()
+            writer.writerow(
+                {
+                    "id": str(uuid.uuid4()),
+                    "timestamp": timestamp,
+                    "symbol": symbol,
+                    "side": side,
+                    "qty": qty,
+                    "price": fill_price,
+                    "mode": (extra_info or ""),
+                    "result": "",
+                }
+            )
+    except Exception as exc:  # pragma: no cover - I/O errors
+        logger.error("Failed to record trade: %s", exc)
 

--- a/tests/test_audit_smoke.py
+++ b/tests/test_audit_smoke.py
@@ -16,7 +16,7 @@ def force_coverage(mod):
 def test_log_trade(tmp_path, monkeypatch):
     path = tmp_path / "trades.csv"
     monkeypatch.setattr(audit, "TRADE_LOG_FILE", str(path))
-    audit.log_trade("AAPL", "buy", 1, 100.0, "filled", "TEST")
+    audit.log_trade("AAPL", 1, "buy", 100.0, "filled", "TEST")
     rows = list(csv.DictReader(open(path)))
     assert rows and rows[0]["symbol"] == "AAPL"
     force_coverage(audit)

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -88,9 +88,9 @@ def log_trade(
     symbol: str,
     qty: int,
     side: str,
-    price: float,
+    fill_price: float,
     timestamp: str,
-    order_id: str,
+    extra_info: Any | None = None,
 ) -> None:
     """Log basic trade execution details."""
     logger = logging.getLogger(__name__)
@@ -100,9 +100,9 @@ def log_trade(
             "symbol": symbol,
             "qty": qty,
             "side": side,
-            "price": price,
+            "price": fill_price,
             "timestamp": timestamp,
-            "order_id": order_id,
+            "extra": extra_info,
         },
     )
 
@@ -531,11 +531,11 @@ class ExecutionEngine:
             )
             audit_log_trade(
                 symbol,
-                side,
                 slice_qty,
+                side,
                 fill_price,
-                status,
-                "SHADOW" if SHADOW_MODE else "LIVE",
+                datetime.now(timezone.utc).isoformat(),
+                {"status": status, "mode": "SHADOW" if SHADOW_MODE else "LIVE"},
             )
             log_trade(
                 symbol,


### PR DESCRIPTION
## Summary
- update audit log_trade signature and implementation
- adjust trade_execution log_trade calls
- check port 9000 availability before starting Flask
- add MIN_EXPECTED_ROWS guard in data_fetcher
- update audit smoke test

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'alpaca_trade_api')*

------
https://chatgpt.com/codex/tasks/task_e_686bfd1ebff48330be77a72d9c68cb19