### PR TITLE
Refactor main process

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from flask import Flask
+
+
+def create_app() -> Flask:
+    """Flask application factory used by the scheduler API."""
+    app = Flask(__name__)
+
+    @app.route("/health")
+    @app.route("/healthz")
+    def _health() -> dict[str, str]:  # pragma: no cover - trivial route
+        return {"status": "ok"}
+
+    return app

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -1,116 +1,58 @@
-"""Primary entry module for the ai_trading package."""
-
 from __future__ import annotations
 
-import argparse
 import logging
 import os
-import sys
-import subprocess
-import threading  # AI-AGENT-REF: needed for API serving thread
-from threading import Lock
-from pathlib import Path
-import signal
+import time
+from threading import Thread
 
-from bot_engine import run_all_trades_worker, BotState
-import config  # AI-AGENT-REF: allow tests to patch config attributes
-from config import Settings as Config
+from dotenv import load_dotenv
+
+from ai_trading.app import create_app
+from ai_trading.runner import run_cycle
+
+logger = logging.getLogger(__name__)
 
 
 def validate_environment() -> None:
-    """Expose config validation with testable hook."""
+    """Ensure required environment variables are present."""
+    import config
+
     if not config.WEBHOOK_SECRET:
         raise RuntimeError("Missing required environment variables: WEBHOOK_SECRET")
     config.validate_environment()
-from logger import setup_logging
-from dotenv import load_dotenv
-import utils
-from flask import Flask
-
-logger = logging.getLogger(__name__)
-_run_lock = Lock()
 
 
-def run_bot(python: str, run_py: str, extra_args: list[str] | None = None) -> int:
-    """Spawn a trading child process using ``python`` to execute ``run_py``."""
-    # AI-AGENT-REF: ensure child process only runs trading loop
-    cmd = [python, "-m", "ai_trading.main", "--bot-only"]
-    if extra_args:
-        cmd.extend(extra_args)
-    return subprocess.call(cmd)
+def run_bot(*_a, **_k) -> int:
+    """Compatibility wrapper to execute one trading cycle."""
+    # AI-AGENT-REF: run cycle directly instead of spawning subprocesses
+    run_cycle()
+    return 0
 
 
-def create_flask_app() -> Flask:
-    """Factory for the Flask application (used by tests)."""
-    app = Flask(__name__)
-
-    @app.route("/health")
-    @app.route("/healthz")
-    def _health():  # pragma: no cover - simple route
-        return {"status": "ok"}
-
-    return app
-
-
-def run_flask_app(port: int | None = None):
-    """Run the Flask server on ``port`` falling back when in use."""
-    port = port or int(os.getenv("PORT", 8000))
-    if utils.get_pid_on_port(port):
-        port = utils.get_free_port()
-    app = create_flask_app()
-    app.run(host="0.0.0.0", port=port)
-
-
-def run_all_trades() -> None:
-    """Run trading loop if not already in progress."""
-    if not _run_lock.acquire(blocking=False):
-        logger.info("RUN_ALL_TRADES_SKIPPED_OVERLAP")
-        return
-    try:
-        run_all_trades_worker(BotState(), None)
-    finally:
-        _run_lock.release()
+def start_api() -> None:
+    """Spin up the Flask API server."""
+    app = create_app()
+    app.run(host="0.0.0.0", port=int(os.getenv("API_PORT", 9001)), debug=False)
 
 
 def main() -> None:
-    """Entry-point used by ``python -m ai_trading``."""
+    """Start the API thread and repeatedly run trading cycles."""
     load_dotenv()
     validate_environment()
-    setup_logging()
-    project_root = Path(__file__).resolve().parents[1]
 
-    if "--bot-only" in sys.argv:
-        # AI-AGENT-REF: invoke current interpreter rather than venv path
-        exit_code = run_bot(sys.executable, str(project_root / "runner.py"))
-        sys.exit(exit_code)
-        return
+    t = Thread(target=start_api, daemon=True)
+    t.start()
 
-    if "--serve-api" in sys.argv:
-        port = int(os.getenv("FLASK_PORT", 8000))
-        stop_event = threading.Event()
-
-        def _handler(_s, _f) -> None:
-            stop_event.set()
-            sys.exit(0)
-
-        signal.signal(signal.SIGINT, _handler)
-        thread = threading.Thread(target=run_flask_app, args=(port,), daemon=True)
-        thread.start()
-        # spawn trading child in --bot-only mode using same interpreter
-        run_bot(sys.executable, str(project_root / "run.py"))
-        # now block parent until a shutdown signal arrives
-        stop_event.wait()
-
-    run_flask_app()
-
-
-__all__ = [
-    "run_bot",
-    "create_flask_app",
-    "run_flask_app",
-    "run_all_trades",
-    "main",
-]
+    interval = int(os.getenv("SCHEDULER_SLEEP_SECONDS", 30))
+    iterations = int(os.getenv("SCHEDULER_ITERATIONS", 0))  # AI-AGENT-REF: test hook
+    count = 0
+    while iterations <= 0 or count < iterations:
+        try:
+            run_cycle()
+        except Exception:  # pragma: no cover - log unexpected errors
+            logger.exception("run_cycle failed")
+        count += 1
+        time.sleep(interval)
 
 
 if __name__ == "__main__":

--- a/ai_trading/runner.py
+++ b/ai_trading/runner.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from threading import Lock
+
+from bot_engine import run_all_trades_worker, BotState
+from logger import get_logger
+
+log = get_logger(__name__)
+
+_run_lock = Lock()
+
+
+def run_cycle() -> None:
+    """Execute a single trading cycle if not already running."""
+    # AI-AGENT-REF: run cycle in-process to avoid extra interpreter forks
+    if not _run_lock.acquire(blocking=False):
+        log.info("RUN_ALL_TRADES_SKIPPED_OVERLAP")
+        return
+    try:
+        run_all_trades_worker(BotState(), None)
+    finally:
+        _run_lock.release()

--- a/start.sh
+++ b/start.sh
@@ -1,30 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-echo "🔁 Starting AI Trading Bot Scheduler..."
-
 cd /home/aiuser/ai-trading-bot
-git config --global --add safe.directory /home/aiuser/ai-trading-bot
-
-if [ -f .env ]; then
-  echo "📦 Loading environment variables from .env"
-  set +u; set -a
-  source .env
-  set +a; set -u
-fi
-
-if [ ! -d "venv" ]; then
-  echo "🛠 Creating virtual environment and installing dependencies..."
-  python3.12 -m venv venv
-  venv/bin/pip install --upgrade pip setuptools wheel
-  venv/bin/pip install -r requirements.txt
-fi
-
 source venv/bin/activate
-export PYTHONUNBUFFERED=1
-export WEB_CONCURRENCY=${WEB_CONCURRENCY:-1}
-
-echo "🔍 Validating environment variables..."
 python validate_env.py
-
-echo "🚀 Starting core trading bot..."
-exec python -u -m ai_trading.main --serve-api
+exec python -u -m ai_trading.main


### PR DESCRIPTION
## Summary
- load Flask app via new `create_app` factory
- run trading cycle in-process with `run_cycle`
- combine API and scheduler in `main`
- simplify start script
- adjust tests for new entrypoints

## Testing
- `pip install pytest-xdist`
- `pip install -r requirements.txt`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError and runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_688278d84db08330b3900c39d162d666