### PR TITLE
Fix locking and unique order IDs

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -6,6 +6,7 @@ import logging
 import warnings
 import os
 import time
+from filelock import FileLock, Timeout
 
 # AI-AGENT-REF: suppress noisy external library warnings
 warnings.filterwarnings("ignore", category=SyntaxWarning, message="invalid escape sequence")
@@ -72,7 +73,13 @@ def main() -> None:  # pragma: no cover - thin wrapper for entrypoint
         get_logger(__name__).warning(
             "\ud83d\ude80 FORCE_TRADES is ENABLED. This run will ignore normal health halts!"
         )
-    entrypoint()
+    lock = FileLock("/tmp/ai_trading_bot.lock", timeout=0)
+    try:
+        with lock:
+            entrypoint()
+    except Timeout:
+        get_logger(__name__).info("RUN_ALL_TRADES_SKIPPED_OVERLAP")
+        return
 
 
 if __name__ == "__main__":

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -5759,6 +5759,7 @@ def _process_symbols(
                 )
                 skipped_duplicates.inc()
                 continue
+            # qty < 0 → real short, queue close
             if qty < 0:
                 logger.info(
                     "SHORT_CLOSE_QUEUED | symbol=%s  qty=%d",

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,8 @@ python-dateutil==2.9.0.post0
 optuna==3.6.1
 # Monitor CPU load
 psutil>=5.9.8
+# lightweight cross-process locks
+filelock>=3.13.1
 # For Python 3.12 use the CPU wheel index:
 # https://download.pytorch.org/whl/cpu
 torch==2.2.2+cpu  # CPU-only wheel for Python 3.12

--- a/tests/test_client_order_id.py
+++ b/tests/test_client_order_id.py
@@ -1,0 +1,22 @@
+import types
+import alpaca_api
+
+
+class DummyAPI:
+    def __init__(self):
+        self.ids = []
+
+    def submit_order(self, order_data=None):
+        self.ids.append(order_data.client_order_id)
+        return types.SimpleNamespace(id=len(self.ids), client_order_id=order_data.client_order_id)
+
+
+def make_req(symbol="AAPL"):
+    return types.SimpleNamespace(symbol=symbol, qty=1, side="buy", time_in_force="day")
+
+
+def test_unique_client_order_id():
+    api = DummyAPI()
+    alpaca_api.submit_order(api, make_req())
+    alpaca_api.submit_order(api, make_req())
+    assert len(set(api.ids)) == 2

--- a/tests/test_skip_logic.py
+++ b/tests/test_skip_logic.py
@@ -1,0 +1,26 @@
+import types
+import pandas as pd
+import bot_engine
+
+
+def test_skip_logic(monkeypatch, caplog):
+    state = bot_engine.BotState()
+    state.position_cache = {"MSFT": 10, "TSLA": -10}
+    caplog.set_level("INFO")
+
+    orders = []
+    monkeypatch.setattr(bot_engine, "submit_order", lambda ctx, symbol, qty, side: orders.append((symbol, qty, side)))
+    monkeypatch.setattr(bot_engine, "is_market_open", lambda: True)
+    monkeypatch.setattr(bot_engine, "fetch_minute_df_safe", lambda s: pd.DataFrame({"close": [1]}, index=[pd.Timestamp("2023-01-01")]))
+    monkeypatch.setattr(bot_engine, "_safe_trade", lambda *a, **k: None)
+    monkeypatch.setattr(bot_engine.prediction_executor, "submit", lambda fn, s: types.SimpleNamespace(result=lambda: fn(s)))
+    monkeypatch.setattr(bot_engine, "log_skip_cooldown", lambda *a, **k: None)
+    monkeypatch.setattr(bot_engine.skipped_duplicates, "inc", lambda: None)
+
+    processed, _ = bot_engine._process_symbols(["MSFT", "TSLA"], 1000.0, None, True)
+    assert processed == []
+    assert ("TSLA", 10, "buy") in orders
+    assert all(o[0] != "MSFT" for o in orders)
+    msgs = [r.message for r in caplog.records]
+    assert any("SHORT_CLOSE_QUEUED" in m and "TSLA" in m for m in msgs)
+    assert any("SKIP_HELD_POSITION" in m and "MSFT" in m for m in msgs)


### PR DESCRIPTION
## Summary
- prevent concurrent bot instances with FileLock
- ensure unique Alpaca client order IDs
- comment short-cover logic
- add filelock dependency
- test client order IDs and skip logic

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'numba')*
- `pytest tests/test_skip_logic.py tests/test_client_order_id.py tests/test_run_overlap.py -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'numba')*

------
https://chatgpt.com/codex/tasks/task_e_687943a5ec188330ab2977a233226f11