### PR TITLE
Refactor tests to canonical imports; remove legacy references

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1444,7 +1444,7 @@ def stub_capital_scaling(monkeypatch):
     
     # Add TradingConfig stub to config module
     try:
-        import config
+        import ai_trading.config as config
         if not hasattr(config, 'TradingConfig'):
             # Set the attribute on the config module instance, not the class
             if hasattr(config, '__dict__'):

--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -13,7 +13,7 @@ import pydantic
 
 try:
     import pydantic_settings  # noqa: F401
-    import config
+    import ai_trading.config as config
     from ai_trading import meta_learning
 except Exception:
     pytest.skip("pydantic v2 required", allow_module_level=True)
@@ -25,7 +25,7 @@ import ml_model
 import risk_engine
 import ai_trading.main as main
 from ai_trading import utils
-from strategies.mean_reversion import MeanReversionStrategy
+from ai_trading.strategies.mean_reversion import MeanReversionStrategy
 
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -199,7 +199,7 @@ if "pandas_ta" in sys.modules:
     sys.modules["pandas_ta"].obv = lambda *a, **k: pd.Series([0])
     sys.modules["pandas_ta"].vwap = lambda *a, **k: pd.Series([0])
 
-import bot_engine as bot
+from ai_trading.core import bot_engine as bot
 
 
 def test_screen_candidates_empty(monkeypatch):

--- a/tests/test_bot_engine.py
+++ b/tests/test_bot_engine.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 # AI-AGENT-REF: Replaced unsafe _raise_dynamic_exec_disabled() with direct import from shim module
-from ai_trading.bot_engine import prepare_indicators
+from ai_trading.core.bot_engine import prepare_indicators
 
 np.random.seed(0)
 

--- a/tests/test_bot_engine_edge_cases.py
+++ b/tests/test_bot_engine_edge_cases.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 # AI-AGENT-REF: Replaced unsafe _raise_dynamic_exec_disabled() with direct import from shim module
-from ai_trading.bot_engine import prepare_indicators
+from ai_trading.core.bot_engine import prepare_indicators
 
 
 def test_prepare_indicators_missing_close_column():
@@ -15,7 +15,7 @@ def test_prepare_indicators_missing_close_column():
 
 def test_prepare_indicators_non_numeric_close(monkeypatch):
     print('Testing prepare_indicators with non-numeric Close column')
-    import bot_engine
+    from ai_trading.core import bot_engine
 
     def fake_rsi(close, length=14):
         if not pd.api.types.is_numeric_dtype(close):

--- a/tests/test_bot_extended.py
+++ b/tests/test_bot_extended.py
@@ -198,7 +198,7 @@ class _DummyBreaker:
 
 sys.modules["pybreaker"].CircuitBreaker = _DummyBreaker
 
-import bot_engine as bot
+from ai_trading.core import bot_engine as bot
 
 
 def test_compute_time_range():

--- a/tests/test_centralized_config.py
+++ b/tests/test_centralized_config.py
@@ -10,7 +10,7 @@ import os
 import pytest
 os.environ["TESTING"] = "1"
 
-from config import TradingConfig
+from ai_trading.config import TradingConfig
 from ai_trading.core.bot_engine import BotMode
 
 

--- a/tests/test_config_additional.py
+++ b/tests/test_config_additional.py
@@ -1,7 +1,7 @@
 
 import pytest
 
-import config
+import ai_trading.config as config
 
 
 def test_get_env_required_missing(monkeypatch):

--- a/tests/test_config_deadlock_fix.py
+++ b/tests/test_config_deadlock_fix.py
@@ -6,7 +6,7 @@ import os
 import pytest
 from unittest.mock import patch
 
-import config
+import ai_trading.config as config
 
 
 def test_no_hang_on_basic_validation():

--- a/tests/test_critical_datetime_fixes.py
+++ b/tests/test_critical_datetime_fixes.py
@@ -95,12 +95,12 @@ class TestMetaLearningDataFetching(unittest.TestCase):
         
         try:
             # Mock the TRADE_LOG_FILE to use our test file
