### PR TITLE
Robust `.env` loading for systemd deploys + fix secret-masking crash in logger + explicit Alpaca env diagnostics

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1376,6 +1376,12 @@ def _require_cfg(value: str | None, name: str) -> str:
 
 # Defer credential checks to runtime (avoid import-time crashes before .env loads)
 def _resolve_alpaca_env():
+    # AI-AGENT-REF: ensure .env is loaded before resolving Alpaca environment
+    try:
+        from ai_trading.env import ensure_dotenv_loaded
+        ensure_dotenv_loaded()
+    except Exception:
+        pass
     key = os.getenv("ALPACA_API_KEY") or os.getenv("APCA_API_KEY_ID")
     secret = os.getenv("ALPACA_SECRET_KEY") or os.getenv("APCA_API_SECRET_KEY")
     base_url = (

--- a/ai_trading/env.py
+++ b/ai_trading/env.py
@@ -2,21 +2,76 @@ from __future__ import annotations
 
 import os
 
-from dotenv import load_dotenv
-
+from dotenv import find_dotenv, load_dotenv
 
 _ENV_LOADED = False
 
 
 def ensure_dotenv_loaded() -> None:
     """
-    Idempotently load .env early in process startup.
-    Tests assert MULTI_LOAD_TEST == 'safe_value' after multiple loads.
-    """
+    Idempotently load .env early in process startup **without** assuming it's in the repo.
+
+    Search order (first hit wins, non-destructive):
+      1) $DOTENV_PATH (if set)
+      2) autodetect via find_dotenv(usecwd=True)
+      3) CWD/.env
+      4) repo root (two levels up from this file)/.env
+      5) /etc/default/ai-trading  (common systemd EnvironmentFile style)
+      6) /etc/ai-trading.env
+      7) $HOME/.config/ai-trading/.env
+    Emits a once-per-process info line indicating which path (if any) was used.
+    """  # AI-AGENT-REF: search common droplet paths
     global _ENV_LOADED
-    # Always set/keep the sentinel to show safe multi-load behavior
     os.environ.setdefault("MULTI_LOAD_TEST", "safe_value")
     if _ENV_LOADED:
         return
-    load_dotenv()  # allow file to populate os.environ; non-destructive by default
+
+    candidates: list[str | None] = []
+    candidates.append(os.environ.get("DOTENV_PATH"))
+    auto = find_dotenv(usecwd=True)
+    if auto:
+        candidates.append(auto)
+    candidates.append(os.path.join(os.getcwd(), ".env"))
+    here = os.path.abspath(os.path.dirname(__file__))
+    repo_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
+    candidates.append(os.path.join(repo_root, ".env"))
+    candidates.extend([
+        "/etc/default/ai-trading",
+        "/etc/ai-trading.env",
+        os.path.expanduser("~/.config/ai-trading/.env"),
+    ])
+
+    loaded_from: str | None = None
+    for path in candidates:
+        if not path:
+            continue
+        try:
+            if os.path.exists(path):
+                if load_dotenv(dotenv_path=path, override=False):
+                    loaded_from = path
+                    break
+        except Exception:
+            continue
+
+    if not loaded_from:
+        try:
+            if load_dotenv():
+                loaded_from = "<autodetect>"
+        except Exception:
+            pass
+
     _ENV_LOADED = True
+
+    try:
+        from ai_trading.logging import get_logger, logger_once
+        get_logger(__name__)
+        if loaded_from:
+            logger_once.info(
+                "ENV_LOADED_FROM",
+                key=f"env_loaded:{loaded_from}",
+                extra={"dotenv_path": loaded_from},
+            )
+        else:
+            logger_once.info("ENV_NOT_FOUND", key="env_not_found")
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- harden lazy imports and add safe `_mask_secret` to prevent logging crashes
- search common droplet paths when loading `.env` and log chosen source
- load `.env` before resolving Alpaca credentials for clearer diagnostics

## Testing
- `ruff check ai_trading/logging.py ai_trading/env.py ai_trading/core/bot_engine.py`
- `python - <<'PY'
import py_compile, pathlib
fails=[]
for p in pathlib.Path('.').rglob('*.py'):
    try:
        py_compile.compile(str(p), doraise=True)
    except Exception as e:
        fails.append((str(p), e))
print('py_compile failures:', len(fails))
for f in fails:
    print(f)
PY`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68a381668e288330a23261a07b39b783