### PR TITLE
feat: centralize timeouts and lazy deps

### DIFF
--- a/ai_trading/analysis/sentiment.py
+++ b/ai_trading/analysis/sentiment.py
@@ -27,7 +27,7 @@ from ai_trading.logging import logger
 
 # AI-AGENT-REF: Import config
 from ai_trading.settings import get_news_api_key, get_settings
-from ai_trading.utils import HTTP_TIMEOUT_S  # AI-AGENT-REF: timeout helper
+from ai_trading.utils import HTTP_DEFAULT_TIMEOUT  # AI-AGENT-REF: timeout helper
 
 SENTIMENT_API_KEY = os.getenv("SENTIMENT_API_KEY", "")
 
@@ -220,7 +220,7 @@ def fetch_sentiment(ctx, ticker: str) -> float:
             f"q={ticker}&sortBy=publishedAt&language=en&pageSize=5"
             f"&apiKey={api_key}"
         )
-        resp = requests.get(url, timeout=HTTP_TIMEOUT_S)
+        resp = requests.get(url, timeout=HTTP_DEFAULT_TIMEOUT)
 
         # AI-AGENT-REF: Enhanced rate limiting detection and handling
         if resp.status_code == 429:
@@ -389,7 +389,7 @@ def _try_alternative_sentiment_sources(ticker: str) -> float | None:
 
     try:
         primary_url_full = f"{primary_url}?symbol={ticker}&apikey={primary_key}"
-        timeout_v = HTTP_TIMEOUT_S
+        timeout_v = HTTP_DEFAULT_TIMEOUT
         primary_resp = requests.get(primary_url_full, timeout=timeout_v)
         if primary_resp.status_code in {429, 500, 502, 503, 504} and alt_api_key and alt_api_url:
             time.sleep(0.5)
@@ -553,7 +553,7 @@ def fetch_form4_filings(ticker: str) -> list[dict]:
         headers = {"User-Agent": "AI Trading Bot"}
         backoff = 0.5
         for attempt in range(3):
-            r = requests.get(url, headers=headers, timeout=HTTP_TIMEOUT_S)
+            r = requests.get(url, headers=headers, timeout=HTTP_DEFAULT_TIMEOUT)
             if r.status_code in {429, 500, 502, 503, 504} and attempt < 2:
                 time.sleep(backoff)
                 backoff *= 2

--- a/ai_trading/position/__init__.py
+++ b/ai_trading/position/__init__.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-try:  # pragma: no cover - best effort
-    from .regime import MarketRegime
-except Exception:  # pragma: no cover - fallback
+try:
+    from .regimes import MarketRegime  # real enum if available
+except Exception:  # noqa: BLE001
     from enum import Enum
 
     class MarketRegime(Enum):
         BULL = "bull"
         BEAR = "bear"
-        NEUTRAL = "neutral"
+        SIDEWAYS = "sideways"
 
 
 __all__ = ["MarketRegime"]

--- a/ai_trading/tools/validate_env.py
+++ b/ai_trading/tools/validate_env.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import json
+import os
 import sys
 
 
 def _main(argv: list[str] | None = None) -> int:
     argv = argv or sys.argv[1:]
-    # Minimal checks only
-    print("ENV_OK: true")
-    return 0
+    required = ["ALPACA_API_KEY", "ALPACA_SECRET_KEY"]
+    missing = [k for k in required if not os.getenv(k)]
+    print(json.dumps({"ok": not missing, "missing": missing}))
+    return 0 if not missing else 1
 
 
 if __name__ == "__main__":

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -1,31 +1,72 @@
 from __future__ import annotations
 
