### PR TITLE
fix: remove unsupported kwargs from ExecutionEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
   - **Breaking**: Root imports are no longer supported as of this version
 
 ### Fixed
+- **ExecutionEngine**: Removed unsupported slippage metrics kwargs from initialization to prevent runtime `TypeError`.
 - **Import Blocker**: Replaced corrupted `ai_trading/model_registry.py` with clean, minimal, typed model registry implementation
 - Removed hard `data_client` dependency in risk engine with optional Alpaca client.
 - Added `RLTrader` alias and completed config defaults for stable runtime.

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -4393,12 +4393,9 @@ class LazyBotContext:
                 else None
             ),
         )
-        _exec_engine = ExecutionEngine(
-            self._context,
-            slippage_total=slippage_total,
-            slippage_count=slippage_count,
-            orders_total=orders_total,
-        )
+        # ExecutionEngine does not accept slippage/metrics kwargs.
+        # Metrics remain tracked in bot_engine via Prometheus counters.
+        _exec_engine = ExecutionEngine(self._context)  # AI-AGENT-REF: remove unsupported kwargs
         self._context.execution_engine = _exec_engine
 
         # Propagate the capital_scaler to the risk engine so that position_size


### PR DESCRIPTION
## Summary
- remove unsupported slippage metrics kwargs from ExecutionEngine instantiation
- document ExecutionEngine kwargs removal in changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'pandas_ta')*


------
https://chatgpt.com/codex/tasks/task_e_689d0a6a244c8330858951f4a7fffaa9