### PR TITLE
Implement new short close, health route, and signal evaluation

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from flask import Flask
+from flask import Flask, jsonify
 
 
-def create_app() -> Flask:
-    """Flask application factory used by the scheduler API."""
+def create_app():
     app = Flask(__name__)
 
     @app.route("/health")
-    @app.route("/healthz")
-    def _health() -> dict[str, str]:  # pragma: no cover - trivial route
-        return {"status": "ok"}
+    def health():
+        return jsonify(status="ok")
 
     return app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,8 @@ pytest
 pytest-cov
 flake8
 mypy
+pytest-xdist
+numba
+matplotlib
+hypothesis
+pytest-benchmark


### PR DESCRIPTION
## Summary
- tweak `_process_symbols` to queue buy-to-cover but skip adding to processed list
- simplify `create_app` to expose only `/health` route
- streamline `SignalManager.evaluate` confidence and label computation
- install testing utilities

## Testing
- `make test-all` *(fails: tests/test_additional_coverage.py::test_create_flask_routes, tests/test_data_fetcher.py::test_fetch_minute_df_safe_retries, tests/test_data_fetcher.py::test_fetch_minute_df_safe_raises)*

------
https://chatgpt.com/codex/tasks/task_e_6882abacb88083309c2b51cccd899aea