### PR TITLE
Make yfinance optional + CI-safe via lazy import helper and test stub

### DIFF
--- a/ai_trading/data_providers/__init__.py
+++ b/ai_trading/data_providers/__init__.py
@@ -1,0 +1,5 @@
+"""Optional data provider helpers."""
+
+from ai_trading.util.optional_imports import get_yfinance, has_yfinance  # AI-AGENT-REF: re-export yfinance helpers
+
+__all__ = ["get_yfinance", "has_yfinance"]

--- a/ai_trading/util/__init__.py
+++ b/ai_trading/util/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for optional dependencies."""  # AI-AGENT-REF: init util package

--- a/ai_trading/util/optional_imports.py
+++ b/ai_trading/util/optional_imports.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Optional, Tuple
+
+# AI-AGENT-REF: helper for lazy optional imports
+
+def try_import(module_name: str) -> Tuple[Optional[object], bool, Optional[Exception]]:
+    try:
+        m = import_module(module_name)
+        return m, True, None
+    except Exception as e:  # intentionally broad to capture env issues
+        return None, False, e
+
+
+def get_yfinance():
+    mod, ok, _ = try_import("yfinance")
+    return mod if ok else None
+
+
+def has_yfinance() -> bool:
+    _, ok, _ = try_import("yfinance")
+    return ok

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ pythonpath =
 asyncio_mode = auto
 env =
     PYTHONPATH = tests/_compat:${PYTHONPATH}
+    YFINANCE_STUB=1  # AI-AGENT-REF: ensure yfinance stub for tests
 markers =
     integration: may require network/keys; auto-skip if unavailable
     broker: hits broker API; auto-skip if missing keys

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ pandas-ta
 pandas-market-calendars>=4.4,<5.0
 alpaca-trade-api>=3.0,<4.0
 cachetools>=5.3,<6.0
-yfinance
+yfinance>=0.2.40,<0.3  # AI-AGENT-REF: pin yfinance for CI
 
 # System/process utilities used by perf checks & test helpers (CI-only)
 # Pin to <6 to avoid upcoming API changes that may break older helpers.

--- a/scripts/quick_verify.sh
+++ b/scripts/quick_verify.sh
@@ -83,3 +83,14 @@ c = get_alpaca_config()
 print("alpaca_cfg:", bool(c.base_url and c.key_id))
 PY
 
+# AI-AGENT-REF: smoke test yfinance availability
+python - <<'PY'
+import os, importlib
+os.environ.setdefault("YFINANCE_STUB","1")
+m = importlib.import_module("yfinance")
+print("yfinance import ok:", getattr(m, "__version__", "unknown"))
+has_dl = hasattr(m, "download")
+t = getattr(m, "Ticker", None)
+print("has_download:", has_dl, "has_Ticker:", bool(t))
+PY
+

--- a/tests/_compat/sitecustomize.py
+++ b/tests/_compat/sitecustomize.py
@@ -21,3 +21,13 @@ try:
 except Exception:
     pass
 
+# AI-AGENT-REF: stub yfinance when unavailable or disabled
+if os.getenv("YFINANCE_STUB", "1") == "1":
+    from tests._compat import yfinance_stub as _stub
+    sys.modules["yfinance"] = _stub
+else:
+    try:
+        import yfinance  # noqa: F401
+    except Exception:
+        from tests._compat import yfinance_stub as _stub
+        sys.modules.setdefault("yfinance", _stub)

--- a/tests/_compat/yfinance_stub.py
+++ b/tests/_compat/yfinance_stub.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import types
+import pandas as pd
+from datetime import datetime
+
+__version__ = "stub-0.0"
+
+# AI-AGENT-REF: offline yfinance stub
+
+def _make_df():
+    # tiny deterministic OHLCV frame
+    idx = pd.date_range(datetime(2024,1,2,9,30), periods=5, freq="1min")
+    return pd.DataFrame({
+        "Open":[100,101,102,103,104],
+        "High":[101,102,103,104,105],
+        "Low":[ 99,100,101,102,103],
+        "Close":[100,101,102,103,104],
+        "Volume":[1000,1001,1002,1003,1004],
+    }, index=idx)
+
+def download(tickers, period=None, interval=None, **kwargs):
+    # mimic yfinance.download signature, return a simple DataFrame
+    df = _make_df()
+    if isinstance(tickers, (list, tuple, set)) or (isinstance(tickers, str) and "," in tickers):
+        return {t.strip(): df.copy() for t in (tickers if not isinstance(tickers, str) else tickers.split(","))}
+    return df
+
+class _FastInfo(dict):
+    def __getattr__(self, k):
+        return self.get(k)
+
+class Ticker:
+    def __init__(self, symbol: str):
+        self.ticker = symbol
+        self.info = {"symbol": symbol, "sector": "Technology", "currency": "USD"}
+        self.fast_info = _FastInfo(last_price=104.0, day_high=105.0, day_low=99.0)
+
+    def history(self, period="1d", interval="1m", **kwargs):
+        return _make_df()
+
+__all__ = ["download", "Ticker", "__version__"]


### PR DESCRIPTION
## Summary
- add `optional_imports` helper to lazily load optional modules like yfinance
- expose `get_yfinance`/`has_yfinance` via `data_providers` package
- introduce offline `yfinance` stub auto-loaded in tests and quick verify script

## Testing
- `python - <<'PY'
from ai_trading.data_providers import get_yfinance, has_yfinance
print('helper:', bool(get_yfinance), bool(has_yfinance))
PY`
- `PYTHONPATH=tests/_compat:$PYTHONPATH YFINANCE_STUB=1 python - <<'PY'
import yfinance as yf
print('yf:', getattr(yf,'__version__','?'))
d = yf.download('AAPL', period='1d', interval='1m')
print('download_rows:', getattr(d, 'shape', (0,0))[0] if hasattr(d,'shape') else len(d))
print('ticker_ok:', hasattr(yf, 'Ticker'))
PY`
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile ok'`
- `FINNHUB_API_KEY=dummy pytest -n auto --disable-warnings` *(fails: AttributeError: 'Settings' object has no attribute 'finnhub_api_key')*

------
https://chatgpt.com/codex/tasks/task_e_689c9a7dad288330ba44be9434ceb3c2