### PR TITLE
Add legacy scaling aliases and fix VWAP bias

### DIFF
--- a/ai_trading/capital_scaling.py
+++ b/ai_trading/capital_scaling.py
@@ -238,6 +238,21 @@ def cvar_scaling(returns: np.ndarray, alpha: float = 0.05) -> float:
     cvar = np.mean(sorted_returns[sorted_returns <= var])
     return abs(cvar) if cvar < 0 else 1.0
 
+# ---------------------------------------------------------------------------
+# Backward-compatible helper functions
+# These functions provide legacy aliases for older modules/tests. They
+# delegate to the primary implementations above and should be considered
+# deprecated. Remove them only after confirming nothing references them.
+
+def drawdown_adjusted_kelly_alt(account_value: float, equity_peak: float, raw_kelly: float) -> float:
+    """Legacy wrapper for drawdown_adjusted_kelly."""
+    return drawdown_adjusted_kelly(account_value, equity_peak, raw_kelly)
+
+
+def volatility_parity_position_alt(base_risk: float, atr_value: float) -> float:
+    """Legacy wrapper for volatility_parity_position."""
+    return volatility_parity_position(base_risk, atr_value)
+
 
 __all__ = [
     "CapitalScalingEngine",
@@ -250,6 +265,9 @@ __all__ = [
     "kelly_fraction",
     "volatility_parity",
     "cvar_scaling",
+    # legacy aliases retained for backward compatibility
+    "drawdown_adjusted_kelly_alt",
+    "volatility_parity_position_alt",
 ]
 
 

--- a/ai_trading/rl_trading/features.py
+++ b/ai_trading/rl_trading/features.py
@@ -70,9 +70,12 @@ def compute_features(df: pd.DataFrame | None, window: int = 10) -> np.ndarray:
         else:
             atr_series = pd.Series(0.0, index=close.index).tail(window)
 
-        # VWAP bias requires volume; fallback to zeros if missing
-        if {"volume"}.issubset(df.columns):
-            vwap_bias = get_vwap_bias(close, df["volume"].astype(float)).tail(window)
+        # VWAP bias requires high, low and volume; fallback to zeros if missing
+        if {"high", "low", "volume"}.issubset(df.columns):
+            high = df["high"].astype(float)
+            low = df["low"].astype(float)
+            volume = df["volume"].astype(float)
+            vwap_bias = get_vwap_bias(close, high, low, volume).fillna(0.0).tail(window)
         else:
             vwap_bias = pd.Series(0.0, index=close.index).tail(window)
 


### PR DESCRIPTION
## Summary
- add deprecated helpers `drawdown_adjusted_kelly_alt` and `volatility_parity_position_alt`
- expose the aliases from `capital_scaling`
- compute VWAP bias using high/low/volume inputs

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'numba')*

------
https://chatgpt.com/codex/tasks/task_e_6885489ad27883308dcbd4425ce1451b