### PR TITLE
fix: stabilize data APIs and settings

### DIFF
--- a/ai_trading/core/__init__.py
+++ b/ai_trading/core/__init__.py
@@ -5,6 +5,8 @@ Import bot engine symbols directly from ai_trading.core.bot_engine where needed.
 """
 
 # Import core enums and constants (safe imports)
+import importlib
+
 from .constants import TRADING_CONSTANTS
 from .enums import AssetClass, OrderSide, OrderStatus, OrderType, RiskLevel, TimeFrame
 
@@ -23,3 +25,9 @@ __all__ = [
     # For everything else, consumers must do:
     #   from ai_trading.core.bot_engine import BotState, run_all_trades_worker
 ]
+
+
+def __getattr__(name: str):  # AI-AGENT-REF: lazy bot_engine access
+    if name == "bot_engine":
+        return importlib.import_module(".bot_engine", __name__)
+    raise AttributeError(name)

--- a/ai_trading/data_fetcher/__init__.py
+++ b/ai_trading/data_fetcher/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import sys
 import time
 from collections.abc import Iterable
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 try:  # pragma: no cover - pandas optional in some tests
@@ -14,157 +15,135 @@ except Exception:  # pragma: no cover
 
 __all__ = [
     "ensure_datetime",
-    "ensure_utc",
-    "rfc3339",
+    "ensure_rfc3339",
     "get_bars",
-    "get_minute_df",
     "get_historical_data",
+    "get_minute_df",
+    "set_data_client",
     "_DATA_CLIENT",
-    "get_bars_batch",
-    "get_minute_bars",
-    "get_minute_bars_batch",
-    "warmup_cache",
-    "get_cached_minute_timestamp",
-    "last_minute_bar_age_seconds",
-    "_MINUTE_CACHE",
 ]
 
 _DATA_CLIENT: Any | None = None
-_MINUTE_CACHE: dict[str, tuple[Any, datetime]] = {}
+
+# AI-AGENT-REF: legacy import alias
+sys.modules.setdefault("data_fetcher", sys.modules[__name__])
 
 
-def ensure_utc(dt: datetime) -> datetime:
-    """Return a timezone-aware UTC datetime."""
-    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+def set_data_client(client: Any) -> None:
+    """Set the global data client used by helpers."""  # AI-AGENT-REF: patchable client
+    global _DATA_CLIENT
+    _DATA_CLIENT = client
 
 
-def ensure_datetime(dt: Any) -> datetime:
-    """Normalize various datetime inputs to aware UTC ``datetime``."""
+def ensure_datetime(dt: datetime | date | str) -> datetime:
+    """Return an aware ``datetime`` in UTC."""  # AI-AGENT-REF: normalize inputs
     if isinstance(dt, datetime):
-        return ensure_utc(dt)
-    try:  # pandas Timestamp support
-        if pd is not None and isinstance(dt, pd.Timestamp):
-            return ensure_utc(dt.to_pydatetime())
-    except Exception:  # pragma: no cover - defensive
-        pass
+        return dt.astimezone(UTC) if dt.tzinfo else dt.replace(tzinfo=UTC)
+    if isinstance(dt, date):
+        return datetime(dt.year, dt.month, dt.day, tzinfo=UTC)
     if isinstance(dt, str):
-        try:
-            parsed = datetime.fromisoformat(dt.replace("Z", "+00:00"))
-            return ensure_utc(parsed)
-        except Exception:  # pragma: no cover - simple parser
-            pass
-    raise TypeError(f"Unsupported datetime value: {type(dt)!r}")
+        parsed = datetime.fromisoformat(dt.replace("Z", "+00:00"))
+        return parsed.astimezone(UTC) if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+    raise TypeError(f"Unsupported datetime value: {dt!r}")
 
 
-def rfc3339(dt: datetime | str) -> str:
-    """Return an RFC3339 UTC timestamp string."""
+def ensure_rfc3339(dt: datetime | date | str) -> str:
+    """Return RFC3339 formatted timestamp in UTC."""
     return ensure_datetime(dt).isoformat().replace("+00:00", "Z")
 
 
-def _require_client():  # pragma: no cover - simple guard
+def _client() -> Any:
     if _DATA_CLIENT is None:
-        raise RuntimeError(
-            "Data client not configured; patch ai_trading.data_fetcher._DATA_CLIENT"
-        )
+        raise RuntimeError("DATA_CLIENT not configured")
     return _DATA_CLIENT
 
 
-def _call_bars(
-    symbol: str, start: datetime, end: datetime, timeframe: str, limit: int | None
-):
-    client = _require_client()
+def get_bars(
+    symbols: Iterable[str] | str,
+    timeframe: str,
+    start: datetime | date | str,
+    end: datetime | date | str | None = None,
+    *,
+    limit: int | None = None,
+    retries: int = 3,
+    backoff_s: float = 0.2,
+) -> dict[str, pd.DataFrame]:
+    """Fetch bars for ``symbols`` and return mapping of symbol to DataFrame."""
+    sym_list = [symbols] if isinstance(symbols, str) else list(symbols)
+    start_s = ensure_rfc3339(start)
+    end_s = ensure_rfc3339(end) if end is not None else None
+    client = _client()
     fn = getattr(client, "get_stock_bars", None) or getattr(client, "get_bars", None)
     if fn is None:
-        raise RuntimeError("Data client missing get_stock_bars/get_bars")
-    return fn(
-        symbol=symbol,
-        start=rfc3339(start),
-        end=rfc3339(end),
-        timeframe=timeframe,
-        limit=limit,
-    )
-
-
-def get_bars(
-    symbol: str,
-    start: datetime | str,
-    end: datetime | str,
-    timeframe: str = "1Min",
-    limit: int | None = None,
-    *,
-    max_retries: int = 3,
-    retry_sleep_s: float = 0.25,
-):
-    """Fetch OHLCV bars with bounded retries."""
-    start_dt, end_dt = ensure_datetime(start), ensure_datetime(end)
-    last_exc: Exception | None = None
-    for attempt in range(max_retries + 1):
-        try:
-            return _call_bars(symbol, start_dt, end_dt, timeframe, limit)
-        except Exception as e:  # pragma: no cover - network mocked in tests
-            last_exc = e
-            msg = str(e)
-            if "Invalid format for parameter start" in msg and attempt >= max_retries:
-                raise
-            if attempt < max_retries:
-                time.sleep(retry_sleep_s)
-                continue
-            raise
-    raise last_exc or RuntimeError("get_bars failed unexpectedly")
-
-
-def get_minute_df(symbol: str, start: datetime | str, end: datetime | str, **kw):
-    """Fetch minute-level bars."""
-    return get_bars(symbol, start, end, timeframe="1Min", **kw)
-
-
-def get_historical_data(
-    symbols: Iterable[str],
-    start: datetime | str,
-    end: datetime | str,
-    timeframe: str = "1Day",
-    **kw,
-):
-    """Fetch bars for multiple symbols and return mapping of symbol->DataFrame."""
-    out: dict[str, Any] = {}
-    for sym in symbols:
-        out[sym] = get_bars(sym, start, end, timeframe=timeframe, **kw)
+        raise RuntimeError("DATA_CLIENT missing get_stock_bars/get_bars")
+    out: dict[str, pd.DataFrame] = {}
+    for sym in sym_list:
+        last_exc: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                out[sym] = fn(
+                    symbol=sym,
+                    timeframe=timeframe,
+                    start=start_s,
+                    end=end_s,
+                    limit=limit,
+                )
+                break
+            except Exception as e:  # pragma: no cover - network mocked in tests
+                last_exc = e
+                if attempt >= retries:
+                    raise
+                time.sleep(backoff_s)
+        else:
+            if last_exc:
+                raise last_exc
     return out
 
 
-def get_bars_batch(*args, **kwargs):  # pragma: no cover - legacy stub
-    raise NotImplementedError("get_bars_batch is no longer implemented")
+def get_historical_data(
+    symbol: str,
+    start: datetime | date | str,
+    end: datetime | date | str,
+    *,
+    timeframe: str = "1Min",
+    limit: int | None = 1000,
+    retries: int = 3,
+    backoff_s: float = 0.2,
+) -> pd.DataFrame:
+    """Fetch historical bars for a single ``symbol``."""
+    return get_bars(
+        [symbol],
+        timeframe,
+        start,
+        end,
+        limit=limit,
+        retries=retries,
+        backoff_s=backoff_s,
+    )[symbol]
 
 
-def get_minute_bars(*args, **kwargs):  # pragma: no cover - legacy stub
-    raise NotImplementedError("get_minute_bars is no longer implemented")
-
-
-def get_minute_bars_batch(*args, **kwargs):  # pragma: no cover - legacy stub
-    raise NotImplementedError("get_minute_bars_batch is no longer implemented")
-
-
-def warmup_cache(*args, **kwargs):  # pragma: no cover - legacy stub
-    return None
-
-
-def get_cached_minute_timestamp(symbol: str):
-    item = _MINUTE_CACHE.get(symbol)
-    if not item:
-        return None
-    ts = item[1]
-    if isinstance(ts, pd.Timestamp):
-        return ts
-    return pd.Timestamp(ts, tz="UTC") if pd is not None else ts
-
-
-def last_minute_bar_age_seconds(symbol: str, now: datetime | None = None):
-    ts = get_cached_minute_timestamp(symbol)
-    if ts is None:
-        return None
-    now_dt = now or datetime.now(UTC)
-    if isinstance(ts, pd.Timestamp):
-        ts_dt = ts.to_pydatetime()
-    else:
-        ts_dt = ts
-    return (now_dt - ts_dt).total_seconds()
+def get_minute_df(
+    symbol: str,
+    start_dt: datetime | date | str,
+    end_dt: datetime | date | str,
+    *,
+    retries: int = 3,
+    backoff_s: float = 0.2,
+) -> pd.DataFrame:
+    """Fetch minute-level bars for ``symbol``."""  # AI-AGENT-REF: bounded retry
+    start_s = ensure_rfc3339(start_dt)
+    end_s = ensure_rfc3339(end_dt)
+    client = _client()
+    fn = getattr(client, "get_stock_bars", None) or getattr(client, "get_bars", None)
+    if fn is None:
+        raise RuntimeError("DATA_CLIENT missing get_stock_bars/get_bars")
+    last_exc: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            return fn(symbol=symbol, timeframe="1Min", start=start_s, end=end_s, limit=None)
+        except Exception as e:  # pragma: no cover - network mocked
+            last_exc = e
+            if "Invalid format for parameter" in str(e) or attempt >= retries:
+                raise
+            time.sleep(backoff_s)
+    raise last_exc or RuntimeError("get_minute_df failed")

--- a/ai_trading/data_validation.py
+++ b/ai_trading/data_validation.py
@@ -82,6 +82,4 @@ def validate_trading_data(
     """Basic sanity checks for OHLCV dataframes."""
     if df is None or df.shape[0] < min_rows:
         return False
-    if not allow_na and df.isna().any().any():
-        return False
-    return True
+    return not (not allow_na and df.isna().any().any())

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from functools import lru_cache
 from typing import Any
 
 from pydantic import Field, SecretStr, computed_field, field_validator
@@ -182,17 +183,10 @@ class Settings(BaseSettings):
     )  # AI-AGENT-REF: AI_TRADER_ env prefix
 
 
-_SETTINGS_SINGLETON: Settings | None = None
-
-
+@lru_cache
 def get_settings() -> Settings:
-    """Cached settings accessor."""  # AI-AGENT-REF: cache settings
-    global _SETTINGS_SINGLETON
-    if _SETTINGS_SINGLETON is None:
-        _SETTINGS_SINGLETON = (
-            Settings()
-        )  # pydantic-settings auto-loads .env when present
-    return _SETTINGS_SINGLETON
+    """Cached settings accessor."""  # AI-AGENT-REF: lru_cache singleton
+    return Settings()
 
 
 def get_news_api_key() -> str | None:
@@ -202,7 +196,7 @@ def get_news_api_key() -> str | None:
 
 def get_rebalance_interval_min() -> int:
     """Lazy accessor for rebalance interval."""
-    return int(get_settings().rebalance_interval_min)
+    return get_settings().rebalance_interval_min
 
 
 # ---- Lazy getters (access only at runtime; never at module import) ----

--- a/ai_trading/shutdown_handler.py
+++ b/ai_trading/shutdown_handler.py
@@ -74,10 +74,6 @@ class ShutdownStatus:
 class ShutdownHandler:
     """Comprehensive shutdown handler for trading system."""
 
-    _pre_shutdown_hooks: list[Callable[[], None]] | None = (
-        None  # AI-AGENT-REF: avoid mutable class defaults
-    )
-
     def __init__(self):
         self.logger = logger
         self._status = ShutdownStatus(
@@ -173,9 +169,7 @@ class ShutdownHandler:
         self._position_handlers.append(handler)
         self.logger.debug(f"Registered position handler: {handler.__name__}")
 
-    def register_order_handler(
-        self, handler: Callable[[], list[dict[str, Any]]]
-    ) -> None:
+    def register_order_handler(self, handler: Callable) -> None:
         """Register an order handler that returns list of orders to cancel."""
         self._order_handlers.append(handler)
         self.logger.debug(f"Registered order handler: {handler.__name__}")
@@ -414,9 +408,7 @@ class ShutdownHandler:
                     self._status.errors.append(f"Order cancel error: {e}")
                     continue
 
-            success_rate = self._status.orders_canceled / max(
-                self._status.orders_to_cancel, 1
-            )
+            success_rate = self._status.orders_canceled / max(self._status.orders_to_cancel, 1)
             self.logger.info(
                 f"Canceled {self._status.orders_canceled}/{self._status.orders_to_cancel} orders ({success_rate:.1%})"  # noqa: E501
             )
@@ -476,9 +468,7 @@ class ShutdownHandler:
                     self._status.errors.append(f"Position close error: {e}")
                     continue
 
-            success_rate = self._status.positions_closed / max(
-                self._status.positions_to_close, 1
-            )
+            success_rate = self._status.positions_closed / max(self._status.positions_to_close, 1)
             self.logger.info(
                 f"Closed {self._status.positions_closed}/{self._status.positions_to_close} positions ({success_rate:.1%})"  # noqa: E501
             )
@@ -508,16 +498,13 @@ class ShutdownHandler:
         """Save complete system state."""
         try:
             state_file = (
-                Path("logs")
-                / f"shutdown_state_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}.json"
+                Path("logs") / f"shutdown_state_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}.json"
             )
             state_file.parent.mkdir(exist_ok=True)
 
             state_data = {
                 "shutdown_info": {
-                    "reason": (
-                        self._status.reason.value if self._status.reason else None
-                    ),
+                    "reason": (self._status.reason.value if self._status.reason else None),
                     "timestamp": datetime.now(UTC).isoformat(),
                     "phase": self._status.phase.value,
                     "positions_status": {
@@ -552,8 +539,7 @@ class ShutdownHandler:
         """Save only critical state for emergency shutdown."""
         try:
             state_file = (
-                Path("logs")
-                / f"emergency_state_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}.json"
+                Path("logs") / f"emergency_state_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}.json"
             )
             state_file.parent.mkdir(exist_ok=True)
 

--- a/ai_trading/tools/validate_env.py
+++ b/ai_trading/tools/validate_env.py
@@ -17,18 +17,17 @@ def _validate() -> tuple[bool, list[str]]:
     return (not missing, missing)
 
 
-def _main() -> int:
+def _main(argv: list[str] | None = None) -> int:
     ok, missing = _validate()
     if ok:
-        print("environment ok")  # noqa: T201
         return 0
     print("missing vars: " + ",".join(missing))  # noqa: T201
     return 1
 
 
-def main() -> int:
-    return _main()
+def main(argv: list[str] | None = None) -> int:
+    return _main(argv)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
-    _main()
+    raise SystemExit(_main())

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -7,7 +7,7 @@ Unified utilities export layer.
 Only re-export light symbols needed by production modules to avoid import-time heaviness.
 """
 import os
