### PR TITLE
Update start script to serve API

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -37,4 +37,6 @@ echo "🔍 Validating environment variables..."
 python validate_env.py
 
 echo "🚀 Starting core trading bot..."
-python -m ai_trading
+
+# Launch both API and bot loop under one process (unbuffered)
+exec python -u -m ai_trading --serve-api


### PR DESCRIPTION
## Summary
- start API and bot loop together from shell script

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'numpy', 'pandas', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688110ad56d88330b25c6199ee56e31f