### PR TITLE
Fix future import placement

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -1,6 +1,7 @@
-__all__ = ["pre_trade_health_check"]
+#!/usr/bin/env python3.12
 from __future__ import annotations
-
+# (any existing comments or module docstring go below the future import)
+__all__ = ["pre_trade_health_check"]
 import asyncio
 import logging
 import os


### PR DESCRIPTION
## Summary
- ensure `from __future__ import annotations` is placed before other module code

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687c172e151c83309d393cf31a401539