### PR TITLE
fix: pin numpy and add api defaults

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -5,6 +5,10 @@ import logging
 from flask import Flask, jsonify
 
 
+# AI-AGENT-REF: expose a sensible default port when running the API directly
+DEFAULT_PORT = 9001
+
+
 def create_app():
     app = Flask(__name__)
     # AI-AGENT-REF: silence Flask development server noise
@@ -15,3 +19,15 @@ def create_app():
         return jsonify(status="ok")
 
     return app
+
+
+if __name__ == "__main__":
+    from os import getenv
+    from dotenv import load_dotenv
+    from ai_trading.config import get_settings
+
+    load_dotenv()
+    settings = get_settings()
+    port = getattr(settings, "api_port", None) or int(getenv("PORT", DEFAULT_PORT))
+    app = create_app()
+    app.run(host="0.0.0.0", port=port, debug=False)

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -165,13 +165,19 @@ def run_flask_app(port: int = 5000, ready_signal: threading.Event = None) -> Non
         ready_signal.set()
 
     logger.info(f"Starting Flask app on 0.0.0.0:{port}")
-    application.run(host="0.0.0.0", port=port)
+    # AI-AGENT-REF: disable debug mode in production server
+    application.run(host="0.0.0.0", port=port, debug=False)
 
 
 def start_api(ready_signal: threading.Event = None) -> None:
     """Spin up the Flask API server."""
     settings = get_settings()
-    run_flask_app(settings.api_port, ready_signal)
+    from os import getenv
+
+    # AI-AGENT-REF: ensure default port fallback if unset
+    DEFAULT_PORT = 9001
+    port = getattr(settings, "api_port", None) or int(getenv("PORT", DEFAULT_PORT))
+    run_flask_app(port, ready_signal)
 
 
 def main() -> None:
@@ -234,6 +240,7 @@ def main() -> None:
 
     interval = config.scheduler_sleep_seconds
     iterations = config.scheduler_iterations  # AI-AGENT-REF: test hook
+    iterations = 0 if iterations is None else iterations  # AI-AGENT-REF: treat None as infinite
     count = 0
 
     # AI-AGENT-REF: Track memory optimization cycles

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Core production dependencies
+# AI-AGENT-REF: pin NumPy to 1.x for pandas-ta compatibility
+numpy==1.26.4
+-e .


### PR DESCRIPTION
## Summary
- pin NumPy 1.26.4 for pandas-ta compatibility
- add default Flask port fallback and disable debug mode
- allow scheduler to accept `iterations=None`

## Testing
- `python - <<'PY'
import numpy as np
print("numpy:", np.__version__)
print("has NaN:", hasattr(np, "NaN"))
PY`
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from ai_trading.config import get_settings
s = get_settings()
print("api_port:", getattr(s, "api_port", None))
PY`
- `python - <<'PY'
iterations = None
def cond(iters, count):
    iters = 0 if iters is None else iters
    return (iters <= 0) or (count < iters)
print("loop_ok_none:", cond(None, 0))
print("loop_ok_5:", cond(5, 3))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689ca51969848330b1e99f5a649ec151