### PR TITLE
Update main entrypoint and runner handling

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -168,4 +168,8 @@ if __name__ == "__main__":
     import sys
     import os
     once = "--once" in sys.argv or os.getenv("RUN_ONCE", "1") == "1"
-    start_runner(once=once)
+    try:
+        start_runner(once=once)
+    except SystemExit as exc:  # AI-AGENT-REF: allow clean shutdown
+        if exc.code != 0:
+            raise


### PR DESCRIPTION
## Summary
- import config module so tests can override settings
- revamp `main.main` logic to load env and handle CLI flags
- ignore `SystemExit(0)` in runner entrypoint to keep pytest happy

## Testing
- `pytest -n auto --disable-warnings tests/test_main_extended2.py::test_run_bot_success -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688022c62b8c8330b92c80f3f79e84c4