### PR TITLE
Expose MARKET_CALENDAR via Settings & TradingConfig

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -1526,6 +1526,8 @@ class TradingConfig(BaseModel):
         0.05, ge=0, le=1
     )  # AI-AGENT-REF: bounded dollar risk
     max_portfolio_risk: float = 0.10  # AI-AGENT-REF: portfolio risk cap
+    # AI-AGENT-REF: enable calendar configurability for optional mcal integration
+    market_calendar: str = "XNYS"
     max_position_size: float = 8000.0  # AI-AGENT-REF: default max position
     # Optional ML model hints (referenced by bot_engine for model loading)
     # These were previously relied upon via extra/overrides; make them explicit
@@ -1690,6 +1692,10 @@ class TradingConfig(BaseModel):
         base.buy_threshold = _env_or_get("BUY_THRESHOLD", get_buy_threshold)
         base.lookback_days = int(os.getenv("LOOKBACK_DAYS") or base.lookback_days)
         base.seed = int(os.getenv("SEED") or get_seed_int())
+        # AI-AGENT-REF: allow override via env; default stays XNYS
+        base.market_calendar = os.getenv(
+            "MARKET_CALENDAR", getattr(base, "market_calendar", "XNYS")
+        )
         if overrides:
             base = base.model_copy(update=overrides)
         return base

--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -31,6 +31,8 @@ class Settings(BaseSettings):
     """Minimal project settings for tests and CI."""
 
     env: str = Field(default="test", alias="APP_ENV")
+    # AI-AGENT-REF: allow market calendar override via droplet .env
+    market_calendar: str = Field(default="XNYS", alias="MARKET_CALENDAR")
     data_provider: str = Field(default="mock", alias="DATA_PROVIDER")
     log_level: str = Field(default="INFO", alias="LOG_LEVEL")
     enable_memory_optimization: bool = Field(default=True)

--- a/tests/test_runtime_params_hydration.py
+++ b/tests/test_runtime_params_hydration.py
@@ -45,6 +45,15 @@ def test_trading_config_from_env_loads_parameters():
         assert cfg.max_position_size == 2.0
 
 
+def test_trading_config_from_env_market_calendar(monkeypatch):
+    """TradingConfig.from_env picks up MARKET_CALENDAR."""  # AI-AGENT-REF
+    from ai_trading.config.management import TradingConfig
+
+    monkeypatch.setenv("MARKET_CALENDAR", "XNAS")
+    cfg = TradingConfig.from_env()
+    assert cfg.market_calendar == "XNAS"
+
+
 def test_build_runtime_hydrates_all_parameters():
     """Test that build_runtime creates runtime with all required parameters."""
     from ai_trading.core.runtime import build_runtime, REQUIRED_PARAM_DEFAULTS

--- a/tests/test_settings_config.py
+++ b/tests/test_settings_config.py
@@ -34,3 +34,10 @@ def test_worker_defaults_and_overrides(monkeypatch):
     s2 = Settings()
     assert s2.effective_executor_workers(8) == 3
     assert s2.effective_prediction_workers(8) == 5
+
+
+def test_market_calendar_env(monkeypatch):
+    """MARKET_CALENDAR env var flows into Settings."""  # AI-AGENT-REF
+    monkeypatch.setenv("MARKET_CALENDAR", "XNAS")
+    s = Settings()
+    assert s.market_calendar == "XNAS"


### PR DESCRIPTION
## Summary
- allow .env MARKÉT_CALENDAR override through Settings
- carry market_calendar in TradingConfig and from_env
- cover env propagation with targeted tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings` *(fails: TypeError: catching classes that do not inherit from BaseException, plus 4 others)*
- `pytest tests/test_settings_config.py::test_market_calendar_env -vv --maxfail=1 --disable-warnings`
- `pytest tests/test_runtime_params_hydration.py::test_trading_config_from_env_market_calendar -vv --maxfail=1 --disable-warnings`
- `export MARKET_CALENDAR=XNAS && python - <<'PY'\nfrom ai_trading.core.bot_engine import _is_market_open_now\nprint(_is_market_open_now())\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68a38daf2454833088bde0cd52f88141