### PR TITLE
Improve risk logs and strategy hysteresis

### DIFF
--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -46,12 +46,15 @@ class MeanReversionStrategy(Strategy):
             zscores = mean_reversion_zscore(close_series, self.lookback)
             if zscores.empty:
                 continue
+            if len(zscores) < 2:
+                continue
             z = zscores.iloc[-1]
+            prev = zscores.iloc[-2]
             if pd.isna(z):
                 logger.warning("%s: invalid rolling statistics", sym)  # AI-AGENT-REF: clarify log message
                 continue
             scores[sym] = float(z)
-            if z > self.z:
+            if z > self.z and prev > self.z:
                 signals.append(
                     TradeSignal(
                         symbol=sym,
@@ -61,7 +64,7 @@ class MeanReversionStrategy(Strategy):
                         asset_class=asset_class_for(sym),
                     )
                 )
-            elif z < -self.z:
+            elif z < -self.z and prev < -self.z:
                 signals.append(
                     TradeSignal(
                         symbol=sym,

--- a/strategies/momentum.py
+++ b/strategies/momentum.py
@@ -17,8 +17,10 @@ class MomentumStrategy(Strategy):
 
     name = "momentum"
 
-    def __init__(self, lookback: int = 20) -> None:
+    def __init__(self, lookback: int = 20, threshold: float | None = None) -> None:
         self.lookback = lookback
+        import os
+        self.threshold = float(os.getenv("MOMENTUM_THRESHOLD", "0.01")) if threshold is None else threshold
 
     def generate(self, ctx) -> List[TradeSignal]:
         signals: List[TradeSignal] = []
@@ -35,7 +37,8 @@ class MomentumStrategy(Strategy):
                 logger.warning("%s: no valid momentum data", sym)
                 continue
             ret = ret_series.iloc[-1]
-            if pd.isna(ret):
+            if pd.isna(ret) or abs(ret) < self.threshold:
+                logger.debug("%s momentum below threshold", sym)
                 continue
             side = "buy" if ret > 0 else "sell"
             signals.append(

--- a/tests/test_momentum_extra.py
+++ b/tests/test_momentum_extra.py
@@ -32,3 +32,10 @@ def test_generate_ret_nan(monkeypatch):
     ctx.data_fetcher.df.loc[len(df)-1, "close"] = float('nan')
     monkeypatch.setattr(momentum.pd, "isna", lambda v: True)
     assert strat.generate(ctx) == []
+
+
+def test_threshold_skip():
+    df = pd.DataFrame({"close": [1, 1.02, 1.03]})
+    ctx = Ctx(df)
+    strat = MomentumStrategy(lookback=1, threshold=0.05)
+    assert strat.generate(ctx) == []

--- a/tests/test_risk_engine_module.py
+++ b/tests/test_risk_engine_module.py
@@ -45,6 +45,9 @@ def test_register_and_position_size(monkeypatch):
     assert qty == 10
     eng.register_fill(sig)
     assert eng.exposure["equity"] == sig.weight
+    sell = TradeSignal(symbol="AAPL", side="sell", confidence=1.0, strategy="s", weight=sig.weight)
+    eng.register_fill(sell)
+    assert round(eng.exposure["equity"], 6) == 0
 
 
 def test_check_max_drawdown():

--- a/tests/test_strategy_allocator_exit.py
+++ b/tests/test_strategy_allocator_exit.py
@@ -1,0 +1,16 @@
+import importlib
+from strategies import TradeSignal
+
+strategy_allocator = importlib.import_module("strategy_allocator")
+
+
+def test_exit_confirmation():
+    alloc = strategy_allocator.StrategyAllocator()
+    buy = TradeSignal(symbol="A", side="buy", confidence=1.0, strategy="s")
+    sell = TradeSignal(symbol="A", side="sell", confidence=1.0, strategy="s")
+    out1 = alloc.allocate({"s": [buy]})
+    assert any(s.side == "buy" for s in out1)
+    out2 = alloc.allocate({"s": [sell]})
+    assert not any(s.side == "sell" for s in out2)
+    out3 = alloc.allocate({"s": [sell]})
+    assert any(s.side == "sell" for s in out3)


### PR DESCRIPTION
## Summary
- log inputs in `position_size` and return signed exposure
- wait for exposure updates at the start of trade cycles
- avoid duplicate longs and update exposure for exits
- tighten strategy thresholds and add exit confirmation logic
- test momentum threshold and strategy allocator confirmation

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'meta_learning')*

------
https://chatgpt.com/codex/tasks/task_e_6887acd6d5ac8330983d26fb2632a9a1