### PR TITLE
test: stabilize timeout plugin

### DIFF
--- a/tests/watchdog_ext.py
+++ b/tests/watchdog_ext.py
@@ -1,9 +1,8 @@
-import os
-import time
-import socket
 import faulthandler
-import requests
-import types
+import os
+import socket
+import time
+
 import pytest
 
 
@@ -30,15 +29,22 @@ def _short_sleep(monkeypatch):
 
 @pytest.fixture(scope="session", autouse=True)
 def _requests_default_timeout(monkeypatch):
-    orig_request = requests.sessions.Session.request
+    try:
+        import requests
+    except Exception:
+        return
     default_timeout = float(os.getenv("HTTP_TIMEOUT_S", "10") or 10)
 
-    def request_with_timeout(self, method, url, **kw):
-        if "timeout" not in kw or kw["timeout"] is None:
-            kw["timeout"] = default_timeout
-        return orig_request(self, method, url, **kw)
+    # Robust: patch the commonly exposed class attribute
+    # (some environments don't have `requests.sessions` attr)
+    orig_request = requests.Session.request
 
-    monkeypatch.setattr(requests.sessions.Session, "request", request_with_timeout)
+    def _request_with_default_timeout(self, method, url, **kwargs):
+        if "timeout" not in kwargs or kwargs["timeout"] is None:
+            kwargs["timeout"] = default_timeout
+        return orig_request(self, method, url, **kwargs)
+
+    monkeypatch.setattr(requests.Session, "request", _request_with_default_timeout)
     yield
 
 
@@ -57,7 +63,8 @@ def _block_external_network(monkeypatch):
         if ip.startswith("127.") or ip in ("::1", "localhost"):
             return orig_connect(self, address)
         raise RuntimeError(
-            f"External network blocked in tests (host={host}). Set ALLOW_EXTERNAL_NETWORK=1 to override."
+            f"External network blocked in tests (host={host}). "
+            "Set ALLOW_EXTERNAL_NETWORK=1 to override."
         )
 
     monkeypatch.setattr(socket.socket, "connect", guarded_connect)
@@ -72,4 +79,3 @@ def _test_env():
     os.environ.setdefault("HTTP_TIMEOUT_S", "10")
     os.environ.setdefault("FLASK_PORT", "0")
     yield
-


### PR DESCRIPTION
## Summary
- patch tests to monkeypatch `requests.Session.request` for default timeouts
- rewrite timeout test with spy HTTPAdapter and register plugin

## Testing
- `pre-commit run --files tests/watchdog_ext.py tests/test_http_timeouts.py` (fails: repo-guard, detect-secrets)
- `pytest -q -n 0 -vv -k test_http_timeouts -s` (fails: No module named 'sklearn')
- `pytest -q -n 0 --maxfail=20 --disable-warnings` (fails: missing dependencies such as sklearn, cachetools, tenacity)


------
https://chatgpt.com/codex/tasks/task_e_68a0981270588330962aca2ff6b53837