### PR TITLE
Apply user patches

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -37,6 +37,11 @@ def check_health_rows(rows: int) -> None:
 
 
 def skip_cooldown(symbols: list[str]) -> None:
+    # Enforce immediate cooldown protection to avoid double buying
+    for sym in symbols:
+        if sym in positions:
+            continue  # Already holding, skip re-buy
+        cooldown_tracker[sym] = time.time()
     """Batch SKIP_COOLDOWN symbols until flushed."""
     global _skip_cooldown_symbols
     _skip_cooldown_symbols.update(symbols)

--- a/alpaca_api.py
+++ b/alpaca_api.py
@@ -124,6 +124,9 @@ def get_account() -> Optional[Dict[str, Any]]:
 
 
 def submit_order(api, req, log: logging.Logger | None = None):
+    if req["symbol"] in [order["symbol"] for order in pending_orders.values()]:
+        print(f"Skipping duplicate order for {req['symbol']} still pending")
+        return None
     """Submit an order with retry and optional shadow mode."""
     log = log or logger
     if DRY_RUN:

--- a/risk_engine.py
+++ b/risk_engine.py
@@ -313,6 +313,14 @@ def register_trade(size: int) -> dict | None:
     return {"size": size}
 
 
+def check_exposure_caps(portfolio, exposure, cap):
+    for sym in positions:
+        if exposure[sym] > cap:
+            print(f"Exposure cap triggered, blocking new orders for {sym}")
+            return False
+    # Original exposure logic continues here...
+
+
 import pandas_ta as ta
 
 


### PR DESCRIPTION
## Summary
- adjust skip_cooldown to enforce cooldown immediately
- skip duplicate orders still pending
- check open positions when evaluating exposure caps

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686fdbf066a88330a064a4c528470ae6