### PR TITLE
Fix psutil import and exception indentation

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -630,22 +630,22 @@ def get_minute_df(
                     logger.debug(
                         "FETCH_YFINANCE_MINUTE_BARS: got %s bars", len(df) if df is not None else 0
                     )
-            except Exception as exc:
-                yexc = exc
-                logger.error("[DataFetcher] yfinance failed: %s", exc)
-                logger.error(
-                    "DATA_SOURCE_RETRY_FINAL: alpaca failed=%s; finnhub failed=%s; yfinance failed=%s | last=%s",
-                    alpaca_exc,
-                    fh_err,
-                    exc,
-                    "yfinance",
-                )
-                logger.debug("yfinance fetch error: %s", exc)
-                raise DataSourceDownException(symbol) from exc
-            else:
-                logger.critical(
-                    "Secondary provider failed for %s: %s", symbol, fh_err
-                )
+                except Exception as exc:
+                    yexc = exc
+                    logger.error("[DataFetcher] yfinance failed: %s", exc)
+                    logger.error(
+                        "DATA_SOURCE_RETRY_FINAL: alpaca failed=%s; finnhub failed=%s; yfinance failed=%s | last=%s",
+                        alpaca_exc,
+                        fh_err,
+                        exc,
+                        "yfinance",
+                    )
+                    logger.debug("yfinance fetch error: %s", exc)
+                    raise DataSourceDownException(symbol) from exc
+                else:
+                    logger.critical(
+                        "Secondary provider failed for %s: %s", symbol, fh_err
+                    )
                 raise DataSourceDownException(symbol) from fh_err
         except Exception as fh_err:
             finnhub_exc = fh_err

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,4 @@ torch>=2.0
 joblib>=1.3
 torch==2.5.1
 joblib>=1.3
+psutil

--- a/utils.py
+++ b/utils.py
@@ -13,11 +13,14 @@ from zoneinfo import ZoneInfo
 
 import pandas as pd
 import config
+
+logger = logging.getLogger(__name__)
+
 try:
     import psutil
-except Exception as e:  # pragma: no cover - optional dependency
-    logging.getLogger(__name__).error("psutil import failed", exc_info=e)
+except ImportError:
     psutil = None
+    logger.warning("psutil import failed — memory stats disabled")
 
 try:
     from tzlocal import get_localzone
@@ -27,8 +30,6 @@ except ImportError:  # pragma: no cover - optional dependency
     def get_localzone() -> ZoneInfo:
         return ZoneInfo("UTC")
 
-
-logger = logging.getLogger(__name__)
 
 # AI-AGENT-REF: throttle noisy logs
 _LAST_MARKET_HOURS_LOG = 0.0


### PR DESCRIPTION
## Summary
- handle optional psutil dependency in `utils`
- correct indentation of yfinance fallback `except` block
- add psutil to requirements

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'alpaca_trade_api')*

------
https://chatgpt.com/codex/tasks/task_e_6878313ce94c83309a408acc1ed789fd