### PR TITLE
feat: add rebalancer settings

### DIFF
--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -53,6 +53,23 @@ class Settings(BaseSettings):
     alpaca_data_feed: str | None = Field(default=None, alias="ALPACA_DATA_FEED")
     scheduler_sleep_seconds: int = Field(60, alias="SCHEDULER_SLEEP_SECONDS")
 
+    # AI-AGENT-REF: rebalancer defaults
+    rebalance_interval_min: int = Field(
+        15,
+        env="AI_TRADER_REBALANCE_INTERVAL_MIN",
+        description="How often (minutes) to consider portfolio rebalancing.",
+    )
+    rebalance_on_fill: bool = Field(
+        True,
+        env="AI_TRADER_REBALANCE_ON_FILL",
+        description="Trigger a rebalance pass after order fills.",
+    )
+    rebalance_max_trades_per_cycle: int = Field(
+        10,
+        env="AI_TRADER_REBALANCE_MAX_TRADES_PER_CYCLE",
+        description="Safety cap to limit rebalance churn.",
+    )
+
     # AI-AGENT-REF: runtime defaults for deterministic behavior and loops
     seed: int | None = 42
     loop_interval_seconds: int = 60


### PR DESCRIPTION
## Summary
- add rebalance config defaults to Settings so rebalancer imports cleanly

## Testing
- `PYTHONPATH=. pytest` *(fails: AttributeError: 'Settings' object has no attribute 'news_api_key')*

------
https://chatgpt.com/codex/tasks/task_e_689e55f267d48330b3d8ae65bfeac4cc