### PR TITLE
feat: sample universe cli and workers

### DIFF
--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -19,7 +19,6 @@ from pathlib import Path
 
 from ai_trading.utils import sleep as psleep, clamp_timeout, http
 from ai_trading.utils.prof import StageTimer
-import requests
 import urllib3
 from requests.exceptions import RequestException
 from tenacity import (
@@ -201,7 +200,7 @@ def _log_http_request(
     )
 
 
-def _log_http_response(resp: requests.Response) -> None:
+def _log_http_response(resp: Any) -> None:
     logger.debug("HTTP_RESPONSE status=%s body=%s", resp.status_code, resp.text[:300])
 
 
@@ -373,7 +372,7 @@ def _fetch_bars(
                     url, params=params, headers=headers
                 )
             break
-        except requests.exceptions.RequestException as exc:
+        except RequestException as exc:
             logger.warning(
                 "HTTP request failed %s/%s for %s: %s", attempt + 1, 3, symbol, exc
             )

--- a/ai_trading/tools/__init__.py
+++ b/ai_trading/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility CLI tools for ai_trading."""

--- a/ai_trading/tools/fetch_sample_universe.py
+++ b/ai_trading/tools/fetch_sample_universe.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import datetime, timedelta, UTC
+
+from ai_trading.logging import get_logger
+from ai_trading.utils import http
+from ai_trading.utils.prof import StageTimer
+
+logger = get_logger(__name__)
+
+__all__ = ["run", "parse_cli_and_run"]
+
+
+# AI-AGENT-REF: manual probe for pooled HTTP fetch
+
+def run(symbols: list[str], timeout: float | None = None) -> int:
+    """Fetch daily data for ``symbols`` using the pooled HTTP client."""
+    if not symbols:
+        return 0
+    from ai_trading.data_fetcher import _build_daily_url  # local import to ease patching
+
+    end = datetime.now(UTC)
+    start = end - timedelta(days=7)
+    urls = [_build_daily_url(sym, start, end) for sym in symbols]
+    failures = 0
+    with StageTimer(logger, "UNIVERSE_FETCH", universe_size=len(symbols)):
+        results = http.map_get(urls, timeout=timeout)
+    logger.info("HTTP_POOL_STATS", extra=http.pool_stats())
+    for (url, code, _), sym in zip(results, symbols):
+        if code != 200:
+            logger.error("fetch failed for %s status=%s", sym, code)
+            failures += 1
+    return 0 if failures == 0 else 1
+
+
+def parse_cli_and_run() -> int:
+    parser = argparse.ArgumentParser(description="Fetch sample universe using pooled HTTP")
+    parser.add_argument("--symbols", help="Comma separated symbols", default="")
+    parser.add_argument("--timeout", type=float, default=None)
+    args = parser.parse_args()
+
+    if args.symbols:
+        symbols = [s.strip() for s in args.symbols.split(",") if s.strip()]
+    else:
+        env_syms = os.getenv("SAMPLE_UNIVERSE", "AAPL,MSFT,GOOGL")
+        symbols = [s.strip() for s in env_syms.split(",") if s.strip()]
+
+    timeout = args.timeout
+    if timeout is None:
+        try:
+            timeout = float(os.getenv("HTTP_TIMEOUT_S", "10"))
+        except Exception:
+            timeout = 10.0
+    return run(symbols, timeout=timeout)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    sys.exit(parse_cli_and_run())

--- a/ai_trading/utils/workers.py
+++ b/ai_trading/utils/workers.py
@@ -1,0 +1,48 @@
+from concurrent.futures import ThreadPoolExecutor, Future
+import atexit
+import os
+import threading
+
+
+# AI-AGENT-REF: standardized bounded worker pools
+_EXECUTORS: dict[str, ThreadPoolExecutor] = {}
+_LOCK = threading.Lock()
+
+
+def _cfg_int(name: str, default: int) -> int:
+    try:
+        v = os.getenv(name)
+        return int(v) if v is not None else default
+    except Exception:
+        return default
+
+
+def get_executor(name: str, max_workers: int | None = None) -> ThreadPoolExecutor:
+    max_workers = max_workers or _cfg_int("WORKER_MAX_THREADS", 8)
+    with _LOCK:
+        ex = _EXECUTORS.get(name)
+        if ex is None:
+            ex = ThreadPoolExecutor(
+                max_workers=max(1, int(max_workers)), thread_name_prefix=f"{name}-w"
+            )
+            _EXECUTORS[name] = ex
+    return ex
+
+
+def submit_background(name: str, fn, *args, **kwargs) -> Future:
+    return get_executor(name).submit(fn, *args, **kwargs)
+
+
+def map_background(name: str, fn, iterable):
+    ex = get_executor(name)
+    return list(ex.map(fn, iterable))
+
+
+def shutdown_all(wait: bool = True):
+    with _LOCK:
+        for ex in _EXECUTORS.values():
+            ex.shutdown(wait=wait, cancel_futures=not wait)
+        _EXECUTORS.clear()
+
+
+atexit.register(shutdown_all)

--- a/tests/test_fetch_sample_universe_cli.py
+++ b/tests/test_fetch_sample_universe_cli.py
@@ -1,0 +1,36 @@
+from ai_trading.tools.fetch_sample_universe import run
+
+
+def test_run_success(monkeypatch):
+    urls_captured = []
+    logged = []
+
+    def fake_build(symbol, start, end):
+        return f"https://example.com/{symbol}"
+
+    def fake_map_get(urls, timeout=None):
+        urls_captured.extend(urls)
+        return [(u, 200, b"OK") for u in urls]
+
+    def fake_info(msg, *args, **kwargs):
+        logged.append((msg, kwargs.get("extra", {})))
+
+    monkeypatch.setattr("ai_trading.data_fetcher._build_daily_url", fake_build)
+    monkeypatch.setattr("ai_trading.utils.http.map_get", fake_map_get)
+    monkeypatch.setattr(
+        "ai_trading.utils.http.pool_stats",
+        lambda: {"workers": 1, "per_host": 1, "pool_maxsize": 1},
+    )
+    monkeypatch.setattr("ai_trading.tools.fetch_sample_universe.logger.info", fake_info)
+
+    rc = run(["AAA", "BBB", "CCC"], timeout=1.0)
+    assert rc == 0
+    assert urls_captured == [
+        "https://example.com/AAA",
+        "https://example.com/BBB",
+        "https://example.com/CCC",
+    ]
+    timing = [m for m in logged if m[0] == "STAGE_TIMING"]
+    assert timing and timing[0][1]["stage"] == "UNIVERSE_FETCH" and timing[0][1]["universe_size"] == 3
+    stats = [m for m in logged if m[0] == "HTTP_POOL_STATS"]
+    assert stats and {"workers", "per_host", "pool_maxsize"} <= stats[0][1].keys()

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,19 @@
+
+from ai_trading.utils import workers
+
+
+def teardown_module(module):
+    workers.shutdown_all()
+
+
+def test_get_executor_singleton():
+    ex1 = workers.get_executor("alpha")
+    ex2 = workers.get_executor("alpha")
+    assert ex1 is ex2
+
+
+def test_submit_and_map_background():
+    fut = workers.submit_background("beta", lambda x: x + 1, 1)
+    assert fut.result() == 2
+    res = workers.map_background("gamma", lambda x: x * 2, [1, 2, 3])
+    assert res == [2, 4, 6]


### PR DESCRIPTION
## Summary
- add CLI to fetch sample universe using pooled HTTP
- introduce bounded background workers utility
- drop unused requests import and fix exception in data fetcher

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -c /dev/null -q tests/test_workers.py tests/test_fetch_sample_universe_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68a00d785d008330b42e7a8fd79c48d7