### PR TITLE
feat: add http pool and profiling helpers

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -35,6 +35,7 @@ import io
 import inspect
 import logging
 from ai_trading.utils import http, clamp_timeout  # AI-AGENT-REF: enforce request timeouts
+from ai_trading.utils.prof import StageTimer
 from ai_trading.logging import (
     get_logger,  # AI-AGENT-REF: use sanitizing adapter
     _get_metrics_logger,
@@ -10433,9 +10434,10 @@ def run_all_trades_worker(state: BotState, runtime) -> None:
             retries = 3
             processed, row_counts = [], {}
             for attempt in range(retries):
-                processed, row_counts = _process_symbols(
-                    symbols, current_cash, alpha_model, regime_ok
-                )
+                with StageTimer(_log, "INDICATORS_COMPUTE", symbols=len(symbols)):
+                    processed, row_counts = _process_symbols(
+                        symbols, current_cash, alpha_model, regime_ok
+                    )
                 if processed:
                     if attempt:
                         _log.info(

--- a/ai_trading/utils/http.py
+++ b/ai_trading/utils/http.py
@@ -1,13 +1,107 @@
-"""
-HTTP utilities with default timeout and retry logic.
+"""HTTP utilities with default timeout, retry, and pooled concurrency."""
 
-Provides a centralized HTTP session with sensible defaults for timeouts
-and retry behavior to replace raw requests calls.
-"""
+import os
+import time
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+
+# Lazy singletons
+__HTTP_EXECUTOR: ThreadPoolExecutor | None = None
+__HTTP_LOCK = threading.Lock()
+__SESSIONS: dict[str, "requests.Session"] = {}
+__HOST_SEMAPHORES: dict[str, threading.Semaphore] = {}
+__HOST_RPS: dict[str, float] = {}
+__HOST_RPS_WINDOWS: dict[str, list[float]] = {}
+
+
+def _cfg_int(name: str, default: int) -> int:
+    v = os.getenv(name)
+    try:
+        return int(v) if v is not None else default
+    except Exception:
+        return default
+
+
+def _cfg_float(name: str, default: float) -> float:
+    v = os.getenv(name)
+    try:
+        return float(v) if v is not None else default
+    except Exception:
+        return default
+
+
+def _get_executor() -> ThreadPoolExecutor:
+    global __HTTP_EXECUTOR
+    if __HTTP_EXECUTOR is None:
+        with __HTTP_LOCK:
+            if __HTTP_EXECUTOR is None:
+                workers = _cfg_int("HTTP_MAX_WORKERS", 8)
+                __HTTP_EXECUTOR = ThreadPoolExecutor(
+                    max_workers=max(2, workers), thread_name_prefix="httpw"
+                )
+    return __HTTP_EXECUTOR
+
+
+def _session_for_host(host: str):
+    s = __SESSIONS.get(host)
+    if s is None:
+        with __HTTP_LOCK:
+            s = __SESSIONS.get(host)
+            if s is None:
+                s = requests.Session()
+                retries = Retry(
+                    total=_cfg_int("HTTP_RETRY_TOTAL", 3),
+                    backoff_factor=0.5,
+                    status_forcelist=(429, 500, 502, 503, 504),
+                )
+                pool_max = _cfg_int(
+                    "HTTP_POOL_MAXSIZE",
+                    max(_cfg_int("HTTP_MAX_WORKERS", 8), 10),
+                )
+                adapter = HTTPAdapter(
+                    max_retries=retries,
+                    pool_connections=pool_max,
+                    pool_maxsize=pool_max,
+                )
+                s.mount("http://", adapter)
+                s.mount("https://", adapter)
+                __SESSIONS[host] = s
+                key = f"HTTP_RPS_LIMIT_{host.replace('.', '_').replace('-', '_')}"
+                if os.getenv(key):
+                    __HOST_RPS[host] = _cfg_float(key, 0.0)
+                    __HOST_RPS_WINDOWS[host] = []
+    return s
+
+
+def _host_semaphore(host: str) -> threading.Semaphore:
+    sem = __HOST_SEMAPHORES.get(host)
+    if sem is None:
+        with __HTTP_LOCK:
+            sem = __HOST_SEMAPHORES.get(host)
+            if sem is None:
+                sem = threading.Semaphore(_cfg_int("HTTP_MAX_PER_HOST", 6))
+                __HOST_SEMAPHORES[host] = sem
+    return sem
+
+
+def _maybe_rate_limit(host: str):
+    rps = __HOST_RPS.get(host, 0.0)
+    if rps <= 0:
+        return
+    win = __HOST_RPS_WINDOWS[host]
+    now = time.monotonic()
+    while win and now - win[0] > 1.0:
+        win.pop(0)
+    if len(win) >= rps:
+        sleep_for = 1.0 - (now - win[0])
+        if sleep_for > 0:
+            time.sleep(sleep_for)
+    win.append(time.monotonic())
 
 
 class HTTPSession:
@@ -71,5 +165,86 @@ put = _default_session.put
 delete = _default_session.delete
 head = _default_session.head
 options = _default_session.options
+
+# Bounded concurrency helpers
+
+
+def map_get(
+    urls: list[str],
+    timeout: float | None = None,
+    headers: dict | None = None,
+) -> list[tuple[str, int, bytes]]:
+    """Fetch multiple URLs concurrently while preserving order."""
+    results: list[tuple[str, int, bytes]] = [("", 0, b"")] * len(urls)
+    futs = []
+    execu = _get_executor()
+    tout = timeout or _cfg_float("HTTP_TIMEOUT_S", 10.0)
+
+    def _task(idx: int, url: str):
+        parsed = urlparse(url)
+        host = parsed.netloc
+        sem = _host_semaphore(host)
+        sess = _session_for_host(host)
+        _maybe_rate_limit(host)
+        with sem:
+            resp = sess.get(url, timeout=tout, headers=headers)
+            return (idx, url, resp.status_code, resp.content)
+
+    for i, u in enumerate(urls):
+        futs.append(execu.submit(_task, i, u))
+
+    for f in as_completed(futs):
+        idx, url, code, content = f.result()
+        results[idx] = (url, code, content)
+    return results
+
+
+def map_post(
+    urls: list[str],
+    data: list | None = None,
+    timeout: float | None = None,
+    headers: dict | None = None,
+) -> list[tuple[str, int, bytes]]:
+    """POST to multiple URLs concurrently while preserving order."""
+    if data is None:
+        data = [None] * len(urls)
+    results: list[tuple[str, int, bytes]] = [("", 0, b"")] * len(urls)
+    futs = []
+    execu = _get_executor()
+    tout = timeout or _cfg_float("HTTP_TIMEOUT_S", 10.0)
+
+    def _task(idx: int, url: str, payload):
+        parsed = urlparse(url)
+        host = parsed.netloc
+        sem = _host_semaphore(host)
+        sess = _session_for_host(host)
+        _maybe_rate_limit(host)
+        with sem:
+            resp = sess.post(url, data=payload, timeout=tout, headers=headers)
+            return (idx, url, resp.status_code, resp.content)
+
+    for i, (u, p) in enumerate(zip(urls, data)):
+        futs.append(execu.submit(_task, i, u, p))
+
+    for f in as_completed(futs):
+        idx, url, code, content = f.result()
+        results[idx] = (url, code, content)
+    return results
+
+
+def pool_stats() -> dict:
+    execu = __HTTP_EXECUTOR
+    in_flight = execu._work_queue.qsize() if execu else 0
+    sems = {h: getattr(s, "_value", 0) for h, s in __HOST_SEMAPHORES.items()}
+    return {
+        "workers": _cfg_int("HTTP_MAX_WORKERS", 8),
+        "per_host": _cfg_int("HTTP_MAX_PER_HOST", 6),
+        "pool_maxsize": _cfg_int(
+            "HTTP_POOL_MAXSIZE", max(_cfg_int("HTTP_MAX_WORKERS", 8), 10)
+        ),
+        "hosts": list(__SESSIONS.keys()),
+        "in_flight": in_flight,
+        "host_semaphores": sems,
+    }
 
 # AI-AGENT-REF: HTTP safety module with default timeouts and retry logic

--- a/ai_trading/utils/prof.py
+++ b/ai_trading/utils/prof.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import time
+from contextlib import contextmanager
+
+
+@contextmanager
+def StageTimer(logger, stage_name: str, **extra):
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        dt_ms = int((time.perf_counter() - t0) * 1000)
+        try:
+            logger.info("STAGE_TIMING", extra={"stage": stage_name, "elapsed_ms": dt_ms, **extra})
+        except Exception:
+            pass
+
+
+class SoftBudget:
+    def __init__(self, interval_sec: float, fraction: float):
+        self._deadline = time.monotonic() + max(0.0, interval_sec) * max(0.1, min(1.0, fraction))
+        self._start = time.monotonic()
+
+    def remaining(self) -> float:
+        return max(0.0, self._deadline - time.monotonic())
+
+    def elapsed_ms(self) -> int:
+        return int((time.monotonic() - self._start) * 1000)
+
+    def over(self) -> bool:
+        return time.monotonic() >= self._deadline

--- a/tests/test_http_pooling.py
+++ b/tests/test_http_pooling.py
@@ -1,0 +1,26 @@
+from ai_trading.utils import http as H
+import requests
+
+
+class DummyResp:
+    status_code = 200
+    content = b"ok"
+
+
+def test_pool_config_defaults(monkeypatch):
+    monkeypatch.delenv("HTTP_MAX_WORKERS", raising=False)
+    monkeypatch.delenv("HTTP_MAX_PER_HOST", raising=False)
+    st = H.pool_stats()
+    assert st["workers"] == 8
+    assert st["per_host"] == 6
+    assert st["pool_maxsize"] >= st["workers"]
+
+
+def test_host_semaphore_respects_env(monkeypatch):
+    def fake_get(self, url, timeout=None, headers=None):
+        return DummyResp()
+
+    monkeypatch.setattr(requests.Session, "get", fake_get, raising=False)
+    monkeypatch.setenv("HTTP_MAX_PER_HOST", "3")
+    _ = H.map_get(["https://example.com"])
+    assert H.pool_stats()["per_host"] == 3

--- a/tests/test_prof_budget.py
+++ b/tests/test_prof_budget.py
@@ -1,0 +1,10 @@
+import time
+from ai_trading.utils.prof import SoftBudget
+
+
+def test_soft_budget_elapsed_and_over():
+    b = SoftBudget(interval_sec=0.1, fraction=0.5)
+    time.sleep(0.02)
+    assert b.elapsed_ms() >= 20
+    time.sleep(0.05)
+    assert b.over() is True or b.remaining() == 0.0


### PR DESCRIPTION
## Summary
- add pooled HTTP client with per-host limits and rate limiting
- add StageTimer and SoftBudget helpers and instrument main loop
- cover HTTP pooling and budget helper with tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTEST_ADDOPTS= pytest tests/test_http_pooling.py tests/test_prof_budget.py`
- `AI_TRADER_HEALTH_TICK_SECONDS=5 TESTING=1 CPU_ONLY=1 HTTP_MAX_WORKERS=8 HTTP_MAX_PER_HOST=6 HTTP_TIMEOUT_S=10 python -m ai_trading.main --iterations 3 --interval 0`

------
https://chatgpt.com/codex/tasks/task_e_689ffcf4b77c833096c10fe766d1afc9