-            with patch('bot_engine.TRADE_LOG_FILE', tmp_file_path):
+            with patch('ai_trading.core.bot_engine.TRADE_LOG_FILE', tmp_file_path):
                 from ai_trading.core.bot_engine import load_global_signal_performance
-                
+
                 # This should not return None or empty dict due to METALEARN_INVALID_PRICES
                 result = load_global_signal_performance(min_trades=1, threshold=0.1)
-                
+
                 # Should return signal performance data, not None/empty due to invalid prices
                 if result is None:
                     self.fail("load_global_signal_performance returned None - possible METALEARN_INVALID_PRICES issue")
@@ -128,8 +128,8 @@ class TestSentimentCaching(unittest.TestCase):
             _SENTIMENT_CACHE.clear()
             
             # Mock the API key variables in bot_engine module
-            with patch('bot_engine.SENTIMENT_API_KEY', 'test_key'):
-                with patch('bot_engine.NEWS_API_KEY', 'test_key'):
+            with patch('ai_trading.core.bot_engine.SENTIMENT_API_KEY', 'test_key'):
+                with patch('ai_trading.core.bot_engine.NEWS_API_KEY', 'test_key'):
                     # Mock the requests to simulate rate limiting
                     with patch('requests.get') as mock_get:
                         # First call - simulate rate limit (429)

--- a/tests/test_critical_fixes_focused.py
+++ b/tests/test_critical_fixes_focused.py
@@ -21,7 +21,7 @@ class TestCriticalFixes(unittest.TestCase):
         """Set up test environment."""
         # Import modules after setting TESTING flag
         import trade_execution
-        import sentiment
+        import ai_trading.analysis.sentiment as sentiment
         import strategy_allocator
         self.trade_execution = trade_execution
         self.sentiment = sentiment
@@ -64,8 +64,8 @@ class TestCriticalFixes(unittest.TestCase):
     def test_sector_classification_fallback(self):
         """Test that sector classification includes fallback for BABA."""
         # P2 Fix: Sector classification
-        import bot_engine
-        
+        from ai_trading.core import bot_engine
+
         # Test that BABA is now in sector mappings
         sector = bot_engine.get_sector("BABA")
         self.assertNotEqual(sector, "Unknown", "BABA should have a fallback sector classification")

--- a/tests/test_critical_issues_resolution.py
+++ b/tests/test_critical_issues_resolution.py
@@ -17,7 +17,7 @@ os.environ.setdefault('FLASK_PORT', '5000')
 try:
     from trade_execution import ExecutionEngine, handle_partial_fill, safe_submit_order
     from risk_engine import RiskEngine
-    import bot_engine
+    from ai_trading.core import bot_engine
     HAS_FULL_IMPORTS = True
 except ImportError as e:
     # Continue with minimal testing if imports fail

--- a/tests/test_critical_trading_fixes.py
+++ b/tests/test_critical_trading_fixes.py
@@ -20,10 +20,10 @@ import time
 from datetime import datetime, timezone
 
 # Import modules under test
-import sentiment
+import ai_trading.analysis.sentiment as sentiment
 from ai_trading import meta_learning
 from ai_trading import trade_execution
