### PR TITLE
Fix ML signal filtering

### DIFF
--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -26,6 +26,7 @@ for m in mods:
 sys.modules.setdefault("alpaca_trade_api", types.ModuleType("alpaca_trade_api"))
 sys.modules["dotenv"] = types.ModuleType("dotenv")
 sys.modules["dotenv"].load_dotenv = lambda *a, **k: None
+sys.modules["dotenv"].dotenv_values = lambda *a, **k: {}
 
 
 class _FakeREST:


### PR DESCRIPTION
## Summary
- filter out skipped signal results in `SignalManager.evaluate`
- load models via joblib and log missing model errors
- stub `dotenv_values` in data fetcher tests

## Testing
- `pytest -n auto --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6883be2453c48330a3b05ba42d7765f2