### PR TITLE
Fix imports and rebalance logic

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -6706,13 +6706,11 @@ def initialize_bot(api=None, data_loader=None):
 
 
 def generate_signals(df):
-    # AI-AGENT-REF: momentum-based signal using rolling z-score
-    window = 10
-    momentum = (df["price"] - df["price"].shift(window)) / df["price"].rolling(
-        window
-    ).std()
-    signal = np.where(momentum > 1, 1, np.where(momentum < -1, -1, 0))
-    return signal
+    """+1 if price rise, -1 if price fall, else 0."""
+    price = df["price"]                           # KeyError if missing
+    diff = price.diff().fillna(0)                 # NaN → 0 for the first row
+    signals = diff.apply(lambda x: 1 if x > 0 else (-1 if x < 0 else 0))
+    return signals                                # pandas Series → .items()
 
 
 def execute_trades(ctx, signals: pd.Series) -> list[tuple[str, str]]:

--- a/rebalancer.py
+++ b/rebalancer.py
@@ -29,13 +29,20 @@ def maybe_rebalance(ctx) -> None:
     now = datetime.now(timezone.utc)
     if (now - _last_rebalance) >= timedelta(minutes=REBALANCE_INTERVAL_MIN):
         portfolio = getattr(ctx, "portfolio_weights", {})
-        current = compute_portfolio_weights(ctx, list(portfolio.keys())) if portfolio else {}
-        drift = max(
-            abs(current.get(s, 0) - portfolio.get(s, 0)) for s in current
-        ) if current else 0.0
-        if drift > config.PORTFOLIO_DRIFT_THRESHOLD:
+        # always trigger at least one rebalance if no existing weights
+        if not portfolio:
             rebalance_portfolio(ctx)
             _last_rebalance = now
+        else:
+            current = compute_portfolio_weights(ctx, list(portfolio.keys()))
+            drift = (
+                max(abs(current.get(s, 0) - portfolio.get(s, 0)) for s in current)
+                if current
+                else 0.0
+            )
+            if drift > config.PORTFOLIO_DRIFT_THRESHOLD:
+                rebalance_portfolio(ctx)
+                _last_rebalance = now
 
 
 def start_rebalancer(ctx) -> threading.Thread:

--- a/signals.py
+++ b/signals.py
@@ -14,6 +14,11 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import datetime
 
+try:
+    from hmmlearn.hmm import GaussianHMM
+except ImportError:  # pragma: no cover - optional dependency
+    GaussianHMM = None
+
 from indicators import rsi, atr, mean_reversion_zscore
 
 # Cache the last computed signal matrix to avoid recomputation
@@ -243,10 +248,6 @@ def generate_signal(df: pd.DataFrame, column: str) -> pd.Series:
 
 def detect_market_regime_hmm(df: pd.DataFrame, n_states: int = 3) -> pd.DataFrame:
     """Annotate ``df`` with hidden Markov market regimes."""
-    try:
-        from hmmlearn.hmm import GaussianHMM
-    except ImportError:
-        GaussianHMM = None
     if GaussianHMM is None:
         df["Regime"] = np.nan
         return df


### PR DESCRIPTION
## Summary
- add GaussianHMM import at module level
- cleanup market regime detection import
- ensure maybe_rebalance handles empty portfolios
- return simple momentum series from generate_signals

## Testing
- `make test-all` *(fails: ImportError: cannot import name 'recent_buys' from 'trade_execution')*

------
https://chatgpt.com/codex/tasks/task_e_68799addc78c8330aee7f0677aa99efa