### PR TITLE
Harden imports, unify Alpaca flag, standardize timeouts, and fix packaging

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,12 @@
+name: smoke
+on: [push, pull_request]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: pip install -U pip
+      - run: pip install .[base] || pip install .
+      - run: python -c "import ai_trading; import ai_trading.core.bot_engine; print('IMPORT_OK')"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ cd ai-trading-bot
 # Install Python dependencies (ta library included)
 pip install -r requirements.txt
 
+# Optional extras for broker/calendar features
+# pip install .[markets,broker]
+
 # Alternative automated setup
 make install-dev
 make validate-env

--- a/ai_trading/__init__.py
+++ b/ai_trading/__init__.py
@@ -1,47 +1,18 @@
-"""AI Trading Bot Module - Institutional Grade Trading Platform
-
-This module contains the core trading bot functionality and institutional-grade
-components for professional trading operations including:
-
-- Core trading enums and constants
-- Database models and connection management
-- Kelly Criterion risk management
-- Strategy framework and execution engine
-- Performance monitoring and alerting
-- Institutional-grade order management
-
-The platform is designed for institutional-scale operations with proper
-risk controls, monitoring, and compliance capabilities.
-"""
+"""Top-level package for ai_trading with light optional imports."""  # AI-AGENT-REF
 
 from __future__ import annotations
 
-import importlib.util as _ils
 import os as _os
 import sys as _sys
 
 __version__ = "2.0.0"
 
+from ai_trading.utils.optdeps import module_ok as _module_ok
 
-def _module_ok(name: str) -> bool:  # AI-AGENT-REF: lightweight optional import check
-    try:
-        return _ils.find_spec(name) is not None
-    except Exception:  # noqa: BLE001
-        return False
-
-
-ALPACA_AVAILABLE = any(
-    [
-        _module_ok("alpaca"),
-        _module_ok("alpaca_trade_api"),
-        _module_ok("alpaca.trading"),
-        _module_ok("alpaca.data"),
-    ]
-) and _os.environ.get("TESTING", "").lower() not in {"1", "true:force_unavailable"}
+from .alpaca_api import ALPACA_AVAILABLE  # AI-AGENT-REF: canonical flag
 
 FINNHUB_AVAILABLE = _module_ok("finnhub")
 
