### PR TITLE
Fix imports for test collection

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -1,4 +1,5 @@
 __all__ = ["pre_trade_health_check"]
+from __future__ import annotations
 
 import asyncio
 import logging

--- a/main.py
+++ b/main.py
@@ -36,7 +36,10 @@ import socket
 import utils
 
 import bot_engine
-import runner
+try:
+    import runner
+except ImportError:
+    pass
 
 import config
 from alerting import send_slack_alert

--- a/runner.py
+++ b/runner.py
@@ -34,10 +34,7 @@ except ImportError:  # AI-AGENT-REF: gracefully handle optional scaling helpers
     kelly_fraction = lambda *a, **k: None  # type: ignore
 from utils import get_phase_logger, log_cpu_usage
 
-try:  # prefer 'bot' module for backward compat
-    from bot import main  # type: ignore
-except Exception:
-    from bot_engine import main
+from main import main
 
 logger = get_phase_logger(__name__, "RUNNER")
 


### PR DESCRIPTION
## Summary
- allow postponed annotation evaluation in `bot_engine.py`
- make runner import optional in `main.py`
- always import CLI entrypoint from `main` in `runner.py`

## Testing
- `pytest -n auto --disable-warnings` *(fails: 35 failed, 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c147829bc8330a13b71bf13a2d915