### PR TITLE
Fix env validation extras

### DIFF
--- a/validate_env.py
+++ b/validate_env.py
@@ -3,6 +3,7 @@
 import logging
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import Extra
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
+        extra=Extra.ignore,  # AI-AGENT-REF: allow unknown env vars
     )
 
 


### PR DESCRIPTION
## Summary
- allow unknown environment variables in `validate_env.py` so SLACK_WEBHOOK doesn't crash

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688265bf80fc8330bdbd03d7627dba21