### PR TITLE
Exception hygiene: signals.py, transaction_costs.py, shutdown_handler.py

### DIFF
--- a/ai_trading/execution/transaction_costs.py
+++ b/ai_trading/execution/transaction_costs.py
@@ -158,8 +158,11 @@ class TransactionCostCalculator:
 
             return spread_cost
 
-        except Exception as e:
-            logger.error(f"Error calculating spread cost for {symbol}: {e}")
+        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:  # AI-AGENT-REF: narrow exception
+            logger.error(
+                "SPREAD_COST_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "symbol": symbol},
+            )
             # Conservative fallback
             price = market_data.get('prices', {}).get(symbol, 100.0)
             return abs(trade_size) * price * 0.001  # 10 bps fallback
@@ -191,8 +194,11 @@ class TransactionCostCalculator:
 
             return commission
 
-        except Exception as e:
-            logger.error(f"Error calculating commission for {symbol}: {e}")
+        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:  # AI-AGENT-REF: narrow exception
+            logger.error(
+                "COMMISSION_CALC_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "symbol": symbol},
+            )
             return max(self.min_commission, trade_value * 0.0001)  # 1bp fallback
 
     def calculate_market_impact(self,
@@ -248,8 +254,11 @@ class TransactionCostCalculator:
 
             return temporary_impact, permanent_impact
 
-        except Exception as e:
-            logger.error(f"Error calculating market impact for {symbol}: {e}")
+        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:  # AI-AGENT-REF: narrow exception
+            logger.error(
+                "MARKET_IMPACT_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "symbol": symbol},
+            )
             # Conservative fallback
             trade_value = abs(trade_size) * market_data.get('prices', {}).get(symbol, 100.0)
             impact = trade_value * 0.005  # 50 bps fallback
@@ -287,8 +296,11 @@ class TransactionCostCalculator:
 
             return opportunity_cost
 
-        except Exception as e:
-            logger.error(f"Error calculating opportunity cost for {symbol}: {e}")
+        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:  # AI-AGENT-REF: narrow exception
+            logger.error(
+                "OPPORTUNITY_COST_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "symbol": symbol},
+            )
             return 0.0
 
     def calculate_borrowing_cost(self,
@@ -325,8 +337,11 @@ class TransactionCostCalculator:
 
             return borrowing_cost
 
-        except Exception as e:
-            logger.error(f"Error calculating borrowing cost for {symbol}: {e}")
+        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:  # AI-AGENT-REF: narrow exception
+            logger.error(
+                "BORROWING_COST_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "symbol": symbol},
+            )
             return 0.0
 
     def calculate_total_transaction_cost(self,
@@ -393,8 +408,11 @@ class TransactionCostCalculator:
                 cost_percentage=cost_percentage
             )
 
-        except Exception as e:
-            logger.error(f"Error calculating transaction cost for {symbol}: {e}")
+        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:  # AI-AGENT-REF: narrow exception
+            logger.error(
+                "TRANSACTION_COST_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "symbol": symbol},
+            )
             # Conservative fallback
             fallback_cost = abs(trade_size) * price * 0.01  # 1% fallback
             return TransactionCostBreakdown(
@@ -475,8 +493,11 @@ class TransactionCostCalculator:
         except KeyError as e:
             logger.warning(f"Missing market data for {symbol}: {e}")
             raise KeyError(f"Required market data missing: {str(e)}")
-        except Exception as e:
-            logger.error(f"Error validating trade profitability for {symbol}: {e}")
+        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:  # AI-AGENT-REF: narrow exception
+            logger.error(
+                "PROFITABILITY_VALIDATION_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "symbol": symbol},
+            )
             return ProfitabilityAnalysis(
                 expected_profit=expected_profit,
                 transaction_cost=abs(expected_profit) * 0.5,  # Assume high cost
@@ -504,7 +525,11 @@ class TransactionCostCalculator:
 
             return spread_estimates.get(liquidity_tier, 0.005)
 
-        except Exception:
+        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:  # AI-AGENT-REF: narrow exception
+            logger.warning(
+                "SPREAD_PERCENT_ESTIMATE_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "symbol": symbol},
+            )
             return 0.005  # 50 bps default
 
     def _classify_liquidity(self, symbol: str, market_data: dict[str, Any]) -> LiquidityTier:
@@ -523,7 +548,11 @@ class TransactionCostCalculator:
             else:
                 return LiquidityTier.ILLIQUID
 
-        except Exception:
+        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:  # AI-AGENT-REF: narrow exception
+            logger.warning(
+                "LIQUIDITY_CLASSIFICATION_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "symbol": symbol},
+            )
             return LiquidityTier.MEDIUM_LIQUIDITY
 
 

--- a/ai_trading/shutdown_handler.py
+++ b/ai_trading/shutdown_handler.py
@@ -130,11 +130,11 @@ class ShutdownHandler:
                 f"Signal handlers registered for: {[s.name for s in signals_to_handle]}"
             )
 
-        except (APIError, TimeoutError, ConnectionError) as e:
+        except (APIError, TimeoutError, ConnectionError, OSError) as e:  # AI-AGENT-REF: include OSError in shutdown handling
             self.logger.error(
                 "SIGNAL_HANDLER_SETUP_FAILED",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
-            )  # AI-AGENT-REF: narrow exception for signal handler setup
+            )
 
     def _signal_handler(self, signum: int, frame) -> None:
         """Handle shutdown signals."""
@@ -223,7 +223,7 @@ class ShutdownHandler:
 
             return success
 
-        except (APIError, TimeoutError, ConnectionError) as e:
+        except (APIError, TimeoutError, ConnectionError, OSError) as e:
             self._status.phase = ShutdownPhase.FAILED
             self._status.current_action = f"Shutdown error: {str(e)}"
             self._status.errors.append(str(e))
@@ -290,7 +290,7 @@ class ShutdownHandler:
 
             return True
 
-        except (APIError, TimeoutError, ConnectionError) as e:
+        except (APIError, TimeoutError, ConnectionError, OSError) as e:
             self.logger.error(
                 "GRACEFUL_SHUTDOWN_FAILED",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -323,7 +323,7 @@ class ShutdownHandler:
 
             return True
 
-        except (APIError, TimeoutError, ConnectionError) as e:
+        except (APIError, TimeoutError, ConnectionError, OSError) as e:
             self.logger.error(
                 "EMERGENCY_SHUTDOWN_FAILED",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -339,7 +339,7 @@ class ShutdownHandler:
                     await hook()
                 else:
                     hook()
-            except (APIError, TimeoutError, ConnectionError) as e:
+            except (APIError, TimeoutError, ConnectionError, OSError) as e:
                 self.logger.error(
                     "PRE_SHUTDOWN_HOOK_FAILED",
                     extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -362,7 +362,7 @@ class ShutdownHandler:
                     orders = handler()
                     if orders:
                         all_orders.extend(orders)
-                except (APIError, TimeoutError, ConnectionError) as e:
+                except (APIError, TimeoutError, ConnectionError, OSError) as e:
                     self.logger.error(
                         "ORDER_HANDLER_FAILED",
                         extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -386,7 +386,7 @@ class ShutdownHandler:
                     await self._cancel_single_order(order)
                     self._status.orders_canceled += 1
 
-                except (APIError, TimeoutError, ConnectionError) as e:
+                except (APIError, TimeoutError, ConnectionError, OSError) as e:
                     self.logger.warning(
                         "SHUTDOWN_CANCEL_FAILED",
                         extra={
@@ -407,7 +407,7 @@ class ShutdownHandler:
 
             return success_rate >= 0.9  # 90% success rate required
 
-        except (APIError, TimeoutError, ConnectionError) as e:
+        except (APIError, TimeoutError, ConnectionError, OSError) as e:
             self.logger.error(
                 "ORDER_CANCELLATION_FAILED",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -424,7 +424,7 @@ class ShutdownHandler:
                     positions = handler()
                     if positions:
                         all_positions.extend(positions)
-                except (APIError, TimeoutError, ConnectionError) as e:
+                except (APIError, TimeoutError, ConnectionError, OSError) as e:
                     self.logger.error(
                         "POSITION_HANDLER_FAILED",
                         extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -448,7 +448,7 @@ class ShutdownHandler:
                     await self._close_single_position(position)
                     self._status.positions_closed += 1
 
-                except (APIError, TimeoutError, ConnectionError) as e:
+                except (APIError, TimeoutError, ConnectionError, OSError) as e:
                     self.logger.warning(
                         "SHUTDOWN_CLOSE_POSITION_FAILED",
                         extra={
@@ -469,7 +469,7 @@ class ShutdownHandler:
 
             return success_rate >= 0.9  # 90% success rate required
 
-        except (APIError, TimeoutError, ConnectionError) as e:
+        except (APIError, TimeoutError, ConnectionError, OSError) as e:
             self.logger.error(
                 "POSITION_CLOSING_FAILED",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -525,7 +525,7 @@ class ShutdownHandler:
 
             self.logger.info(f"System state saved to: {state_file}")
 
-        except (APIError, TimeoutError, ConnectionError) as e:
+        except (APIError, TimeoutError, ConnectionError, OSError) as e:
             self.logger.error(
                 "STATE_SAVE_FAILED",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -556,7 +556,7 @@ class ShutdownHandler:
 
             self.logger.info(f"Critical state saved to: {state_file}")
 
-        except (APIError, TimeoutError, ConnectionError) as e:
+        except (APIError, TimeoutError, ConnectionError, OSError) as e:
             self.logger.error(
                 "CRITICAL_STATE_SAVE_FAILED",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -570,7 +570,7 @@ class ShutdownHandler:
                     await hook()
                 else:
                     hook()
-            except (APIError, TimeoutError, ConnectionError) as e:
+            except (APIError, TimeoutError, ConnectionError, OSError) as e:
                 self.logger.error(
                     "CLEANUP_HOOK_FAILED",
                     extra={"cause": e.__class__.__name__, "detail": str(e)},
@@ -590,7 +590,7 @@ class ShutdownHandler:
                     await hook()
                 else:
                     hook()
-            except (APIError, TimeoutError, ConnectionError) as e:
+            except (APIError, TimeoutError, ConnectionError, OSError) as e:
                 self.logger.error(
                     "POST_SHUTDOWN_HOOK_FAILED",
                     extra={"cause": e.__class__.__name__, "detail": str(e)},


### PR DESCRIPTION
## Summary
- narrow broad `except Exception` blocks in signal generation to explicit tuples with structured warning fields
- handle I/O-related failures in transaction cost analysis using explicit exception tuples and structured logs
- extend shutdown handler error handling to include `OSError`

## Testing
- `git diff --name-only | grep -v -E '(ai_trading/signals.py|ai_trading/execution/transaction_costs.py|ai_trading/shutdown_handler.py)$' && echo "FAIL: out-of-scope" || echo "OK: scope limited"`
- `grep -n "except Exception" ai_trading/signals.py ai_trading/execution/transaction_costs.py ai_trading/shutdown_handler.py && echo "FAIL: broad catch left" || echo "OK: cleaned"`
- `grep -R --line-number '"cause": e.__class__.__name__' ai_trading | head -n1 >/dev/null && echo "OK: cause present"`
- `grep -R --line-number '"detail": str(e)' ai_trading | head -n1 >/dev/null && echo "OK: detail present"`
- `grep -R --line-number "except ImportError" ai_trading | grep -v tests && echo "FAIL: ImportError guard in prod" || echo "OK: no ImportError guards"` *(fails: comment in imports.py)*
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_689bcf6ebf1c833097465aca1d255b7e