### PR TITLE
fix: stabilize submit_order and data helpers

### DIFF
--- a/ai_trading/__init__.py
+++ b/ai_trading/__init__.py
@@ -1,5 +1,4 @@
-"""
-AI Trading Bot Module - Institutional Grade Trading Platform
+"""AI Trading Bot Module - Institutional Grade Trading Platform
 
 This module contains the core trading bot functionality and institutional-grade
 components for professional trading operations including:
@@ -15,16 +14,48 @@ The platform is designed for institutional-scale operations with proper
 risk controls, monitoring, and compliance capabilities.
 """
 
+from __future__ import annotations
+
+import importlib.util as _ils
+import os as _os
+import sys as _sys
+
+from .data_fetcher import _MINUTE_CACHE, YFIN_AVAILABLE
+
 __version__ = "2.0.0"
 
+
+def _module_ok(name: str) -> bool:  # AI-AGENT-REF: lightweight optional import check
+    try:
+        return _ils.find_spec(name) is not None
+    except Exception:  # noqa: BLE001
+        return False
+
+
+ALPACA_AVAILABLE = any(
+    [
+        _module_ok("alpaca"),
+        _module_ok("alpaca_trade_api"),
+        _module_ok("alpaca.trading"),
+        _module_ok("alpaca.data"),
+    ]
+) and _os.environ.get("TESTING", "").lower() not in {"1", "true:force_unavailable"}
+
+FINNHUB_AVAILABLE = _module_ok("finnhub")
+
 # Import-light init - only expose version and basic metadata
-__all__ = ["__version__"]
-import sys as _sys
+__all__ = [
+    "__version__",
+    "_MINUTE_CACHE",
+    "ALPACA_AVAILABLE",
+    "FINNHUB_AVAILABLE",
+    "YFIN_AVAILABLE",
+]
 
 # AI-AGENT-REF: expose validate_env module at top-level for tests
 try:
     from .tools import validate_env as _validate_env_mod
 
     _sys.modules.setdefault("validate_env", _validate_env_mod)
-except Exception:
+except Exception:  # pragma: no cover  # noqa: BLE001
     pass

--- a/ai_trading/data_validation.py
+++ b/ai_trading/data_validation.py
@@ -41,7 +41,10 @@ def check_data_freshness(
 def get_stale_symbols(
     data_map: Mapping[str, object], *, max_staleness_minutes: int = 15
 ) -> list[str]:
-    """Return symbols whose data is stale."""  # AI-AGENT-REF: accepts legacy shapes
+    """Return symbols whose data is stale.
+
+    Accepts either ``{sym: DataFrame}`` or ``{sym: info mapping}``.
+    """  # AI-AGENT-REF: accepts legacy shapes
     out: list[str] = []
     for sym, info in (data_map or {}).items():
         if isinstance(info, Mapping):
@@ -75,29 +78,33 @@ def validate_trading_data(
 
 
 def emergency_data_check(
-    data_or_symbols: Sequence[str] | pd.DataFrame,
-    symbol: str | None = None,
+    arg1,
+    arg2: str | None = None,
+    *,
     fetcher: Callable[..., pd.DataFrame] | None = None,
 ) -> bool:
-    """Flexible emergency data check for legacy call patterns."""
-    if isinstance(data_or_symbols, pd.DataFrame):
-        return data_or_symbols is not None and not data_or_symbols.empty
-    symbols = list(data_or_symbols)
+    """Probe recent minute bars for emergency data availability.
+
+    Supports both call patterns:
+      - Legacy: ``emergency_data_check(df, "AAPL")``
+      - New: ``emergency_data_check(["AAPL", "MSFT"], fetcher=get_bars)``
+    """
+    if isinstance(arg1, pd.DataFrame) and isinstance(arg2, str):
+        return not arg1.empty
+
+    if isinstance(arg1, Sequence) and not isinstance(arg1, (str, bytes)):  # noqa: UP038
+        symbols = list(arg1)
+    else:
+        symbols = [str(arg1)]
+
     fetch = fetcher or get_bars
     end = datetime.now(UTC)
     start = end - timedelta(minutes=1)
     for sym in symbols:
         try:
-            # Try common call shapes without penalizing callers
-            try:
-                df = fetch(sym, "1Min", start, end)
-            except TypeError:
-                try:
-                    df = fetch(sym, start, end)  # legacy shape
-                except TypeError:
-                    df = fetch(sym, start=start, end=end)
-            if df is not None and not df.empty:
-                return True
+            df = fetch(sym, "1Min", start, end)
+            if df is None or df.empty:
+                return False
         except Exception:  # noqa: BLE001
-            pass
-    return False
+            return False
+    return True


### PR DESCRIPTION
## Summary
- make Alpaca submit_order resilient to missing API methods and always yield broker/client IDs
- relax data validation helpers for legacy & new call patterns
- surface availability flags and minute cache at package root for tests

## Testing
- `ruff check ai_trading/alpaca_api.py ai_trading/data_validation.py ai_trading/__init__.py --fix`
- `black ai_trading/alpaca_api.py ai_trading/data_validation.py ai_trading/__init__.py`
- `pytest tests/test_alpaca_api_module.py::test_submit_order_missing_submit tests/test_critical_fixes.py::test_data_validation_emergency_check tests/test_cli_smoke.py::test_ai_trade_dry_run_exits_zero -q`
- `python -m ai_trading.__main__ --dry-run --symbols AAPL,MSFT`


------
https://chatgpt.com/codex/tasks/task_e_68a262cbe6508330aca307b702a8de76