### PR TITLE
Use sys.executable for bot runner

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -80,7 +80,8 @@ def main() -> None:
     project_root = Path(__file__).resolve().parents[1]
 
     if "--bot-only" in sys.argv:
-        exit_code = run_bot(sys.prefix, str(project_root / "runner.py"))
+        # AI-AGENT-REF: invoke current interpreter rather than venv path
+        exit_code = run_bot(sys.executable, str(project_root / "runner.py"))
         sys.exit(exit_code)
         return
 
@@ -95,8 +96,8 @@ def main() -> None:
         signal.signal(signal.SIGINT, _handler)
         thread = threading.Thread(target=run_flask_app, args=(port,), daemon=True)
         thread.start()
-        # spawn trading child in --bot-only mode
-        run_bot(sys.prefix, str(project_root / "run.py"))
+        # spawn trading child in --bot-only mode using same interpreter
+        run_bot(sys.executable, str(project_root / "run.py"))
         # now block parent until a shutdown signal arrives
         stop_event.wait()
 

--- a/tests/test_main_extended2.py
+++ b/tests/test_main_extended2.py
@@ -100,7 +100,13 @@ def test_validate_environment_missing(monkeypatch):
 def test_main_bot_only(monkeypatch):
     """main runs bot and exits with its return code."""
     monkeypatch.setattr(sys, 'argv', ['ai_trading', '--bot-only'])
-    monkeypatch.setattr(main, 'run_bot', lambda v, s, argv=None: 5)
+    called = {}
+
+    def _run_bot(python, script, argv=None):
+        called['python'] = python
+        return 5
+
+    monkeypatch.setattr(main, 'run_bot', _run_bot)
     monkeypatch.setattr(main, 'run_flask_app', lambda port: None)
     monkeypatch.setattr(main, 'setup_logging', lambda *a, **k: logging.getLogger('t'))
     monkeypatch.setattr(main, 'load_dotenv', lambda *a, **k: None)
@@ -109,3 +115,4 @@ def test_main_bot_only(monkeypatch):
     monkeypatch.setattr(sys, 'exit', lambda code=0: exits.append(code))
     main.main()
     assert exits == [5]
+    assert called['python'] == sys.executable

--- a/validate_env.py
+++ b/validate_env.py
@@ -3,7 +3,6 @@
 import logging
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import Extra
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +53,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",
-        extra=Extra.ignore,  # AI-AGENT-REF: allow unknown env vars
+        extra="ignore",  # allow unknown env vars (e.g. SLACK_WEBHOOK)
     )
 
 


### PR DESCRIPTION
## Summary
- call run_bot using `sys.executable`
- ignore unknown env vars with Pydantic v2 config
- assert interpreter path in main bot-only test

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68826be7f61883309141a8a3fdb9fb0a