-import config
+import ai_trading.config as config
 
 
 class TestSentimentAnalysisRateLimitingFixes(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestSentimentAnalysisRateLimitingFixes(unittest.TestCase):
         self.assertEqual(sentiment.SENTIMENT_MAX_RETRIES, 5)
         self.assertEqual(sentiment.SENTIMENT_BASE_DELAY, 5)
     
-    @patch('sentiment.requests.get')
+    @patch('ai_trading.analysis.sentiment.requests.get')
     def test_enhanced_fallback_strategies(self, mock_get):
         """Test that enhanced fallback strategies work when rate limited."""
         # Simulate rate limiting
@@ -60,7 +60,7 @@ class TestSentimentAnalysisRateLimitingFixes(unittest.TestCase):
         # Should return neutral sentiment when all fallbacks fail
         self.assertEqual(result, 0.0)
     
-    @patch('sentiment.requests.get')
+    @patch('ai_trading.analysis.sentiment.requests.get')
     def test_alternative_sentiment_sources(self, mock_get):
         """Test alternative sentiment source functionality."""
         # Mock environment variables for alternative source
@@ -382,7 +382,7 @@ class TestIntegrationScenarios(unittest.TestCase):
         """Test complete flow when sentiment is rate limited but meta-learning works."""
         # This would be a more complex integration test
         # For now, just ensure modules can be imported together
-        import sentiment
+        import ai_trading.analysis.sentiment as sentiment
         from ai_trading import meta_learning
         import trade_execution
         
@@ -588,7 +588,7 @@ def test_risk_management_sector_exposure_logging():
     """Test that sector exposure rejections include clear reasoning."""
     # This is a minimal test - full test would require bot_engine context
     # Testing the structure exists for enhanced logging
-    from ai_trading.bot_engine import sector_exposure_ok
+    from ai_trading.core.bot_engine import sector_exposure_ok
     
     # Mock BotContext
     mock_ctx = Mock()

--- a/tests/test_critical_trading_issues.py
+++ b/tests/test_critical_trading_issues.py
@@ -22,7 +22,7 @@ os.environ.setdefault('PYTEST_RUNNING', '1')
 
 # Import the modules we need to test
 try:
-    import bot_engine
+    from ai_trading.core import bot_engine
     from ai_trading import meta_learning
     import trade_execution
 except ImportError as e:
@@ -78,9 +78,9 @@ class TestOrderExecutionTracking(unittest.TestCase):
         mock_quote.bid_price = 150.00
         mock_quote.spread = 0.10  # High spread to trigger liquidity retry
         
-        with patch('bot_engine.fetch_minute_df_safe', return_value=mock_df), \
+        with patch('ai_trading.core.bot_engine.fetch_minute_df_safe', return_value=mock_df), \
              patch.object(self.mock_ctx.data_client, 'get_stock_latest_quote', return_value=mock_quote), \
-             patch('bot_engine.submit_order', return_value=self.mock_order) as mock_submit:
+             patch('ai_trading.core.bot_engine.submit_order', return_value=self.mock_order) as mock_submit:
             
             # Test that we can access the POV submit function
             if hasattr(bot_engine, 'pov_submit'):
@@ -289,7 +289,7 @@ class TestLiquidityManagement(unittest.TestCase):
         total_qty = 100
         pct = 0.1  # 10% participation rate
         
-        with patch('bot_engine.fetch_minute_df_safe', return_value=mock_df), \
+        with patch('ai_trading.core.bot_engine.fetch_minute_df_safe', return_value=mock_df), \
              patch.object(self.mock_ctx.data_client, 'get_stock_latest_quote', return_value=mock_quote):
             
             # Current logic in pov_submit:

--- a/tests/test_deprecation_warnings.py
+++ b/tests/test_deprecation_warnings.py
@@ -1,13 +1,14 @@
 """
 Test deprecation warnings for root module imports.
 """
+import importlib
 import warnings
 
 def test_bot_engine_deprecation_warning():
     """Test that importing bot_engine shows deprecation warning."""
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        import bot_engine  # noqa: F401
+        importlib.import_module("bot_engine")
         
         # Check that a deprecation warning was raised
         assert len(w) >= 1

--- a/tests/test_drawdown_integration.py
+++ b/tests/test_drawdown_integration.py
@@ -18,7 +18,7 @@ os.environ["PYTEST_RUNNING"] = "1"
 # Add the current directory to the path so we can import modules
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-import config
+import ai_trading.config as config
 from ai_trading.risk.circuit_breakers import DrawdownCircuitBreaker
 
 
@@ -100,7 +100,7 @@ class TestDrawdownIntegration(unittest.TestCase):
         self.assertEqual(tc.max_drawdown_threshold, 0.15)
         self.assertEqual(tc.daily_loss_limit, 0.03)
 
-    @patch('bot_engine.ctx')
+    @patch('ai_trading.core.bot_engine.ctx')
     def test_bot_context_integration(self, mock_ctx):
         """Test that bot context includes drawdown circuit breaker."""
         # Mock the context with a circuit breaker

--- a/tests/test_env_flags.py
+++ b/tests/test_env_flags.py
@@ -28,7 +28,7 @@ def test_disable_daily_retrain_env_parsing():
             del os.sys.modules['config']
         
         # Import config module
-        import config
+        import ai_trading.config as config
         
         # Test the result
         actual = config.DISABLE_DAILY_RETRAIN
@@ -52,7 +52,7 @@ def test_disable_daily_retrain_unset():
         del os.sys.modules['config']
     
     # Import config module
-    import config
+    import ai_trading.config as config
     
     # Should default to False
     assert config.DISABLE_DAILY_RETRAIN == False
@@ -71,7 +71,7 @@ def test_disable_daily_retrain_fallback_settings():
     os.environ["TESTING"] = "1"
     os.environ["DISABLE_DAILY_RETRAIN"] = "true"
     
-    import config
+    import ai_trading.config as config
     
     # Check that fallback settings work
     fallback = config._FallbackSettings()

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -2,7 +2,7 @@ import sys
 import types
 import pandas as pd
 import pytest
-from features import build_features_pipeline
+from ai_trading.features import build_features_pipeline
 
 dotenv_stub = types.ModuleType("dotenv")
 dotenv_stub.load_dotenv = lambda *a, **k: None

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -228,7 +228,7 @@ sys.modules["torch.optim"] = torch_optim
 
 # AI-AGENT-REF: Remove ai_trading.main import that causes deep torch dependency chain
 # from ai_trading.main import main  # Not used in this test, causes torch import issues
-from ai_trading.bot_engine import pre_trade_health_check
+from ai_trading.core.bot_engine import pre_trade_health_check
 
 
 class DummyFetcher:

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 
 def test_ichimoku_indicator_returns_dataframe(monkeypatch):
-    import bot_engine as bot
+    from ai_trading.core import bot_engine as bot
 
     if not hasattr(bot.ta, "ichimoku"):
         setattr(bot.ta, "ichimoku", lambda *a, **k: (pd.DataFrame(), {}))
@@ -21,7 +21,7 @@ def test_ichimoku_indicator_returns_dataframe(monkeypatch):
 
 
 def test_compute_ichimoku_returns_df_pair(monkeypatch):
-    import bot_engine as bot
+    from ai_trading.core import bot_engine as bot
     if not hasattr(bot.ta, "ichimoku"):
         setattr(bot.ta, "ichimoku", lambda *a, **k: (pd.DataFrame(), {}))
     ich_df = pd.DataFrame({"ITS_9": [1.0]})

--- a/tests/test_initial_rebalance.py
+++ b/tests/test_initial_rebalance.py
@@ -1,7 +1,7 @@
 import types
 import pandas as pd
 import datetime
-import bot_engine
+from ai_trading.core import bot_engine
 
 class DummyFetcher:
     def get_daily_df(self, ctx, symbol):

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -355,7 +355,7 @@ def test_bot_main_normal(monkeypatch):
             }
         ),
     ):
