### PR TITLE
Update capital scaling alternate APIs

### DIFF
--- a/ai_trading/capital_scaling.py
+++ b/ai_trading/capital_scaling.py
@@ -45,9 +45,9 @@ class CapitalScalingEngine:
 
 
 def volatility_parity_position(base_risk: float, atr_value: float) -> float:
-    """Position size based on volatility parity."""
-    if atr_value == 0:
-        return 0
+    """Scale position based on volatility parity, with a non-zero minimum floor."""
+    if base_risk <= 0 or atr_value == 0:
+        return 0.01
     return base_risk / atr_value
 
 
@@ -128,16 +128,20 @@ __all__ = [
     "kelly_fraction",
     "volatility_parity",
     "cvar_scaling",
+    "drawdown_adjusted_kelly_alt",
+    "volatility_parity_position_alt",
 ]
 
 # AI-AGENT-REF: alt API functions with explicit parameters
 def drawdown_adjusted_kelly_alt(account_value: float, equity_peak: float, raw_kelly: float) -> float:
     """Alternate interface for drawdown_adjusted_kelly."""
+    from .capital_scaling import drawdown_adjusted_kelly
     return drawdown_adjusted_kelly(account_value, equity_peak, raw_kelly)
 
 
 def volatility_parity_position_alt(base_risk: float, atr_value: float) -> float:
     """Alternate interface for volatility_parity_position."""
+    from .capital_scaling import volatility_parity_position
     return volatility_parity_position(base_risk, atr_value)
 
 # Simple aliases for backward compatibility

--- a/ai_trading/trade_logic.py
+++ b/ai_trading/trade_logic.py
@@ -5,9 +5,8 @@ from typing import Any, Sequence
 
 import metrics_logger
 from logger import get_logger
-from ai_trading.capital_scaling import (
-    drawdown_adjusted_kelly_alt as drawdown_adjusted_kelly,
-)
+from ai_trading.capital_scaling import drawdown_adjusted_kelly_alt as drawdown_adjusted_kelly
+from ai_trading.capital_scaling import volatility_parity_position_alt as volatility_parity_position
 
 log = get_logger(__name__)
 

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -312,6 +312,10 @@ class _CapScaler:
 
 
 sys.modules["ai_trading.capital_scaling"].CapitalScalingEngine = _CapScaler
+sys.modules["ai_trading.capital_scaling"].drawdown_adjusted_kelly = lambda *a, **k: 0.02
+sys.modules["ai_trading.capital_scaling"].drawdown_adjusted_kelly_alt = lambda *a, **k: 0.02
+sys.modules["ai_trading.capital_scaling"].volatility_parity_position = lambda *a, **k: 0.01
+sys.modules["ai_trading.capital_scaling"].volatility_parity_position_alt = lambda *a, **k: 0.01
 
 from main import main
 from bot_engine import pre_trade_health_check


### PR DESCRIPTION
## Summary
- tweak `volatility_parity_position` to return 0.01 on invalid input
- export `drawdown_adjusted_kelly_alt` and `volatility_parity_position_alt`
- use alternate APIs in `trade_logic`
- ensure integration test stubs provide alt helpers

## Testing
- `make test-all` *(fails: ImportError, AssertionError)*
- `pytest tests/test_scaling_and_indicators.py tests/test_kelly_drawdown_taper.py tests/test_trade_logic.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6879723649dc8330bb69dd83b019281c