### PR TITLE
Refactor historical data fetch handling

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -304,7 +304,6 @@ def get_historical_data(
     start_date,
     end_date,
     timeframe: str,
-    raise_on_empty: bool = False,
 ) -> pd.DataFrame:
     """Fetch historical bars from Alpaca and ensure OHLCV float columns."""
 
@@ -418,8 +417,15 @@ def get_historical_data(
             raise KeyError(f"Missing '{col}' column for {symbol}")
         df[col] = df[col].astype(float)
 
-    if df.empty and raise_on_empty:
-        raise DataFetchError("DATA_SOURCE_EMPTY")
+    if df.empty:
+        logger.warning(
+            "No historical data for %s at timeframe %s; returning empty DataFrame",
+            symbol,
+            timeframe,
+        )
+        return pd.DataFrame(
+            columns=["timestamp", "open", "high", "low", "close", "volume"]
+        )
 
     # ensure there's a timestamp column for the tests
     df = df.reset_index()


### PR DESCRIPTION
## Summary
- remove `raise_on_empty` parameter from `get_historical_data`
- warn and return empty DataFrame instead of raising when no data

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'numba', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687fb19dd2c48330bbc8adc121776a18