### PR TITLE
Improve order logs and quiet duplicate permission errors

### DIFF
--- a/bot_engine.py
+++ b/bot_engine.py
@@ -1734,10 +1734,8 @@ class TradeLogger:
                             "reward",
                         ]
                     )
-            except PermissionError as exc:  # AI-AGENT-REF: avoid duplicate audit log
-                logger.debug(
-                    "TradeLogger init unable to write %s: %s", path, exc
-                )
+            except PermissionError:
+                logger.debug("TradeLogger init path not writable: %s", path)
         if not os.path.exists(REWARD_LOG_FILE):
             try:
                 os.makedirs(os.path.dirname(REWARD_LOG_FILE) or ".", exist_ok=True)
@@ -1784,10 +1782,8 @@ class TradeLogger:
                         "",
                     ]
                 )
-        except PermissionError as exc:  # AI-AGENT-REF: avoid duplicate audit log
-            logger.debug(
-                "TradeLogger entry unable to write %s: %s", self.path, exc
-            )
+        except PermissionError:
+            logger.debug("TradeLogger entry log skipped; path not writable")
 
     def log_exit(self, state: BotState, symbol: str, exit_price: float) -> None:
         try:
@@ -1831,10 +1827,8 @@ class TradeLogger:
                 w = csv.writer(f)
                 w.writerow(header)
                 w.writerows(data)
-        except PermissionError as exc:  # AI-AGENT-REF: avoid duplicate audit log
-            logger.debug(
-                "TradeLogger exit unable to write %s: %s", self.path, exc
-            )
+        except PermissionError:
+            logger.debug("TradeLogger exit log skipped; path not writable")
             return
 
         # log reward

--- a/trade_execution.py
+++ b/trade_execution.py
@@ -933,7 +933,11 @@ class ExecutionEngine:
                     setattr(order_req, "client_order_id", new_cid)
             try:
                 order = submit_order(api, order_req, self.logger)
-                self.logger.info("Order submit response for %s: %s", symbol, order)
+                self.logger.info(
+                    "Order submit response for %s: %s",
+                    symbol,
+                    utils.format_order_for_log(order),
+                )
                 if not getattr(order, "id", None) and not SHADOW_MODE:
                     self.logger.error("Order failed for %s: %s", symbol, order)
                 return order
@@ -1025,7 +1029,11 @@ class ExecutionEngine:
                     setattr(order_req, "client_order_id", new_cid)
             try:
                 order = submit_order(api, order_req, self.logger)
-                self.logger.info("Order submit response for %s: %s", symbol, order)
+                self.logger.info(
+                    "Order submit response for %s: %s",
+                    symbol,
+                    utils.format_order_for_log(order),
+                )
                 if not getattr(order, "id", None) and not SHADOW_MODE:
                     self.logger.error("Order failed for %s: %s", symbol, order)
                 return order

--- a/utils.py
+++ b/utils.py
@@ -11,6 +11,8 @@ import warnings
 import time
 from datetime import date, timezone
 from typing import Any, Sequence
+from enum import Enum
+from uuid import UUID
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -118,6 +120,26 @@ def backoff_delay(attempt: int, base: float = 1.0, cap: float = 30.0, jitter: fl
         jitter_amt = random.uniform(-jitter * delay, jitter * delay)
         delay = max(0.0, delay + jitter_amt)
     return delay
+
+
+def format_order_for_log(order: Any) -> str:
+    """Return compact string representation of an order for logging."""
+    if order is None:
+        return ""
+    parts = []
+    for k, v in vars(order).items():
+        if isinstance(v, (dt.datetime, date)):
+            val = v.isoformat()
+        elif isinstance(v, Enum):
+            val = v.value
+        elif isinstance(v, UUID):
+            val = str(v)
+        elif isinstance(v, (int, float, bool)) or v is None:
+            val = v
+        else:
+            val = str(v)
+        parts.append(f"{k}={val}")
+    return ", ".join(parts)
 
 
 MARKET_OPEN_TIME = dt.time(9, 30)


### PR DESCRIPTION
## Summary
- add `format_order_for_log` helper in `utils`
- use helper to clean `Order` logging
- quiet duplicate permission denied messages from `bot_engine`

## Testing
- `pytest -n auto --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6887a229af288330a4f43578a15ca91d