-# Import-light init - only expose version and basic metadata
 __all__ = [
     "__version__",
     "ALPACA_AVAILABLE",
@@ -63,9 +34,9 @@ def __getattr__(name: str):  # AI-AGENT-REF: lazy data_fetcher exposure
 
 
 # AI-AGENT-REF: expose validate_env module at top-level for tests
-try:
+try:  # pragma: no cover
     from .tools import validate_env as _validate_env_mod
 
     _sys.modules.setdefault("validate_env", _validate_env_mod)
-except Exception:  # pragma: no cover  # noqa: BLE001
+except Exception:  # noqa: BLE001
     pass

--- a/ai_trading/execution/production_engine.py
+++ b/ai_trading/execution/production_engine.py
@@ -12,11 +12,15 @@ from typing import Any
 
 # Use the centralized logger as per AGENTS.md
 from ai_trading.logging import logger
-try:
-    from alpaca_trade_api.rest import APIError  # AI-AGENT-REF: guard Alpaca dependency
+
+try:  # AI-AGENT-REF: resilient Alpaca import
+    from alpaca.common.exceptions import APIError  # type: ignore
+    from alpaca.trading.client import TradingClient  # type: ignore  # noqa: F401
 except Exception:  # AI-AGENT-REF: local fallback when SDK missing
-    class APIError(Exception):
-        pass
+    TradingClient = None  # type: ignore
+
+    class APIError(Exception): ...
+
 
 from ..core.constants import EXECUTION_PARAMETERS
 from ..core.enums import OrderSide, OrderType, RiskLevel

--- a/ai_trading/utils/optdeps.py
+++ b/ai_trading/utils/optdeps.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+# AI-AGENT-REF: helpers for optional dependencies
+import importlib.util as _ils
+from types import ModuleType
+from typing import Optional
+
+
+def module_ok(name: str) -> bool:
+    """Return True if *name* can be imported."""  # AI-AGENT-REF: import guard
+    try:
+        return _ils.find_spec(name) is not None
+    except Exception:
+        return False
+
+
+def try_import(name: str) -> Optional[ModuleType]:
+    """Attempt to import *name*, returning module or None."""  # AI-AGENT-REF
+    try:
+        return __import__(name)
+    except Exception:
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ dependencies = [
     "pydantic-settings>=2.2,<3",
     "requests>=2.31,<3",
     "numpy>=1.24,<3.0",
-    "pandas>=2",
-    "scikit-learn>=1.4.2",
-    "pandas_market_calendars>=4.3",
+    "pandas>=1.5",
     "tenacity==8.2.2",
     "ratelimit==2.2.1",
     "ta==0.11.0",
@@ -20,29 +18,22 @@ dependencies = [
     "tzlocal==4.3",
     "pyarrow>=12.0.0",
     "pandas_ta==0.3.14b0",
-    "beautifulsoup4>=4.11.1",
     "flask>=2.3.0",
     "schedule>=1.1.0",
     "portalocker==2.7.0",
-    "alpaca-py>=0.42.0",
-    "hmmlearn>=0.3.0",
     "finnhub-python>=2.4.0",
-    "lightgbm>=4.2.1",
     "pybreaker==1.0.0",
     "pytz>=2024.1",
     "yfinance>=0.2.28",
     "websockets>=10.4,<11",
     "urllib3>=2.0,<3",
     "statsmodels>=0.14.1,<0.15",
-    "transformers==4.35.2",
-    "torch>=1.9.0",
     "python-dateutil>=2.9.0",
     "optuna==3.6.1",
     "stable-baselines3==2.3.2",
     "gymnasium==0.29.1",
     "psutil>=5.9.8",
     "filelock>=3.13.1",
-    "xgboost>=1.7.6",
     "lxml",
     "sqlalchemy>=2.0.0",
     "alembic>=1.12.0",
@@ -103,6 +94,11 @@ rl = [  # AI-AGENT-REF: optional RL dependencies
   "hmmlearn",
   "torch>=2.1; platform_system != 'Windows'",
 ]
+
+markets = ["pandas-market-calendars>=4.4"]
+broker = ["alpaca-py>=0.21"]
+nlp = ["transformers>=4.41", "torch>=2.2", "beautifulsoup4>=4.12"]
+ml = ["scikit-learn>=1.4", "xgboost>=2.0", "lightgbm>=4.2.1"]
 
 [tool.black]
 line-length = 88

--- a/tests/test_logging_scrubbed.py
+++ b/tests/test_logging_scrubbed.py
@@ -1,0 +1,13 @@
+import logging
+import os
+
+from ai_trading.logging import get_logger
+
+
+def test_no_secrets_in_logs(caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("NEWS_API_KEY", "TOPSECRETKEY")
+    logger = get_logger(__name__)
+    logger.info("boot with key=%s", os.getenv("NEWS_API_KEY"))
+    joined = "\n".join(m.message for m in caplog.records)
+    assert "TOPSECRETKEY" not in joined


### PR DESCRIPTION
## Summary
- Add optional dependency helper and reuse it across package init
- Normalize Alpaca submit_order return and guard Alpaca imports
- Make market calendar optional, add smoke CI, and split heavy extras

## Testing
- `ruff check ai_trading/__init__.py ai_trading/alpaca_api.py ai_trading/broker/alpaca.py ai_trading/core/bot_engine.py ai_trading/execution/live_trading.py ai_trading/execution/production_engine.py ai_trading/rebalancer.py ai_trading/risk/engine.py ai_trading/shutdown_handler.py ai_trading/signals.py ai_trading/utils/optdeps.py tests/test_logging_scrubbed.py` *(failure: F401, BLE001, etc.)*
- `black ai_trading/__init__.py ai_trading/alpaca_api.py ai_trading/broker/alpaca.py ai_trading/core/bot_engine.py ai_trading/execution/live_trading.py ai_trading/execution/production_engine.py ai_trading/rebalancer.py ai_trading/risk/engine.py ai_trading/shutdown_handler.py ai_trading/signals.py ai_trading/utils/optdeps.py tests/test_logging_scrubbed.py`
- `pytest -q tests/test_logging_scrubbed.py -q` *(missing dependency: pandas)*
- `python -c "import ai_trading; import ai_trading.core.bot_engine; print('OK')"` *(missing dependency: pydantic)*
- `pytest -q tests/test_alpaca_api_module.py::test_submit_order_missing_submit -q` *(missing dependency: pandas)*
- `pytest -n auto --disable-warnings` *(missing dependency: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b8c0a92483308269e857cb6c3be2