### PR TITLE
Handle empty data sources cleanly

### DIFF
--- a/ai_trading/__main__.py
+++ b/ai_trading/__main__.py
@@ -1,0 +1,44 @@
+import logging
+import time
+from threading import Lock
+from filelock import FileLock, Timeout
+
+from bot_engine import run_all_trades_worker, BotState
+from data_fetcher import DataFetchError
+import config
+
+logger = logging.getLogger(__name__)
+_run_lock = Lock()
+
+
+def run_all_trades() -> None:
+    """Run trading loop if not already in progress."""
+    if not _run_lock.acquire(blocking=False):
+        logger.info("RUN_ALL_TRADES_SKIPPED_OVERLAP")
+        return
+    try:
+        run_all_trades_worker(BotState(), None)
+    finally:
+        _run_lock.release()
+
+
+def main() -> None:
+    logging.basicConfig(
+        format="%(asctime)sZ %(levelname)s [%(name)s] %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    while True:
+        try:
+            run_all_trades()
+        except DataFetchError as exc:
+            logger.warning("DATA_SOURCE_EMPTY | %s", exc)
+        time.sleep(config.SCHEDULER_SLEEP_SECONDS)
+
+
+if __name__ == "__main__":
+    lock = FileLock("/tmp/ai_trading_scheduler.lock", timeout=0)
+    try:
+        with lock:
+            main()
+    except Timeout:
+        logger.info("RUN_ALL_TRADES_SKIPPED_OVERLAP")

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -593,7 +593,7 @@ def fetch_minute_df_safe(symbol: str) -> pd.DataFrame:
             df.index = df.index.get_level_values(1)
         df.index = pd.to_datetime(df.index)
         return df
-    except data_fetcher.DataFetchException:
+    except data_fetcher.DataFetchError:
         # AI-AGENT-REF: handle empty data source gracefully
         logger.warning("DATA_SOURCE_EMPTY | symbol=%s", symbol)
         return pd.DataFrame()

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -427,10 +427,8 @@ def get_historical_data(
         df[col] = df[col].astype(float)
 
     if df is None or df.empty:
-        logger.warning(f"No data returned for {symbol}, skipping symbol")
-        return pd.DataFrame(
-            columns=["timestamp", "open", "high", "low", "close", "volume"]
-        )
+        # AI-AGENT-REF: raise explicit error when all providers return empty
+        raise DataFetchError(f"No data returned for {symbol}")
 
     # ensure there's a timestamp column for the tests
     df = df.reset_index()
@@ -748,10 +746,8 @@ def get_minute_df(
                 logger.debug("yfinance fetch error: %s", exc)
                 raise DataSourceDownException(symbol) from exc
     if df is None or df.empty:
-        logger.warning(f"No data returned for {symbol}, skipping symbol")
-        return pd.DataFrame(
-            columns=["timestamp", "open", "high", "low", "close", "volume"]
-        )
+        # AI-AGENT-REF: raise explicit error when all providers return empty
+        raise DataFetchError(f"No data returned for {symbol}")
     required_cols = {"open", "high", "low", "close", "volume"}
     missing = required_cols - set(df.columns)
     if missing:


### PR DESCRIPTION
## Summary
- update fetch_minute_df_safe to catch DataFetchError
- raise DataFetchError when all minute-bar fallbacks return no data
- add simple scheduler entrypoint with overlap guard

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'numba')*

------
https://chatgpt.com/codex/tasks/task_e_687fdd95a9448330abfbb9794fdd5e2a