### PR TITLE
refactor: runtime-based screener

### DIFF
--- a/ai_trading/core/runtime.py
+++ b/ai_trading/core/runtime.py
@@ -8,7 +8,7 @@ access to trading parameters and configuration across the system.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, List
 
 if TYPE_CHECKING:
     from ai_trading.config.management import TradingConfig
@@ -49,6 +49,7 @@ class BotRuntime:
     """
     cfg: "TradingConfig"
     params: dict[str, Any] = field(default_factory=dict)
+    tickers: List[str] = field(default_factory=list)  # AI-AGENT-REF: runtime-selected tickers
     
     # Additional runtime attributes will be set by _ensure_initialized
     # These are forwarded from the underlying LazyBotContext


### PR DESCRIPTION
## Summary
- thread runtime through screening paths and store selected tickers on runtime
- warn once per process when `tickers.csv` missing
- add `tickers` list to `BotRuntime`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings` *(fails: NameError: MockYfinance is not defined)*
- `sudo systemctl restart ai-trading.service` *(fails: System has not been booted with systemd)*
- `journalctl -u ai-trading.service -f | sed -n '1,200p'` *(fails: No journal files were found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8ae6b4bc8330a0ba7caeb0b5cd94