### PR TITLE
Update bot utilities

### DIFF
--- a/ai_trading/capital_scaling.py
+++ b/ai_trading/capital_scaling.py
@@ -19,13 +19,13 @@ class _CapScaler:
 
 
 class CapitalScalingEngine:
-    def __init__(self, config=None):
-        self.params = config or {}
-        self._cs = _CapScaler(self.params)
+    def __init__(self, config):
+        self._cs = _CapScaler(config)
 
     def scale_position(self, size: float) -> float:
-        """Scale a raw position size via the internal _CapScaler."""
-        # AI-AGENT-REF: delegate to _CapScaler callable
+        """
+        Wrap the internal _CapScaler so tests can call .scale_position().
+        """
         return self._cs(size)
 
     def compression_factor(self, balance: float) -> float:

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -550,6 +550,9 @@ def assert_row_integrity(
 
 def fetch_minute_df_safe(symbol: str) -> pd.DataFrame:
     """Fetches minute-level data, returning an empty DataFrame on error."""
+    # if market is closed, return an empty DataFrame immediately
+    if not market_is_open():
+        return pd.DataFrame()
     try:
         if symbol in _MINUTE_CACHE:
             df_cached, ts = _MINUTE_CACHE[symbol]

--- a/bot_engine_unit.py
+++ b/bot_engine_unit.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from typing import Optional, Union
+import os
+import joblib
+import logging
+import numpy as np
+
+logger = logging.getLogger(__name__)
+MODEL_PATH = "model.pkl"
+
+class EnsembleModel:
+    def __init__(self, models):
+        self.models = models
+
+    def predict_proba(self, X):
+        probs = [m.predict_proba(X) for m in self.models]
+        return np.mean(probs, axis=0)
+
+    def predict(self, X):
+        proba = self.predict_proba(X)
+        return np.argmax(proba, axis=1)
+
+
+def load_model(path: str = MODEL_PATH) -> Optional[Union[dict, EnsembleModel]]:
+    # return None if file doesn’t exist
+    if not os.path.exists(path):
+        return None
+    try:
+        obj = joblib.load(path)
+        # single-model PKL should be a dict
+        if isinstance(obj, dict):
+            logger.info("MODEL_LOADED")
+            return obj
+        # ensemble files are lists
+        if isinstance(obj, list):
+            model = EnsembleModel(obj)
+            logger.info("MODEL_LOADED")
+            return model
+        # fallback
+        logger.info("MODEL_LOADED")
+        return obj
+    except Exception as e:
+        logger.exception("MODEL_LOAD_FAILED: %s", e)
+        return None


### PR DESCRIPTION
## Summary
- implement safe `load_model` in `bot_engine_unit`
- expose `scale_position` for capital scaling
- check market hours in `fetch_minute_df_safe`

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_687ec780752483308d7b206444e4756f