### PR TITLE
Enhance RL features and clean scaling

### DIFF
--- a/ai_trading/capital_scaling.py
+++ b/ai_trading/capital_scaling.py
@@ -250,42 +250,6 @@ __all__ = [
     "kelly_fraction",
     "volatility_parity",
     "cvar_scaling",
-    "drawdown_adjusted_kelly_alt",
-    "volatility_parity_position_alt",
 ]
 
-# AI-AGENT-REF: alt API functions with explicit parameters
-def drawdown_adjusted_kelly_alt(account_value: float, equity_peak: float, raw_kelly: float) -> float:
-    """Alternate interface for drawdown_adjusted_kelly."""
-    return drawdown_adjusted_kelly(account_value, equity_peak, raw_kelly)
-
-
-def volatility_parity_position_alt(base_risk: float, atr_value: float) -> float:
-    """Alternate interface for volatility_parity_position."""
-    return volatility_parity_position(base_risk, atr_value)
-
-# Simple aliases for backward compatibility
-drawdown_adjusted_kelly_alias = drawdown_adjusted_kelly
-volatility_parity_position_alias = volatility_parity_position
-
-# AI-AGENT-REF: fallback stubs for optional imports
-if "fractional_kelly" not in globals():
-    def fractional_kelly(*args, **kwargs):
-        """Stub for import; tests don’t execute this."""
-        raise NotImplementedError("fractional_kelly stub")
-
-if "volatility_parity" not in globals():
-    def volatility_parity(*args, **kwargs):
-        """Stub for import; tests don’t execute this."""
-        raise NotImplementedError("volatility_parity stub")
-
-if "cvar_scaling" not in globals():
-    def cvar_scaling(*args, **kwargs):
-        """Stub for import; tests don’t execute this."""
-        raise NotImplementedError("cvar_scaling stub")
-
-if "kelly_fraction" not in globals():
-    def kelly_fraction(*args, **kwargs):
-        """Stub for import; tests don’t execute this."""
-        raise NotImplementedError("kelly_fraction stub")
 

--- a/ai_trading/rl_trading/features.py
+++ b/ai_trading/rl_trading/features.py
@@ -1,21 +1,22 @@
 """Feature engineering for reinforcement learning.
 
-This module provides a simple function to compute a flattened feature
-vector from historical price data.  The RL agent expects a 1-D
-observation per symbol consisting of recent returns and technical
-indicators.  The default window size is 10 periods, and three types
-of features are included by default:
+This module provides helpers to compute flattened feature vectors from
+historical price data for reinforcement learning.  The goal is to
+capture multiple dimensions of market behaviour – momentum, volatility
+and price-volume bias – so that the RL policy can make more informed
+decisions.  Each feature vector has a fixed length ``window * num_features``
+where ``window`` is the number of lookback periods and ``num_features``
+is the number of indicators per period.  The default configuration uses
+six features per period:
 
-1. **Returns** – Normalized percentage change of closing prices.
-2. **RSI** – Normalized relative strength index values (centered around
-   zero) derived from the closing price series.
-3. **ATR** – The average true range, measuring volatility.  When
-   ``high`` and ``low`` columns are unavailable, zeros are used.
+1. **Returns** – Normalized percentage changes of closing prices, capturing momentum.
+2. **RSI** – Normalized relative strength index values (centered around zero), providing an oscillator measure of overbought/oversold conditions.
+3. **ATR** – Average true range, measuring historical volatility.
+4. **VWAP bias** – Ratio of price to volume-weighted average price minus one, indicating whether the closing price is above or below the VWAP.
+5. **Bollinger position** – Relative position of the last close within its Bollinger Bands (normalized between −1 and 1).
+6. **OBV (On-Balance Volume)** – Normalized On-Balance Volume, measuring buying/selling pressure via volume.
 
-This function can be extended to include additional indicators (e.g.,
-Bollinger Bands, VWAP bias, OBV) by concatenating the corresponding
-values into the return array.  All inputs are padded to ensure a
-consistent length of ``window * num_features``.
+These features are concatenated in order and padded with zeros when insufficient history is available.  Additional indicators (e.g., macro data) can be appended by extending the return array.
 """
 
 from __future__ import annotations
@@ -23,7 +24,13 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from indicators import calculate_atr, get_rsi_signal
+from indicators import (
+    calculate_atr,
+    get_rsi_signal,
+    get_vwap_bias,
+    bollinger_bands,
+    obv,
+)
 
 
 def compute_features(df: pd.DataFrame | None, window: int = 10) -> np.ndarray:
