### PR TITLE
Normalize core API and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init test lint verify
+.PHONY: init test lint verify test-all
 
 init:
 	python -m pip install --upgrade pip
@@ -10,10 +10,12 @@ init:
 test:
 	pytest -q -n auto --maxfail=1 --disable-warnings
 
+test-all: test
+
 lint:
 	python -m py_compile $(shell git ls-files '*.py')
 
 verify:
-        @if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-        chmod +x scripts/quick_verify.sh
-        ./scripts/quick_verify.sh
+	@if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+	chmod +x scripts/quick_verify.sh
+	./scripts/quick_verify.sh

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -27,6 +27,9 @@ from json import JSONDecodeError  # AI-AGENT-REF: narrow exception imports
 
 _log = logging.getLogger(__name__)
 
+# AI-AGENT-REF: canonical tickers path
+TICKERS_FILE = Path(os.getenv("TICKERS_FILE", "data/tickers.csv"))
+
 # --- path helpers (no imports of heavy deps) ---
 BASE_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
@@ -1794,8 +1797,7 @@ def get_git_hash() -> str:
         return "unknown"
 
 
-# Tickers file resides at repo root by convention
-TICKERS_FILE = abspath_repo_root("tickers.csv")
+# TICKERS_FILE defined near top via environment
 DEFAULT_TICKERS = ["AAPL", "GOOG", "AMZN"]  # AI-AGENT-REF: fallback tickers
 # AI-AGENT-REF: use centralized trade log path
 TRADE_LOG_FILE = default_trade_log_path()

--- a/ai_trading/features/__init__.py
+++ b/ai_trading/features/__init__.py
@@ -1,6 +1,28 @@
 """
-Feature engineering and processing modules for AI trading.
-
-This module provides leak-proof feature pipelines, transformers,
-and preprocessing capabilities for machine learning models.
+Feature engineering public API.
 """
+from .indicators import (
+    compute_macd,
+    compute_macds,
+    compute_atr,
+    compute_vwap,
+    ensure_columns,
+)
+
+
+def build_features_pipeline(df, symbol: str):
+    """
+    Minimal pipeline expected by tests:
+    - ensure expected columns
+    - compute MACD/MACD signal, ATR, VWAP
+    """
+    # AI-AGENT-REF: minimal feature pipeline for tests
+    df = ensure_columns(df, symbol)
+    df = compute_macd(df)
+    df = compute_macds(df)
+    df = compute_atr(df)
+    df = compute_vwap(df)
+    return df
+
+
+__all__ = ["build_features_pipeline"]

--- a/ai_trading/strategies/__init__.py
+++ b/ai_trading/strategies/__init__.py
@@ -1,68 +1,9 @@
 """
-Advanced Trading Strategies Module - Institutional Grade Strategy Framework
-
-This module provides comprehensive trading strategy capabilities for
-institutional trading operations including:
-
-- Multi-timeframe analysis and signal generation
-- Market regime detection and adaptation
-- Advanced strategy orchestration and coordination
-- Signal combination and conflict resolution
-- Adaptive algorithm frameworks
-
-The module is designed for institutional-scale operations with proper
-strategy diversification, risk management, and performance monitoring.
+Canonical strategies public API.
 """
+from .momentum import MomentumStrategy
+from .mean_reversion import MeanReversionStrategy
+from .base import StrategySignal as TradeSignal
 
-# Import lightweight core components only
-from .base import BaseStrategy, StrategySignal
-
-# Provide lazy imports for heavy components to reduce startup time
-def get_backtest_engine():
-    """Lazy import BacktestEngine to avoid heavy startup costs."""
-    from .backtest import BacktestEngine
-    return BacktestEngine
-
-def get_multi_timeframe_components():
-    """Lazy import multi-timeframe analysis components."""
-    from .multi_timeframe import (
-        MultiTimeframeAnalyzer,
-        MultiTimeframeSignal,
-        SignalDirection,
-        SignalStrength,
-        TimeframeHierarchy,
-    )
-    return {
-        'MultiTimeframeAnalyzer': MultiTimeframeAnalyzer,
-        'MultiTimeframeSignal': MultiTimeframeSignal,
-        'SignalDirection': SignalDirection,
-        'SignalStrength': SignalStrength,
-        'TimeframeHierarchy': TimeframeHierarchy,
-    }
-
-def get_regime_detection_components():
-    """Lazy import regime detection components."""
-    from .regime_detection import (
-        MarketRegime,
-        RegimeDetector,
-        TrendStrength,
-        VolatilityRegime,
-    )
-    return {
-        'MarketRegime': MarketRegime,
-        'RegimeDetector': RegimeDetector,
-        'TrendStrength': TrendStrength,
-        'VolatilityRegime': VolatilityRegime,
-    }
-
-# Export lightweight strategy classes and lazy loading functions
-__all__ = [
-    # Core lightweight components
-    "BaseStrategy",
-    "StrategySignal", 
-    "TradingSignal",  # For backward compatibility
-    # Lazy loading functions
-    "get_backtest_engine",
-    "get_multi_timeframe_components",
-    "get_regime_detection_components",
-]
+# AI-AGENT-REF: expose canonical strategies
+__all__ = ["MomentumStrategy", "MeanReversionStrategy", "TradeSignal"]


### PR DESCRIPTION
## Summary
- expose build_features_pipeline and minimal feature pipeline
- add MeanReversionStrategy and canonical strategy exports
- define configurable TICKERS_FILE and refresh Makefile with test-all alias

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `rg -n "build_features_pipeline" ai_trading/features/__init__.py`
- `rg -n "class MeanReversionStrategy" ai_trading/strategies/mean_reversion.py`
- `python - <<'PY'\nfrom ai_trading.features import build_features_pipeline\nfrom ai_trading.strategies.mean_reversion import MeanReversionStrategy\nfrom ai_trading.strategies import MomentumStrategy, TradeSignal\nfrom ai_trading.core.bot_engine import TICKERS_FILE\nprint('imports successful', TICKERS_FILE)\nPY`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'ml_model')*

------
https://chatgpt.com/codex/tasks/task_e_689d52296bdc8330a745d335f333cb88