### PR TITLE
fix(imports): correct RL import path, harden RL init, and add missing package init

### DIFF
--- a/ai_trading/database/__init__.py
+++ b/ai_trading/database/__init__.py
@@ -1,0 +1,6 @@
+"""
+Make `ai_trading.database` a proper package so absolute imports won’t fail later.
+"""
+# AI-AGENT-REF: ensure database package importability
+__all__: list[str] = []
+

--- a/tests/test_imports_smoke.py
+++ b/tests/test_imports_smoke.py
@@ -1,0 +1,23 @@
+"""Basic smoke test to ensure submodules import cleanly."""
+
+import importlib
+import pkgutil
+
+# AI-AGENT-REF: smoke test for package imports
+
+
+def _safe_import(name: str) -> None:
+    """Import module unless it's a known heavy orchestrator."""
+    skip_prefixes = {
+        "ai_trading.core.bot_engine",  # heavy orchestrator
+    }
+    if any(name.startswith(p) for p in skip_prefixes):
+        return
+    importlib.import_module(name)
+
+
+def test_submodules_import() -> None:
+    pkg = importlib.import_module("ai_trading")
+    for modinfo in pkgutil.walk_packages(pkg.__path__, pkg.__name__ + "."):
+        _safe_import(modinfo.name)
+


### PR DESCRIPTION
## Summary
- Replace stale RL import with `ai_trading.rl_trading.RLTrader` and load agent defensively
- Add RL import self-check log mirroring ATR check
- Add `ai_trading/database/__init__.py` and light import smoke test

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'finnhub')*

------
https://chatgpt.com/codex/tasks/task_e_689cfa01e4c083309cdf970d8c3944ce