### PR TITLE
Update torch pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ optuna==3.6.1
 # Monitor CPU load
 psutil>=5.9.8
 # For Python 3.12 wheels use the CPU index when installing PyTorch locally
-torch==2.1.2
+torch>=2.2.2,<2.8.0   # 2.2.x+cpu wheels exist for Python 3.12
 
 
 xgboost>=1.7.6


### PR DESCRIPTION
## Summary
- ensure torch is pinned to an available version for Python 3.12

## Testing
- `pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements.txt` *(failed: system interrupted)*
- `pytest -n auto --disable-warnings` *(failed: missing pytest-xdist)*
- `sudo systemctl restart ai-trading.service` *(failed: no systemd)*

------
https://chatgpt.com/codex/tasks/task_e_687838849854833099e05b1e3a13a0bb