### PR TITLE
Fix hold_protect decrement

### DIFF
--- a/strategy_allocator.py
+++ b/strategy_allocator.py
@@ -70,9 +70,11 @@ class StrategyAllocator:
             )
 
             for sym in list(self.hold_protect):
+                # AI-AGENT-REF: ensure cooldown decrements only once per cycle
                 if vol < float(os.getenv("VOL_THRESHOLD", 1.2)):
                     self.hold_protect[sym] = max(0, self.hold_protect[sym] - 2)
-                self.hold_protect[sym] -= 1
+                else:
+                    self.hold_protect[sym] = max(0, self.hold_protect[sym] - 1)
                 if self.hold_protect[sym] <= 0:
                     last_ts = self._last_cooldown_log.get(sym, 0.0)
                     if (


### PR DESCRIPTION
## Summary
- patch strategy_allocator to decrement hold cooldown only once per cycle

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68715c6568c88330b629a879e3548883