### PR TITLE
Remove xdist from pytest opts

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,6 @@ markers =
     slow
     smoke
 timeout = 10
-addopts = -ra --disable-warnings -n auto
+addopts = -ra --disable-warnings
 testpaths = tests
 python_files = test_*.py


### PR DESCRIPTION
## Summary
- adjust pytest configuration so running `pytest` no longer spawns xdist workers

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch==2.2.2+cpu)*

------
https://chatgpt.com/codex/tasks/task_e_687980790e288330add951aba31b5f3f