### PR TITLE
Refactor capital scaling init

### DIFF
--- a/ai_trading/capital_scaling.py
+++ b/ai_trading/capital_scaling.py
@@ -14,11 +14,7 @@ class _CapScaler:
 
 class CapitalScalingEngine:
     def __init__(self, params=None):
-        # AI-AGENT-REF: accept params but scaler no longer uses them
         self.params = params or {}
-        self.scaler = _CapScaler()
-        # AI-AGENT-REF: base level for compression factor calculations
-        self._base = float(self.params.get("COMPRESSION_BASE", 100000))
 
     def compression_factor(self, balance: float) -> float:
         """Return risk compression factor based on ``balance``."""


### PR DESCRIPTION
## Summary
- simplify CapitalScalingEngine.__init__

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687add80af2483308d2606ca0d3189be