-        import bot_engine as bot
+        from ai_trading.core import bot_engine as bot
 
         setattr(bot, "main", lambda: True)
 
@@ -383,7 +383,7 @@ def test_bot_main_data_fetch_error(monkeypatch):
             }
         ),
     ):
-        import bot_engine as bot
+        from ai_trading.core import bot_engine as bot
 
         monkeypatch.setattr(
             bot,
@@ -416,7 +416,7 @@ def test_bot_main_signal_nan(monkeypatch):
             }
         ),
     ):
-        import bot_engine as bot
+        from ai_trading.core import bot_engine as bot
 
         monkeypatch.setattr(bot, "main", lambda: None)
         try:

--- a/tests/test_integration_simple.py
+++ b/tests/test_integration_simple.py
@@ -8,7 +8,7 @@ import os
 os.environ["TESTING"] = "1"
 
 from ai_trading.risk.circuit_breakers import DrawdownCircuitBreaker
-import config
+import ai_trading.config as config
 
 def test_integration():
     """Test the basic integration points."""

--- a/tests/test_kelly_confidence_fix.py
+++ b/tests/test_kelly_confidence_fix.py
@@ -17,7 +17,7 @@ def test_kelly_confidence_normalization():
     # Mock BotContext for testing
     # Import the actual function (if available)
     try:
