### PR TITLE
Remove config logging

### DIFF
--- a/config.py
+++ b/config.py
@@ -103,7 +103,6 @@ def log_config(keys: list[str] | None = None) -> None:
             # AI-AGENT-REF: avoid logging secret values entirely
             val = "<hidden>"
         cfg[k] = val
-    logger.info("Configuration: %s", cfg)
     _CONFIG_LOGGED = True
 
 

--- a/tests/test_config_additional.py
+++ b/tests/test_config_additional.py
@@ -38,10 +38,11 @@ def test_validate_alpaca_credentials_missing(monkeypatch):
         config.validate_alpaca_credentials()
 
 
-def test_log_config_masks_secrets(monkeypatch, caplog):
+def test_log_config_does_not_log(monkeypatch, caplog):
     monkeypatch.setenv("ALPACA_API_KEY", "secret1234")
     caplog.set_level("INFO")
     config._CONFIG_LOGGED = False
     config.log_config(["ALPACA_API_KEY"])
-    assert "<hidden>" in caplog.text
+    assert caplog.text == ""
     assert "secret1234" not in caplog.text
+    assert config._CONFIG_LOGGED


### PR DESCRIPTION
## Summary
- avoid logging config values from config.log_config
- update config tests

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError, AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_687ab99b35c483308f00e2656b7a2851