### PR TITLE
fix: add test-aware timing and network safeguards

### DIFF
--- a/ai_trading/integrations/rate_limit.py
+++ b/ai_trading/integrations/rate_limit.py
@@ -10,6 +10,7 @@ import logging
 import random
 import threading
 import time
+from ai_trading.utils import sleep as psleep
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -330,7 +331,7 @@ class RateLimiter:
 
         # Wait outside the lock
         self.logger.debug(f"Rate limiting {route}: waiting {wait_time:.2f}s")
-        time.sleep(wait_time)
+        psleep(wait_time)
 
         # Try again after waiting
         with self._lock:

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import logging
 import threading
-import time
 from threading import Thread
 
 # AI-AGENT-REF: Load .env BEFORE importing any heavy modules or Settings
@@ -14,7 +13,7 @@ load_dotenv()
 # AI-AGENT-REF: Import only essential modules at top level for import-light entrypoint
 from ai_trading.config import get_settings as get_config
 from ai_trading.settings import get_settings, get_seed_int  # AI-AGENT-REF: runtime env settings
-from ai_trading.utils import get_free_port, get_pid_on_port
+from ai_trading.utils import get_free_port, get_pid_on_port, sleep as psleep
 
 # AI-AGENT-REF: expose run_cycle for monkeypatching
 def _default_run_cycle():
@@ -291,7 +290,7 @@ def main() -> None:
         except Exception:  # pragma: no cover - log unexpected errors
             logger.exception("run_cycle failed")
         count += 1
-        time.sleep(int(max(1, interval)))
+        psleep(int(max(1, interval)))
 
 
 if __name__ == "__main__":
@@ -300,3 +299,4 @@ if __name__ == "__main__":
 
 from ai_trading.config import get_settings as get_config
 cfg = get_config()
+test_mode = getattr(cfg, "scheduler_iterations", 0) != 0

--- a/ai_trading/monitoring/alerting.py
+++ b/ai_trading/monitoring/alerting.py
@@ -18,6 +18,7 @@ from enum import Enum
 from typing import Any
 
 import requests
+from ai_trading.utils import clamp_timeout
 
 # Use the centralized logger as per AGENTS.md
 from ai_trading.logging import logger
@@ -267,7 +268,11 @@ class SlackAlerter:
                     )
 
             # Send to Slack
-            response = requests.post(self.webhook_url, json=payload, timeout=10)
+            response = requests.post(
+                self.webhook_url,
+                json=payload,
+                timeout=clamp_timeout(10, 10, 0.5),
+            )
             response.raise_for_status()
 
             logger.info(f"Slack alert sent: {alert.title}")

--- a/ai_trading/monitoring/alerts.py
+++ b/ai_trading/monitoring/alerts.py
@@ -8,6 +8,7 @@ management for institutional trading operations.
 import logging
 import threading
 import time
+from ai_trading.utils import sleep as psleep
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from enum import Enum
@@ -277,11 +278,11 @@ class AlertManager:
                     self.alerts = [a for a in self.alerts if a.timestamp >= cutoff_time]
 
                 # Sleep for an hour
-                time.sleep(3600)
+                psleep(3600)
 
             except Exception as e:
                 logger.error(f"Error in alert cleanup: {e}")
-                time.sleep(300)  # Sleep 5 minutes on error
+                psleep(300)  # Sleep 5 minutes on error
 
 
 class RiskAlertEngine:

--- a/ai_trading/monitoring/order_health_monitor.py
+++ b/ai_trading/monitoring/order_health_monitor.py
@@ -11,6 +11,7 @@ import json
 import logging
 import threading
 import time
+from ai_trading.utils import sleep as psleep
 from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -151,11 +152,11 @@ class OrderHealthMonitor:
                     self._order_metrics.append(metrics)
 
                 # Sleep until next check
-                time.sleep(self.cleanup_interval)
+                psleep(self.cleanup_interval)
 
             except Exception as e:
                 self.logger.error("Error in order monitoring loop: %s", e, exc_info=True)
-                time.sleep(10)  # Back off on errors
+                psleep(10)  # Back off on errors
 
     def _check_stale_orders(self) -> None:
         """Check for and handle stale orders."""

--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 import os
 import time
+from ai_trading.utils import sleep as psleep, clamp_timeout
 from functools import lru_cache
 from typing import Any, Dict, Iterable  # AI-AGENT-REF: broaden typing for signals
 
@@ -117,14 +118,14 @@ def _fetch_api(url: str, retries: int = 3, delay: float = 1.0) -> dict:
     """Fetch JSON from an API with simple retry logic and backoff."""
     for attempt in range(1, retries + 1):
         try:
-            resp = requests.get(url, timeout=5)
+            resp = requests.get(url, timeout=clamp_timeout(5, 5, 0.5))
             resp.raise_for_status()
             return resp.json()
         except (
             requests.exceptions.RequestException
         ) as exc:  # pragma: no cover - network may be mocked
             logger.warning("API request failed (%s/%s): %s", attempt, retries, exc)
-            time.sleep(delay * attempt)
+            psleep(delay * attempt)
     return {}
 
 

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -38,6 +38,8 @@ from .determinism import (
     unlock_model_spec,
 )
 from .time import now_utc
+from .timing import sleep, clamp_timeout  # AI-AGENT-REF: test-aware timing helpers
+from .process_manager import acquire_lock, release_lock, file_lock
 from . import process_manager
 
 
