### PR TITLE
Refactor tests and Alpaca API

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -38,7 +38,6 @@ mods = [
     "metrics_logger",
     "prometheus_client",
     "finnhub",
-    "joblib",
     "pybreaker",
     "trade_execution",
     "ai_trading.capital_scaling",
@@ -82,7 +81,6 @@ sys.modules["sklearn.ensemble"].RandomForestClassifier = object
 sys.modules["sklearn.linear_model"].Ridge = object
 sys.modules["sklearn.linear_model"].BayesianRidge = object
 sys.modules["sklearn.decomposition"].PCA = object
-sys.modules["joblib"] = types.ModuleType("joblib")
 
 
 class _FakeREST:

--- a/tests/test_bot_extended.py
+++ b/tests/test_bot_extended.py
@@ -37,7 +37,6 @@ mods = [
     "metrics_logger",
     "prometheus_client",
     "finnhub",
-    "joblib",
     "pybreaker",
     "ratelimit",
     "trade_execution",
@@ -131,8 +130,6 @@ class _PCA:
         pass
 
 sys.modules["sklearn.decomposition"].PCA = _PCA
-sys.modules["joblib"] = types.ModuleType("joblib")
-
 sys.modules["alpaca_trade_api.rest"].REST = object
 sys.modules["alpaca_trade_api.rest"].APIError = Exception
 class _DummyTradingClient:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -38,7 +38,6 @@ mods = [
     "metrics_logger",
     "prometheus_client",
     "finnhub",
-    "joblib",
     "pybreaker",
     "ratelimit",
     "trade_execution",
@@ -140,8 +139,6 @@ class _PCA:
         pass
 
 sys.modules["sklearn.decomposition"].PCA = _PCA
-sys.modules["joblib"] = types.ModuleType("joblib")
-
 sys.modules["alpaca_trade_api.rest"].REST = object
 sys.modules["alpaca_trade_api.rest"].APIError = Exception
 

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -72,7 +72,6 @@ mods = [
     "alpaca.common.exceptions",
     "dotenv",
     "finnhub",
-    "joblib",
     "sklearn.ensemble",
     "sklearn.linear_model",
     "sklearn.decomposition",
@@ -284,7 +283,6 @@ sys.modules["prometheus_client"].Gauge = lambda *a, **k: None
 sys.modules["prometheus_client"].Histogram = lambda *a, **k: None
 sys.modules["pipeline"] = types.ModuleType("pipeline")
 sys.modules["metrics_logger"] = types.ModuleType("metrics_logger")
-sys.modules["joblib"] = types.ModuleType("joblib")
 sys.modules["pybreaker"] = types.ModuleType("pybreaker")
 sys.modules["pipeline"].model_pipeline = lambda *a, **k: None
 sys.modules["metrics_logger"].log_metrics = lambda *a, **k: None

--- a/tests/test_retrain_smoke.py
+++ b/tests/test_retrain_smoke.py
@@ -64,9 +64,6 @@ def _import_retrain(monkeypatch):
     opt = types.ModuleType("optuna")
     opt.create_study = lambda direction: types.SimpleNamespace(optimize=lambda f, n_trials: None, best_params={})
     monkeypatch.setitem(sys.modules, "optuna", opt)
-    jb = types.ModuleType("joblib")
-    jb.dump = lambda obj, path: None
-    monkeypatch.setitem(sys.modules, "joblib", jb)
     skl_ms = types.ModuleType("sklearn.model_selection")
     skl_ms.ParameterSampler = lambda *a, **k: []
     skl_ms.cross_val_score = lambda *a, **k: [0.0]


### PR DESCRIPTION
## Summary
- remove joblib stubs from several tests
- update Alpaca submit_order to handle single-object API

## Testing
- `pytest -n auto --disable-warnings` *(fails: 42 failed, 184 passed, 4 skipped, 23 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687bc4647b1c833098382af5036a6ce3