### PR TITLE
Add historical backtesting wrapper

### DIFF
--- a/backtester.py
+++ b/backtester.py
@@ -1,20 +1,269 @@
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List
+
 import pandas as pd
 
-class Backtester:
-    def __init__(self, initial_capital=100000):
-        self.initial_capital = initial_capital
-        self.equity = initial_capital
-        self.equity_curve = []
+import config
+import signals  # noqa: F401 - used for side effects in bot modules
+import risk_engine
+import data_fetcher
+try:
+    import execution_api as execution_api  # type: ignore
+except Exception:  # pragma: no cover - fallback for older repo layout
+    import trade_execution as execution_api  # type: ignore
+import bot_engine
 
-    def run(self, df, signals, stop_levels, scaler):
-        position = 0
-        for i in range(1, len(df)):
-            if signals[i] != 0 and position == 0:
-                vol = df['close'].rolling(10).std().iloc[i]
-                draw = 1 - (self.equity / self.initial_capital)
-                position = scaler.compute_position_size(self.equity, vol, draw) * signals[i]
-            elif position != 0 and df['close'].iloc[i] < stop_levels.iloc[i]:
-                self.equity += position * (df['close'].iloc[i] - df['close'].iloc[i-1])
-                position = 0
-            self.equity_curve.append(self.equity)
-        return self.equity_curve
+
+@dataclass
+class Order:
+    symbol: str
+    qty: int
+    side: str  # 'buy' or 'sell'
+    price: float
+
+
+@dataclass
+class Fill:
+    order: Order
+    fill_price: float
+    timestamp: datetime
+    commission: float = 0.0
+
+
+class ExecutionModel(ABC):
+    """Abstract execution model interface."""
+
+    @abstractmethod
+    def on_order(self, order: Order) -> List[Fill]:
+        """Handle an order and return resulting fills."""
+
+    def on_bar(self) -> List[Fill]:
+        """Advance one bar and release pending fills."""
+        return []
+
+
+class ImmediateExecutionModel(ExecutionModel):
+    """Fill orders immediately at the order price."""
+
+    def on_order(self, order: Order) -> List[Fill]:
+        return [
+            Fill(
+                order=order,
+                fill_price=order.price,
+                timestamp=datetime.now(timezone.utc),
+            )
+        ]
+
+
+class CommissionModel(ExecutionModel):
+    def __init__(self, per_share_fee: float, inner: ExecutionModel) -> None:
+        self.per_share_fee = per_share_fee
+        self.inner = inner
+
+    def on_order(self, order: Order) -> List[Fill]:
+        fills = self.inner.on_order(order)
+        for f in fills:
+            f.commission += self.per_share_fee * order.qty
+        return fills
+
+    def on_bar(self) -> List[Fill]:
+        return self.inner.on_bar()
+
+
+class SlippageModel(ExecutionModel):
+    def __init__(self, pips: float, inner: ExecutionModel) -> None:
+        self.pips = pips
+        self.inner = inner
+
+    def on_order(self, order: Order) -> List[Fill]:
+        fills = self.inner.on_order(order)
+        adj = self.pips if order.side.lower() == "buy" else -self.pips
+        for f in fills:
+            f.fill_price += adj
+        return fills
+
+    def on_bar(self) -> List[Fill]:
+        return self.inner.on_bar()
+
+
+class LatencyModel(ExecutionModel):
+    def __init__(self, bar_delay: int, inner: ExecutionModel) -> None:
+        self.bar_delay = bar_delay
+        self.inner = inner
+        self._queue: List[tuple[int, Fill]] = []
+
+    def on_order(self, order: Order) -> List[Fill]:
+        fills = self.inner.on_order(order)
+        for f in fills:
+            self._queue.append((self.bar_delay, f))
+        return []
+
+    def on_bar(self) -> List[Fill]:
+        ready: List[Fill] = []
+        new_q: List[tuple[int, Fill]] = []
+        for delay, f in self._queue:
+            if delay <= 0:
+                ready.append(f)
+            else:
+                new_q.append((delay - 1, f))
+        self._queue = new_q
+        return ready
+
+
+class DefaultExecutionModel(ExecutionModel):
+    """Default composition: commission → slippage → latency."""
+
+    def __init__(self, per_share_fee: float = 0.0, slippage_pips: float = 0.0, latency: int = 0) -> None:
+        base = ImmediateExecutionModel()
+        base = CommissionModel(per_share_fee, base)
+        base = SlippageModel(slippage_pips, base)
+        self.model = LatencyModel(latency, base)
+
+    def on_order(self, order: Order) -> List[Fill]:
+        return self.model.on_order(order)
+
+    def on_bar(self) -> List[Fill]:
+        return self.model.on_bar()
+
+
+@dataclass
+class BacktestResult:
+    trades: pd.DataFrame
+    equity_curve: pd.DataFrame
+    net_pnl: float
+    cagr: float
+    max_drawdown: float
+    sharpe: float
+    calmar: float
+    turnover: float
+
+
+class BacktestEngine:
+    """Historical simulator executing the live trading cycle."""
+
+    def __init__(self, data: Dict[str, pd.DataFrame], execution_model: ExecutionModel, initial_cash: float = 100000.0) -> None:
+        config.reload_env()
+        self.data = data
+        self.execution_model = execution_model
+        self.cash = initial_cash
+        self.positions: Dict[str, int] = {s: 0 for s in data}
+        self.trades: List[Fill] = []
+        self.equity_curve: List[Dict[str, float]] = []
+
+    def _apply_fill(self, fill: Fill, ts: pd.Timestamp) -> None:
+        if hasattr(bot_engine, "apply_fill"):
+            try:
+                bot_engine.apply_fill(fill)
+            except Exception:
+                pass
+        qty = fill.order.qty if fill.order.side.lower() == "buy" else -fill.order.qty
+        cost = fill.fill_price * qty
+        if qty > 0:
+            self.cash -= cost + fill.commission
+        else:
+            self.cash += -cost - fill.commission
+        self.positions[fill.order.symbol] += qty
+        self.trades.append(fill)
+
+    def _snapshot(self, ts: pd.Timestamp) -> None:
+        pos_val = 0.0
+        for sym, qty in self.positions.items():
+            df = self.data.get(sym)
+            if df is not None and ts in df.index:
+                pos_val += qty * float(df.loc[ts, "close"])
+        total = self.cash + pos_val
+        self.equity_curve.append({
+            "timestamp": ts,
+            "cash": self.cash,
+            "positions": pos_val,
+            "total_equity": total,
+        })
+
+    def run(self, symbols: List[str]) -> BacktestResult:
+        combined = sorted(set().union(*(df.index for df in self.data.values())))
+        for ts in combined:
+            for sym in symbols:
+                df = self.data.get(sym)
+                if df is not None and ts in df.index and hasattr(bot_engine, "update_market_data"):
+                    try:
+                        bot_engine.update_market_data(sym, df.loc[ts])
+                    except Exception:
+                        pass
+            orders = []
+            if hasattr(bot_engine, "next_cycle"):
+                try:
+                    orders = bot_engine.next_cycle()
+                except Exception:
+                    orders = []
+            for order in orders:
+                for fill in self.execution_model.on_order(order):
+                    self._apply_fill(fill, ts)
+            for fill in self.execution_model.on_bar():
+                self._apply_fill(fill, ts)
+            self._snapshot(ts)
+        trades_df = pd.DataFrame([{
+            "symbol": f.order.symbol,
+            "qty": f.order.qty,
+            "side": f.order.side,
+            "price": f.fill_price,
+            "timestamp": f.timestamp,
+            "commission": f.commission,
+        } for f in self.trades])
+        eq_df = pd.DataFrame(self.equity_curve).set_index("timestamp")
+        stats = self._stats(eq_df, trades_df)
+        return BacktestResult(trades_df, eq_df, **stats)
+
+    def _stats(self, equity: pd.DataFrame, trades: pd.DataFrame) -> Dict[str, float]:
+        if equity.empty:
+            return {k: 0.0 for k in ["net_pnl", "cagr", "max_drawdown", "sharpe", "calmar", "turnover"]}
+        net_pnl = float(equity["total_equity"].iloc[-1] - equity["total_equity"].iloc[0])
+        returns = equity["total_equity"].pct_change().dropna()
+        sharpe = returns.mean() / returns.std() * (252 ** 0.5) if returns.std() else float("nan")
+        duration_years = len(equity) / 252 if len(equity) else 0
+        cagr = (equity["total_equity"].iloc[-1] / equity["total_equity"].iloc[0]) ** (1 / max(duration_years, 1e-9)) - 1
+        drawdown = (equity["total_equity"] / equity["total_equity"].cummax() - 1).min()
+        turnover = trades["qty"].abs().mul(trades["price"]).sum() / equity["total_equity"].iloc[0]
+        calmar = cagr / abs(drawdown) if drawdown else float("inf")
+        return {
+            "net_pnl": net_pnl,
+            "cagr": cagr,
+            "max_drawdown": abs(drawdown),
+            "sharpe": sharpe,
+            "calmar": calmar,
+            "turnover": turnover,
+        }
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run backtest over historical data")
+    parser.add_argument("--symbols", required=True, help="Comma separated symbols")
+    parser.add_argument("--data", nargs="+", help="symbol:path to CSV or Parquet")
+    parser.add_argument("--commission", type=float, default=0.0)
+    parser.add_argument("--slippage", type=float, default=0.0)
+    parser.add_argument("--latency", type=int, default=0)
+    args = parser.parse_args()
+
+    data_dict: Dict[str, pd.DataFrame] = {}
+    for entry in args.data:
+        sym, path = entry.split(":", 1)
+        if path.endswith(".parquet"):
+            df = pd.read_parquet(path)
+        else:
+            df = pd.read_csv(path, parse_dates=[0], index_col=0)
+        data_dict[sym] = df
+
+    exec_model = DefaultExecutionModel(args.commission, args.slippage, args.latency)
+    engine = BacktestEngine(data_dict, exec_model)
+    result = engine.run(args.symbols.split(","))
+
+    print("Net PnL:", result.net_pnl)
+    print("Sharpe:", result.sharpe)
+    result.trades.to_csv("trades.csv", index=False)
+    result.equity_curve.to_csv("equity_curve.csv")


### PR DESCRIPTION
## Summary
- implement configurable execution model pipeline
- build `BacktestEngine` for simulating live cycle with historical data
- support CLI usage to run backtests and save results

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'pandas_ta')*

------
https://chatgpt.com/codex/tasks/task_e_6884252bd78c8330859e287365a66814