### PR TITLE
fix: improve runtime safety and config handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
   - **Breaking**: Root imports are no longer supported as of this version
 
 ### Fixed
+- **Runtime safety**: improved Alpaca availability checks, stable logging shutdown,
+  lazy client init, config parity, and added utility/environment helpers.
 - **ExecutionEngine**: Removed unsupported slippage metrics kwargs from initialization to prevent runtime `TypeError`.
 - **Import Blocker**: Replaced corrupted `ai_trading/model_registry.py` with clean, minimal, typed model registry implementation
 - Removed hard `data_client` dependency in risk engine with optional Alpaca client.

--- a/ai_trading/config/__init__.py
+++ b/ai_trading/config/__init__.py
@@ -34,6 +34,34 @@ def _require_env_vars(*names: str) -> None:
         logger.critical(msg)
         raise RuntimeError(msg)
 
+
+def validate_environment() -> None:
+    TradingConfig.from_env().validate_environment()
+
+
+def validate_alpaca_credentials() -> None:
+    cfg = TradingConfig.from_env()
+    missing = []
+    if not getattr(cfg, "ALPACA_API_KEY", None):
+        missing.append("ALPACA_API_KEY")
+    if not getattr(cfg, "ALPACA_SECRET_KEY", None):
+        missing.append("ALPACA_SECRET_KEY")
+    if not getattr(cfg, "ALPACA_BASE_URL", None):
+        missing.append("ALPACA_BASE_URL")
+    if missing:
+        raise RuntimeError("Missing required settings: " + ", ".join(missing))
+
+
+def log_config(redact_keys=None):
+    cfg = TradingConfig.from_env()
+    d = cfg.to_dict(safe=True)
+    for k in (redact_keys or []):
+        if k in d:
+            d[k] = "***"
+    logging.getLogger("ai_trading.logging").info(
+        "CONFIG_SNAPSHOT", extra={"config": d}
+    )
+
 __all__ = [
     "Settings",
     "get_settings",
@@ -44,5 +72,8 @@ __all__ = [
     "get_env",
     "_require_env_vars",
     "reload_env",
+    "validate_environment",
+    "validate_alpaca_credentials",
+    "log_config",
 ]
 

--- a/ai_trading/execution/__init__.py
+++ b/ai_trading/execution/__init__.py
@@ -61,11 +61,14 @@ from .position_reconciler import (
     stop_position_monitoring,
     update_bot_position,
 )
-from .production_engine import (
-    ExecutionResult,
-    OrderRequest,
-    ProductionExecutionCoordinator,
-)
+try:  # AI-AGENT-REF: optional production engine when Alpaca deps missing
+    from .production_engine import (
+        ExecutionResult,
+        OrderRequest,
+        ProductionExecutionCoordinator,
+    )
+except Exception:  # pragma: no cover
+    ExecutionResult = OrderRequest = ProductionExecutionCoordinator = None  # type: ignore
 
 # Export all execution classes
 __all__ = [

--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -48,7 +48,7 @@ def submit_market_order(symbol: str, side: str, quantity: int):
             "ORDER_INPUT_INVALID",
             extra={"cause": type(e).__name__, "detail": str(e)},
         )
-        return {"status": "error", "code": "ORDER_INPUT_INVALID", "error": str(e)}
+        raise ValueError("ORDER_INPUT_INVALID") from e
     return {
         "status": "submitted",
         "symbol": symbol,
@@ -187,7 +187,7 @@ class AlpacaExecutionEngine:
                 "ORDER_INPUT_INVALID",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
             )
-            return {"status": "error", "code": "ORDER_INPUT_INVALID", "error": str(e), "order_id": None}
+            raise ValueError("ORDER_INPUT_INVALID") from e
 
         start_time = time.time()
         order_data = {
@@ -254,7 +254,7 @@ class AlpacaExecutionEngine:
                 "ORDER_INPUT_INVALID",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
             )
-            return {"status": "error", "code": "ORDER_INPUT_INVALID", "error": str(e), "order_id": None}
+            raise ValueError("ORDER_INPUT_INVALID") from e
 
         start_time = time.time()
         order_data = {

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -30,6 +30,7 @@ try:
         health_check,
         get_latest_close,
         ensure_utc,
+        get_ohlcv_columns,
     )
 except Exception:  # pragma: no cover - optional deps
     HAS_PANDAS = False
@@ -39,7 +40,7 @@ except Exception:  # pragma: no cover - optional deps
 
     get_free_port = get_pid_on_port = is_market_holiday = is_market_open = is_weekend = _stub
     log_health_row_check = log_warning = model_lock = portfolio_lock = requires_pandas = _stub
-    safe_to_datetime = validate_ohlcv = validate_ohlcv_basic = health_check = get_latest_close = ensure_utc = _stub
+    safe_to_datetime = validate_ohlcv = validate_ohlcv_basic = health_check = get_latest_close = ensure_utc = get_ohlcv_columns = _stub
     EASTERN_TZ = ZoneInfo("America/New_York")
 from .determinism import (
     ensure_deterministic_training,
@@ -77,4 +78,5 @@ __all__ = [
     "EASTERN_TZ",
     "health_check",
     "ensure_utc",
+    "get_ohlcv_columns",
 ]

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -35,6 +35,12 @@ Series = pd.Series
 Index = pd.Index
 
 
+def get_ohlcv_columns(df) -> list[str]:
+    cols = [str(c).lower() for c in getattr(df, "columns", [])]
+    wanted = ("open", "high", "low", "close", "volume", "vwap")
+    return [w for w in wanted if w in cols]
+
+
 def requires_pandas(func):
     """Decorator to ensure pandas is available for a function."""
 

--- a/validate_env.py
+++ b/validate_env.py
@@ -1,18 +1,15 @@
-from ai_trading.config import _require_env_vars, reload_env
+import importlib.util
+import pathlib
 
-# AI-AGENT-REF: allow runpy.run_module execution
 if __spec__ is None:  # pragma: no cover
-    import importlib.util, pathlib
-
-    _p = pathlib.Path(__file__).resolve()
-    __spec__ = importlib.util.spec_from_file_location("validate_env", _p)
+    __spec__ = importlib.util.spec_from_file_location("validate_env", pathlib.Path(__file__).resolve())
 
 
-def _main() -> int:
-    reload_env()
-    _require_env_vars("WEBHOOK_SECRET", "ALPACA_API_KEY", "ALPACA_SECRET_KEY", "ALPACA_BASE_URL")
-    return 0
+def _main() -> None:
+    from ai_trading.config.management import TradingConfig
+    TradingConfig.from_env().validate_environment()
+    print("Environment OK")
 
 
-if __name__ == "__main__":
-    raise SystemExit(_main())
+if __name__ == "__main__":  # pragma: no cover
+    _main()


### PR DESCRIPTION
## Summary
- refine Alpaca availability check and avoid import-time client creation
- harden config management defaults and expose utility exports
- add safe logging shutdown and run-cycle hook for tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_alpaca_import.py::test_ai_trading_import_without_alpaca` *(fails: No module named 'pybreaker')*


------
https://chatgpt.com/codex/tasks/task_e_689f55761dcc8330964bce9a46cb6380