### PR TITLE
Fix skip logic and logging

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -5957,6 +5957,8 @@ def _process_symbols(
             if price_df.empty or "close" not in price_df.columns:
                 logger.info(f"SKIP_NO_PRICE_DATA | {symbol}")
                 return
+            if symbol in state.position_cache:
+                return  # AI-AGENT-REF: skip symbol with open position
             processed.append(symbol)
             _safe_trade(ctx, state, symbol, current_cash, model, regime_ok)
         except Exception as exc:

--- a/main.py
+++ b/main.py
@@ -122,6 +122,9 @@ def create_flask_app() -> Flask:
 def run_flask_app(port: int) -> None:
     """Start the Flask application on an available ``port``."""
     app = create_flask_app()
+    import logging
+    if not hasattr(app, "logger"):
+        app.logger = logging.getLogger(__name__)  # AI-AGENT-REF: ensure fallback logger
 
     candidate = port
     if port == 9000 and is_port_in_use(9000):

--- a/meta_learning.py
+++ b/meta_learning.py
@@ -290,7 +290,9 @@ def optimize_signals(signal_data: Any, cfg: Any, model: Any | None = None, *, vo
         preds = np.clip(preds, -1.2, 1.2)
         factor = 1.0 if volatility <= 1.0 else 1.0 / max(volatility, 1e-3)
         preds = preds * factor
-        return preds
+        if preds is not None and len(preds) > 0:
+            return preds  # AI-AGENT-REF: ensure non-empty predictions
+        return signal_data
     except (ValueError, RuntimeError) as exc:  # pragma: no cover - model may fail
         logger.exception("optimize_signals failed: %s", exc)
         return signal_data


### PR DESCRIPTION
## Summary
- skip open positions when processing symbols
- guard Flask logger setup
- ensure signal optimizer returns only non-empty predictions

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687bce2976b88330be25601ff4459fbb