### PR TITLE
fix(core,config,exec,utils): align contracts with tests

### DIFF
--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -48,7 +48,12 @@ def submit_market_order(symbol: str, side: str, quantity: int):
             "ORDER_INPUT_INVALID",
             extra={"cause": type(e).__name__, "detail": str(e)},
         )
-        raise ValueError("ORDER_INPUT_INVALID") from e
+        return {
+            "status": "error",
+            "code": "ORDER_INPUT_INVALID",
+            "error": str(e),
+            "order_id": None,
+        }
     return {
         "status": "submitted",
         "symbol": symbol,
@@ -187,7 +192,12 @@ class AlpacaExecutionEngine:
                 "ORDER_INPUT_INVALID",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
             )
-            raise ValueError("ORDER_INPUT_INVALID") from e
+            return {
+                "status": "error",
+                "code": "ORDER_INPUT_INVALID",
+                "error": str(e),
+                "order_id": None,
+            }
 
         start_time = time.time()
         order_data = {
@@ -254,7 +264,12 @@ class AlpacaExecutionEngine:
                 "ORDER_INPUT_INVALID",
                 extra={"cause": e.__class__.__name__, "detail": str(e)},
             )
-            raise ValueError("ORDER_INPUT_INVALID") from e
+            return {
+                "status": "error",
+                "code": "ORDER_INPUT_INVALID",
+                "error": str(e),
+                "order_id": None,
+            }
 
         start_time = time.time()
         order_data = {

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -108,6 +108,8 @@ class Settings(BaseSettings):
     # loop control
     interval: int = Field(60, alias="AI_TRADING_INTERVAL")  # AI-AGENT-REF: interval alias
     iterations: int = Field(0, alias="AI_TRADING_ITERATIONS")  # AI-AGENT-REF: iterations alias
+    scheduler_iterations: int = Field(0, validation_alias="SCHEDULER_ITERATIONS")
+    scheduler_sleep_seconds: int = Field(60, validation_alias="SCHEDULER_SLEEP_SECONDS")
     seed: int = Field(42, alias="AI_TRADING_SEED")  # AI-AGENT-REF: seed alias
 
     # paths

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -8,40 +8,27 @@ Only re-export light symbols needed by production modules to avoid import-time h
 """
 from zoneinfo import ZoneInfo
 import pandas as pd
-# Keep this import small; base.py already imports get_settings safely.
-# AI-AGENT-REF: tolerate missing heavy dependencies
-try:
-    from .base import (
-        HAS_PANDAS,
-        EASTERN_TZ,
-        get_free_port,
-        get_pid_on_port,
-        is_market_holiday,
-        is_market_open,
-        is_weekend,
-        log_health_row_check,
-        log_warning,
-        model_lock,
-        portfolio_lock,
-        requires_pandas,
-        safe_to_datetime,
-        validate_ohlcv,
-        validate_ohlcv_basic,
-        health_check,
-        get_latest_close,
-        ensure_utc,
-        get_ohlcv_columns,
-    )
-except Exception:  # pragma: no cover - optional deps
-    HAS_PANDAS = False
-
-    def _stub(*args, **kwargs):
-        return None
-
-    get_free_port = get_pid_on_port = is_market_holiday = is_market_open = is_weekend = _stub
-    log_health_row_check = log_warning = model_lock = portfolio_lock = requires_pandas = _stub
-    safe_to_datetime = validate_ohlcv = validate_ohlcv_basic = health_check = get_latest_close = ensure_utc = get_ohlcv_columns = _stub
-    EASTERN_TZ = ZoneInfo("America/New_York")
+from .base import (
+    HAS_PANDAS,
+    EASTERN_TZ,
+    get_free_port,
+    get_pid_on_port,
+    is_market_holiday,
+    is_market_open,
+    is_weekend,
+    log_health_row_check,
+    log_warning,
+    model_lock,
+    portfolio_lock,
+    requires_pandas,
+    safe_to_datetime,
+    validate_ohlcv,
+    validate_ohlcv_basic,
+    health_check,
+    get_latest_close,
+    ensure_utc,
+    get_ohlcv_columns,
+)
 from .determinism import (
     ensure_deterministic_training,
     get_model_spec,

--- a/validate_env.py
+++ b/validate_env.py
@@ -1,15 +1,10 @@
-import importlib.util
-import pathlib
-
-if __spec__ is None:  # pragma: no cover
-    __spec__ = importlib.util.spec_from_file_location("validate_env", pathlib.Path(__file__).resolve())
+from ai_trading.config import validate_environment
 
 
 def _main() -> None:
-    from ai_trading.config.management import TradingConfig
-    TradingConfig.from_env().validate_environment()
-    print("Environment OK")
+    validate_environment()
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     _main()
+


### PR DESCRIPTION
## Summary
- return structured error dictionaries from live execution submit functions instead of raising
- add scheduler iteration settings and harden environment validation APIs
- improve Alpaca availability detection and pipeline import contract; export concrete utils

## Testing
- `python tools/import_contract.py`
- `PYTHONPATH=. pytest -q -n auto --maxfail=1` *(fails: TypeError: unsupported type for timedelta minutes component: FieldInfo)*

------
https://chatgpt.com/codex/tasks/task_e_689f5f0c33a8833084861fe9d0d72883