-HTTP_TIMEOUT_S: float = 10.0
-SUBPROCESS_TIMEOUT_S: float = 8.0
+import os
+
+# --- timeouts & clamps ---
+HTTP_DEFAULT_TIMEOUT: float = float(os.environ.get("AI_HTTP_TIMEOUT", "10"))  # seconds
+SUBPROCESS_DEFAULT_TIMEOUT: float = float(os.environ.get("AI_SUBPROC_TIMEOUT", "3"))
 
 
-def clamp_timeout(
-    v: float | int | None, *, lo: float = 0.1, hi: float = 60.0, default: float = 10.0
-) -> float:
-    if v is None:
-        return float(default)
+def clamp_timeout(value: float | int, min_s: float = 0.5, max_s: float = 60.0) -> float:
     try:
-        fv = float(v)
-    except Exception:
-        return float(default)
-    return max(lo, min(hi, fv))
+        v = float(value)
+    except Exception:  # noqa: BLE001
+        return HTTP_DEFAULT_TIMEOUT
+    return max(min_s, min(v, max_s))
 
 
+# Import only when actually needed to respect import contract
 def get_process_manager():
-    # Lazy import to honor import-contract
-    from . import process_manager  # type: ignore
+    from . import process_manager  # local import on demand
 
     return process_manager
 
 
 __all__ = [
-    "HTTP_TIMEOUT_S",
-    "SUBPROCESS_TIMEOUT_S",
+    "HTTP_DEFAULT_TIMEOUT",
+    "SUBPROCESS_DEFAULT_TIMEOUT",
     "clamp_timeout",
     "get_process_manager",
+    "log_warning",
+    "model_lock",
+    "safe_to_datetime",
+    "validate_ohlcv",
 ]
