### PR TITLE
Apply health and indicator fixes

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -2587,9 +2587,7 @@ def pre_trade_health_check(
         | set(summary["missing_columns"])
         | set(summary.get("invalid_values", []))
     )
-
-    if failures and len(failures) == len(symbols):
-        raise RuntimeError("Pre-trade health check failed for all symbols")
+    # AI-AGENT-REF: do not raise when all symbols fail; always return summary
 
     return summary
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -240,8 +240,8 @@ class DummyCtx:
 def test_health_check_empty_dataframe(monkeypatch):
     monkeypatch.setenv("HEALTH_MIN_ROWS", "30")
     ctx = DummyCtx(pd.DataFrame())
-    with pytest.raises(RuntimeError, match="Pre-trade health check failed"):
-        pre_trade_health_check(ctx, ["AAA"])
+    summary = pre_trade_health_check(ctx, ["AAA"])
+    assert summary["failures"] == ["AAA"]
 
 
 def test_health_check_succeeds(monkeypatch):


### PR DESCRIPTION
## Summary
- return summary even if all symbols fail
- support DataFrame inputs in `bollinger_bands` and `hurst_exponent`
- update health test for new behavior

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687da39f1110833091860339e132c913