### PR TITLE
Fix health rows and optimize signals

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -2465,7 +2465,7 @@ def pre_trade_health_check(
         Summary dictionary of issues encountered.
     """
 
-    min_rows = int(os.getenv("HEALTH_MIN_ROWS", 100))
+    min_rows = int(os.getenv("HEALTH_MIN_ROWS", min_rows))
 
     summary = {
         "checked": 0,

--- a/meta_learning.py
+++ b/meta_learning.py
@@ -290,9 +290,7 @@ def optimize_signals(signal_data: Any, cfg: Any, model: Any | None = None, *, vo
         preds = np.clip(preds, -1.2, 1.2)
         factor = 1.0 if volatility <= 1.0 else 1.0 / max(volatility, 1e-3)
         preds = preds * factor
-        if preds is not None and len(preds) > 0:
-            return preds  # AI-AGENT-REF: ensure non-empty predictions
-        return signal_data
+        return list(preds)  # AI-AGENT-REF: return list to avoid bool ambiguity
     except (ValueError, RuntimeError) as exc:  # pragma: no cover - model may fail
         logger.exception("optimize_signals failed: %s", exc)
         return signal_data

--- a/utils.py
+++ b/utils.py
@@ -8,7 +8,7 @@ import threading
 import warnings
 import time
 from datetime import date, timezone
-from typing import Any
+from typing import Any, Sequence
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -222,6 +222,9 @@ def log_health_row_check(rows: int, passed: bool) -> None:
 
 def health_rows_passed(rows) -> bool:
     """Log HEALTH_ROWS every 100 rows at INFO level."""
+    if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes)):
+        # AI-AGENT-REF: handle list of row counts
+        rows = rows[-1]
     if rows % 100 == 0:
         logger.debug("HEALTH_ROWS_PASSED: received %d rows", rows)
     else:


### PR DESCRIPTION
## Summary
- allow sequences in `health_rows_passed`
- return list from `optimize_signals`
- respect default `min_rows` in `pre_trade_health_check`

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError during dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_687c192972e083308f40aece83ca2080