@@ -63,6 +65,11 @@ __all__ = [
     "lock_model_spec",
     "unlock_model_spec",
     "now_utc",
+    "sleep",
+    "clamp_timeout",
+    "acquire_lock",
+    "release_lock",
+    "file_lock",
     "get_latest_close",
     "EASTERN_TZ",
     "health_check",

--- a/ai_trading/utils/process_manager.py
+++ b/ai_trading/utils/process_manager.py
@@ -1,20 +1,83 @@
+"""Process-level locking utilities with xdist-safe file locks."""
+
 from __future__ import annotations
 
-"""Utility helpers for managing placeholder processes.
-
-These functions are intentionally side-effect free and are primarily used by
-unit tests to verify module import paths.
-"""
-
+import errno
+import fcntl
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from time import monotonic
 from typing import Dict
 
+from .timing import sleep as psleep
 
+_LOCKS: dict[str, int] = {}
+
+
+def _lock_path(name: str) -> Path:
+    worker = os.getenv("PYTEST_XDIST_WORKER")
+    suffix = f".{worker}" if worker else ""
+    d = Path("/tmp/ai-trading-locks")
+    d.mkdir(parents=True, exist_ok=True)
+    return d / f"{name}{suffix}.lock"
+
+
+def acquire_lock(name: str, timeout: float = 2.0) -> bool:
+    """Non-blocking lock with timeout. Returns True if acquired, False on timeout."""
+    path = _lock_path(name)
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT, 0o600)
+    start = monotonic()
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            _LOCKS[name] = fd
+            return True
+        except OSError as e:
+            if e.errno not in (errno.EAGAIN, errno.EACCES):
+                os.close(fd)
+                raise
+            if (monotonic() - start) >= timeout:
+                os.close(fd)
+                return False
+            psleep(0.05)
+
+
+def release_lock(name: str) -> None:
+    fd = _LOCKS.pop(name, None)
+    if fd is not None:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+@contextmanager
+def file_lock(name: str, timeout: float = 2.0):
+    ok = acquire_lock(name, timeout=timeout)
+    try:
+        if not ok:
+            raise TimeoutError(f"Could not acquire process lock {name!r} within {timeout}s")
+        yield
+    finally:
+        if ok:
+            release_lock(name)
+
+
+# Compatibility helpers used in tests
 def start_process(name: str) -> Dict[str, str]:
-    """Return a started process descriptor without spawning anything."""
     return {"status": "started", "name": name}
 
 
 def stop_process(name: str) -> Dict[str, str]:
-    """Return a stopped process descriptor without killing anything."""
     return {"status": "stopped", "name": name}
+
+
+__all__ = [
+    "acquire_lock",
+    "release_lock",
+    "file_lock",
+    "start_process",
+    "stop_process",
+]
 

--- a/ai_trading/utils/timing.py
+++ b/ai_trading/utils/timing.py
@@ -1,0 +1,31 @@
+"""Test-aware timing utilities."""
+
+from __future__ import annotations
+
+import os
+import time as _time
+
+
+def _is_test_env() -> bool:
+    return any(
+        os.getenv(k, "").lower() in {"1", "true", "yes"}
+        for k in ("PYTEST_RUNNING", "TESTING")
+    )
+
+
+# default clamp used in *all* retry/sleep loops under tests
+def sleep(seconds: float) -> None:
+    if _is_test_env():
+        seconds = min(seconds, 0.05)  # cap sleeps in tests
+    _time.sleep(max(0.0, seconds))
+
+
+def clamp_timeout(t: float | None, default_non_test: float, default_test: float) -> float:
+    """Return a timeout value respecting tests."""
+    if _is_test_env():
+        return default_test
+    return default_non_test if t is None else t
+
+
+__all__ = ["sleep", "clamp_timeout"]
+

--- a/risk_engine/__init__.py
+++ b/risk_engine/__init__.py
@@ -2,3 +2,5 @@
 
 from ai_trading.risk.engine import *  # noqa: F401,F403
 
+__all__ = [name for name in dir() if not name.startswith("_")]
+

--- a/trade_execution/__init__.py
+++ b/trade_execution/__init__.py
@@ -2,3 +2,5 @@
 
 from ai_trading.execution.live_trading import *  # noqa: F401,F403
 
+__all__ = [name for name in dir() if not name.startswith("_")]
+

--- a/validate_env/__init__.py
+++ b/validate_env/__init__.py
@@ -1,18 +1,25 @@
+"""Environment variable validation entrypoint."""
+
 from __future__ import annotations
 
 import os
+import sys
 
 
 def _main() -> None:
-    """Validate required environment variables for runtime."""
-    webhook = os.getenv("WEBHOOK_SECRET", "")
-    if len(webhook) < 32:
-        raise RuntimeError("WEBHOOK_SECRET too short")
-    api = os.getenv("ALPACA_API_KEY", "")
-    secret = os.getenv("ALPACA_SECRET_KEY", "")
-    base = os.getenv("ALPACA_BASE_URL", "")
-    if not (api and secret and base):
-        raise RuntimeError("Missing alpaca environment variables")
+    # minimal non-verbose validation; do not print secrets
+    required = [
+        "WEBHOOK_SECRET",
+        "ALPACA_API_KEY",
+        "ALPACA_SECRET_KEY",
+        "ALPACA_BASE_URL",
+    ]
+    for key in required:
+        if not os.getenv(key, ""):
+            raise RuntimeError(f"Missing required env: {key}")
+    if len(os.getenv("WEBHOOK_SECRET", "")) < 32:
+        raise RuntimeError("WEBHOOK_SECRET must be >= 32 characters")
 
 
 __all__ = ["_main"]
+


### PR DESCRIPTION
## Summary
- add test-aware sleep and timeout helpers
- implement xdist-safe process file locks
- clamp network timeouts and retries across data fetching and API calls

## Testing
- `make test-all` *(fails: ModuleNotFoundError: No module named 'pandas_market_calendars')*


------
https://chatgpt.com/codex/tasks/task_e_689fa60881d48330a908ad5cd823c98a