### PR TITLE
style: indent docstring

### DIFF
--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -307,14 +307,14 @@ def get_historical_data(
     *,
     raise_on_empty: bool = False,
 ) -> pd.DataFrame:
-"""Fetch historical bars from Alpaca and ensure OHLCV float columns.
+    """Fetch historical bars from Alpaca and ensure OHLCV float columns.
 
     Parameters
     ----------
     raise_on_empty : bool, optional
         If ``True`` and no data is returned, raise :class:`DataFetchError`.
         Defaults to ``False`` where an empty DataFrame is returned instead.
-"""
+    """
 
     if start_date is None or end_date is None:
         logger.error(


### PR DESCRIPTION
## Summary
- indent `get_historical_data` docstring in `data_fetcher.py`

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'alpaca_trade_api')*

------
https://chatgpt.com/codex/tasks/task_e_687fcf5131448330a738158907b66387