### PR TITLE
Improve ML model loading and data fetch retries

### DIFF
--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -229,3 +229,53 @@ def test_fetch_bars_empty_uses_last_bar(monkeypatch):
     )
 
     assert not df.empty and df.equals(last)
+
+import ast
+import types
+
+
+def _build_fetcher_module():
+    src = Path(__file__).resolve().parents[1] / "bot_engine.py"
+    tree = ast.parse(src.read_text())
+    func = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "fetch_minute_df_safe")
+    mod = types.ModuleType("fetch_safe")
+    mod.pd = pd
+    mod.datetime = datetime.datetime
+    mod.timedelta = datetime.timedelta
+    mod.timezone = datetime.timezone
+    mod.time = types.SimpleNamespace(sleep=lambda s: None)
+    mod.market_is_open = lambda now=None: True
+    mod._MINUTE_CACHE = {}
+    class _Err(Exception):
+        pass
+    mod.DataFetchError = _Err
+    mod.data_fetcher = types.SimpleNamespace(DataFetchError=_Err)
+    mod.get_minute_df = lambda s, start, end: pd.DataFrame()
+    mod.logger = __import__("logging").getLogger("fetch_safe")
+    exec(compile(ast.Module([func], []), filename=str(src), mode="exec"), mod.__dict__)
+    return mod
+
+
+def test_fetch_minute_df_safe_retries(monkeypatch):
+    mod = _build_fetcher_module()
+    calls = []
+
+    def fake_get(sym, start, end):
+        calls.append(1)
+        if len(calls) < 4:
+            return pd.DataFrame()
+        return pd.DataFrame({"close": [1]}, index=[pd.Timestamp("2023-01-01")])
+
+    monkeypatch.setattr(mod, "get_minute_df", fake_get)
+    result = mod.fetch_minute_df_safe("AAPL")
+    assert len(calls) == 4
+    assert not result.empty
+
+
+def test_fetch_minute_df_safe_raises(monkeypatch, caplog):
+    mod = _build_fetcher_module()
+    monkeypatch.setattr(mod, "get_minute_df", lambda *a, **k: pd.DataFrame())
+    caplog.set_level("ERROR")
+    with pytest.raises(mod.DataFetchError):
+        mod.fetch_minute_df_safe("AAPL")
+    assert any("No minute bars available for AAPL" in r.message for r in caplog.records)

--- a/tests/test_ml_model_loading.py
+++ b/tests/test_ml_model_loading.py
@@ -1,0 +1,45 @@
+import ast
+import types
+import os
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.dummy import DummyClassifier
+
+# Extract _load_ml_model from bot_engine using AST to avoid heavy import
+SRC = Path(__file__).resolve().parents[1] / "bot_engine.py"
+source = SRC.read_text()
+tree = ast.parse(source)
+func = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_load_ml_model")
+mod = types.ModuleType("bot_ml")
+mod.logger = __import__("logging").getLogger("bot_ml")
+mod.joblib = joblib
+mod.Path = Path
+mod._ML_MODEL_CACHE = {}
+exec(compile(ast.Module([func], []), filename=str(SRC), mode="exec"), mod.__dict__)
+
+
+def test_load_missing_logs_error(caplog):
+    caplog.set_level("ERROR")
+    result = mod._load_ml_model("FAKE")
+    assert result is None
+    assert any("ML model for FAKE not found" in r.message for r in caplog.records)
+
+
+def test_load_real_model(tmp_path, monkeypatch):
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    model = DummyClassifier(strategy="most_frequent")
+    X = np.array([[0], [1]])
+    y = np.array([0, 1])
+    model.fit(X, y)
+    path = models_dir / "TESTSYM.pkl"
+    joblib.dump(model, path)
+    monkeypatch.chdir(tmp_path)
+    loaded = mod._load_ml_model("TESTSYM")
+    assert loaded is not None
+    pred = loaded.predict([[0]])[0]
+    assert pred in [0, 1]


### PR DESCRIPTION
## Summary
- cache per-symbol ML models and gracefully skip missing ones
- retry minute fetches in `fetch_minute_df_safe`
- skip symbols cleanly when data fetch fails
- add tests for ML model loading and retry logic

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError and others)*

------
https://chatgpt.com/codex/tasks/task_e_68827f21e3a483308a759f35a67074a7