### PR TITLE
Cleanup: remove _execute_sliced & prepare_indicators_compat, fail-fast imports in transaction_costs, and narrow broad catches in hot paths

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -4580,17 +4580,17 @@ def pre_trade_health_check(
             )
             _validate_timezones(df, results, sym)
         except (
-            FileNotFoundError,
-            OSError,
+            APIError,
+            TimeoutError,
+            ConnectionError,
             KeyError,
             ValueError,
             TypeError,
-            TimeoutError,
-            ConnectionError,
-        ) as e:  # AI-AGENT-REF: explicit error logging for data health
+            OSError,
+        ) as e:  # AI-AGENT-REF: tighten health probe error handling
             results["failures"].append((sym, str(e)))
             _log.warning(
-                "HEALTH_DATA_PROBE_FAILED",
+                "HEALTH_CHECK_FAILED",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
             )
     return results
@@ -9326,17 +9326,17 @@ def health() -> str:
         pre_trade_health_check(runtime, runtime.tickers or REGIME_SYMBOLS)
         status = "ok"
     except (
-        FileNotFoundError,
-        OSError,
+        APIError,
+        TimeoutError,
+        ConnectionError,
         KeyError,
         ValueError,
         TypeError,
-        TimeoutError,
-        ConnectionError,
-    ) as e:  # AI-AGENT-REF: explicit error logging for data health
+        OSError,
+    ) as e:  # AI-AGENT-REF: tighten health probe error handling
         status = f"degraded: {e}"
         _log.warning(
-            "HEALTH_DATA_PROBE_FAILED",
+            "HEALTH_CHECK_FAILED",
             extra={"cause": e.__class__.__name__, "detail": str(e)},
         )
     summary = {
@@ -9356,8 +9356,18 @@ def start_healthcheck() -> None:
         _log.warning(
             f"Healthcheck port {port} in use: {e}. Skipping health-endpoint."
         )
-    except Exception as e:
-        _log.exception(f"start_healthcheck failed: {e}")
+    except (
+        APIError,
+        TimeoutError,
+        ConnectionError,
+        KeyError,
+        ValueError,
+        TypeError,
+    ) as e:  # AI-AGENT-REF: tighten health probe error handling
+        _log.warning(
+            "HEALTH_CHECK_FAILED",
+            extra={"cause": e.__class__.__name__, "detail": str(e)},
+        )
 
 
 def start_metrics_server(default_port: int = 9200) -> None:

--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -626,6 +626,13 @@ class ExecutionEngine:
             self.execution_stats["rejected_orders"] += 1
             return None
 
+    def execute_sliced(
+        self, symbol: str, quantity: int, side: OrderSide, **kwargs
+    ):
+        """Execute order slices by delegating to execute_order."""
+        # AI-AGENT-REF: delegate sliced execution to unified path
+        return self.execute_order(symbol, side, quantity, **kwargs)
+
     def _simulate_market_execution(self, order: Order):
         """Simulate market order execution (demo purposes)."""
         try:

--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -155,7 +155,20 @@ class AlpacaExecutionEngine:
         logger.info(f"Submitting market order: {side} {quantity} {symbol}")
 
         # Execute with retry logic
-        result = self._execute_with_retry(self._submit_order_to_alpaca, order_data)
+        try:
+            result = self._execute_with_retry(
+                self._submit_order_to_alpaca, order_data
+            )
+        except (APIError, TimeoutError, ConnectionError) as e:
+            logger.error(
+                "ORDER_API_FAILED",
+                extra={
+                    "cause": e.__class__.__name__,
+                    "detail": str(e),
+                    "op": "submit",
+                },
+            )  # AI-AGENT-REF: log submission failure
+            raise
 
         # Update statistics
         execution_time = time.time() - start_time
@@ -210,7 +223,20 @@ class AlpacaExecutionEngine:
         )
 
         # Execute with retry logic
-        result = self._execute_with_retry(self._submit_order_to_alpaca, order_data)
+        try:
+            result = self._execute_with_retry(
+                self._submit_order_to_alpaca, order_data
+            )
+        except (APIError, TimeoutError, ConnectionError) as e:
+            logger.error(
+                "ORDER_API_FAILED",
+                extra={
+                    "cause": e.__class__.__name__,
+                    "detail": str(e),
+                    "op": "submit",
+                },
+            )  # AI-AGENT-REF: log submission failure
+            raise
 
         # Update statistics
         execution_time = time.time() - start_time
@@ -431,7 +457,7 @@ class AlpacaExecutionEngine:
                         },
                     )  # AI-AGENT-REF: log retry exhaustion
                     self._handle_execution_failure(e)
-                    return None
+                    raise
 
                 logger.warning(
                     "RETRY_ATTEMPT_FAILED",

--- a/ai_trading/execution/transaction_costs.py
+++ b/ai_trading/execution/transaction_costs.py
@@ -18,6 +18,9 @@ from ai_trading.logging import logger
 # Import configuration directly; fail fast on missing dependency
 from ai_trading.core.constants import EXECUTION_PARAMETERS, RISK_PARAMETERS  # AI-AGENT-REF: direct import without shim
 
+# AI-AGENT-REF: mark enhanced config availability without optional guard
+ENHANCED_CONFIG_AVAILABLE = True
+
 
 class TradeType(Enum):
     """Type of trade for cost calculation."""


### PR DESCRIPTION
## Summary
- delegate `execute_sliced` to the core order executor and drop legacy shim
- fail-fast on enhanced config imports in transaction cost calculations
- tighten health check exception handling and surface order submission API failures

## Testing
- `grep -R --line-number "_execute_sliced" ai_trading/execution/engine.py || echo "OK: _execute_sliced gone"`
- `grep -R --line-number "prepare_indicators_compat" ai_trading/core/bot_engine.py || echo "OK: prepare_indicators_compat gone"`
- `grep -n "ImportError" ai_trading/execution/transaction_costs.py && echo "FAIL: ImportError guard left" || echo "OK: no ImportError guards in transaction_costs"`
- `grep -n "except Exception" ai_trading/core/bot_engine.py | grep -E "_load_primary_model|screen_(candidates|universe)|check_market_regime|detect_regime_state|HEALTH" && echo "FAIL: broad catch remained" || echo "OK: hot paths narrowed"`
- `grep -n "except Exception" ai_trading/execution/production_engine.py ai_trading/execution/live_trading.py | grep -E "submit|cancel" && echo "FAIL: broad catch remained at submit/cancel" || echo "OK: no broad catches at submit/cancel"`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings` *(fails: NameError: name 'MockYfinance' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689bbfdf9e208330ba91e82411ddd063