### PR TITLE
fix: stabilize runtime imports and defaults

### DIFF
--- a/AUDIT_FIX_SUMMARY.md
+++ b/AUDIT_FIX_SUMMARY.md
@@ -102,3 +102,10 @@ AAPL,2025-08-05T17:00:00+00:00,150.75,,,100,buy,MOMENTUM,,,,
 
 ## Impact
 This fix prevents systematic data corruption that was affecting trading decisions and compliance auditing. The trade log CSV files now maintain proper data integrity with correct column alignment.
+
+## Latest Changes
+
+- Removed hard `data_client` dependency from `RiskEngine` and introduced a lazy Alpaca resolver for historical data.
+- Added `RLTrader` alias to maintain backward compatibility with modules expecting the old class name.
+- Completed `Settings` and `TradingConfig` with missing defaults for lookbacks, sklearn enablement, and retraining flags.
+- Replaced test mock imports in `sentiment` analysis with a local stub to prevent test leakage into production.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Import Blocker**: Replaced corrupted `ai_trading/model_registry.py` with clean, minimal, typed model registry implementation
+- Removed hard `data_client` dependency in risk engine with optional Alpaca client.
+- Added `RLTrader` alias and completed config defaults for stable runtime.
+- Replaced test mock imports in sentiment module with local stub to avoid leakage.
   - Supports `register_model`, `load_model`, and `latest_for` operations
   - Maintains JSON index for model metadata
   - Includes dataset fingerprint verification for reproducibility

--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -25,6 +25,12 @@ class Settings(BaseSettings):
     )
     bot_mode: str = Field(default="test", alias="BOT_MODE")
 
+    REGIME_MIN_ROWS: int = Field(200, alias="REGIME_MIN_ROWS")
+    data_warmup_lookback_days: int = Field(60, alias="DATA_WARMUP_LOOKBACK_DAYS")
+    disable_daily_retrain: bool = Field(False, alias="DISABLE_DAILY_RETRAIN")
+    enable_sklearn: bool = Field(False, alias="ENABLE_SKLEARN")
+    intraday_lookback_minutes: int = Field(120, alias="INTRADAY_LOOKBACK_MINUTES")
+
     # AI-AGENT-REF: runtime defaults for deterministic behavior and loops
     seed: int | None = 42
     loop_interval_seconds: int = 60

--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -82,3 +82,13 @@ class RLAgent:
         except Exception as exc:
             logger.error("RL prediction failed: %s", exc)
             return None
+
+
+class RLTrader(RLAgent):
+    """Backward-compatible alias used by bot_engine."""
+    pass
+
+try:
+    __all__.append("RLTrader")
+except NameError:
+    __all__ = ["RLAgent", "RLTrader"]


### PR DESCRIPTION
## Summary
- remove hard data_client dependency in risk engine with Alpaca fallback
- expose RLTrader alias and fill missing configuration defaults
- stub sentiment analysis to avoid test-only imports

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -c "import ai_trading, ai_trading.core.bot_engine, ai_trading.risk.engine, ai_trading.rl_trading; from ai_trading.rl_trading import RLTrader; print(RLTrader)"`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'ml_model')*


------
https://chatgpt.com/codex/tasks/task_e_689d00aed8e48330bbbe6516b79a9a20