### PR TITLE
Adjust runner loop and historical fetch options

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -304,8 +304,17 @@ def get_historical_data(
     start_date,
     end_date,
     timeframe: str,
+    *,
+    raise_on_empty: bool = False,
 ) -> pd.DataFrame:
-    """Fetch historical bars from Alpaca and ensure OHLCV float columns."""
+"""Fetch historical bars from Alpaca and ensure OHLCV float columns.
+
+    Parameters
+    ----------
+    raise_on_empty : bool, optional
+        If ``True`` and no data is returned, raise :class:`DataFetchError`.
+        Defaults to ``False`` where an empty DataFrame is returned instead.
+"""
 
     if start_date is None or end_date is None:
         logger.error(
@@ -418,6 +427,9 @@ def get_historical_data(
         df[col] = df[col].astype(float)
 
     if df.empty:
+        if raise_on_empty:
+            # AI-AGENT-REF: optionally raise if no data returned
+            raise DataFetchError(f"No historical data for {symbol}")
         logger.warning(
             "No historical data for %s at timeframe %s; returning empty DataFrame",
             symbol,

--- a/runner.py
+++ b/runner.py
@@ -86,7 +86,8 @@ def _run_forever() -> NoReturn:
             if any(time.time() - ts < 2 for ts in recent_buys.values()):
                 logger.info("Post-buy sync wait")
                 time.sleep(2)
-            time.sleep(5)
+            # AI-AGENT-REF: slow down runner loop to once per minute
+            time.sleep(60)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- slow down the runner loop to run every minute
- allow get_historical_data to optionally raise when no data is returned

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'alpaca_trade_api')*

------
https://chatgpt.com/codex/tasks/task_e_687fcad63ab08330bed82a45f150b442