### PR TITLE
Fix capital scaling aliases

### DIFF
--- a/capital_scaling.py
+++ b/capital_scaling.py
@@ -129,9 +129,14 @@ def volatility_parity_position_alt(base_risk: float, atr_value: float) -> float:
     """Alternate interface for volatility_parity_position."""
     return volatility_parity_position(base_risk, atr_value)
 
-# Alias for tests
-try:
+# AI-AGENT-REF: ensure aliases exist for both API names
+if 'drawdown_adjusted_kelly_alt' in globals() and 'drawdown_adjusted_kelly' not in globals():
+    drawdown_adjusted_kelly = drawdown_adjusted_kelly_alt
+elif 'drawdown_adjusted_kelly' in globals() and 'drawdown_adjusted_kelly_alt' not in globals():
     drawdown_adjusted_kelly_alt = drawdown_adjusted_kelly
-except NameError:
-    pass
+
+if 'volatility_parity_position_alt' in globals() and 'volatility_parity_position' not in globals():
+    volatility_parity_position = volatility_parity_position_alt
+elif 'volatility_parity_position' in globals() and 'volatility_parity_position_alt' not in globals():
+    volatility_parity_position_alt = volatility_parity_position
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,7 @@ def stub_capital_scaling(monkeypatch):
     import capital_scaling as cs
     monkeypatch.setattr(cs, "drawdown_adjusted_kelly", lambda *a, **k: 0.02)
     monkeypatch.setattr(cs, "drawdown_adjusted_kelly_alt", lambda *a, **k: 0.015)
+    monkeypatch.setattr(cs, "volatility_parity_position", lambda *a, **k: 0.01)
     monkeypatch.setattr(cs, "volatility_parity_position_alt", lambda *a, **k: 0.01)
     yield
 

--- a/tests/test_kelly_drawdown_taper.py
+++ b/tests/test_kelly_drawdown_taper.py
@@ -1,10 +1,10 @@
 import pytest
-from capital_scaling import drawdown_adjusted_kelly as drawdown_adjusted_kelly_alt
+from capital_scaling import drawdown_adjusted_kelly
 
 
 def test_drawdown_adjusted_kelly_basic():
-    assert 0.0 <= drawdown_adjusted_kelly_alt(9000, 10000, 0.5) <= 1.0
+    assert 0.0 <= drawdown_adjusted_kelly(9000, 10000, 0.5) <= 1.0
 
 
 def test_drawdown_adjusted_kelly_zero_drawdown():
-    assert drawdown_adjusted_kelly_alt(10000, 10000, 0.5) > 0.0
+    assert drawdown_adjusted_kelly(10000, 10000, 0.5) > 0.0

--- a/tests/test_scaling_and_indicators.py
+++ b/tests/test_scaling_and_indicators.py
@@ -1,5 +1,5 @@
 import pytest
-from capital_scaling import volatility_parity_position_alt as volatility_parity_position
+from capital_scaling import volatility_parity_position
 
 
 def test_volatility_parity_position_basic():


### PR DESCRIPTION
## Summary
- alias drawdown & volatility helpers in `capital_scaling`
- update tests to import non-alt helper names
- stub volatility helper in conftest for both names

## Testing
- `make test-all` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_686efc72e6ac83308207676ef55a4ff5