@@ -34,7 +41,7 @@ def compute_features(df: pd.DataFrame | None, window: int = 10) -> np.ndarray:
     df : pandas.DataFrame or None
         A DataFrame containing at least a ``close`` column. ``high`` and
         ``low`` columns are optional but used when present. If ``df`` is
-        ``None`` or empty, a zero-vector of length ``window * 3`` is
+        ``None`` or empty, a zero-vector of length ``window * num_features`` is
         returned.
     window : int, optional
         The lookback window to compute features for (default: ``10``).
@@ -42,10 +49,11 @@ def compute_features(df: pd.DataFrame | None, window: int = 10) -> np.ndarray:
     Returns
     -------
     numpy.ndarray
-        A 1-D numpy array of length ``window * 3`` containing recent
-        returns, RSI values and ATR values.
+        A 1-D numpy array of length ``window * num_features`` containing recent
+        returns and technical indicators.
     """
-    num_features = 3  # returns, RSI, ATR
+    # Number of distinct indicators per period: returns, RSI, ATR, VWAP bias, Bollinger position, OBV
+    num_features = 6
     total_len = window * num_features
     if df is None or df.empty or "close" not in df.columns:
         return np.zeros(total_len, dtype=np.float32)
@@ -54,16 +62,55 @@ def compute_features(df: pd.DataFrame | None, window: int = 10) -> np.ndarray:
         pct_change = close.pct_change().fillna(0.0)
         returns = pct_change.tail(window)
         rsi_series = get_rsi_signal(close, period=14).tail(window)
+        # ATR requires high and low; fallback to zeros
         if {"high", "low"}.issubset(df.columns):
             high = df["high"].astype(float)
             low = df["low"].astype(float)
             atr_series = calculate_atr(high, low, close, period=14).fillna(0.0).tail(window)
         else:
             atr_series = pd.Series(0.0, index=close.index).tail(window)
+
+        # VWAP bias requires volume; fallback to zeros if missing
+        if {"volume"}.issubset(df.columns):
+            vwap_bias = get_vwap_bias(close, df["volume"].astype(float)).tail(window)
+        else:
+            vwap_bias = pd.Series(0.0, index=close.index).tail(window)
+
+        # Compute Bollinger band position: normalized between −1 and 1 (close relative to upper/lower bands)
+        if {"high", "low"}.issubset(df.columns):
+            bb = bollinger_bands(close, length=20, num_std=2.0)
+            bb_upper = bb["bb_upper"].tail(window).fillna(method="bfill")
+            bb_lower = bb["bb_lower"].tail(window).fillna(method="bfill")
+            bb_mid = bb["bb_mid"].tail(window).fillna(method="bfill")
+            # Avoid division by zero by adding epsilon to denominator
+            bb_range = (bb_upper - bb_lower).replace(0.0, np.nan).fillna(method="bfill")
+            bollinger_pos = ((close.tail(window) - bb_mid) / bb_range).clip(-1.0, 1.0).fillna(0.0)
+        else:
+            bollinger_pos = pd.Series(0.0, index=close.index).tail(window)
+
+        # Compute OBV (On-Balance Volume) normalized to [-1, 1]
+        if {"volume"}.issubset(df.columns):
+            obv_series = pd.Series(
+                obv(
+                    close.tail(window + 1).to_numpy(),
+                    df["volume"].astype(float).tail(window + 1).to_numpy(),
+                ),
+                index=close.tail(window + 1).index,
+            )
+            # Normalize OBV over the window
+            obv_norm = (obv_series - obv_series.mean()) / (obv_series.std() + 1e-8)
+            obv_norm = obv_norm.tail(window).fillna(0.0).clip(-1.0, 1.0)
+        else:
+            obv_norm = pd.Series(0.0, index=close.index).tail(window)
+
+        # Concatenate all series into one feature vector
         feat = np.concatenate([
             returns.to_numpy(dtype=np.float32),
             rsi_series.to_numpy(dtype=np.float32),
             atr_series.to_numpy(dtype=np.float32),
+            vwap_bias.to_numpy(dtype=np.float32),
+            bollinger_pos.to_numpy(dtype=np.float32),
+            obv_norm.to_numpy(dtype=np.float32),
         ])
         if feat.size < total_len:
             feat = np.pad(feat, (0, total_len - feat.size), constant_values=0.0)

--- a/data_fetcher.py
+++ b/data_fetcher.py
@@ -646,18 +646,13 @@ def get_minute_df(
         df_cached, ts = cached
         if not df_cached.empty:
             first_idx = df_cached.index[0]
-            # Normalize index to UTC before comparison.  If the index is
-            # timezone-naive (no tzinfo) we assume it refers to UTC and
-            # localize accordingly.  This prevents comparing naive vs
-            # aware datetimes (which raises TypeError).
+            # Normalize naive timestamps to UTC so offset-aware comparisons succeed
             if isinstance(first_idx, pd.Timestamp):
                 if first_idx.tzinfo is None or first_idx.tzinfo.utcoffset(first_idx) is None:
                     first_idx = first_idx.tz_localize("UTC")
             else:
-                # Non-Timestamp index; skip caching
                 cached = None
                 first_idx = None  # type: ignore
-            # If after normalization we still have a first index, compare
             if first_idx is not None and isinstance(first_idx, pd.Timestamp):
                 if start_dt < first_idx:
                     cached = None

--- a/risk_engine.py
+++ b/risk_engine.py
@@ -358,6 +358,7 @@ class RiskEngine:
         if np.isnan(raw_dollars) or np.isnan(price):
             logger.error("position_size received NaN inputs")
             return 0
+        # Determine current account equity; default to cash if unavailable
         current_equity = cash
         if api is not None:
             try:
@@ -365,6 +366,7 @@ class RiskEngine:
                 current_equity = float(getattr(acct, "equity", cash))
             except Exception:
                 pass
+        # Adjust the raw dollars using capital scaling (volatility & drawdown)
         try:
             scaler = getattr(self, "capital_scaler", None)
             volatility = float(np.std(self._returns[-10:])) if self._returns else 0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,9 +81,7 @@ def stub_capital_scaling(monkeypatch):
     """Provide simple stubs for heavy capital scaling functions."""
     import ai_trading.capital_scaling as cs
     monkeypatch.setattr(cs, "drawdown_adjusted_kelly", lambda *a, **k: 0.02)
-    monkeypatch.setattr(cs, "drawdown_adjusted_kelly_alt", lambda *a, **k: 0.015)
     monkeypatch.setattr(cs, "volatility_parity_position", lambda *a, **k: 0.01)
-    monkeypatch.setattr(cs, "volatility_parity_position_alt", lambda *a, **k: 0.01)
     yield
 
 

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -317,9 +317,7 @@ class _CapScaler:
 
 sys.modules["ai_trading.capital_scaling"].CapitalScalingEngine = _CapScaler
 sys.modules["ai_trading.capital_scaling"].drawdown_adjusted_kelly = lambda *a, **k: 0.02
-sys.modules["ai_trading.capital_scaling"].drawdown_adjusted_kelly_alt = lambda *a, **k: 0.02
 sys.modules["ai_trading.capital_scaling"].volatility_parity_position = lambda *a, **k: 0.01
-sys.modules["ai_trading.capital_scaling"].volatility_parity_position_alt = lambda *a, **k: 0.01
 
 from ai_trading.main import main
 from bot_engine import pre_trade_health_check

--- a/tests/test_kelly_drawdown_taper.py
+++ b/tests/test_kelly_drawdown_taper.py
@@ -1,7 +1,5 @@
 import pytest
-from ai_trading.capital_scaling import (
-    drawdown_adjusted_kelly_alt as drawdown_adjusted_kelly,
-)
+from ai_trading.capital_scaling import drawdown_adjusted_kelly
 
 
 def test_drawdown_adjusted_kelly_basic():

--- a/tests/test_scaling_and_indicators.py
+++ b/tests/test_scaling_and_indicators.py
@@ -1,7 +1,5 @@
 import pytest
-from ai_trading.capital_scaling import (
-    volatility_parity_position_alt as volatility_parity_position,
-)
+from ai_trading.capital_scaling import volatility_parity_position
 
 
 def test_volatility_parity_position_basic():


### PR DESCRIPTION
## Summary
- expand RL feature engineering with Bollinger, OBV and VWAP metrics
- clarify fallback behavior in TradingEnv
- normalize minute-bar cache timestamps to UTC
- tidy risk engine capital scaling logic
- drop unused capital_scaling aliases and update tests

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError, ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_688544b02efc8330aa40956d39a82f85