-        from ai_trading.bot_engine import fractional_kelly_size
+        from ai_trading.core.bot_engine import fractional_kelly_size
         
         ctx = MockBotContext()
         balance = 10000.0
@@ -70,7 +70,7 @@ def test_kelly_input_validation():
     """Test that Kelly calculation properly validates all inputs."""
     # Mock BotContext for testing
     try:
-        from ai_trading.bot_engine import fractional_kelly_size
+        from ai_trading.core.bot_engine import fractional_kelly_size
         
         ctx = MockBotContext()
         

--- a/tests/test_logging_behavior.py
+++ b/tests/test_logging_behavior.py
@@ -3,9 +3,9 @@ import time
 import pytest
 
 from ai_trading import utils
-import bot_engine
+from ai_trading.core import bot_engine
 import alpaca_api
-from strategies.base import TradeSignal
+from ai_trading.strategies.base import TradeSignal
 
 
 def test_health_rows_throttle(monkeypatch, caplog):

--- a/tests/test_mean_reversion_extra.py
+++ b/tests/test_mean_reversion_extra.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from strategies.mean_reversion import MeanReversionStrategy
+from ai_trading.strategies.mean_reversion import MeanReversionStrategy
 
 
 class DummyFetcher:

--- a/tests/test_momentum_extra.py
+++ b/tests/test_momentum_extra.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
-from strategies import momentum
-from strategies.momentum import MomentumStrategy
+from ai_trading.strategies import momentum
+from ai_trading.strategies.momentum import MomentumStrategy
 
 
 class DummyFetcher:

--- a/tests/test_moving_average_crossover_extra.py
+++ b/tests/test_moving_average_crossover_extra.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from strategies.moving_average_crossover import MovingAverageCrossoverStrategy
+from ai_trading.strategies.moving_average_crossover import MovingAverageCrossoverStrategy
 
 
 class DummyFetcher:

