### PR TITLE
fix: repair pybreaker stub and add compile test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
   - **Breaking**: Root imports are no longer supported as of this version
 
 ### Fixed
+- Fix IndentationError in `bot_engine.py` (pybreaker stub); add static compile guard.
 - **Runtime safety**: improved Alpaca availability checks, stable logging shutdown,
   lazy client init, config parity, and added utility/environment helpers.
 - **ExecutionEngine**: Removed unsupported slippage metrics kwargs from initialization to prevent runtime `TypeError`.

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1433,16 +1433,16 @@ except Exception:  # pragma: no cover - fallback
 
     class pybreaker:  # type: ignore
             class CircuitBreaker:
-            def __init__(self, *args, **kwargs):
-                pass
-            def call(self, func):
-                def _wrapped(*a, **kw):
-                    return func(*a, **kw)
+                def __init__(self, *args, **kwargs):
+                    pass
+                def call(self, func):
+                    def _wrapped(*a, **kw):
+                        return func(*a, **kw)
 
-                return _wrapped
+                    return _wrapped
 
-            def __call__(self, func):
-                return self.call(func)
+                def __call__(self, func):
+                    return self.call(func)
 
 
 # AI-AGENT-REF: optional prometheus_client dependency via shim

--- a/tests/test_static_compile.py
+++ b/tests/test_static_compile.py
@@ -1,0 +1,8 @@
+import compileall
+import pathlib
+
+
+def test_package_compiles():
+    """Statically compile the package to catch Syntax/Indentation errors early."""
+    pkg = pathlib.Path(__file__).resolve().parents[1] / "ai_trading"
+    assert compileall.compile_dir(str(pkg), quiet=1)


### PR DESCRIPTION
## Summary
- fix indentation in fallback pybreaker stub to restore bot engine import
- add static compile test to catch syntax errors early
- document fix and guard in changelog

## Testing
- `python -m compileall -q .`
- `ruff check ai_trading/core/bot_engine.py tests/test_static_compile.py --fix`
- `black --check ai_trading/core/bot_engine.py tests/test_static_compile.py` *(fails: would reformat)*
- `pytest -q tests/test_static_compile.py::test_package_compiles`
- `python -m ai_trading.__main__ --dry-run --symbols AAPL,MSFT`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68a34ae121a88330a8fff8d9282117b9