### PR TITLE
Update run_bot API

### DIFF
--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -73,7 +73,7 @@ def test_create_flask_routes():
 def test_main_serve_api(monkeypatch):
     """main launches Flask thread and bot when --serve-api used."""
     monkeypatch.setattr(sys, "argv", ["ai_trading", "--serve-api"])
-    monkeypatch.setattr(main, "run_bot", lambda v, s: 0)
+    monkeypatch.setattr(main, "run_bot", lambda v, s, extra_args=None: 0)
     called = {}
 
     class DummyThread:


### PR DESCRIPTION
## Summary
- spawn the trading child in bot-only mode
- wait on stop event when serving API
- update tests for new run_bot behavior

## Testing
- `pytest -n auto --disable-warnings` *(fails: pydantic_core._pydantic_core.*)*

------
https://chatgpt.com/codex/tasks/task_e_688253ee64d4833085dd7afde43181b8