### PR TITLE
Improve fetch fallback and logging

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -381,20 +381,18 @@ def get_historical_data(
 
     df = pd.DataFrame(bars)
     if df.empty:
+        logger.warning(f"Empty primary data for {symbol}; falling back to Alpaca")
         for attempt in range(3):
             pytime.sleep(0.5 * (attempt + 1))
             bars = _fetch(_DEFAULT_FEED)
             df = pd.DataFrame(bars)
             if not df.empty:
                 break
-        if df.empty or len(df) < MIN_EXPECTED_ROWS:
-            logger.warning(
-                f"Data incomplete for {symbol}, got {len(df)} rows. Skipping this cycle."
-            )
-            if raise_on_empty:
-                # AI-AGENT-REF: optionally propagate empty-data condition
-                raise DataFetchError("DATA_SOURCE_EMPTY")
-            return pd.DataFrame()
+    if df.empty or len(df) < MIN_EXPECTED_ROWS:
+        logger.warning(
+            f"Data incomplete for {symbol}, got {len(df)} rows. Skipping this cycle."
+        )
+        return pd.DataFrame()
 
     if isinstance(df.columns, pd.MultiIndex):
         df.columns = df.columns.get_level_values(-1)
@@ -420,6 +418,9 @@ def get_historical_data(
         if col not in df.columns:
             raise KeyError(f"Missing '{col}' column for {symbol}")
         df[col] = df[col].astype(float)
+
+    if df.empty and raise_on_empty:
+        raise DataFetchError("DATA_SOURCE_EMPTY")
 
     return df[["timestamp", "open", "high", "low", "close", "volume"]]
 

--- a/main.py
+++ b/main.py
@@ -20,9 +20,7 @@ warnings.filterwarnings("ignore", message=".*_register_pytree_node.*")
 logging.basicConfig(
     format="%(asctime)sZ %(levelname)s [%(name)s] %(message)s",
     datefmt="%Y-%m-%dT%H:%M:%S",
-    level=logging.INFO,
 )
-logging.Formatter.converter = time.gmtime
 
 from alpaca_trade_api.rest import APIError  # noqa: F401
 from dotenv import load_dotenv
@@ -285,9 +283,10 @@ if __name__ == "__main__":
                 try:
                     main()
                     break
-                except DataSourceEmpty:
-                    logging.getLogger(__name__).warning(
-                        "No data on attempt %d/3; retrying", attempt
+                except DataSourceEmpty as e:
+                    logging.getLogger(__name__).warning(str(e))
+                    logging.getLogger(__name__).info(
+                        "Skipped this cycle due to no data; will retry on next heartbeat"
                     )
                     time.sleep(attempt * 2)
             else:

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -346,7 +346,7 @@ class ExecutionEngine:
                     return float(getattr(p, "qty", 0))
         except APIError as exc:  # pragma: no cover - network or API errors
             if getattr(exc, "code", None) == 40410000:
-                self.logger.warning("No existing position for %s, skipping", symbol)
+                self.logger.debug("No existing position for %s, skipping", symbol)
                 return 0.0
             raise
         except Exception as exc:  # pragma: no cover - network or API errors

--- a/utils.py
+++ b/utils.py
@@ -80,9 +80,15 @@ def log_warning(
     if extra is None:
         extra = {}
     if exc is not None:
-        logger.warning("%s: %s", msg, exc, extra=extra, exc_info=True)
+        if msg == "HEALTH_STALE_DATA":
+            logger.debug("%s: %s", msg, exc, extra=extra, exc_info=True)
+        else:
+            logger.warning("%s: %s", msg, exc, extra=extra, exc_info=True)
     else:
-        logger.warning(msg, extra=extra)
+        if msg == "HEALTH_STALE_DATA":
+            logger.debug(msg, extra=extra)
+        else:
+            logger.warning(msg, extra=extra)
 
 
 # Cache of last logged stale timestamp per symbol


### PR DESCRIPTION
## Summary
- warn on empty primary data before Alpaca fallback
- streamline logging setup and retry handling
- reduce noise for missing positions
- log stale data checks at debug level

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687e8b7bc6848330968e00673631f47e