+
+
+def log_warning(*args, **kwargs):
+    from .base import log_warning as _log_warning
+
+    return _log_warning(*args, **kwargs)
+
+
+class _ModelLockProxy:
+    _lock = None
+
+    def _ensure(self):
+        if self._lock is None:
+            from .base import model_lock as _model_lock
+
+            self._lock = _model_lock
+        return self._lock
+
+    def __enter__(self):
+        return self._ensure().__enter__()
+
+    def __exit__(self, *args):
+        return self._ensure().__exit__(*args)
+
+
+model_lock = _ModelLockProxy()
+
+
+def safe_to_datetime(*args, **kwargs):
+    from .base import safe_to_datetime as _safe_to_datetime
+
+    return _safe_to_datetime(*args, **kwargs)
+
+
+def validate_ohlcv(*args, **kwargs):
+    from .base import validate_ohlcv as _validate_ohlcv
+
+    return _validate_ohlcv(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,4 +111,4 @@ line-length = 100
 line-length = 100
 
 [tool.ruff.lint]
-extend-select = ["I", "UP", "B", "C90"]
+extend-select = ["E", "F", "I", "UP", "SIM", "B", "BLE"]

--- a/tests/test_alpaca_api_module.py
+++ b/tests/test_alpaca_api_module.py
@@ -1,57 +1,44 @@
 import types
 
-import pytest
-
-try:
-    from ai_trading import alpaca_api  # AI-AGENT-REF: canonical import
-except Exception:
-    pytest.skip("alpaca_api not available", allow_module_level=True)
+from ai_trading import alpaca_api
 
 
 class DummyAPI:
-    def __init__(self):
+    def __init__(self, fail_status: int | None = None):
         self.calls = 0
+        self.fail_status = fail_status
 
     def submit_order(self, **order_data):
         self.calls += 1
-        if self.calls == 1:
-            return types.SimpleNamespace(status_code=429)
-        return types.SimpleNamespace(id=1, **order_data)
-
-
-def make_req():
-    return types.SimpleNamespace(symbol="AAPL", qty=1, side="buy", time_in_force="day")
+        if self.fail_status and self.calls == 1:
+            err = Exception("fail")
+            err.status = self.fail_status
+            raise err
+        return types.SimpleNamespace(id="123", **order_data)
 
 
 def test_submit_order_shadow(monkeypatch):
     api = DummyAPI()
     monkeypatch.setattr(alpaca_api, "SHADOW_MODE", True)
-    result = alpaca_api.submit_order(api, make_req())
-    assert result.id == "dry-run"
-    assert result.status == "accepted"
+    res = alpaca_api.submit_order(api, symbol="AAPL", qty=1, side="buy")
+    assert res.success
+    assert res.order_id.startswith("dryrun")
     assert api.calls == 0
 
 
 def test_submit_order_missing_submit(monkeypatch):
     monkeypatch.setattr(alpaca_api, "SHADOW_MODE", False)
-    api = object()  # lacks submit_order
-    result = alpaca_api.submit_order(api, make_req())
-    assert result.id == "dry-run"
-    assert result.status == "accepted"
+    api = object()
+    res = alpaca_api.submit_order(api, symbol="AAPL", qty=1, side="buy")
+    assert res.success
+    assert res.order_id.startswith("dryrun")
 
 
 def test_submit_order_rate_limit(monkeypatch):
-    api = DummyAPI()
     monkeypatch.setattr(alpaca_api, "SHADOW_MODE", False)
-    monkeypatch.setattr(
-        alpaca_api.requests,
-        "exceptions",
-        types.SimpleNamespace(HTTPError=Exception),
-        raising=False,
-    )
-    sleeps = []
-    monkeypatch.setattr(alpaca_api.time, "sleep", lambda s: sleeps.append(s))
-    result = alpaca_api.submit_order(api, make_req())
-    assert getattr(result, "id", None) == 1
-    assert api.calls == 2
-    assert sleeps
+    api = DummyAPI(fail_status=429)
+    res = alpaca_api.submit_order(api, symbol="AAPL", qty=1, side="buy")
+    assert not res.success
+    assert res.retryable
+    assert res.status == 429
+    assert api.calls == 1

--- a/tests/test_minute_cache_helpers.py
+++ b/tests/test_minute_cache_helpers.py
@@ -1,7 +1,8 @@
 from datetime import UTC, datetime
 
 from ai_trading.data_fetcher import (
-    age_cached_minute_timestamp,
+    _MINUTE_CACHE,  # type: ignore
+    age_cached_minute_timestamps,
     clear_cached_minute_timestamp,
     get_cached_minute_timestamp,
     set_cached_minute_timestamp,
@@ -20,13 +21,15 @@ def test_set_and_get() -> None:
     assert get_cached_minute_timestamp("AAPL") == ts
 
 
-def test_age_cached_minute_timestamp() -> None:
+def test_age_cached_minute_timestamps() -> None:
     now = int(datetime.now(UTC).timestamp())
     earlier = now - 30
     set_cached_minute_timestamp("MSFT", earlier)
-    age = age_cached_minute_timestamp("MSFT", now_ts=now)
-    assert age is not None
-    assert 29 <= age <= 31
+    # simulate old insertion
+    _MINUTE_CACHE["MSFT"] = (earlier, now - 30)
+    removed = age_cached_minute_timestamps(max_age_seconds=10)
+    assert removed == 1
+    assert get_cached_minute_timestamp("MSFT") is None
 
 
 def test_clear_cached_timestamp() -> None:


### PR DESCRIPTION
## Summary
- centralize HTTP/subprocess timeouts and expose lazy utilities
- add UTC-aware data fetching cache helpers and Alpaca API submit wrapper
- improve import guards and validation helpers

## Testing
- `python tools/import_contract.py`
- `pytest -q -n 0 -vv -s tests/test_minute_cache_helpers.py`
- `pytest -q -n 0 -vv -s tests/test_alpaca_api_module.py tests/test_alpaca_api_extended.py`
- `pytest -q -n 0 -vv -s tests/test_critical_datetime_fixes.py` *(fails: ImportError: cannot import name 'REGISTRY' from 'prometheus_client')*
- `pytest -q -n 0 -vv -s tests/test_alpaca_import.py tests/test_alpaca_import_handling.py` *(fails: ImportError: cannot import name 'REGISTRY' from 'prometheus_client')*
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_68a16a1ffffc83309b5c7d7ccf5bac58