### PR TITLE
feat: add device picker and lazy state

### DIFF
--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -122,6 +122,10 @@ class Settings(BaseSettings):
 
     # cooling
     trade_cooldown_min: int = Field(15, alias="TRADE_COOLDOWN_MIN")  # AI-AGENT-REF: cooldown minutes
+    health_tick_seconds: int = Field(
+        default=300, env="AI_TRADER_HEALTH_TICK_SECONDS"
+    )  # AI-AGENT-REF: scheduler heartbeat
+    cpu_only: bool = Field(default=False, validation_alias="CPU_ONLY")  # AI-AGENT-REF: ML device override
 
     # External APIs
     news_api_key: Optional[str] = None  # AI-AGENT-REF: optional News API key

--- a/ai_trading/utils/device.py
+++ b/ai_trading/utils/device.py
@@ -1,0 +1,36 @@
+import logging
+import os
+from typing import Any
+
+_log = logging.getLogger(__name__)  # AI-AGENT-REF: structured logging
+
+
+def pick_torch_device() -> tuple[str, Any | None]:
+    try:
+        import torch  # type: ignore
+    except Exception:
+        _log.info("ML_DEVICE_SELECTED", extra={"device": "cpu", "reason": "torch_unavailable"})
+        return "cpu", None
+
+    if os.getenv("CPU_ONLY", "").strip() == "1":
+        dev = "cpu"
+    elif torch.cuda.is_available():
+        dev = "cuda"
+    elif getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():  # macOS
+        dev = "mps"
+    else:
+        dev = "cpu"
+
+    _log.info("ML_DEVICE_SELECTED", extra={"device": dev})
+    return dev, torch
+
+
+def tensors_to_device(batch: dict, device: str):
+    """Move a tokenizer batch (dict of tensors) to the target device."""  # AI-AGENT-REF: device helper
+    tv = []
+    try:
+        from torch import Tensor  # type: ignore
+        tv.append(Tensor)
+    except Exception:
+        return batch
+    return {k: (v.to(device) if isinstance(v, tuple(tv)) else v) for k, v in batch.items()}

--- a/ai_trading/utils/timefmt.py
+++ b/ai_trading/utils/timefmt.py
@@ -8,6 +8,12 @@ issue and ensure consistent ISO-8601 format compliance throughout the applicatio
 from datetime import UTC, datetime
 
 
+def utc_now_iso_from(now: datetime) -> str:
+    """Format provided datetime as ISO-8601 UTC string."""  # AI-AGENT-REF: deterministic timestamp
+    dt = now.astimezone(UTC)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
 def utc_now_iso() -> str:
     """
     Generate a properly formatted UTC timestamp in ISO-8601 format.


### PR DESCRIPTION
## Summary
- lazy-initialize BotState to avoid heavy import side effects
- centralize torch device selection and sentiment device moves
- inject now-provider for snapshots and trade logic, add scheduler heartbeat

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_portfolio_snapshot.py tests/test_health.py -q --override-ini addopts=` *(fails: No module named 'pybreaker')*
- `pytest -n auto --disable-warnings` *(fails: No module named 'pybreaker')*
- `TESTING=1 CPU_ONLY=1 python -m ai_trading.main --iterations 2 --interval 0` *(fails: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_689fd97e55288330819d5ae5e4c2f074