### PR TITLE
Fix data fallback and ML loader

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from flask import Flask, jsonify
+import logging
 
 
 def create_app():
     app = Flask(__name__)
+    # AI-AGENT-REF: silence Flask development server noise
+    logging.getLogger("werkzeug").setLevel(logging.ERROR)
 
     @app.route("/health")
     def health():


### PR DESCRIPTION
## Summary
- handle empty feature DataFrame fallbacks
- skip trade cycle when there are pending orders
- enhance ML model loading with clearer path logging
- silence Flask dev server logs

## Testing
- `pytest -n auto --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6883d40986e88330bb1209556b8e01b9