### PR TITLE
Fix alt interface functions

### DIFF
--- a/ai_trading/capital_scaling.py
+++ b/ai_trading/capital_scaling.py
@@ -135,13 +135,11 @@ __all__ = [
 # AI-AGENT-REF: alt API functions with explicit parameters
 def drawdown_adjusted_kelly_alt(account_value: float, equity_peak: float, raw_kelly: float) -> float:
     """Alternate interface for drawdown_adjusted_kelly."""
-    from .capital_scaling import drawdown_adjusted_kelly
     return drawdown_adjusted_kelly(account_value, equity_peak, raw_kelly)
 
 
 def volatility_parity_position_alt(base_risk: float, atr_value: float) -> float:
     """Alternate interface for volatility_parity_position."""
-    from .capital_scaling import volatility_parity_position
     return volatility_parity_position(base_risk, atr_value)
 
 # Simple aliases for backward compatibility


### PR DESCRIPTION
## Summary
- clean up alt capital scaling helpers so they call local functions

## Testing
- `make test-all` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest --maxfail=1 --disable-warnings -vv -s` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6879764ccadc8330a43e976a1c4320f2