### PR TITLE
refactor: defer settings and metrics imports

### DIFF
--- a/ai_trading/telemetry/__init__.py
+++ b/ai_trading/telemetry/__init__.py
@@ -1,13 +1,5 @@
-from .metrics_logger import (
-    log_metrics,
-    compute_max_drawdown,
-    log_volatility,
-    log_regime_toggle,
-)
+"""Telemetry package public API."""
 
-__all__ = [
-    "log_metrics",
-    "compute_max_drawdown",
-    "log_volatility",
-    "log_regime_toggle",
-]
+# AI-AGENT-REF: avoid import-time heavy re-exports
+__all__ = ("metrics_logger",)
+

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -15,7 +15,6 @@ import pandas as pd
 
 # AI-AGENT-REF: Use HTTP utilities with proper timeout/retry
 from ai_trading.config.management import TradingConfig, reload_env
-from ai_trading.telemetry.metrics_logger import log_metrics
 from scripts.retrain import prepare_indicators
 CONFIG = TradingConfig()
 
@@ -218,13 +217,17 @@ def predict(csv_path: str, freq: str = "intraday") -> tuple[int | None, float | 
         pred,
         proba,
     )
-    log_metrics({
-        "timestamp": pd.Timestamp.now(tz="UTC").isoformat(),
-        "symbol": symbol,
-        "regime": regime,
-        "prediction": int(pred),
-        "probability": float(proba),
-    }, filename="metrics/predictions.csv")
+    from ai_trading.logging import _get_metrics_logger  # AI-AGENT-REF: lazy metrics import
+    _get_metrics_logger().log_metrics(
+        {
+            "timestamp": pd.Timestamp.now(tz="UTC").isoformat(),
+            "symbol": symbol,
+            "regime": regime,
+            "prediction": int(pred),
+            "probability": float(proba),
+        },
+        filename="metrics/predictions.csv",
+    )
     return pred, proba
 
 

--- a/scripts/retrain.py
+++ b/scripts/retrain.py
@@ -18,7 +18,6 @@ import pandas as pd
 from ai_trading.config import management as config
 from ai_trading.config.management import TradingConfig
 CONFIG = TradingConfig()
-from ai_trading.telemetry.metrics_logger import log_metrics
 
 from ai_trading.utils.base import safe_to_datetime
 
@@ -640,7 +639,8 @@ def save_model_version(clf, regime: str) -> str:
         logger.exception("Failed to save model %s: %s", regime, e)
         raise
     log_hyperparam_result(regime, -1, {"model_path": filename}, 0.0)
-    log_metrics(
+    from ai_trading.logging import _get_metrics_logger  # AI-AGENT-REF: lazy metrics import
+    _get_metrics_logger().log_metrics(
         {
             "timestamp": datetime.now(UTC).isoformat(),
             "type": "model_checkpoint",
@@ -902,7 +902,8 @@ def retrain_meta_learner(
         try:
             path = save_model_version(pipe, regime)
             logger.info("Saved %s model to %s", regime, path)
-            log_metrics(
+            from ai_trading.logging import _get_metrics_logger  # AI-AGENT-REF: lazy metrics import
+            _get_metrics_logger().log_metrics(
                 {
                     "timestamp": datetime.now(UTC).isoformat(),
                     "type": "retrain_model",

--- a/scripts/slippage.py
+++ b/scripts/slippage.py
@@ -1,5 +1,4 @@
 import logging
-from ai_trading.telemetry.metrics_logger import log_metrics
 from validate_env import settings
 
 logger = logging.getLogger(__name__)
@@ -11,7 +10,10 @@ def monitor_slippage(expected: float | None, actual: float, symbol: str) -> None
     """Check slippage and send alert when above threshold."""
     if expected:
         pct = abs(actual - expected) / expected
-        log_metrics({"symbol": symbol, "slippage_pct": pct}, filename="metrics/slippage.csv")
+        from ai_trading.logging import _get_metrics_logger  # AI-AGENT-REF: lazy metrics import
+        _get_metrics_logger().log_metrics(
+            {"symbol": symbol, "slippage_pct": pct}, filename="metrics/slippage.csv"
+        )
         if pct > SLIPPAGE_THRESHOLD:
             msg = f"High slippage {pct:.2%} on {symbol}"
             logger.warning(msg)


### PR DESCRIPTION
## Summary
- lazy-initialize executors and settings in `bot_engine` to avoid import-time side effects
- switch metrics logging to `_get_metrics_logger` and defer telemetry exports
- move metrics logger imports under function scope in runtime scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import importlib
try:
    importlib.import_module("ai_trading.core.bot_engine")
    print("Imported OK; no side effects.")
except Exception as e:
    print("Import failed:", e)
PY`
- `pytest -n auto --disable-warnings` *(fails: Failed: DID NOT RAISE <class 'ImportError'>, AttributeError, assertion and ImportError for prometheus_client)*

------
https://chatgpt.com/codex/tasks/task_e_689f3837f3488330ac44808ef09e710b