### PR TITLE
Cleanup: remove shims and tighten broker exception handling

### DIFF
--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -552,17 +552,6 @@ class ExecutionEngine:
 
         logger.info("ExecutionEngine initialized")
 
-    # --- Back-compat shim for tests ---
-    def _execute_sliced(self, *args, **kwargs):  # pragma: no cover
-        """
-        Back-compat wrapper so tests can monkeypatch this private hook.
-        Delegates to whichever sliced-exec implementation exists.
-        """
-        for name in ("execute_sliced", "execute_twap_slice", "_execute_twap_slice"):
-            impl = getattr(self, name, None)
-            if callable(impl):
-                return impl(*args, **kwargs)
-        raise NotImplementedError("_execute_sliced delegate not found")
 
     def execute_order(
         self,
@@ -609,9 +598,9 @@ class ExecutionEngine:
                 side = quantity_or_side
                 quantity = side_or_quantity
 
-            # If method is "twap" and we have a _execute_sliced method, use it
-            if method == "twap" and hasattr(self, "_execute_sliced"):
-                return self._execute_sliced(symbol, quantity, side, **kwargs)
+            # AI-AGENT-REF: call sliced execution directly for TWAP
+            if method == "twap":
+                return self.execute_sliced(symbol, quantity, side, **kwargs)
 
             # Create order
             order = Order(symbol, side, quantity, order_type, **kwargs)

--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -266,14 +266,15 @@ class AlpacaExecutionEngine:
             return False
         except (APIError, TimeoutError, ConnectionError) as e:
             logger.error(
-                "ORDER_CANCEL_FAILED",
+                "ORDER_API_FAILED",
                 extra={
                     "cause": e.__class__.__name__,
                     "detail": str(e),
+                    "op": "cancel",
                     "order_id": order_id,
                 },
             )  # AI-AGENT-REF: log cancellation failure cause
-            return False
+            raise
 
     def get_order_status(self, order_id: str) -> dict | None:
         """

--- a/ai_trading/execution/production_engine.py
+++ b/ai_trading/execution/production_engine.py
@@ -434,25 +434,15 @@ class ProductionExecutionCoordinator:
 
         except (APIError, TimeoutError, ConnectionError) as e:
             logger.error(
-                "ORDER_REQUEST_FAILED",
+                "ORDER_API_FAILED",
                 extra={
                     "cause": e.__class__.__name__,
                     "detail": str(e),
+                    "op": "submit",
                     "order_id": order_request.client_order_id,
                 },
             )  # AI-AGENT-REF: log order request failure
-            return ExecutionResult(
-                status="error",
-                order_id=order_request.client_order_id,
-                symbol=order_request.symbol,
-                side=(
-                    order_request.side.value
-                    if isinstance(order_request.side, OrderSide)
-                    else order_request.side
-                ),
-                quantity=order_request.quantity,
-                message=f"Submission error: {e}",
-            )
+            raise
 
     async def submit_order(
         self,
@@ -536,22 +526,15 @@ class ProductionExecutionCoordinator:
 
         except (APIError, TimeoutError, ConnectionError) as e:
             logger.error(
-                "ORDER_SUBMISSION_FAILED",
+                "ORDER_API_FAILED",
                 extra={
                     "cause": e.__class__.__name__,
                     "detail": str(e),
+                    "op": "submit",
                     "order_id": "unknown",
                 },
             )  # AI-AGENT-REF: log submission failure
-            return ExecutionResult(
-                status="error",
-                order_id="unknown",
-                symbol=symbol,
-                side=side.value if isinstance(side, OrderSide) else side,
-                quantity=quantity,
-                message=f"Submission error: {e}",
-                error_code="submission_error",
-            )
+            raise
 
     async def _comprehensive_safety_check(self, order: Order) -> dict[str, Any]:
         """Perform comprehensive safety checks before execution."""
@@ -1097,17 +1080,12 @@ class ProductionExecutionCoordinator:
 
         except (APIError, TimeoutError, ConnectionError) as e:
             logger.error(
-                "ORDER_CANCEL_FAILED",
+                "ORDER_API_FAILED",
                 extra={
                     "cause": e.__class__.__name__,
                     "detail": str(e),
+                    "op": "cancel",
                     "order_id": order_id,
                 },
             )
-            return ExecutionResult(
-                status="error",
-                order_id=order_id,
-                symbol="unknown",
-                message=f"Cancellation error: {e}",
-                error_code="cancellation_error",
-            )
+            raise

--- a/ai_trading/execution/transaction_costs.py
+++ b/ai_trading/execution/transaction_costs.py
@@ -15,14 +15,8 @@ from typing import Any
 # Use the centralized logger as per AGENTS.md
 from ai_trading.logging import logger
 
-# Import configuration if available
-try:
-    from ai_trading.core.constants import EXECUTION_PARAMETERS, RISK_PARAMETERS
-    ENHANCED_CONFIG_AVAILABLE = True
-except ImportError:
-    ENHANCED_CONFIG_AVAILABLE = False
-    EXECUTION_PARAMETERS = {}
-    RISK_PARAMETERS = {}
+# Import configuration directly; fail fast on missing dependency
+from ai_trading.core.constants import EXECUTION_PARAMETERS, RISK_PARAMETERS  # AI-AGENT-REF: direct import without shim
 
 
 class TradeType(Enum):
@@ -101,14 +95,10 @@ class TransactionCostCalculator:
         self.max_commission = max_commission
         self.safety_margin_multiplier = safety_margin_multiplier
 
-        # Load enhanced parameters if available
-        if ENHANCED_CONFIG_AVAILABLE:
-            self.limit_slippage = EXECUTION_PARAMETERS.get('LIMIT_ORDER_SLIPPAGE', 0.005)
-            self.max_market_impact = EXECUTION_PARAMETERS.get('MAX_MARKET_IMPACT', 0.01)
-            self.safety_margin_multiplier = RISK_PARAMETERS.get('SAFETY_MARGIN_MULTIPLIER', 2.0)
-        else:
-            self.limit_slippage = 0.005
-            self.max_market_impact = 0.01
+        # Load enhanced parameters
+        self.limit_slippage = EXECUTION_PARAMETERS.get('LIMIT_ORDER_SLIPPAGE', 0.005)
+        self.max_market_impact = EXECUTION_PARAMETERS.get('MAX_MARKET_IMPACT', 0.01)
+        self.safety_margin_multiplier = RISK_PARAMETERS.get('SAFETY_MARGIN_MULTIPLIER', 2.0)
 
         # Market impact model parameters
         self.impact_model_params = {

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -1111,11 +1111,8 @@ def check_exposure_caps(portfolio, exposure, cap):
     # Original exposure logic continues here...
 
 
-# AI-AGENT-REF: guard pandas_ta import for test environments
-try:
-    import pandas_ta as ta
-except ImportError:
-    ta = None
+# AI-AGENT-REF: direct pandas_ta import without guard
+import pandas_ta as ta
 
 
 def apply_trailing_atr_stop(
@@ -1132,9 +1129,6 @@ def apply_trailing_atr_stop(
             logger.warning(
                 "apply_trailing_atr_stop invalid entry price: %.2f", entry_price
             )
-            return
-        if ta is None:
-            logger.warning("pandas_ta not available, skipping ATR calculation")
             return
         atr = df.ta.atr()
         trailing_stop = entry_price - 2 * atr


### PR DESCRIPTION
## Summary
- drop legacy execution and indicator shims in favor of direct calls
- fail fast on missing dependencies for transaction cost and risk engines
- narrow critical exception handling for screening, regime checks, health checks and order API calls

## Testing
- `grep -R --line-number "_execute_sliced" ai_trading/execution/engine.py || echo "OK: _execute_sliced gone"`
- `grep -R --line-number "prepare_indicators_compat" ai_trading/core/bot_engine.py || echo "OK: prepare_indicators_compat gone"`
- `grep -n "ImportError" ai_trading/execution/transaction_costs.py ai_trading/risk/engine.py && echo "FAIL: ImportError guard left" || echo "OK: no ImportError guards"`
- `grep -n "except Exception" ai_trading/core/bot_engine.py | grep -E "_load_primary_model|screen_(candidates|universe)|check_market_regime|detect_regime_state|HEALTH|submit|cancel" && echo "FAIL: broad catch remained" || echo "OK: no broad catches in hot paths"`
- `grep -n "except Exception" ai_trading/execution/production_engine.py ai_trading/execution/live_trading.py | grep -E "submit|cancel" && echo "FAIL: broad catch remained at submit/cancel" || echo "OK: no broad catches at submit/cancel"`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings` *(fails: NameError: name 'MockYfinance' is not defined)*
- `sudo systemctl restart ai-trading.service` *(fails: System has not been booted with systemd as init system)*
- `journalctl -u ai-trading.service -n 200 --no-pager` *(fails: No journal files were found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb9386234833088bbb975d15fbd9a