### PR TITLE
Remove secrets from log output

### DIFF
--- a/config.py
+++ b/config.py
@@ -90,7 +90,7 @@ _CONFIG_LOGGED = False
 
 
 def log_config(keys: list[str] | None = None) -> None:
-    """Log key configuration values with secrets masked."""
+    """Log selected configuration values with secrets hidden."""
     global _CONFIG_LOGGED
     if _CONFIG_LOGGED:
         return
@@ -100,7 +100,8 @@ def log_config(keys: list[str] | None = None) -> None:
     for k in keys:
         val = os.getenv(k, "")
         if "KEY" in k or "SECRET" in k:
-            val = mask_secret(val)
+            # AI-AGENT-REF: avoid logging secret values entirely
+            val = "<hidden>"
         cfg[k] = val
     logger.info("Configuration: %s", cfg)
     _CONFIG_LOGGED = True

--- a/tests/test_config_additional.py
+++ b/tests/test_config_additional.py
@@ -43,5 +43,5 @@ def test_log_config_masks_secrets(monkeypatch, caplog):
     caplog.set_level("INFO")
     config._CONFIG_LOGGED = False
     config.log_config(["ALPACA_API_KEY"])
-    assert "****1234" in caplog.text
+    assert "<hidden>" in caplog.text
     assert "secret1234" not in caplog.text


### PR DESCRIPTION
## Summary
- hide actual secret values when logging config
- update tests for new log message

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'alpaca_trade_api')*

------
https://chatgpt.com/codex/tasks/task_e_68706089cf108330afa1c8ab12e22980