### PR TITLE
Fix capital scaling imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import sys
 import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from pathlib import Path
 
 import pytest

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -15,3 +15,9 @@ def test_imports():
         except Exception as exc:
             raise AssertionError(f"Failed to import {mod}: {exc}")
 
+
+def test_import_capital_scaling():
+    from capital_scaling import drawdown_adjusted_kelly, volatility_parity_position
+    assert callable(drawdown_adjusted_kelly)
+    assert callable(volatility_parity_position)
+

--- a/tests/test_trade_logic.py
+++ b/tests/test_trade_logic.py
@@ -1,4 +1,5 @@
 from trade_logic import should_enter_trade
+from capital_scaling import drawdown_adjusted_kelly
 
 
 def test_should_enter_trade_basic():


### PR DESCRIPTION
## Summary
- add top-level path insert in tests
- validate capital_scaling imports
- update trade_logic test import

## Testing
- `pytest tests/test_imports.py::test_import_capital_scaling -vv`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: pandas and other deps)*

------
https://chatgpt.com/codex/tasks/task_e_686f037ac36883309fc886bff07a510b