### PR TITLE
Fix save error propagation and runner exit

### DIFF
--- a/meta_learning.py
+++ b/meta_learning.py
@@ -282,8 +282,12 @@ def retrain_meta_learner(
 def optimize_signals(signal_data: Any, cfg: Any, model: Any | None = None, *, volatility: float = 1.0) -> Any:
     """Optimize trading signals using ``model`` if provided."""
     if model is not None:
-        # when a model instance is provided, return its raw predictions exactly
-        return list(model.predict(signal_data))
+        try:
+            # when a model instance is provided, return its raw predictions exactly
+            return list(model.predict(signal_data))
+        except (ValueError, RuntimeError) as exc:
+            logger.exception("optimize_signals failed: %s", exc)
+            return signal_data
     if model is None:
         model = load_model_checkpoint(cfg.MODEL_PATH)
     if model is None:

--- a/ml_model.py
+++ b/ml_model.py
@@ -94,7 +94,6 @@ class MLModel:
         return preds
 
     def save(self, path: str | None = None) -> str:
-        import joblib
         ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
         model_dir = Path(__file__).parent / "models"
         path = Path(path) if path else model_dir / f"model_{ts}.pkl"

--- a/runner.py
+++ b/runner.py
@@ -55,11 +55,14 @@ signal.signal(signal.SIGINT, _handle_signal)
 def _run_forever() -> NoReturn:
     """Run ``bot.main`` in a loop until a shutdown signal is received."""
 
+    global _shutdown
+
     while not _shutdown:
         try:
             main()
         except SystemExit as exc:  # graceful exit
             if exc.code == 0:
+                _shutdown = True
                 break
             logger.error("Bot exited with code %s", exc.code)
         except requests.exceptions.RequestException as exc:


### PR DESCRIPTION
## Summary
- ensure MLModel.save uses module-level joblib
- swallow ValueError/RuntimeError when optimize_signals model predict fails
- exit runner loop on SystemExit(0)

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687eaeaaa55483308882e79d18a0efd1