### PR TITLE
feat: expand TradingConfig fields and defer settings

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 
 from flask import Flask, jsonify
-from ai_trading.config.settings import get_settings
 
 
 def create_app():
@@ -19,6 +18,8 @@ def create_app():
 
 
 if __name__ == "__main__":
+    from ai_trading.config.settings import get_settings
+
     s = get_settings()
     port = int(s.api_port or 9001)  # AI-AGENT-REF: default Flask port fallback
     app = create_app()

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -16,8 +16,6 @@ from ai_trading.config import Settings, get_settings as get_config
 from ai_trading.settings import get_settings  # AI-AGENT-REF: runtime env settings
 from ai_trading.utils import get_free_port, get_pid_on_port
 
-S = get_settings()  # AI-AGENT-REF: resolve runtime defaults once
-
 # AI-AGENT-REF: Import memory optimization only
 def get_memory_optimizer():
     from ai_trading.config import get_settings
@@ -235,6 +233,8 @@ def main() -> None:
         # Handle any other synchronization errors
         logger.error("Unexpected error during API startup synchronization: %s", e)
         raise RuntimeError(f"API startup synchronization failed: {e}")
+
+    S = get_settings()
 
     # CLI takes precedence; then settings
     iterations = args.iterations if args.iterations is not None else S.iterations

--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -1,8 +1,6 @@
 from ai_trading.config import get_settings
 from importlib.util import find_spec
 
-S = get_settings()
-
 # AI-AGENT-REF: detect sklearn availability at import time
 try:  # pragma: no cover - optional dependency
     import sklearn  # type: ignore  # noqa: F401
@@ -588,7 +586,8 @@ def retrain_meta_learner(
 
     # Set default trade log path
     if trade_log_path is None:
-        trade_log_path = S.trade_log_file if config else "trades.csv"
+        settings = get_settings()
+        trade_log_path = settings.trade_log_file if config else "trades.csv"
 
     logger.info(
         "META_RETRAIN_START",


### PR DESCRIPTION
## Summary
- attach Finnhub, seed, liquidity, meta-learning, and audit fields in `TradingConfig.from_env`
- shift `SENTIMENT_SUCCESS_RATE_TARGET` default to 0.90
- defer `get_settings()` evaluation across modules to avoid import-time snapshots

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `git grep -n "get_settings()" ai_trading | grep -v bot_engine.py`
- `python - <<'PY'
from ai_trading.config.management import TradingConfig
cfg = TradingConfig.from_env()
assert hasattr(cfg, "FINNHUB_API_KEY")
assert hasattr(cfg, "DISABLE_DAILY_RETRAIN")
assert hasattr(cfg, "SEED")
assert hasattr(cfg, "TRADE_AUDIT_DIR")
for k in (
    "LIQUIDITY_SPREAD_THRESHOLD","LIQUIDITY_VOL_THRESHOLD",
    "LIQUIDITY_REDUCTION_AGGRESSIVE","LIQUIDITY_REDUCTION_MODERATE",
    "META_LEARNING_BOOTSTRAP_ENABLED","META_LEARNING_MIN_TRADES_REDUCED",
    "META_LEARNING_BOOTSTRAP_WIN_RATE","_CONFIG_LOGGED","_LOCK_TIMEOUT",
    "SENTIMENT_SUCCESS_RATE_TARGET",
):
    assert hasattr(cfg, k)
assert cfg.SENTIMENT_SUCCESS_RATE_TARGET == 0.90
print('TradingConfig smoke ok')
PY`
- `python - <<'PY'
import importlib
for m in (
    "ai_trading.alpaca_api","ai_trading.app","ai_trading.indicators",
    "ai_trading.main","ai_trading.meta_learning",
    "ai_trading.evaluation.walkforward","ai_trading.utils.base",
):
    importlib.reload(importlib.import_module(m))
print("Imported OK with no config side-effects.")
PY`
- `pytest -n auto --disable-warnings` (fails: import path assumptions and runtime dependencies)


------
https://chatgpt.com/codex/tasks/task_e_689f43fcb60c83309a443579a26c1a63