### PR TITLE
Fix torch pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # Ensure PyYAML can build under Python 3.12
 Cython>=0.29.36         # needed to build PyYAML on Python 3.12
 PyYAML==6.0.1             # ensure a wheel install
-
 tenacity==8.2.2
 ratelimit==2.2.1
 numpy>=1.24.0
@@ -38,15 +37,8 @@ python-dateutil==2.9.0.post0
 optuna==3.6.1
 # Monitor CPU load
 psutil>=5.9.8
-# For Python 3.12 wheels use the CPU index when installing PyTorch locally
-torch>=2.2.2,<2.8.0   # 2.2.x+cpu wheels exist for Python 3.12
-
-
+# For Python 3.12 use the CPU wheel index:
+# https://download.pytorch.org/whl/cpu
+torch==2.2.2+cpu  # CPU-only wheel for Python 3.12
 xgboost>=1.7.6
 alpaca-trade-api>=3.0.0
-
-torch>=2.0
-joblib>=1.3
-torch==2.5.1
-joblib>=1.3
-psutil


### PR DESCRIPTION
## Summary
- remove merge conflict duplicates from requirements
- document torch extra-index
- pin to torch 2.2.2+cpu

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68783b696ab08330ab8db6be78a3988f