--- a/tests/test_nameerror_integration.py
+++ b/tests/test_nameerror_integration.py
@@ -43,7 +43,7 @@ os.environ.update({
 
 try:
     # This should trigger validate_trading_parameters() during import
-    import bot_engine
+from ai_trading.core import bot_engine
     
     print("SUCCESS: bot_engine imported without NameError")
     exit_code = 0

--- a/tests/test_phase2_enhancements.py
+++ b/tests/test_phase2_enhancements.py
@@ -23,7 +23,7 @@ test_env = {
 }
 
 with patch.dict(os.environ, test_env):
-    import config
+    import ai_trading.config as config
     from order_health_monitor import OrderHealthMonitor, OrderInfo
     from system_health_checker import SystemHealthChecker, ComponentHealth
 

--- a/tests/test_production_fixes.py
+++ b/tests/test_production_fixes.py
@@ -35,7 +35,7 @@ class TestSentimentAPIConfiguration(unittest.TestCase):
     
     def test_sentiment_api_env_vars_in_config(self):
         """Test that sentiment API variables are properly configured."""
-        import config
+        import ai_trading.config as config
         
         # Test that the new environment variables are accessible
         self.assertTrue(hasattr(config, 'SENTIMENT_API_KEY') or 'SENTIMENT_API_KEY' in dir(config))

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -29,7 +29,7 @@ def setup_ctx():
 
 
 def manual_fractional(balance, price, atr, win_prob, peak):
-    import bot_engine as bot
+    from ai_trading.core import bot_engine as bot
     base_frac = 0.6
     comp = 1.0
     base_frac *= comp
@@ -57,7 +57,7 @@ def test_fractional_kelly_drawdown(monkeypatch, tmp_path):
     import types
     sys.modules.setdefault('schedule', types.ModuleType('schedule'))
     sys.modules.setdefault('yfinance', types.ModuleType('yfinance'))
-    import bot_engine as bot
+    from ai_trading.core import bot_engine as bot
     ctx = setup_ctx()
     monkeypatch.setattr(bot, 'PEAK_EQUITY_FILE', tmp_path / 'p.txt')
     monkeypatch.setattr(bot, 'is_high_vol_thr_spy', lambda: False)

--- a/tests/test_risk_engine_additional.py
+++ b/tests/test_risk_engine_additional.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 import risk_engine
-from strategies import TradeSignal
+from ai_trading.strategies import TradeSignal
 
 
 def test_can_trade_invalid_type(caplog):

--- a/tests/test_risk_engine_module.py
+++ b/tests/test_risk_engine_module.py
@@ -9,7 +9,7 @@ for m in ["strategies", "strategies.momentum", "strategies.mean_reversion"]:
     sys.modules.pop(m, None)
 sys.modules.pop("risk_engine", None)
 from risk_engine import RiskEngine
-from strategies import TradeSignal
+from ai_trading.strategies import TradeSignal
 
 
 class DummyAPI:

--- a/tests/test_run_overlap.py
+++ b/tests/test_run_overlap.py
@@ -1,7 +1,7 @@
 import threading
 import time
 import types
-import bot_engine
+from ai_trading.core import bot_engine
 
 
 def test_run_all_trades_overlap(monkeypatch, caplog):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -66,7 +66,7 @@ def test_prepare_indicators_calculates(sample_df, monkeypatch):
 
 def test_composite_signal_confidence(monkeypatch):
     """SignalManager combines weights into final score."""
-    import bot_engine as bot
+    from ai_trading.core import bot_engine as bot
     sm = bot.SignalManager()
     monkeypatch.setattr(sm, 'load_signal_weights', lambda: {})
     monkeypatch.setattr(bot, 'load_global_signal_performance', lambda: [])

--- a/tests/test_skip_logic.py
+++ b/tests/test_skip_logic.py
@@ -1,6 +1,6 @@
 import types
 import pandas as pd
-import bot_engine
+from ai_trading.core import bot_engine
 
 
 def test_skip_logic(monkeypatch, caplog):

--- a/tests/test_strategies_base_extra.py
+++ b/tests/test_strategies_base_extra.py
@@ -1,4 +1,5 @@
-from strategies.base import Strategy, asset_class_for
+from ai_trading.strategies.base import Strategy
+from ai_trading.core.bot_engine import asset_class_for
 
 
 def test_asset_class_for_crypto():

--- a/tests/test_strategies_module.py
+++ b/tests/test_strategies_module.py
@@ -12,8 +12,8 @@ for m in [
 ]:
     sys.modules.pop(m, None)
 
-from strategies import (MeanReversionStrategy, MomentumStrategy,
-                        asset_class_for)
+from ai_trading.strategies import MeanReversionStrategy, MomentumStrategy
+from ai_trading.core.bot_engine import asset_class_for
 
 
 class DummyFetcher:

--- a/tests/test_strategy_allocator_exit.py
+++ b/tests/test_strategy_allocator_exit.py
@@ -1,4 +1,4 @@
-from strategies import TradeSignal
+from ai_trading.strategies import TradeSignal
 import sys
 from pathlib import Path
 import pytest

--- a/tests/test_strategy_allocator_regression.py
+++ b/tests/test_strategy_allocator_regression.py
@@ -6,7 +6,7 @@ confirmation bug that was causing test_allocator to fail with empty results
 on the second call when min_confidence=0.0.
 """
 
-from strategies import TradeSignal
+from ai_trading.strategies import TradeSignal
 import strategy_allocator
 
 

--- a/tests/test_strategy_allocator_smoke.py
+++ b/tests/test_strategy_allocator_smoke.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from strategies import TradeSignal
+from ai_trading.strategies import TradeSignal
 
 import strategy_allocator
 

--- a/tests/test_submit_order_fix.py
+++ b/tests/test_submit_order_fix.py
@@ -26,8 +26,8 @@ os.environ.update({
 def test_submit_order_with_uninitialized_exec_engine():
     """Test that submit_order raises proper error when _exec_engine is None."""
     # Import after setting environment
-    import bot_engine
-    from ai_trading.bot_engine import submit_order, BotContext
+    from ai_trading.core import bot_engine
+    from ai_trading.core.bot_engine import submit_order, BotContext
     
     # Ensure _exec_engine is None
     original_exec_engine = bot_engine._exec_engine
@@ -35,7 +35,7 @@ def test_submit_order_with_uninitialized_exec_engine():
     
     try:
         # Mock market_is_open to return True
-        with patch('bot_engine.market_is_open', return_value=True):
+        with patch('ai_trading.core.bot_engine.market_is_open', return_value=True):
             # Create a mock context
             mock_ctx = Mock(spec=BotContext)
             
@@ -51,11 +51,11 @@ def test_submit_order_with_uninitialized_exec_engine():
 def test_submit_order_with_market_closed():
     """Test that submit_order returns None when market is closed."""
     # Import after setting environment
-    from ai_trading.bot_engine import submit_order, BotContext
+    from ai_trading.core.bot_engine import submit_order, BotContext
     from unittest.mock import Mock
     
     # Mock market_is_open to return False
-    with patch('bot_engine.market_is_open', return_value=False):
+    with patch('ai_trading.core.bot_engine.market_is_open', return_value=False):
         mock_ctx = Mock(spec=BotContext)
         result = submit_order(mock_ctx, "AAPL", 10, "buy")
         assert result is None
@@ -64,8 +64,8 @@ def test_submit_order_with_market_closed():
 def test_submit_order_successful_execution():
     """Test that submit_order works correctly when properly initialized."""
     # Import after setting environment
-    import bot_engine
-    from ai_trading.bot_engine import submit_order, BotContext
+    from ai_trading.core import bot_engine
+    from ai_trading.core.bot_engine import submit_order, BotContext
     from unittest.mock import Mock
     
     # Mock the execution engine
@@ -79,7 +79,7 @@ def test_submit_order_successful_execution():
     
     try:
         # Mock market_is_open to return True
-        with patch('bot_engine.market_is_open', return_value=True):
+        with patch('ai_trading.core.bot_engine.market_is_open', return_value=True):
             mock_ctx = Mock(spec=BotContext)
             
             # Should successfully execute order
@@ -96,8 +96,8 @@ def test_submit_order_successful_execution():
 def test_submit_order_execution_error_propagation():
     """Test that submit_order properly propagates execution errors."""
     # Import after setting environment
-    import bot_engine
-    from ai_trading.bot_engine import submit_order, BotContext
+    from ai_trading.core import bot_engine
+    from ai_trading.core.bot_engine import submit_order, BotContext
     from unittest.mock import Mock
     
     # Mock the execution engine to raise an exception
@@ -111,7 +111,7 @@ def test_submit_order_execution_error_propagation():
     
     try:
         # Mock market_is_open to return True
-        with patch('bot_engine.market_is_open', return_value=True):
+        with patch('ai_trading.core.bot_engine.market_is_open', return_value=True):
             mock_ctx = Mock(spec=BotContext)
             
             # Should propagate the execution error


### PR DESCRIPTION
## Summary
- replace legacy `bot_engine`, `config`, `features`, and `strategies` imports with canonical `ai_trading` modules across tests
- adjust sentiment references and patch targets to canonical paths
- use dynamic import for deprecated module check

## Testing
- `python -m pip install --upgrade pip`
- `pip install -r requirements-dev.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `rg -n "^\s*(from|import)\s+(config|features|sentiment|bot_engine)\b" tests/ || true`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'hmmlearn')*
- `make test-all` *(fails: ModuleNotFoundError: No module named 'hmmlearn')*

------
https://chatgpt.com/codex/tasks/task_e_689d55649fd08330aecaa1fdfa49cbcd