### PR TITLE
Fail-fast imports & remove legacy shims (engine, risk, transaction_costs)

### DIFF
--- a/ai_trading/execution/transaction_costs.py
+++ b/ai_trading/execution/transaction_costs.py
@@ -18,9 +18,6 @@ from ai_trading.logging import logger
 # Import configuration directly; fail fast on missing dependency
 from ai_trading.core.constants import EXECUTION_PARAMETERS, RISK_PARAMETERS  # AI-AGENT-REF: direct import without shim
 
-# AI-AGENT-REF: mark enhanced config availability without optional guard
-ENHANCED_CONFIG_AVAILABLE = True
-
 
 class TradeType(Enum):
     """Type of trade for cost calculation."""

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -11,6 +11,9 @@ import numpy as np
 # AI-AGENT-REF: guard pandas import for test environments
 import pandas as pd
 
+# AI-AGENT-REF: direct pandas_ta import without guard
+import pandas_ta as ta
+
 from ai_trading.config.management import TradingConfig, SEED
 from ai_trading.telemetry import metrics_logger
 from alpaca_trade_api.rest import APIError  # AI-AGENT-REF: narrow Alpaca exceptions
@@ -1111,8 +1114,6 @@ def check_exposure_caps(portfolio, exposure, cap):
     # Original exposure logic continues here...
 
 
-# AI-AGENT-REF: direct pandas_ta import without guard
-import pandas_ta as ta
 
 
 def apply_trailing_atr_stop(


### PR DESCRIPTION
## Summary
- move `pandas_ta` import to module top for fail-fast risk engine setup
- drop obsolete config availability shim in transaction cost calculator

## Testing
- `grep -R --line-number "_execute_sliced" ai_trading/execution/engine.py || echo "OK: _execute_sliced gone"`
- `grep -R --line-number "prepare_indicators_compat" ai_trading/core/bot_engine.py || echo "OK: prepare_indicators_compat gone"`
- `grep -n "ImportError" ai_trading/risk/engine.py ai_trading/execution/transaction_costs.py ai_trading/execution/engine.py | grep -E "except|try" && echo "FAIL: ImportError guard left" || echo "OK: no ImportError guards"`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `sudo systemctl restart ai-trading.service` *(fails: System has not been booted with systemd)*
- `journalctl -u ai-trading.service -n 200 --no-pager` *(fails: No journal files were found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd745cd108330a3c458a7095cc395