### PR TITLE
fix: propagate scaler and import fallback

### DIFF
--- a/ai_trading/trade_logic.py
+++ b/ai_trading/trade_logic.py
@@ -5,8 +5,13 @@ from typing import Any, Sequence
 
 import metrics_logger
 from logger import get_logger
-from ai_trading.capital_scaling import drawdown_adjusted_kelly_alt as drawdown_adjusted_kelly
-from ai_trading.capital_scaling import volatility_parity_position_alt as volatility_parity_position
+try:
+    from ai_trading.capital_scaling import (
+        drawdown_adjusted_kelly_alt as drawdown_adjusted_kelly,
+        volatility_parity_position_alt as volatility_parity_position,
+    )
+except Exception:  # pragma: no cover - fallback for older installs
+    from ai_trading.capital_scaling import drawdown_adjusted_kelly, volatility_parity_position
 
 log = get_logger(__name__)
 

--- a/bot_engine.py
+++ b/bot_engine.py
@@ -2410,13 +2410,13 @@ exec_engine = ExecutionEngine(
 )
 ctx.execution_engine = exec_engine
 
-    # Propagate the capital_scaler to the risk engine so that position_size
-    # can adjust sizing based on account equity, volatility and drawdown.
-    try:
-        if getattr(ctx, "risk_engine", None) is not None and getattr(ctx, "capital_scaler", None) is not None:
-            ctx.risk_engine.capital_scaler = ctx.capital_scaler
-    except Exception:
-        pass
+# Propagate the capital_scaler to the risk engine so that position_size
+# can adjust sizing based on account equity, volatility and drawdown.
+try:
+    if getattr(ctx, "risk_engine", None) is not None and getattr(ctx, "capital_scaler", None) is not None:
+        ctx.risk_engine.capital_scaler = ctx.capital_scaler
+except Exception:
+    pass
 try:
     equity_init = float(ctx.api.get_account().equity)
 except Exception:


### PR DESCRIPTION
## Summary
- correct indentation for capital_scaler propagation
- fallback imports for trade utilities

## Testing
- `pytest -n auto --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68854bef33dc8330a994e8376bd29695