### PR TITLE
Harden logging extras: prevent LogRecord key collisions via safe adapter + tests

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -12,6 +12,7 @@ import atexit
 import io
 import inspect
 import logging
+from ai_trading.logging import get_logger  # AI-AGENT-REF: use sanitizing adapter
 import math
 import os
 import sys
@@ -27,7 +28,7 @@ from pathlib import Path
 from typing import Any, Optional, Union
 from json import JSONDecodeError  # AI-AGENT-REF: narrow exception imports
 
-_log = logging.getLogger(__name__)
+_log = get_logger(__name__)  # AI-AGENT-REF: central logger adapter
 
 # --- path helpers (no imports of heavy deps) ---
 BASE_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -141,7 +142,10 @@ def _load_required_model() -> Any:
                 f"Module '{modname}' missing get_model()/Model() factory."
             )
         mdl = factory() if callable(factory) else factory
-        _log.info("MODEL_LOADED", extra={"source": "module", "module": modname})
+        _log.info(
+            "MODEL_LOADED",
+            extra={"source": "module", "model_module": modname},  # AI-AGENT-REF: avoid reserved key
+        )
         return mdl
 
     msg = (

--- a/ai_trading/runner.py
+++ b/ai_trading/runner.py
@@ -37,7 +37,10 @@ def _preflight_import_health() -> None:
         try:
             importlib.import_module(mod)
         except Exception as exc:  # pragma: no cover - surface import issues
-            log.error("IMPORT_PREFLIGHT_FAILED", extra={"module": mod, "error": repr(exc)})
+            log.error(
+                "IMPORT_PREFLIGHT_FAILED",
+                extra={"module_name": mod, "error": repr(exc)},  # AI-AGENT-REF: avoid reserved key
+            )
             if os.environ.get("FAIL_FAST_IMPORTS", "").lower() in {"1", "true"}:
                 raise SystemExit(1)
     log.info("IMPORT_PREFLIGHT_OK")

--- a/tests/test_logging_sanitizer.py
+++ b/tests/test_logging_sanitizer.py
@@ -1,0 +1,39 @@
+import logging
+
+from ai_trading.logging import get_logger
+
+
+class _CaptureHandler(logging.Handler):
+    """Capture the last log record for assertions."""  # AI-AGENT-REF: test handler
+
+    def __init__(self):
+        super().__init__()
+        self.last = None
+
+    def emit(self, record):  # noqa: D401 - simple capture
+        self.last = record
+
+
+def test_reserved_keys_are_prefixed():
+    """Reserved LogRecord attributes should be prefixed with ``x_``."""
+    log = get_logger("test.sanitize")
+    handler = _CaptureHandler()
+    log.logger.addHandler(handler)
+    try:
+        log.info(
+            "probe",
+            extra={
+                "module": "core",
+                "filename": "x.py",
+                "lineno": 321,
+                "ok": True,
+            },
+        )
+    finally:
+        log.logger.removeHandler(handler)
+
+    record = handler.last
+    assert record.x_module == "core"
+    assert record.x_filename == "x.py"
+    assert record.x_lineno == 321
+    assert record.ok is True


### PR DESCRIPTION
## Summary
- add SanitizingLoggerAdapter that prefixes reserved LogRecord keys with `x_`
- wire `get_logger` to return the sanitizing adapter and update callers
- rename inline `extra` keys that conflicted with LogRecord fields
- add regression test for logging sanitizer

## Testing
- `python - <<'PY'
from ai_trading.logging import get_logger
log = get_logger("smoke")
log.info("SMOKE", extra={"module":"foo","filename":"bar.py","lineno":7,"custom":123})
print("ok")
PY`
- `pytest tests/test_logging_sanitizer.py -q`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_689e454f37fc8330a7f08f0d558ced10