### PR TITLE
fix: correct indentation in get_historical_data

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -259,18 +259,18 @@ def get_historical_data(symbol: str, start_date, end_date, timeframe: str) -> pd
         raise DataFetchError(f"Historical fetch failed for {symbol}: {e}") from e
 
     df = pd.DataFrame(bars)
-        if df.empty:
-            for attempt in range(3):
-                pytime.sleep(0.5 * (attempt + 1))
-                bars = _fetch(_DEFAULT_FEED)
-                df = pd.DataFrame(bars)
-                if not df.empty:
-                    break
-            if df.empty or len(df) < MIN_EXPECTED_ROWS:
-                logger.warning(
-                    f"Data incomplete for {symbol}, got {len(df)} rows. Skipping this cycle."
-                )
-                return []
+    if df.empty:
+        for attempt in range(3):
+            pytime.sleep(0.5 * (attempt + 1))
+            bars = _fetch(_DEFAULT_FEED)
+            df = pd.DataFrame(bars)
+            if not df.empty:
+                break
+        if df.empty or len(df) < MIN_EXPECTED_ROWS:
+            logger.warning(
+                f"Data incomplete for {symbol}, got {len(df)} rows. Skipping this cycle."
+            )
+            return []
 
     if isinstance(df.columns, pd.MultiIndex):
         df.columns = df.columns.get_level_values(-1)


### PR DESCRIPTION
## Summary
- fix indentation around `if df.empty` block in `get_historical_data`
- ensure consistent 4‑space indentation throughout the block

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'alpaca_trade_api')*

------
https://chatgpt.com/codex/tasks/task_e_686c07d2639483308aef4ed51f7c0ec1