### PR TITLE
Fix run_bot arg handling

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -31,14 +31,19 @@ logger = logging.getLogger(__name__)
 _run_lock = Lock()
 
 
-def run_bot(argv=None, service: bool = False) -> int:
-    """Launch the trading bot as a subprocess."""
-    argv = argv or sys.argv[1:]
-    python = sys.executable
-    if not os.path.isfile(python):
-        raise RuntimeError(f"Python executable not found: {python}")
-    cmd = [python, "-m", "ai_trading.main"] + argv
-    return subprocess.call(cmd)
+def run_bot(venv_dir: str, script: str, argv: list[str] | None = None) -> int:
+    """Launch the trading bot located at ``script`` using the venv ``venv_dir``."""
+    # AI-AGENT-REF: ensure subprocess uses specific interpreter version
+    python_exec = os.path.join(
+        venv_dir,
+        "bin",
+        f"python{sys.version_info.major}.{sys.version_info.minor}",
+    )
+    if not os.path.isfile(python_exec):
+        raise RuntimeError(f"Python executable not found: {python_exec}")
+    cmd = [python_exec, script] + (argv or [])
+    proc = subprocess.Popen(cmd)
+    return proc.wait()
 
 
 def create_flask_app() -> Flask:

--- a/start.sh
+++ b/start.sh
@@ -1,24 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
 echo "🔁 Starting AI Trading Bot Scheduler..."
 
 cd /home/aiuser/ai-trading-bot
-
-# Ensure Git doesn't throw ownership warnings in cloud-mounted volumes
 git config --global --add safe.directory /home/aiuser/ai-trading-bot
 
-# Load environment variables from .env (if not already injected by systemd)
 if [ -f .env ]; then
   echo "📦 Loading environment variables from .env"
-  set +u
-  set -a
+  set +u; set -a
   source .env
-  set +a
-  set -u
+  set +a; set -u
 fi
 
-# Create virtual environment if missing
 if [ ! -d "venv" ]; then
   echo "🛠 Creating virtual environment and installing dependencies..."
   python3.12 -m venv venv
@@ -26,10 +19,7 @@ if [ ! -d "venv" ]; then
   venv/bin/pip install -r requirements.txt
 fi
 
-# Activate virtual environment
 source venv/bin/activate
-
-# Force unbuffered Python output for real-time logging
 export PYTHONUNBUFFERED=1
 export WEB_CONCURRENCY=${WEB_CONCURRENCY:-1}
 
@@ -37,6 +27,4 @@ echo "🔍 Validating environment variables..."
 python validate_env.py
 
 echo "🚀 Starting core trading bot..."
-
-# Launch both API and bot loop under one process (unbuffered)
-exec python -u -m ai_trading --serve-api
+exec python -u run.py


### PR DESCRIPTION
## Summary
- restore bootstrapping logic in `start.sh`
- fix `run_bot` helper to build python command correctly
- adjust tests for new helper signature

## Testing
- `pip install -r requirements.txt`
- `pytest -n auto --disable-warnings` *(fails: 33 failed, 23 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688113b2b9d88330b834184ea4de8922