### PR TITLE
refactor: centralize http usage

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -4,11 +4,10 @@ import asyncio
 import logging
 import time  # AI-AGENT-REF: tests patch alpaca_api.time.sleep
 from ai_trading.utils import sleep as psleep, clamp_timeout
+from ai_trading.utils import http
 import types
 import uuid
 from typing import Any, Optional
-
-import requests
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +41,7 @@ def alpaca_get(path_or_url: str, *, params: Optional[dict] = None, timeout: int 
     headers = getattr(S, "alpaca_headers", {})
     url = _resolve_url(path_or_url)
     timeout = clamp_timeout(timeout, 10, 0.5)
-    resp = requests.get(url, headers=headers, params=params or {}, timeout=timeout)
+    resp = http.get(url, headers=headers, params=params or {}, timeout=timeout)
     resp.raise_for_status()
     ctype = resp.headers.get("content-type", "")
     return resp.json() if "json" in ctype else resp.text

--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -13,10 +13,10 @@ from collections.abc import Sequence
 from datetime import datetime, date, timezone, timedelta
 from typing import Any, Union
 
-import requests
 from pathlib import Path
 
-from ai_trading.utils import sleep as psleep, clamp_timeout
+from ai_trading.utils import sleep as psleep, clamp_timeout, http
+import requests
 from tenacity import (
     retry,
     stop_after_attempt,
@@ -380,10 +380,9 @@ def _fetch_bars(
     headers = CFG.alpaca_headers  # AI-AGENT-REF: canonical Alpaca headers
     _log_http_request("GET", url, params, headers)
     delay = 1.0
-    timeout = clamp_timeout(None, 10, 0.5)
     for attempt in range(3):
         try:
-            resp = requests.get(url, params=params, headers=headers, timeout=timeout)
+            resp = http.get(url, params=params, headers=headers)
             if (
                 resp.status_code == 400
                 and "invalid feed" in resp.text.lower()
@@ -393,8 +392,8 @@ def _fetch_bars(
                     "Alpaca invalid feed %s for %s; retrying with SIP", feed, symbol
                 )
                 params["feed"] = "sip"
-                resp = requests.get(
-                    url, params=params, headers=headers, timeout=timeout
+                resp = http.get(
+                    url, params=params, headers=headers
                 )
             break
         except requests.exceptions.RequestException as exc:

--- a/ai_trading/monitoring/alerting.py
+++ b/ai_trading/monitoring/alerting.py
@@ -17,7 +17,7 @@ from email.mime.text import MIMEText
 from enum import Enum
 from typing import Any
 
-import requests
+from ai_trading.utils import http
 from ai_trading.utils.timing import clamp_timeout  # AI-AGENT-REF: avoid circular import
 
 # Use the centralized logger as per AGENTS.md
@@ -268,10 +268,9 @@ class SlackAlerter:
                     )
 
             # Send to Slack
-            response = requests.post(
+            response = http.post(
                 self.webhook_url,
                 json=payload,
-                timeout=clamp_timeout(10, 10, 0.5),
             )
             response.raise_for_status()
 

--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -35,6 +35,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from pathlib import Path
 
+from ai_trading.utils import http
 import requests
 
 # Optional ML dependency: hmmlearn
@@ -127,7 +128,7 @@ def _fetch_api(url: str, retries: int = 3, delay: float = 1.0) -> dict:
     """Fetch JSON from an API with simple retry logic and backoff."""
     for attempt in range(1, retries + 1):
         try:
-            resp = requests.get(url, timeout=clamp_timeout(5, 5, 0.5))
+            resp = http.get(url, timeout=clamp_timeout(5, 5, 0.5))
             resp.raise_for_status()
             return resp.json()
         except (

--- a/tests/test_no_raw_requests.py
+++ b/tests/test_no_raw_requests.py
@@ -1,0 +1,13 @@
+import pathlib, re
+
+
+def test_no_raw_requests_in_src():
+    root = pathlib.Path(__file__).resolve().parents[1] / "ai_trading"
+    banned = []
+    for p in root.rglob("*.py"):
+        if "utils/http.py" in str(p):
+            continue
+        txt = p.read_text(encoding="utf-8", errors="ignore")
+        if re.search(r"\brequests\.(get|post|put|delete|patch|head|options)\b", txt):
+            banned.append(str(p))
+    assert not banned, f"Raw requests.* found in: {banned}"


### PR DESCRIPTION
## Summary
- use ai_trading.utils.http in various modules instead of raw requests
- add regression test banning direct requests.* calls

## Testing
- `git ls-files '*.py' | tr '\n' '\0' | xargs -0 python -m py_compile`
- `pytest -q tests/test_no_raw_requests.py`
- `make test-all` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `TESTING=1 python -m ai_trading.main --iterations 1 --interval 0` *(errors: No module named 'pipeline' / 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_689fd53b4fac8330b97e9e5020c1fab0