### PR TITLE
fix: add shadow submit fallback and explicit timeouts

### DIFF
--- a/ai_trading/audit.py
+++ b/ai_trading/audit.py
@@ -1,5 +1,4 @@
 import csv
-import csv
 import logging
 from pathlib import Path
 
@@ -8,12 +7,35 @@ logger = logging.getLogger(__name__)
 TRADE_LOG_FILE = "trades.csv"
 
 
-def log_trade(symbol, qty, side, fill_price, status="filled", extra_info="", timestamp=""):
+def fix_file_permissions(
+    path: str,
+) -> bool:  # AI-AGENT-REF: guard optional process_manager
+    from ai_trading.utils import process_manager
+
+    if hasattr(process_manager, "fix_file_permissions"):
+        process_manager.fix_file_permissions(path)
+    else:
+        return False
+    return True
+
+
+def log_trade(
+    symbol, qty, side, fill_price, status="filled", extra_info="", timestamp=""
+):
     path = Path(TRADE_LOG_FILE)
     headers = [
-        "symbol", "entry_time", "entry_price", "exit_time", "exit_price",
-        "qty", "side", "strategy", "classification", "signal_tags",
-        "confidence", "reward",
+        "symbol",
+        "entry_time",
+        "entry_price",
+        "exit_time",
+        "exit_price",
+        "qty",
+        "side",
+        "strategy",
+        "classification",
+        "signal_tags",
+        "confidence",
+        "reward",
     ]
     exists = path.exists()
     try:
@@ -21,22 +43,25 @@ def log_trade(symbol, qty, side, fill_price, status="filled", extra_info="", tim
             writer = csv.DictWriter(f, fieldnames=headers)
             if not exists:
                 writer.writeheader()
-            writer.writerow({
-                "symbol": symbol,
-                "entry_time": timestamp,
-                "entry_price": fill_price,
-                "exit_time": "",
-                "exit_price": "",
-                "qty": qty,
-                "side": side,
-                "strategy": extra_info,
-                "classification": "",
-                "signal_tags": "",
-                "confidence": "",
-                "reward": "",
-            })
+            writer.writerow(
+                {
+                    "symbol": symbol,
+                    "entry_time": timestamp,
+                    "entry_price": fill_price,
+                    "exit_time": "",
+                    "exit_price": "",
+                    "qty": qty,
+                    "side": side,
+                    "strategy": extra_info,
+                    "classification": "",
+                    "signal_tags": "",
+                    "confidence": "",
+                    "reward": "",
+                }
+            )
     except PermissionError:
-        from ai_trading.utils import process_manager
-
-        process_manager.fix_file_permissions(path)
-        logger.warning("ProcessManager attempted to fix permissions", extra={"path": str(path)})
+        if fix_file_permissions(path):
+            logger.warning(
+                "ProcessManager attempted to fix permissions",
+                extra={"path": str(path)},
+            )

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5645,6 +5645,7 @@ def get_sec_headlines(ctx: BotContext, ticker: str) -> str:
             f"https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany"
             f"&CIK={ticker}&type=8-K&count=5",
             headers={"User-Agent": "AI Trading Bot"},
+            timeout=HTTP_TIMEOUT,  # AI-AGENT-REF: explicit timeout
         )
         r.raise_for_status()
 
@@ -5775,7 +5776,7 @@ def _fetch_sentiment_ctx(ctx: BotContext, ticker: str) -> float:
             f"q={ticker}&sortBy=publishedAt&language=en&pageSize=5"
             f"&apiKey={api_key}"
         )
-        resp = http.get(url)
+        resp = http.get(url, timeout=HTTP_TIMEOUT)  # AI-AGENT-REF: explicit timeout
 
         if resp.status_code == 429:
             # AI-AGENT-REF: Enhanced rate limiting handling
@@ -5931,6 +5932,7 @@ def fetch_form4_filings(ticker: str) -> list[dict]:
     r = http.get(
         url,
         headers={"User-Agent": "AI Trading Bot"},
+        timeout=HTTP_TIMEOUT,  # AI-AGENT-REF: explicit timeout
     )
     r.raise_for_status()
     soup = BeautifulSoup(r.content, "lxml")

--- a/ai_trading/monitoring/alerting.py
+++ b/ai_trading/monitoring/alerting.py
@@ -5,7 +5,6 @@ Implements comprehensive alerting with email, SMS, and team notifications
 for critical trading events, system failures, and performance issues.
 """
 
-import logging
 import queue
 import smtplib
 import threading
@@ -17,11 +16,12 @@ from email.mime.text import MIMEText
 from enum import Enum
 from typing import Any
 
-from ai_trading.utils import http
-from ai_trading.utils.timing import clamp_timeout  # AI-AGENT-REF: avoid circular import
-
 # Use the centralized logger as per AGENTS.md
 from ai_trading.logging import logger
+from ai_trading.utils import http
+from ai_trading.utils.timing import (
+    HTTP_TIMEOUT,
+)  # AI-AGENT-REF: avoid circular import
 
 
 class AlertSeverity(Enum):
@@ -271,6 +271,7 @@ class SlackAlerter:
             response = http.post(
                 self.webhook_url,
                 json=payload,
+                timeout=HTTP_TIMEOUT,  # AI-AGENT-REF: explicit timeout
             )
             response.raise_for_status()
 


### PR DESCRIPTION
## Summary
- handle missing `submit_order` by returning a successful shadow response
- add explicit HTTP timeouts across API calls
- guard optional `process_manager.fix_file_permissions`

## Testing
- `ruff check ai_trading/alpaca_api.py ai_trading/monitoring/alerting.py ai_trading/core/bot_engine.py ai_trading/audit.py scripts/predict.py --fix` *(fails: BLE001 Do not catch blind exception: `Exception`)*
- `black ai_trading/alpaca_api.py ai_trading/audit.py ai_trading/core/bot_engine.py ai_trading/monitoring/alerting.py scripts/predict.py`
- `pytest tests/test_alpaca_api_module.py::test_submit_order_missing_submit -q` *(fails: logging errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a33137f79c8330a59c9298245a4ebb