### PR TITLE
Harden runtime defaults: seed, loop interval, iterations, and API port

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import logging
 
 from flask import Flask, jsonify
-
-
-# AI-AGENT-REF: expose a sensible default port when running the API directly
-DEFAULT_PORT = 9001
+from ai_trading.config.settings import get_settings
 
 
 def create_app():
@@ -22,12 +19,8 @@ def create_app():
 
 
 if __name__ == "__main__":
-    from os import getenv
-    from dotenv import load_dotenv
-    from ai_trading.config import get_settings
-
-    load_dotenv()
-    settings = get_settings()
-    port = getattr(settings, "api_port", None) or int(getenv("PORT", DEFAULT_PORT))
+    s = get_settings()
+    port = int(s.api_port or 9001)  # AI-AGENT-REF: default Flask port fallback
     app = create_app()
-    app.run(host="0.0.0.0", port=port, debug=False)
+    app.logger.info("Starting Flask", extra={"port": port})
+    app.run(host="0.0.0.0", port=port)

--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -25,6 +25,12 @@ class Settings(BaseSettings):
     )
     bot_mode: str = Field(default="test", alias="BOT_MODE")
 
+    # AI-AGENT-REF: runtime defaults for deterministic behavior and loops
+    seed: int | None = 42
+    loop_interval_seconds: int = 60
+    iterations: int | None = 0  # 0 => run forever
+    api_port: int | None = 9001
+
     # AI-AGENT-REF: optional Finnhub API config
     # --- Finnhub (optional; tests may reference these) ---
     finnhub_api_key: str | None = Field(


### PR DESCRIPTION
## Summary
- provide default seed, loop interval, iterations, and API port in Settings
- guard torch seeding and random seed setup in bot engine
- coalesce Flask port and loop runtime parameters to safe integers

## Testing
- `python - <<'PY'
from ai_trading.core.bot_engine import BotState  # import side-effects include seeding
print("bot_engine import OK")
PY` *(fails: ImportError: cannot import name 'NaN' from 'numpy')*
- `python - <<'PY'
import types, time
from ai_trading.config.settings import get_settings
s = get_settings()
print("settings:", {"seed": s.seed, "iter": s.iterations, "intv": s.loop_interval_seconds, "port": s.api_port})
PY`
- `python - <<'PY'
from ai_trading.main import main
print("main import OK")
PY`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_689ca87744888330ba79a8ef80111444