### PR TITLE
Update utility logic

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -517,9 +517,11 @@ def get_latest_close(df: pd.DataFrame) -> float:
     return float(price)
 
 
-def compute_time_range(minutes: int) -> tuple[int, int]:
-    """Return a simple ``(0, minutes)`` range."""
-    return 0, minutes
+def compute_time_range(minutes: int) -> tuple[datetime, datetime]:
+    """Return a UTC datetime range spanning the past ``minutes`` minutes."""
+    now = datetime.now(timezone.utc)
+    start = now - timedelta(minutes=minutes)
+    return start, now
 
 
 def safe_price(price: float) -> float:

--- a/risk_engine.py
+++ b/risk_engine.py
@@ -315,9 +315,9 @@ def dynamic_position_size(capital: float, volatility: float, drawdown: float) ->
 
     vol = max(volatility, 1e-6)
     kelly_fraction = 0.5 / vol
+    kelly_fraction = min(max(kelly_fraction, 0.0), 1.0)
     if drawdown > 0.1:
         kelly_fraction *= 0.5
-    kelly_fraction = min(max(kelly_fraction, 0.0), 1.0)
     return capital * kelly_fraction
 
 


### PR DESCRIPTION
## Summary
- clamp Kelly fraction before drawdown adjustment in `dynamic_position_size`
- return timezone-aware datetimes in `compute_time_range`

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687be32e4bdc8330b25dbd2e76e77f9c