### PR TITLE
refactor: drop module-level getattr usage

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -10960,9 +10960,9 @@ def main() -> None:
                 target=adaptive_risk_scaling, args=(ctx,), daemon=True
             ).start()
         )
-        schedule.every(CFG.rebalance_interval_min).minutes.do(
+        schedule.every(get_rebalance_interval_min()).minutes.do(
             lambda: Thread(target=maybe_rebalance, args=(ctx,), daemon=True).start()
-        )
+        )  # AI-AGENT-REF: standardize rebalance interval access
         schedule.every().day.at("23:55").do(
             lambda: Thread(target=check_disaster_halt, daemon=True).start()
         )

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -56,9 +56,7 @@ logger = logging.getLogger(__name__)
 
 class MockConfig:
     """Test stub injected by tests via monkeypatch; real code never uses it."""
-
-    def __getattr__(self, name):  # pragma: no cover - simple stub
-        raise AttributeError(name)
+    pass  # AI-AGENT-REF: dynamic attribute stub removed
 
 
 def validate_environment() -> None:

--- a/scripts/validate_env.py
+++ b/scripts/validate_env.py
@@ -233,31 +233,7 @@ else:
             self.FLASK_PORT = int(os.getenv("FLASK_PORT", "9001"))
             # AI-AGENT-REF: Increase default position limit for better portfolio utilization
             self.MAX_PORTFOLIO_POSITIONS = int(os.getenv("MAX_PORTFOLIO_POSITIONS", "20"))
-            
-        def __getattr__(self, name):
-            # AI-AGENT-REF: Dynamic fallback for any missing attributes
-            # Provide sensible defaults for common numeric fields
-            numeric_fields = [
-                'SEED', 'HEALTHCHECK_PORT', 'MIN_HEALTH_ROWS', 'MIN_HEALTH_ROWS_DAILY',
-                'RATE_LIMIT_BUDGET', 'SCHEDULER_SLEEP_SECONDS', 'POSITION_SCALE_FACTOR',
-                'VOLATILITY_LOOKBACK_DAYS', 'SIGNAL_CONFIRMATION_BARS', 'TRADE_COOLDOWN_MIN'
-            ]
-            float_fields = [
-                'BUY_THRESHOLD', 'LIMIT_ORDER_SLIPPAGE', 'DELTA_THRESHOLD', 'MIN_CONFIDENCE',
-                'ATR_MULTIPLIER', 'MAX_EXPOSURE', 'RISK_BUDGET'
-            ]
-            bool_fields = [
-                'RUN_HEALTHCHECK', 'USE_RL_AGENT', 'FORCE_TRADES', 'MEMORY_OPTIMIZED',
-                'DRY_RUN', 'SHADOW_MODE', 'ENABLE_CACHE'
-            ]
-            
-            if name.upper() in numeric_fields:
-                return 42  # Default numeric value
-            elif name.upper() in float_fields:
-                return 0.5  # Default float value
-            elif name.upper() in bool_fields:
-                return 0  # Default boolean (as int)
-            return os.getenv(name, "")
+            # AI-AGENT-REF: dynamic attribute fallback removed; explicit fields only
     
     settings = FallbackSettings()
     logger.warning("Using fallback settings - pydantic-settings not available")


### PR DESCRIPTION
## Summary
- remove runtime __getattr__ stubs and switch to explicit config access
- standardize rebalance interval scheduling via get_rebalance_interval_min

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `git grep -n "def __getattr__" ai_trading scripts`
- `git grep -n "get_rebalance_interval_min"`
- `python -m ai_trading.main --help`
- `ALPACA_API_KEY=ABCD1234567 ALPACA_SECRET_KEY=SECRETLONGVALUE1234567890 TRADE_LOG_FILE=trades.csv PYTHONPATH=. python scripts/validate_env.py --help`
- `pytest -n auto --disable-warnings` *(fails: async def functions are not natively supported; missing ProcessManager, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689f3c7f06ec833080cc25fd55af4871