### PR TITLE
Update confidence calc and add Flask runner

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -7,8 +7,9 @@ from threading import Thread
 
 from dotenv import load_dotenv
 
-from ai_trading.app import create_app
+import ai_trading.app as app
 from ai_trading.runner import run_cycle
+import utils
 
 logger = logging.getLogger(__name__)
 
@@ -29,10 +30,17 @@ def run_bot(*_a, **_k) -> int:
     return 0
 
 
+def run_flask_app(port: int) -> None:
+    """Launch Flask API on an available port."""
+    application = app.create_app()
+    if utils.get_pid_on_port(port):
+        port = utils.get_free_port(port + 1) or (port + 1)
+    application.run(host="0.0.0.0", port=port)
+
+
 def start_api() -> None:
     """Spin up the Flask API server."""
-    app = create_app()
-    app.run(host="0.0.0.0", port=int(os.getenv("API_PORT", 9001)), debug=False)
+    run_flask_app(int(os.getenv("API_PORT", 9001)))
 
 
 def main() -> None:

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -2314,7 +2314,8 @@ class SignalManager:
                 adj.append((s, w, l))
 
         score = sum(s * w for s, w, _ in adj)
-        conf = min(abs(score), 1.0)
+        confidences = [w for _, w, _ in signals]
+        conf = max(confidences) if confidences else 0.0
         if score > 0.5:
             final = 1
         elif score < -0.5:


### PR DESCRIPTION
## Summary
- compute SignalManager confidence as max individual score
- expose utils and add run_flask_app helper

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68829b6150708330a13f5af23db393a0