### PR TITLE
refactor: lazy news and rebalance settings

### DIFF
--- a/ai_trading/analysis/sentiment.py
+++ b/ai_trading/analysis/sentiment.py
@@ -28,12 +28,7 @@ from tenacity import (
 )
 
 # AI-AGENT-REF: Import config
-from ai_trading.config.settings import get_settings
-
-S = get_settings()
-NEWS_API_KEY = S.news_api_key
-SENTIMENT_API_KEY = S.sentiment_api_key or NEWS_API_KEY
-SENTIMENT_API_URL = S.sentiment_api_url
+from ai_trading.settings import get_news_api_key, get_settings
 
 # FinBERT model initialization
 import torch
@@ -146,11 +141,11 @@ def fetch_sentiment(ctx, ticker: str) -> float:
     Returns:
         Sentiment score between -1.0 and 1.0
     """
-    # Use new SENTIMENT_API_KEY or fallback to NEWS_API_KEY for backwards compatibility
-    api_key = SENTIMENT_API_KEY or NEWS_API_KEY
+    settings = get_settings()
+    api_key = settings.sentiment_api_key or get_news_api_key()
     if not api_key:
         logger.debug(
-            "No sentiment API key configured (checked SENTIMENT_API_KEY and NEWS_API_KEY)"
+            "No sentiment API key configured (checked settings.sentiment_api_key and news API key)"
         )
         return 0.0
 
@@ -193,7 +188,7 @@ def fetch_sentiment(ctx, ticker: str) -> float:
     try:
         # 1) Fetch NewsAPI articles using configurable URL
         url = (
-            f"{SENTIMENT_API_URL}?"
+            f"{settings.sentiment_api_url}?"
             f"q={ticker}&sortBy=publishedAt&language=en&pageSize=5"
             f"&apiKey={api_key}"
         )

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -63,9 +63,9 @@ def test_monitor_slippage_alert(monkeypatch):
 def test_maybe_rebalance(monkeypatch):
     """maybe_rebalance triggers a rebalance after the interval."""
     calls = []
-    monkeypatch.setattr(rebalancer, "REBALANCE_INTERVAL_MIN", 0)
+    monkeypatch.setattr(rebalancer, "rebalance_interval_min", lambda: 0)
     monkeypatch.setattr(rebalancer, "rebalance_portfolio", lambda ctx: calls.append(ctx))
-    rebalancer._last_rebalance = rebalancer.datetime.now(rebalancer.timezone.utc) - rebalancer.timedelta(minutes=1)
+    rebalancer._last_rebalance = rebalancer.datetime.now(rebalancer.UTC) - rebalancer.timedelta(minutes=1)
     rebalancer.maybe_rebalance("ctx")
     assert calls == ["ctx"]
 

--- a/tests/test_rebalancer_additional.py
+++ b/tests/test_rebalancer_additional.py
@@ -3,8 +3,8 @@ from ai_trading import rebalancer
 
 def test_maybe_rebalance_triggers(monkeypatch):
     calls = []
-    monkeypatch.setattr(rebalancer, "REBALANCE_INTERVAL_MIN", 1)
-    rebalancer._last_rebalance = rebalancer.datetime.now(rebalancer.timezone.utc) - rebalancer.timedelta(minutes=2)
+    monkeypatch.setattr(rebalancer, "rebalance_interval_min", lambda: 1)
+    rebalancer._last_rebalance = rebalancer.datetime.now(rebalancer.UTC) - rebalancer.timedelta(minutes=2)
     monkeypatch.setattr(rebalancer, "rebalance_portfolio", lambda ctx: calls.append(ctx))
     rebalancer.maybe_rebalance("ctx")
     assert calls == ["ctx"]
@@ -12,7 +12,7 @@ def test_maybe_rebalance_triggers(monkeypatch):
 
 def test_maybe_rebalance_skip(monkeypatch):
     calls = []
-    rebalancer._last_rebalance = rebalancer.datetime.now(rebalancer.timezone.utc)
+    rebalancer._last_rebalance = rebalancer.datetime.now(rebalancer.UTC)
     monkeypatch.setattr(rebalancer, "rebalance_portfolio", lambda ctx: calls.append(ctx))
     rebalancer.maybe_rebalance("ctx")
     assert calls == []


### PR DESCRIPTION
## Summary
- add lazy getters for News API key and rebalance interval
- defer bot_engine and sentiment modules to runtime configuration
- shift rebalancer to runtime interval lookup and update tests

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_689e5a90ff9083309d889c687c40fd1d