### PR TITLE
Fix missing time import

### DIFF
--- a/strategy_allocator.py
+++ b/strategy_allocator.py
@@ -1,6 +1,7 @@
 import logging
 import math
 import os
+import time  # AI-AGENT-REF: needed for monotonic timestamps
 from typing import Dict, List
 
 from strategies import TradeSignal


### PR DESCRIPTION
## Summary
- import `time` in `strategy_allocator`

## Testing
- `pytest -n auto --disable-warnings` *(fails: unrecognized arguments `-n`)*

------
https://chatgpt.com/codex/tasks/task_e_686fd78698108330a3dbc8bdf2cb978c