### PR TITLE
refactor: preload ml models and streamline usage

### DIFF
--- a/ai_trading/model_loader.py
+++ b/ai_trading/model_loader.py
@@ -8,17 +8,22 @@ import config
 
 logger = logging.getLogger(__name__)
 
-BASE_DIR = Path(__file__).parent.parent
+# AI-AGENT-REF: resolve repo root reliably for model loading
+BASE_DIR = Path(__file__).resolve().parents[1]
 _CFG_MODELS_DIR = config.get_env("MODELS_DIR")
 MODELS_DIR = Path(_CFG_MODELS_DIR) if _CFG_MODELS_DIR else BASE_DIR / "models"
 
-# AI-AGENT-REF: helper to load per-symbol ML models safely
+ML_MODELS: dict[str, object | None] = {}
+for sym in getattr(config, "SYMBOLS", []):
+    path = MODELS_DIR / f"{sym}.pkl"
+    if not path.exists():
+        logger.warning(f"No ML model for {sym} at {path}")
+        ML_MODELS[sym] = None
+    else:
+        with path.open("rb") as f:
+            ML_MODELS[sym] = pickle.load(f)
+
 
 def load_model(symbol: str):
-    """Return the ML model for ``symbol`` or ``None`` when missing."""
-    model_path = MODELS_DIR / f"{symbol}.pkl"
-    if not model_path.exists():
-        logger.warning(f"No ML model for {symbol} at {model_path}")
-        return None
-    with model_path.open("rb") as f:
-        return pickle.load(f)
+    """Return the preloaded ML model for ``symbol``."""
+    return ML_MODELS.get(symbol)

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -35,6 +35,7 @@ if sys.version_info < (3, 12, 3):  # pragma: no cover - compat check
 
 import config
 from logger import setup_logging
+from ai_trading.model_loader import ML_MODELS  # AI-AGENT-REF: preloaded models
 
 LOG_PATH = os.getenv("BOT_LOG_FILE", "logs/scheduler.log")
 setup_logging(log_file=LOG_PATH)
@@ -578,14 +579,13 @@ def assert_row_integrity(
 
 
 def _load_ml_model(symbol: str):
-    """Load pickled ML model or return ``None`` if absent."""
-    from ai_trading.model_loader import load_model  # AI-AGENT-REF: shared loader
+    """Return preloaded ML model from ``ML_MODELS`` cache."""
 
     cached = _ML_MODEL_CACHE.get(symbol)
     if cached is not None:
         return cached
 
-    model = load_model(symbol)
+    model = ML_MODELS.get(symbol)
     if model is not None:
         _ML_MODEL_CACHE[symbol] = model
     return model
@@ -2102,7 +2102,6 @@ class SignalManager:
         if model is None and symbol is not None:
             model = _load_ml_model(symbol)
         if model is None:
-            logger.warning("signal_ml skipped: no ML model loaded for %s", symbol)
             return None
         try:
             if hasattr(model, "feature_names_in_"):

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -637,9 +637,13 @@ def get_minute_df(
     cached = _MINUTE_CACHE.get(symbol)
     if cached is not None:
         df_cached, ts = cached
-        if not df_cached.empty and ts >= pd.Timestamp.now(tz="UTC") - pd.Timedelta(minutes=1):
-            logger.debug("minute cache hit for %s", symbol)
-            return df_cached.copy()
+        if not df_cached.empty:
+            first_idx = df_cached.index[0]
+            if not isinstance(first_idx, pd.Timestamp) or start_dt < first_idx:
+                cached = None
+            elif ts >= pd.Timestamp.now(tz="UTC") - pd.Timedelta(minutes=1):
+                logger.debug("minute cache hit for %s", symbol)
+                return df_cached.copy()
 
     alpaca_exc = finnhub_exc = yexc = None
     try:


### PR DESCRIPTION
## Summary
- preload symbol models on import
- reference preloaded models from bot engine
- update ML loader tests for new mapping
- guard minute cache by request range

## Testing
- `pytest -n auto --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6883ddd457ec833098769c0839dba1d8