-from typing import Any, Final
+from typing import Any
 
 import pandas as pd
 
@@ -44,24 +44,26 @@ from .process_manager import acquire_lock, file_lock, release_lock
 from .time import now_utc
 from .timing import sleep  # AI-AGENT-REF: test-aware timing helpers
 
+
 # Shared timeout knobs
-HTTP_TIMEOUT_S: Final[int] = int(os.getenv("HTTP_TIMEOUT_S", "10") or 10)
-DEFAULT_SUBPROCESS_TIMEOUT_S: Final[int] = int(
-    os.getenv("SUBPROCESS_TIMEOUT_S", "10") or 10
-)
+DEFAULT_HTTP_TIMEOUT_S: float = float(os.getenv("HTTP_TIMEOUT_S", "10") or 10)
+SUBPROCESS_TIMEOUT_S: float = float(os.getenv("SUBPROCESS_TIMEOUT_S", "10") or 10)
+
+# Backwards compatibility aliases
+HTTP_TIMEOUT_S = DEFAULT_HTTP_TIMEOUT_S  # AI-AGENT-REF: legacy name
+DEFAULT_SUBPROCESS_TIMEOUT_S = SUBPROCESS_TIMEOUT_S
 
 
 def clamp_timeout(
-    value: float | int | None, *, low: float = 1, high: float = 60
+    value: float | None,
+    *,
+    default: float = DEFAULT_HTTP_TIMEOUT_S,
+    lo: float = 1.0,
+    hi: float = 60.0,
 ) -> float:
