### PR TITLE
feat: stabilize data utils and alpaca helpers

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -55,6 +55,11 @@ def submit_order(api: Any, req: Any, *, timeout: float | None = None) -> Any:
     for attempt in range(max_tries):
         try:
             resp = api.submit_order(**payload, timeout=timeout_v)
+            status = getattr(resp, "status_code", None)
+            if status in RETRYABLE_HTTP_STATUSES and attempt < max_tries - 1:
+                time.sleep(backoff)
+                backoff *= 2
+                continue
             if isinstance(resp, dict):
                 return types.SimpleNamespace(**resp)
             return resp

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -1,51 +1,18 @@
-# ruff: noqa
+"""Lightweight utility exports with lazy submodule access.
+
+This module intentionally keeps imports minimal to avoid heavy import-time side
+effects.  Most helpers live in submodules such as :mod:`ai_trading.utils.base`
+or :mod:`ai_trading.utils.determinism` and are loaded on demand using
+``__getattr__``.  Only a couple of timeout constants and ``clamp_timeout`` are
+eagerly defined here.
+"""
+
 from __future__ import annotations
 
-"""Utility functions and helpers for the AI trading bot.
-
-Unified utilities export layer.
-Only re-export light symbols needed by production modules to avoid import-time heaviness.
-"""
 import os
+from importlib import import_module
 from typing import Any
 
-import pandas as pd
-
-from .base import (
-    EASTERN_TZ,
-    HAS_PANDAS,
-    ensure_utc,
-    ensure_utc_index,
-    get_free_port,
-    get_latest_close,
-    get_ohlcv_columns,
-    get_pid_on_port,
-    health_check,
-    is_market_holiday,
-    is_market_open,
-    is_weekend,
-    log_health_row_check,
-    log_warning,
-    model_lock,
-    portfolio_lock,
-    requires_pandas,
-    safe_to_datetime,
-    validate_ohlcv,
-    validate_ohlcv_basic,
-)
-from .determinism import (
-    ensure_deterministic_training,
-    get_model_spec,
-    lock_model_spec,
-    set_random_seeds,
-    unlock_model_spec,
-)
-from .process_manager import acquire_lock, file_lock, release_lock
-from .time import now_utc
-from .timing import sleep  # AI-AGENT-REF: test-aware timing helpers
-
-
-# Shared timeout knobs
 HTTP_TIMEOUT: float = float(os.getenv("HTTP_TIMEOUT", "10"))
 SUBPROCESS_TIMEOUT_S: float = float(os.getenv("SUBPROCESS_TIMEOUT_S", "5"))
 
@@ -57,59 +24,41 @@ def clamp_timeout(
     low: float = 0.1,
     high: float = 60.0,
 ) -> float:
-    """Clamp timeout to a safe float range."""
+    """Clamp ``t`` to a safe timeout value."""
+
     if t is None:
         return default
     return max(low, min(float(t), high))
 
 
-# Backwards compatibility aliases
-DEFAULT_HTTP_TIMEOUT = HTTP_TIMEOUT
-DEFAULT_SUBPROCESS_TIMEOUT = SUBPROCESS_TIMEOUT_S
-DEFAULT_HTTP_TIMEOUT_S = HTTP_TIMEOUT
-HTTP_TIMEOUT_S = HTTP_TIMEOUT
-DEFAULT_SUBPROCESS_TIMEOUT_S = SUBPROCESS_TIMEOUT_S
+__all__ = ["HTTP_TIMEOUT", "SUBPROCESS_TIMEOUT_S", "clamp_timeout"]
 
-
-import ai_trading.utils.process_manager as process_manager  # noqa: E402
-
-__all__ = [
-    "log_warning",
-    "model_lock",
-    "safe_to_datetime",
-    "validate_ohlcv",
-    "validate_ohlcv_basic",
-    "portfolio_lock",
-    "is_market_open",
-    "is_weekend",
-    "is_market_holiday",
-    "get_free_port",
-    "get_pid_on_port",
-    "log_health_row_check",
-    "pd",
-    "HAS_PANDAS",
-    "requires_pandas",
-    "set_random_seeds",
-    "ensure_deterministic_training",
-    "get_model_spec",
-    "lock_model_spec",
-    "unlock_model_spec",
-    "now_utc",
-    "sleep",
-    "clamp_timeout",
-    "acquire_lock",
-    "release_lock",
-    "file_lock",
-    "get_latest_close",
-    "EASTERN_TZ",
-    "health_check",
-    "ensure_utc",
-    "get_ohlcv_columns",
-    "ensure_utc_index",
+# Submodules imported lazily via ``__getattr__`` to preserve the old API while
+# keeping this module lightweight.  Only names listed here are exposed as
+# modules when accessed via ``from ai_trading.utils import <name>``.
+_LAZY_SUBMODULES = {
     "process_manager",
-    "DEFAULT_HTTP_TIMEOUT",
-    "DEFAULT_SUBPROCESS_TIMEOUT",
-    "DEFAULT_HTTP_TIMEOUT_S",
-    "SUBPROCESS_TIMEOUT_S",
-    "HTTP_TIMEOUT",
-]
+    "http",
+    "paths",
+    "workers",
+    "memory_optimizer",
+}
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin passthrough
+    if name in _LAZY_SUBMODULES:
+        return import_module(f"{__name__}.{name}")
+    # Fallback to attributes from ``base`` and ``determinism`` for backwards
+    # compatibility.  These imports happen lazily to keep import time minimal.
+    for mod_name in ("base", "determinism", "timing"):
+        try:
+            mod = import_module(f"{__name__}.{mod_name}")
+            if hasattr(mod, name):
+                return getattr(mod, name)
+        except Exception:  # pragma: no cover - optional dependency
+            continue
+    raise AttributeError(name) from None
+
+
+def __dir__() -> list[str]:  # pragma: no cover - simple namespace helper
+    return sorted(list(globals().keys()) + list(_LAZY_SUBMODULES))


### PR DESCRIPTION
## Summary
- make utils imports lazy and expose timeout helpers
- add shadow-mode Alpaca helpers with retries
- add sentiment fetcher cache and Alpaca presence detection

## Testing
- `python tools/import_contract.py`
- `pre-commit run --files ai_trading/data_fetcher/__init__.py ai_trading/alpaca_api.py ai_trading/core/bot_engine.py ai_trading/data_validation.py ai_trading/execution/engine.py ai_trading/utils/__init__.py ai_trading/tools/validate_env.py pyproject.toml`
- `pytest -q -n 0 tests/test_alpaca_import.py -vv`
- `pytest -q -n 0 tests/test_critical_datetime_fixes.py::TestSentimentCaching::test_sentiment_cache_rate_limit_handling -vv`


------
https://chatgpt.com/codex/tasks/task_e_68a14219afe08330a31b8e475dda71c0