### PR TITLE
Exception hygiene (part 1): narrow catches in execution/engine.py non-broker paths

### DIFF
--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -254,17 +254,15 @@ class OrderManager:
                 # AI-AGENT-REF: instantiate idempotency cache
                 self._idempotency_cache = OrderIdempotencyCache()
             except (
-                ValueError,
                 KeyError,
+                ValueError,
                 TypeError,
-                OSError,
-                FileNotFoundError,
-                PermissionError,
+                RuntimeError,
             ) as e:
                 logger.error(
                     "IDEMPOTENCY_CACHE_FAILED",
                     extra={"cause": e.__class__.__name__, "detail": str(e)},
-                )
+                )  # AI-AGENT-REF: narrow idempotency cache errors
                 raise
         return self._idempotency_cache
 
@@ -463,12 +461,10 @@ class OrderManager:
             return True
 
         except (
-            ValueError,
             KeyError,
+            ValueError,
             TypeError,
-            OSError,
-            FileNotFoundError,
-            PermissionError,
+            RuntimeError,
         ) as e:
             logger.error(
                 "ORDER_VALIDATION_FAILED",
@@ -530,12 +526,10 @@ class OrderManager:
                 try:
                     callback(order, event_type)
                 except (
-                    ValueError,
                     KeyError,
+                    ValueError,
                     TypeError,
-                    OSError,
-                    FileNotFoundError,
-                    PermissionError,
+                    RuntimeError,
                 ) as e:
                     logger.error(
                         "CALLBACK_FAILED",
@@ -546,12 +540,10 @@ class OrderManager:
                         },
                     )
         except (
-            ValueError,
             KeyError,
+            ValueError,
             TypeError,
-            OSError,
-            FileNotFoundError,
-            PermissionError,
+            RuntimeError,
         ) as e:
             logger.error(
                 "CALLBACK_NOTIFICATION_FAILED",
@@ -657,12 +649,10 @@ class ExecutionEngine:
                 return None
 
         except (
-            ValueError,
             KeyError,
+            ValueError,
             TypeError,
-            OSError,
-            FileNotFoundError,
-            PermissionError,
+            RuntimeError,
         ) as e:
             logger.error(
                 "ORDER_EXECUTION_FAILED",
@@ -710,12 +700,10 @@ class ExecutionEngine:
                 ) / self.execution_stats["filled_orders"]
 
         except (
-            ValueError,
             KeyError,
+            ValueError,
             TypeError,
-            OSError,
-            FileNotFoundError,
-            PermissionError,
+            RuntimeError,
         ) as e:
             logger.error(
                 "SIMULATION_FAILED",


### PR DESCRIPTION
## Summary
- tighten idempotency cache setup with specific runtime exceptions
- restrict order validation and callbacks to key runtime errors with detailed logging
- narrow execution and simulation error handling to internal runtime issues

## Testing
- `grep -n "except Exception" ai_trading/execution/engine.py && echo "FAIL" || echo "OK: no broad catches in execution/engine.py"`
- `grep -n "except (APIError, TimeoutError, ConnectionError)" ai_trading/execution/engine.py || echo "NOTE: broker edges not touched here"`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from ai_trading.config import get_settings
from ai_trading.execution.engine import __name__ as m
print("loaded:", m, get_settings().env)
PY`
- `pytest -n auto --disable-warnings` *(fails: 'Settings' object has no attribute 'finnhub_api_key')*

------
https://chatgpt.com/codex/tasks/task_e_689c1c1bec08833088f95954f1f43d43