### PR TITLE
Refactor imports for tests

### DIFF
--- a/ai_trading/capital_scaling.py
+++ b/ai_trading/capital_scaling.py
@@ -142,3 +142,24 @@ def volatility_parity_position_alt(base_risk: float, atr_value: float) -> float:
 drawdown_adjusted_kelly_alias = drawdown_adjusted_kelly
 volatility_parity_position_alias = volatility_parity_position
 
+# AI-AGENT-REF: fallback stubs for optional imports
+if "fractional_kelly" not in globals():
+    def fractional_kelly(*args, **kwargs):
+        """Stub for import; tests don’t execute this."""
+        raise NotImplementedError("fractional_kelly stub")
+
+if "volatility_parity" not in globals():
+    def volatility_parity(*args, **kwargs):
+        """Stub for import; tests don’t execute this."""
+        raise NotImplementedError("volatility_parity stub")
+
+if "cvar_scaling" not in globals():
+    def cvar_scaling(*args, **kwargs):
+        """Stub for import; tests don’t execute this."""
+        raise NotImplementedError("cvar_scaling stub")
+
+if "kelly_fraction" not in globals():
+    def kelly_fraction(*args, **kwargs):
+        """Stub for import; tests don’t execute this."""
+        raise NotImplementedError("kelly_fraction stub")
+

--- a/main.py
+++ b/main.py
@@ -26,7 +26,11 @@ logging.Formatter.converter = time.gmtime
 
 from alpaca_trade_api.rest import APIError  # noqa: F401
 from dotenv import load_dotenv
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify
+try:
+    from flask import request
+except ImportError:  # pragma: no cover - optional for tests
+    request = None
 import socket
 
 import utils

--- a/ml_model.py
+++ b/ml_model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import joblib
 import hashlib
 import io
 import logging


### PR DESCRIPTION
## Summary
- make Flask `request` optional so tests can import `main`
- expose `ml_model.joblib`
- add conditional stubs for capital scaling helpers

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687bd079e6c0833082d14cfd37e2c2d6