### PR TITLE
fix: lazy process manager and test runner config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: init test lint verify test-all contract
 
+PYTEST_N ?= 0
+
 init:
 	python tools/check_python_version.py
 	python -m pip install --upgrade pip setuptools wheel
@@ -14,7 +16,7 @@ init:
 	python -m pip install "joblib>=1.3,<2"
 
 test: contract
-	PYTHONPATH=. pytest -q -n auto --maxfail=20 --disable-warnings
+	PYTHONPATH=. pytest -q -n $(PYTEST_N) --maxfail=20 --disable-warnings
 
 contract:
 	python tools/import_contract.py

--- a/ai_trading/audit.py
+++ b/ai_trading/audit.py
@@ -36,7 +36,8 @@ def log_trade(symbol, qty, side, fill_price, status="filled", extra_info="", tim
                 "reward": "",
             })
     except PermissionError:
-        from ai_trading.utils import process_manager
+        import importlib
+        process_manager = importlib.import_module("ai_trading.utils.process_manager")
 
         process_manager.fix_file_permissions(path)
         logger.warning("ProcessManager attempted to fix permissions", extra={"path": str(path)})

--- a/ai_trading/data_fetcher/__init__.py
+++ b/ai_trading/data_fetcher/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "set_cached_minute_timestamp",
     "clear_minute_cache",
     "age_minute_cache",
+    "last_minute_bar_age_seconds",
     "retry",
     "FINNHUB_AVAILABLE",
 ]
@@ -84,6 +85,17 @@ def age_minute_cache(max_age_seconds: int) -> int:
                 _MINUTE_CACHE.pop(k, None)
                 removed += 1
     return removed
+
+
+def last_minute_bar_age_seconds(symbol: str) -> int:
+    """Return age in seconds of latest cached minute bar for ``symbol``; 0 if unknown."""
+    ts = get_cached_minute_timestamp(symbol)
+    if ts is None:
+        return 0
+    try:
+        return int(datetime.now(UTC).timestamp() - ts)
+    except Exception:
+        return 0
 
 
 # Backwards compat aliases

--- a/ai_trading/position/__init__.py
+++ b/ai_trading/position/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 try:
-    from .core import MarketRegime  # AI-AGENT-REF: real enum if available
+    from .market_regime import MarketRegime  # AI-AGENT-REF: real enum if available
 except Exception:  # noqa: BLE001
     from enum import Enum
 


### PR DESCRIPTION
## Summary
- lazily load `process_manager` and expose lock helpers via thin wrappers
- make audit's permission fixer import process_manager dynamically
- allow overriding test parallelism with `PYTEST_N`
- export `last_minute_bar_age_seconds` from `data_fetcher` and re-export `MarketRegime`

## Testing
- `python tools/import_contract.py`
- `pre-commit run -a || true`
- `pytest -n 0 -q tests/test_critical_datetime_fixes.py` *(fails: int() argument must be a string, a bytes-like object or a real number, not 'FieldInfo')*
- `pytest -n ${PYTEST_N:-0} -q --maxfail=20 --disable-warnings` *(fails: multiple ModuleNotFoundError errors and TypeError in settings)*


------
https://chatgpt.com/codex/tasks/task_e_68a1dd512e2c8330a5c51f781f7c1d66