### PR TITLE
Normalize broker-unavailable contract; remove false PDT warnings; add regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
   - **Breaking**: Root imports are no longer supported as of this version
 
 ### Fixed
+- Normalize broker-unavailable contract; remove false PDT warnings; add regression tests.
 - Fix IndentationError in `bot_engine.py` (pybreaker stub); add static compile guard.
 - **Runtime safety**: improved Alpaca availability checks, stable logging shutdown,
   lazy client init, config parity, and added utility/environment helpers.

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -3103,11 +3103,13 @@ def get_circuit_breaker_health() -> dict:
 
 # Prometheus-safe account fetch with circuit breaker protection
 @alpaca_breaker
-def safe_alpaca_get_account(ctx: BotContext):
-    """Safely get account information."""
+def safe_alpaca_get_account(ctx: BotContext) -> object | None:
+    """Safely get Alpaca account; returns None when unavailable or on failure."""
     if ctx.api is None:
-        _log.warning("ctx.api is None - Alpaca trading client unavailable")
-        return False
+        _log.info(
+            "ctx.api is None - Alpaca trading client unavailable"
+        )  # AI-AGENT-REF: lowered log level for availability
+        return None
     try:
         return ctx.api.get_account()
     except (
@@ -3119,7 +3121,7 @@ def safe_alpaca_get_account(ctx: BotContext):
             "HEALTH_ACCOUNT_FETCH_FAILED",
             extra={"cause": e.__class__.__name__, "detail": str(e)},
         )
-        return False
+        return None  # AI-AGENT-REF: normalized None return on failure
 
 
 # ─── C. HELPERS ────────────────────────────────────────────────────────────────
@@ -6199,7 +6201,7 @@ def check_pdt_rule(runtime) -> bool:
     acct = safe_alpaca_get_account(runtime)
 
     # If account is unavailable (Alpaca not available), assume no PDT blocking
-    if acct is None:
+    if acct is None:  # AI-AGENT-REF: contract now explicit; keep None-check
         _log.info(
             "PDT_CHECK_SKIPPED - Alpaca unavailable, assuming no PDT restrictions"
         )

--- a/tests/test_broker_unavailable_paths.py
+++ b/tests/test_broker_unavailable_paths.py
@@ -1,0 +1,20 @@
+import logging
+from types import SimpleNamespace
+
+from ai_trading.core.bot_engine import check_pdt_rule, safe_alpaca_get_account
+
+
+def test_safe_account_none():
+    # AI-AGENT-REF: ensure None is returned when Alpaca client missing
+    ctx = SimpleNamespace(api=None)
+    assert safe_alpaca_get_account(ctx) is None
+
+
+def test_pdt_rule_skips_without_false_fail(caplog):
+    # AI-AGENT-REF: verify PDT check logs skip and not failure
+    ctx = SimpleNamespace(api=None)
+    with caplog.at_level(logging.INFO):
+        assert check_pdt_rule(ctx) is False
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("PDT" in m and "PPED" in m for m in msgs)
+    assert not any("PDT_CHECK_FAILED" in m for m in msgs)


### PR DESCRIPTION
## Summary
- normalize Alpaca account fetch to return None and log at info when unavailable
- keep explicit None check in PDT rule to skip false equity warnings
- add regression tests for broker-unavailable paths

## Testing
- `python -m pip install -U pip` *(already satisfied)*
- `python -m pip install -r requirements-test.txt`
- `python -m pip install -r requirements.txt`
- `python -m pip install pydantic`
- `python -m pip install cachetools`
- `python -m pip install scikit-learn`
- `python -m pip install portalocker`
- `python -m pip install pydantic-settings`
- `python -m compileall -q .`
- `ruff check ai_trading/core/bot_engine.py tests/test_broker_unavailable_paths.py --fix`
- `black ai_trading/core/bot_engine.py tests/test_broker_unavailable_paths.py`
- `pytest -q tests/test_broker_unavailable_paths.py::test_safe_account_none`
- `pytest -q tests/test_broker_unavailable_paths.py::test_pdt_rule_skips_without_false_fail`
- `pytest -n auto --disable-warnings` *(fails: logging stream closed)*
- `python -m ai_trading.__main__ --dry-run --symbols AAPL,MSFT` *(missing expected log output)*

------
https://chatgpt.com/codex/tasks/task_e_68a350b0bf1083308e181dd5693259be