### PR TITLE
Fix Kelly sizing and indicator handlers

### DIFF
--- a/indicators.py
+++ b/indicators.py
@@ -173,7 +173,10 @@ def calculate_vwap(high: pd.Series, low: pd.Series, close: pd.Series, volume: pd
     return cum_pv / cum_vol
 
 
-def get_rsi_signal(series: pd.Series, period: int = 14) -> pd.Series:
+def get_rsi_signal(series: pd.Series | pd.DataFrame, period: int = 14) -> pd.Series:
+    """Return normalized RSI signal handling DataFrame or Series input."""
+    if isinstance(series, pd.DataFrame):
+        series = series.get("close") or series.iloc[:, 0]
     vals = rsi(tuple(series.astype(float)), period)
     return (vals - 50) / 50
 

--- a/signals.py
+++ b/signals.py
@@ -334,14 +334,18 @@ def classify_regime(df: pd.DataFrame, window: int = 20) -> pd.Series:
 
 # AI-AGENT-REF: ensemble decision using multiple indicator columns
 def generate_ensemble_signal(df: pd.DataFrame) -> int:
+    def last(col: str) -> float:
+        s = df.get(col, pd.Series(dtype=float))
+        return s.iloc[-1] if not s.empty else np.nan
+
     signals = []
-    if df.get("EMA_5", pd.Series()).iloc[-1] > df.get("EMA_20", pd.Series()).iloc[-1]:
+    if last("EMA_5") > last("EMA_20"):
         signals.append(1)
-    if df.get("SMA_50", pd.Series()).iloc[-1] > df.get("SMA_200", pd.Series()).iloc[-1]:
+    if last("SMA_50") > last("SMA_200"):
         signals.append(1)
-    if df.get("close", pd.Series()).iloc[-1] > df.get("UB", pd.Series()).iloc[-1]:
+    if last("close") > last("UB"):
         signals.append(-1)
-    if df.get("close", pd.Series()).iloc[-1] < df.get("LB", pd.Series()).iloc[-1]:
+    if last("close") < last("LB"):
         signals.append(1)
     avg_signal = np.mean(signals) if signals else 0
     if avg_signal > 0.5:

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -45,7 +45,8 @@ def manual_fractional(balance, price, atr, win_prob, peak):
     kelly = max(edge / 1.5, 0) * frac
     dollars = kelly * balance
     raw = dollars / atr
-    cap_pos = (balance * bot.CAPITAL_CAP) / price
+    cap_scale = frac / base_frac if base_frac else 1.0
+    cap_pos = (balance * bot.CAPITAL_CAP * cap_scale) / price
     risk_cap = (balance * bot.DOLLAR_RISK_LIMIT) / atr
     dollar_cap = 1e9 / price
     size = int(round(min(raw, cap_pos, risk_cap, dollar_cap, bot.MAX_POSITION_SIZE)))


### PR DESCRIPTION
## Summary
- adjust fractional kelly size to reduce cap as drawdown increases
- allow `get_rsi_signal` to accept DataFrames
- guard `generate_ensemble_signal` against missing columns
- sync test helper with new kelly logic

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'numba')*

------
https://chatgpt.com/codex/tasks/task_e_687f0b9ad59083308cd72b096cddd1ef