-    """Clamp timeout between ``low`` and ``high`` seconds."""
-    if value is None:
-        return float(HTTP_TIMEOUT_S)
-    try:
-        v = float(value)
-    except Exception:  # pragma: no cover - defensive
-        v = float(HTTP_TIMEOUT_S)
-    return max(low, min(high, v))
+    """Clamp timeout between ``lo`` and ``hi`` seconds."""
+    v = default if value is None else float(value)
+    return max(lo, min(hi, v))
 
 
 import ai_trading.utils.process_manager as process_manager  # noqa: E402
@@ -100,6 +102,6 @@ __all__ = [
     "get_ohlcv_columns",
     "ensure_utc_index",
     "process_manager",
-    "HTTP_TIMEOUT_S",
-    "DEFAULT_SUBPROCESS_TIMEOUT_S",
+    "DEFAULT_HTTP_TIMEOUT_S",
+    "SUBPROCESS_TIMEOUT_S",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,15 +104,14 @@ rl = [  # AI-AGENT-REF: optional RL dependencies
 ]
 
 [tool.black]
-line-length = 88
+line-length = 100
 target-version = ["py311"]
 
 [tool.ruff]
-line-length = 88
-target-version = "py311"
+line-length = 100
 
 [tool.ruff.lint]
-extend-select = ["F", "E", "W", "I", "UP", "B"]
+select = ["E", "F", "I", "B", "UP", "SIM"]
 ignore = [
     "S101",  # assert found - common in tests
     "S603",  # subprocess without shell=False check (handled by guard)

--- a/validate_env.py
+++ b/validate_env.py
@@ -2,4 +2,4 @@
 from ai_trading.tools.validate_env import _main
 
 if __name__ == "__main__":
-    _main()
+    raise SystemExit(_main())


### PR DESCRIPTION
## Summary
- ensure data_fetcher exports stable client helpers with UTC handling
- add robust alpaca API helpers with retry and client order IDs
- align settings, timeouts, and validate_env entrypoint for consistent runtime

## Testing
- `pre-commit run --files ai_trading/core/__init__.py ai_trading/data_fetcher/__init__.py ai_trading/alpaca_api.py ai_trading/core/bot_engine.py ai_trading/analysis/sentiment.py ai_trading/shutdown_handler.py ai_trading/data_validation.py ai_trading/execution/engine.py ai_trading/utils/__init__.py ai_trading/tools/validate_env.py pyproject.toml validate_env.py`
- `pytest -q tests/test_critical_datetime_fixes.py tests/test_alpaca_import.py tests/test_alpaca_api_module.py tests/test_alpaca_api_extended.py tests/test_alpaca_contract.py tests/test_client_order_id.py -vv` *(fails: ModuleNotFoundError: ai_trading.core.bot_engine::TestMetaLearningDataFetching::test_metalearn_invalid_prices_prevention)*
- `pytest -q -n 0 -k 'additional_coverage' -vv` *(fails: ModuleNotFoundError: cachetools in tests/institutional/test_live_trading.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a12088aad4833099a1656f626e4b9b