### PR TITLE
Improve trade utils and risk checks

### DIFF
--- a/ai_trading/trade_logic.py
+++ b/ai_trading/trade_logic.py
@@ -1,6 +1,8 @@
 # AI-AGENT-REF: basic trade utilities
 
 import random
+from typing import Any, Sequence
+
 import metrics_logger
 from logger import get_logger
 from ai_trading.capital_scaling import (
@@ -17,6 +19,23 @@ def should_enter_trade(price_data, signals, risk_params):
     signal_strength = signals.get("signal_strength", 0)
     max_risk = risk_params.get("max_risk", 0.02)
     return signal_strength > 0.7 and recent_gain > 0 and max_risk < 0.05
+
+
+def extract_price(data: Any) -> float:
+    """Return the last price from various data structures."""
+    # AI-AGENT-REF: handle DataFrame, mapping or sequence inputs
+    try:
+        if hasattr(data, "iloc"):
+            val = data["close"].iloc[-1]
+        elif isinstance(data, dict):
+            val = data.get("close") or data.get("price")
+        elif isinstance(data, Sequence):
+            val = data[-1]
+        else:
+            val = float(data)
+    except Exception:
+        val = 0.0
+    return float(val or 0.0)
 
 def compute_order_price(symbol_data):
     raw_price = extract_price(symbol_data)

--- a/meta_learning.py
+++ b/meta_learning.py
@@ -3,12 +3,7 @@
 import json
 import logging
 import pickle
-import joblib
-import datetime
 import random
-# AI-AGENT-REF: safe utc
-old_generate = datetime.datetime.now(datetime.UTC)  # replaced utcnow for tz-aware
-new_generate = datetime.datetime.now(datetime.UTC)
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional

--- a/risk_engine.py
+++ b/risk_engine.py
@@ -281,11 +281,15 @@ class RiskEngine:
             logger.warning("Empty or invalid returns series—skipping risk computation")
             return {"volatility": 0.0}
 
-        try:
-            vol = float(np.std(returns))
-        except (ValueError, TypeError) as exc:
-            logger.error("Failed computing volatility: %s", exc)
+        if np.isnan(returns).any() or np.isinf(returns).any():
+            logger.error("Failed computing volatility: invalid values present")
             vol = 0.0
+        else:
+            try:
+                vol = float(np.std(returns))
+            except (ValueError, TypeError) as exc:
+                logger.error("Failed computing volatility: %s", exc)
+                vol = 0.0
         return {"volatility": vol}
 
 

--- a/tests/test_risk_engine_additional.py
+++ b/tests/test_risk_engine_additional.py
@@ -65,6 +65,15 @@ def test_compute_volatility_error(monkeypatch):
     assert res['volatility'] == 0.0
 
 
+def test_compute_volatility_nan(caplog):
+    eng = risk_engine.RiskEngine()
+    caplog.set_level("ERROR")
+    arr = np.array([1.0, np.nan])
+    res = eng.compute_volatility(arr)
+    assert res["volatility"] == 0.0
+    assert "invalid values" in caplog.text
+
+
 def test_calculate_position_size_invalid_args():
     """Invalid argument patterns raise TypeError."""
     with pytest.raises(TypeError):

--- a/tests/test_trade_logic.py
+++ b/tests/test_trade_logic.py
@@ -1,4 +1,10 @@
-from ai_trading.trade_logic import should_enter_trade
+import pandas as pd
+
+from ai_trading.trade_logic import (
+    should_enter_trade,
+    compute_order_price,
+    extract_price,
+)
 from ai_trading.capital_scaling import drawdown_adjusted_kelly
 
 
@@ -6,3 +12,15 @@ def test_should_enter_trade_basic():
     assert should_enter_trade(
         [100, 105], {"signal_strength": 0.8}, {"max_risk": 0.02}
     )
+
+
+def test_extract_price_generic():
+    df = pd.DataFrame({"close": [1.0, 2.0]})
+    assert extract_price(df) == 2.0
+    assert extract_price({"close": 3.0}) == 3.0
+    assert extract_price([4.0, 5.0]) == 5.0
+
+
+def test_compute_order_price_slippage():
+    price = compute_order_price({"close": 10})
+    assert price > 0


### PR DESCRIPTION
## Summary
- adjust MetaLearning imports and remove unused vars
- enhance volatility computation with NaN guard
- extend trade utilities with price extraction
- cover new helpers in tests

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68704dde53dc8330a72812ab95530b20