### PR TITLE
Fix exposure cap logging and duplicate order detection

### DIFF
--- a/risk_engine.py
+++ b/risk_engine.py
@@ -314,9 +314,11 @@ def register_trade(size: int) -> dict | None:
 
 
 def check_exposure_caps(portfolio, exposure, cap):
-    for sym in positions:
-        if exposure[sym] > cap:
-            print(f"Exposure cap triggered, blocking new orders for {sym}")
+    for sym, pos in portfolio.positions.items():
+        if pos.quantity > 0 and exposure[sym] > cap:
+            logger.warning(
+                "Exposure cap triggered, blocking new orders for %s", sym
+            )
             return False
     # Original exposure logic continues here...
 


### PR DESCRIPTION
## Summary
- correct duplicate order check in `alpaca_api` and clean up pending order tracking
- fix `check_exposure_caps` to use portfolio positions and logger

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686feca5af9c8330a9e22da7cce3fef5