### PR TITLE
Remove tests.* dependency from live trading; keep test toggle via internal mock

### DIFF
--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -106,8 +106,9 @@ class AlpacaExecutionEngine:
             import os
 
             if os.environ.get("PYTEST_RUNNING"):
-                from tests.mocks import MockTradingClient
-
+                from ai_trading.execution.mocks import (
+                    MockTradingClient,
+                )  # AI-AGENT-REF: internal test mock
                 self.trading_client = MockTradingClient()
                 logger.info("Mock Alpaca client initialized for testing")
             else:

--- a/ai_trading/execution/mocks.py
+++ b/ai_trading/execution/mocks.py
@@ -1,0 +1,14 @@
+class MockTradingClient:
+    """Minimal mock used by live_trading when PYTEST_RUNNING is set."""
+    # AI-AGENT-REF: internal mock for tests
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def submit_order(self, *args, **kwargs):
+        return {"id": "MOCK_ORDER", "status": "accepted"}
+
+    def get_account(self):
+        return type("Acct", (), {"cash": "100000", "status": "ACTIVE"})()
+
+    def get_all_positions(self):
+        return []


### PR DESCRIPTION
## Summary
- add internal MockTradingClient used when `PYTEST_RUNNING` is set
- switch live_trading to import the internal mock instead of tests package

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=$(pwd) PYTEST_RUNNING=1 pytest /tmp/test_mock.py --log-cli-level=INFO -q`


------
https://chatgpt.com/codex/tasks/task_e_689d07b34b948330954fceab2e4a9e67