### PR TITLE
Fix data fetch fallback and model loading

### DIFF
--- a/ai_trading/model_loader.py
+++ b/ai_trading/model_loader.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+import logging
+import pickle
+
+import config
+
+logger = logging.getLogger(__name__)
+
+BASE_DIR = Path(__file__).parent.parent
+_CFG_MODELS_DIR = config.get_env("MODELS_DIR")
+MODELS_DIR = Path(_CFG_MODELS_DIR) if _CFG_MODELS_DIR else BASE_DIR / "models"
+
+# AI-AGENT-REF: helper to load per-symbol ML models safely
+
+def load_model(symbol: str):
+    """Return the ML model for ``symbol`` or ``None`` when missing."""
+    model_path = MODELS_DIR / f"{symbol}.pkl"
+    if not model_path.exists():
+        logger.warning(f"No ML model for {symbol} at {model_path}")
+        return None
+    with model_path.open("rb") as f:
+        return pickle.load(f)

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -579,19 +579,16 @@ def assert_row_integrity(
 
 def _load_ml_model(symbol: str):
     """Load pickled ML model or return ``None`` if absent."""
-    try:
-        models_dir = Path(__file__).parent / "models"
-    except NameError:  # pragma: no cover - fallback for exec() without __file__
-        models_dir = Path("models")
-    model_path = models_dir / f"{symbol}.pkl"
-    if model_path.exists():
-        with open(model_path, "rb") as f:
-            model = pickle.load(f)
-            logger.info(f"Loaded ML model for {symbol} from {model_path}")
-            return model
-    else:
-        logger.warning(f"No ML model for {symbol} found at {model_path}")
-        return None
+    from ai_trading.model_loader import load_model  # AI-AGENT-REF: shared loader
+
+    cached = _ML_MODEL_CACHE.get(symbol)
+    if cached is not None:
+        return cached
+
+    model = load_model(symbol)
+    if model is not None:
+        _ML_MODEL_CACHE[symbol] = model
+    return model
 
 
 def fetch_minute_df_safe(symbol: str) -> pd.DataFrame:

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -435,8 +435,9 @@ def get_historical_data(
         df[col] = df[col].astype(float)
 
     if df is None or df.empty:
-        # AI-AGENT-REF: raise explicit error when all providers return empty
-        raise DataSourceEmpty(symbol)
+        # AI-AGENT-REF: escalate when all fallbacks return no data
+        logger.error("_fetch_minute_data produced empty result for %s", symbol)
+        raise DataFetchError(f"no data for {symbol}")
 
     # ensure there's a timestamp column for the tests
     df = df.reset_index()

--- a/tests/test_ml_model_loading.py
+++ b/tests/test_ml_model_loading.py
@@ -23,6 +23,19 @@ mod.pickle = __import__("pickle")
 mod._ML_MODEL_CACHE = {}
 exec(compile(ast.Module([func], []), filename=str(SRC), mode="exec"), mod.__dict__)
 
+# Provide stub for ai_trading.model_loader used by _load_ml_model
+import sys
+stub = types.ModuleType("ai_trading.model_loader")
+def _stub_load(symbol: str):
+    path = Path("models") / f"{symbol}.pkl"
+    if not path.exists():
+        mod.logger.warning(f"No ML model for {symbol} at {path}")
+        return None
+    with open(path, "rb") as f:
+        return pickle.load(f)
+stub.load_model = _stub_load
+sys.modules["ai_trading.model_loader"] = stub
+
 
 def test_load_missing_logs_error(caplog):
     caplog.set_level("INFO")


### PR DESCRIPTION
## Summary
- raise DataFetchError when minute data remains empty after fallbacks
- centralize ML model loading via new `model_loader` module
- adjust bot ML loader to use new helper
- update ml model loading tests for stubbed loader

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6883d99aa81883309826286c214752d7