### PR TITLE
fix: use plain Alpaca secrets and headers helper

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -16,10 +16,7 @@ S = get_settings()
 _TRADING_BASE = (S.alpaca_base_url or "https://paper-api.alpaca.markets").rstrip("/")
 _DATA_BASE = "https://data.alpaca.markets"  # market data v2
 
-_HEADERS = {
-    "APCA-API-KEY-ID": S.alpaca_api_key or "",
-    "APCA-API-SECRET-KEY": S.alpaca_secret_key_plain or "",  # AI-AGENT-REF: use plain secret string
-}
+_HEADERS = S.alpaca_headers  # AI-AGENT-REF: canonical Alpaca headers
 
 def _resolve_url(path_or_url: str) -> str:
     if path_or_url.startswith("http://") or path_or_url.startswith("https://"):

--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -60,6 +60,14 @@ class Settings(BaseSettings):
     def alpaca_secret_key_plain(self) -> str:
         return self.alpaca_secret_key.get_secret_value()
 
+    @property
+    def alpaca_headers(self) -> dict[str, str]:
+        """Canonical Alpaca auth headers as plain strings."""  # AI-AGENT-REF: standard header builder
+        return {
+            "APCA-API-KEY-ID": self.alpaca_api_key or "",
+            "APCA-API-SECRET-KEY": self.alpaca_secret_key_plain or "",
+        }
+
     # AI-AGENT-REF: allow missing attributes to default to None
     def __getattr__(self, name: str) -> Any:  # pragma: no cover - simple fallback
         return None

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -931,7 +931,7 @@ from ai_trading.utils import log_warning, model_lock, safe_to_datetime, validate
 # ai_trading/core/bot_engine.py:670 - Move retrain_meta_learner import to lazy location
 
 ALPACA_API_KEY = get_settings().alpaca_api_key
-ALPACA_SECRET_KEY = get_settings().alpaca_secret_key
+ALPACA_SECRET_KEY = get_settings().alpaca_secret_key_plain  # AI-AGENT-REF: use plain secret string
 ALPACA_PAPER = getattr(config, "ALPACA_PAPER", None)
 validate_alpaca_credentials = getattr(config, "validate_alpaca_credentials", None)
 CONFIG_NEWS_API_KEY = get_settings().news_api_key
@@ -2821,7 +2821,7 @@ class DataFetcher:
                 return self._daily_cache[symbol]
 
         api_key = get_settings().alpaca_api_key
-        api_secret = get_settings().alpaca_secret_key
+        api_secret = get_settings().alpaca_secret_key_plain  # AI-AGENT-REF: use plain secret string
         if not api_key or not api_secret:
             _log.error(f"Missing Alpaca credentials for {symbol}")
             return None
@@ -2968,7 +2968,7 @@ class DataFetcher:
                 _log.exception("bot.py unexpected", exc_info=exc)
                 raise
         api_key = get_settings().alpaca_api_key
-        api_secret = get_settings().alpaca_secret_key
+        api_secret = get_settings().alpaca_secret_key_plain  # AI-AGENT-REF: use plain secret string
         if not api_key or not api_secret:
             raise RuntimeError(
                 "ALPACA_API_KEY and ALPACA_SECRET_KEY must be set for data fetching"
@@ -3181,7 +3181,7 @@ def prefetch_daily_data(
     symbols: list[str], start_date: date, end_date: date
 ) -> dict[str, pd.DataFrame]:
     alpaca_key = get_settings().alpaca_api_key
-    alpaca_secret = get_settings().alpaca_secret_key
+    alpaca_secret = get_settings().alpaca_secret_key_plain  # AI-AGENT-REF: use plain secret string
     if not alpaca_key or not alpaca_secret:
         raise RuntimeError(
             "ALPACA_API_KEY and ALPACA_SECRET_KEY must be set for data fetching"

--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -306,10 +306,7 @@ def _fetch_bars(
         "timeframe": timeframe,
         "feed": feed,
     }
-    headers = {
-        "APCA-API-KEY-ID": ALPACA_API_KEY,
-        "APCA-API-SECRET-KEY": ALPACA_SECRET_KEY,
-    }
+    headers = CFG.alpaca_headers  # AI-AGENT-REF: canonical Alpaca headers
     _log_http_request("GET", url, params, headers)
     delay = 1.0
     for attempt in range(3):

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -74,8 +74,8 @@ def validate_environment() -> None:
     # Check critical environment variables
     if not cfg.webhook_secret:
         raise RuntimeError("WEBHOOK_SECRET is required")
-    if not cfg.alpaca_api_key or not cfg.alpaca_secret_key:
-        raise RuntimeError("ALPACA_API_KEY and ALPACA_SECRET_KEY are required")
+    if not cfg.alpaca_api_key or not cfg.alpaca_secret_key_plain:
+        raise RuntimeError("ALPACA_API_KEY and ALPACA_SECRET_KEY are required")  # AI-AGENT-REF: check plain secret
 
     # Check optional but important dependencies
     import alpaca_trade_api

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -82,7 +82,7 @@ class RiskEngine:
             if (
                 StockHistoricalDataClient
                 and getattr(s, "alpaca_api_key", None)
-                and getattr(s, "alpaca_secret_key", None)
+                and getattr(s, "alpaca_secret_key_plain", None)  # AI-AGENT-REF: ensure plain secret
             ):
                 self.data_client = StockHistoricalDataClient(
                     api_key=s.alpaca_api_key,


### PR DESCRIPTION
## Summary
- use `alpaca_secret_key_plain` everywhere instead of `SecretStr`
- add `Settings.alpaca_headers` and apply to API helpers
- guard risk engine and bot engine SDK clients with plain secrets

## Testing
- `rg "alpaca_secret_key[^_p]" ai_trading -n | rg -v "alpaca_secret_key_plain"`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `sudo systemctl restart ai-trading.service` *(fails: System has not been booted with systemd as init system)*

------
https://chatgpt.com/codex/tasks/task_e_689d163f96f48330ab008aa96e65ea1a