### PR TITLE
Fix small training and data fetch issues

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -435,10 +435,13 @@ except Exception:  # pragma: no cover - allow tests with stubbed module
             # AI-AGENT-REF: stub passthrough for unit tests
             return position
 class StrategyAllocator:
-    def allocate(self, signals, volatility):
-        # you can wire this into your real allocation logic later,
-        # for now satisfy the test harness
-        return []
+    def __init__(self, *args, **kwargs):
+        # AI-AGENT-REF: delegate to underlying allocator for tests
+        from strategy_allocator import StrategyAllocator as _Alloc
+        self._alloc = _Alloc(*args, **kwargs)
+
+    def allocate(self, *args, **kwargs):
+        return self._alloc.allocate(*args, **kwargs)
 
 
 

--- a/retrain.py
+++ b/retrain.py
@@ -236,7 +236,8 @@ def prepare_indicators(df: pd.DataFrame, freq: str = "daily") -> pd.DataFrame:
     df["atr_band_upper"] = (df["close"] + 1.5 * df["atr"]).astype(float)
     df["atr_band_lower"] = (df["close"] - 1.5 * df["atr"]).astype(float)
     df["avg_vol_20"] = df["volume"].rolling(20).mean().astype(float)
-    df["dow"] = idx.dayofweek.astype(float)
+    if len(idx) == len(df):
+        df["dow"] = idx.dayofweek.astype(float)
 
     df["macd"] = np.nan
     df["macds"] = np.nan


### PR DESCRIPTION
## Summary
- delegate `StrategyAllocator.allocate` to underlying allocator
- guard day-of-week calc in `prepare_indicators`
- normalize timeframe lookup and keep timestamp column when fetching

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687ef7e823b0833083673a6c60d54420