### PR TITLE
fix: convert alpaca secret to plain string

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -18,7 +18,7 @@ _DATA_BASE = "https://data.alpaca.markets"  # market data v2
 
 _HEADERS = {
     "APCA-API-KEY-ID": S.alpaca_api_key or "",
-    "APCA-API-SECRET-KEY": S.alpaca_secret_key or "",
+    "APCA-API-SECRET-KEY": S.alpaca_secret_key_plain or "",  # AI-AGENT-REF: use plain secret string
 }
 
 def _resolve_url(path_or_url: str) -> str:

--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -62,7 +62,7 @@ def abspath(fname: str) -> str:
 
 FINNHUB_API_KEY = CFG.finnhub_api_key
 ALPACA_API_KEY = CFG.alpaca_api_key
-ALPACA_SECRET_KEY = CFG.alpaca_secret_key
+ALPACA_SECRET_KEY = CFG.alpaca_secret_key_plain  # AI-AGENT-REF: use plain secret string
 ALPACA_BASE_URL = CFG.alpaca_base_url
 ALPACA_DATA_FEED = CFG.alpaca_data_feed or "iex"
 HALT_FLAG_PATH = abspath(S.halt_flag_path)  # AI-AGENT-REF: absolute halt flag path

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -7,6 +7,8 @@ from typing import Any
 
 # AI-AGENT-REF: guard numpy import for test environments
 import numpy as np
+if not hasattr(np, "NaN"):
+    np.NaN = np.nan  # AI-AGENT-REF: ensure numpy.NaN for pandas_ta
 
 # AI-AGENT-REF: guard pandas import for test environments
 import pandas as pd
@@ -82,7 +84,7 @@ class RiskEngine:
             ):
                 self.data_client = StockHistoricalDataClient(
                     api_key=s.alpaca_api_key,
-                    secret_key=s.alpaca_secret_key,
+                    secret_key=s.alpaca_secret_key_plain,  # AI-AGENT-REF: use plain secret string
                 )
         except Exception as e:
             logger.warning("Could not initialize StockHistoricalDataClient: %s", e)


### PR DESCRIPTION
## Summary
- use plain Alpaca secret when building headers
- ensure Alpaca data fetcher uses plain secret
- pass plain Alpaca secret into risk engine data client

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings` *(fails: ImportError: cannot import name 'TradingConfig' from 'config')*


------
https://chatgpt.com/codex/tasks/task_e_689d12ec7e8c8330b048df41b6b37fb7