### PR TITLE
Handle empty data feed gracefully

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -292,7 +292,13 @@ def get_last_available_bar(symbol: str) -> pd.DataFrame:
 
 
 @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=8))
-def get_historical_data(symbol: str, start_date, end_date, timeframe: str) -> pd.DataFrame:
+def get_historical_data(
+    symbol: str,
+    start_date,
+    end_date,
+    timeframe: str,
+    raise_on_empty: bool = False,
+) -> pd.DataFrame:
     """Fetch historical bars from Alpaca and ensure OHLCV float columns."""
 
     if start_date is None or end_date is None:
@@ -379,6 +385,9 @@ def get_historical_data(symbol: str, start_date, end_date, timeframe: str) -> pd
             logger.warning(
                 f"Data incomplete for {symbol}, got {len(df)} rows. Skipping this cycle."
             )
+            if raise_on_empty:
+                # AI-AGENT-REF: optionally propagate empty-data condition
+                raise DataFetchError("DATA_SOURCE_EMPTY")
             return pd.DataFrame()
 
     if isinstance(df.columns, pd.MultiIndex):

--- a/main.py
+++ b/main.py
@@ -277,14 +277,17 @@ if __name__ == "__main__":
                     break
                 except DataSourceEmpty:
                     logging.getLogger(__name__).warning(
-                        "DATA_SOURCE_EMPTY, retry %d/3", attempt
+                        "No data on attempt %d/3; retrying", attempt
                     )
                     time.sleep(attempt * 2)
             else:
-                logging.getLogger(__name__).error(
-                    "DATA_SOURCE_EMPTY after 3 retries; skipping cycle"
+                logging.getLogger(__name__).info(
+                    "No data after 3 attempts; skipping this cycle"
                 )
     except Timeout:
         logging.getLogger(__name__).info("RUN_ALL_TRADES_SKIPPED_OVERLAP")
+
+    # Always exit cleanly so the scheduler loop continues:
+    sys.exit(0)
 
 


### PR DESCRIPTION
## Summary
- allow `get_historical_data` to optionally raise on empty results
- retry on empty data source with warning only and always exit cleanly

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687ab59893dc8330bb274901fc498247