### PR TITLE
refactor: pool universe fetch and lazy sentiment deps

### DIFF
--- a/tests/test_optional_ml_imports.py
+++ b/tests/test_optional_ml_imports.py
@@ -1,0 +1,24 @@
+import builtins
+import sys
+
+
+def test_optional_ml_imports(monkeypatch):
+    for mod in ("bs4", "transformers"):
+        sys.modules.pop(mod, None)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("bs4") or name.startswith("transformers"):
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    from ai_trading.analysis import sentiment
+
+    res = sentiment.analyze_text("hello")
+    sentiment.fetch_form4_filings("AAPL")
+
+    assert res == {"available": False, "pos": 0.0, "neg": 0.0, "neu": 1.0}
+    assert sentiment._SENT_DEPS_LOGGED == {"bs4", "transformers"}

--- a/tests/test_universe_fetch_pooling.py
+++ b/tests/test_universe_fetch_pooling.py
@@ -1,0 +1,26 @@
+import types
+from ai_trading import data_fetcher
+from ai_trading.utils import http
+
+
+def test_universe_fetch_pooling(monkeypatch):
+    calls = {}
+
+    def fake_map_get(urls, timeout=None, headers=None):
+        calls['count'] = calls.get('count', 0) + 1
+        calls['len'] = len(urls)
+        return [(u, 200, f"BODY{i}".encode()) for i, u in enumerate(urls)]
+
+    monkeypatch.setattr(http, "map_get", fake_map_get)
+    monkeypatch.setattr(data_fetcher, "_parse_bars", lambda s, c, b: b.decode())
+
+    symbols = ["AAA", "BBB", "CCC"]
+    out = data_fetcher.fetch_daily_data_async(symbols, "2024-01-01", "2024-01-02")
+
+    assert calls['count'] == 1
+    assert calls['len'] == len(symbols)
+    assert [out[s] for s in symbols] == [f"BODY{i}" for i in range(len(symbols))]
+
+    stats = http.pool_stats()
+    for key in ("workers", "per_host", "pool_maxsize"):
+        assert key in stats


### PR DESCRIPTION
## Summary
- bound universe fetch through shared HTTP pool, replacing per-symbol threads
- load bs4 and transformers lazily with neutral fallback when missing
- test coverage for pooled fetch ordering and optional sentiment deps

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_universe_fetch_pooling.py tests/test_optional_ml_imports.py`
- `pytest -q -n auto --maxfail=1` *(fails: ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_68a003c99e848330aea95884a0e28ee4