### PR TITLE
Core: fix ExecutionEngine import to use ai_trading.execution

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1024,7 +1024,7 @@ def _init_metrics() -> None:
 
 
 try:
-    from ai_trading.trade_execution import ExecutionEngine  # type: ignore
+    from ai_trading.execution import ExecutionEngine  # canonical import  # AI-AGENT-REF: fix ExecutionEngine import
 except (FileNotFoundError, PermissionError, IsADirectoryError, JSONDecodeError, ValueError, KeyError, TypeError, OSError):  # pragma: no cover - allow tests with stubbed module  # AI-AGENT-REF: narrow exception
 
     class ExecutionEngine:

--- a/ai_trading/execution/__init__.py
+++ b/ai_trading/execution/__init__.py
@@ -21,7 +21,7 @@ execution controls, monitoring, and compliance capabilities.
 """
 
 # Import execution components
-from .engine import ExecutionAlgorithm, Order
+from .engine import ExecutionAlgorithm, ExecutionEngine, Order  # AI-AGENT-REF: expose ExecutionEngine
 
 
 # Import enhanced debugging and tracking modules
@@ -71,6 +71,7 @@ __all__ = [
     # Core execution engine
     "Order",
     "ExecutionAlgorithm",
+    "ExecutionEngine",  # AI-AGENT-REF: expose ExecutionEngine
     # Production execution coordination
     "ProductionExecutionCoordinator",
     "ExecutionResult",


### PR DESCRIPTION
## Summary
- re-export ExecutionEngine from execution package
- update bot_engine to import ExecutionEngine from ai_trading.execution

## Testing
- `pytest -n auto --disable-warnings` *(fails: TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType')*
- `grep -R --line-number "ai_trading\.trade_execution" ai_trading || echo "OK: no old trade_execution imports"`
- `python - <<'PY'
import importlib
assert importlib.import_module("ai_trading.execution")
EE = getattr(importlib.import_module("ai_trading.execution"), "ExecutionEngine")
print("OK: ExecutionEngine importable:", EE)
PY`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689cac4db5148330b63fe33631b94156