### PR TITLE
Refactor holding logic for indicator-driven exits

### DIFF
--- a/run.py
+++ b/run.py
@@ -153,6 +153,9 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    # AI-AGENT-REF: ensure signal-driven holding by disabling rebalance hold
+    os.environ.setdefault("REBALANCE_HOLD_SECONDS", "0")
+
     # ✅ Fix: get configured logger object from setup_logging
     logger = setup_logging(log_file=args.log_file)
     logger.info("Starting AI Trading Bot unified runner")

--- a/strategy_allocator.py
+++ b/strategy_allocator.py
@@ -129,14 +129,16 @@ class StrategyAllocator:
                         and s.symbol in recent_buys
                         and time.time() - recent_buys[s.symbol] < 120
                     ):
-                        logger.info("SKIP_REBALANCE_RECENT_BUY for %s", s.symbol)
-                        continue
+                        # AI-AGENT-REF: allow sells despite recent buy; log only
+                        logger.info(
+                            "RECENT_BUY_SELL", extra={"symbol": s.symbol}
+                        )
                     last_dir = self.last_direction.get(s.symbol)
                     last_conf = self.last_confidence.get(s.symbol, 0.0)
                     if last_dir and last_dir != s.side:
                         if s.side == "sell" and self.hold_protect.get(s.symbol, 0) > 0:
-                            logger.info("SKIP_HOLD_PROTECTION", extra={"symbol": s.symbol})
-                            continue
+                            # AI-AGENT-REF: remove hold protection block; log only
+                            logger.info("HOLD_PROTECT_ACTIVE", extra={"symbol": s.symbol})
                         if s.confidence < last_conf + self.delta_threshold:
                             logger.info("SKIP_DELTA_THRESHOLD", extra={"symbol": s.symbol})
                             continue


### PR DESCRIPTION
## Summary
- drop sell skips from StrategyAllocator
- make rebalance hold duration configurable via env var
- remove time-based exit checks in bot logic
- disable rebalance hold in runner

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687167430a788330aba872ec85fa317c