### PR TITLE
refactor: narrow exception handling

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -13,7 +13,7 @@ from json import JSONDecodeError
 try:  # pragma: no cover
     import requests  # type: ignore
     RequestException = requests.exceptions.RequestException  # type: ignore[attr-defined]
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover  # AI-AGENT-REF: narrow import handling
     class RequestException(Exception):
         pass
 
@@ -207,11 +207,11 @@ from ai_trading.utils.prof import StageTimer
 # AI-AGENT-REF: optional pipeline import
 try:
     pipeline = _importlib.import_module("ai_trading.pipeline")  # type: ignore
-except Exception:  # pragma: no cover - optional (import resolution only)
+except ImportError:  # pragma: no cover - optional (import resolution only)
     try:
         pipeline = _importlib.import_module("pipeline")  # type: ignore
-    except Exception:  # pragma: no cover
-        pipeline = None  # type: ignore
+    except ImportError:  # pragma: no cover
+        pipeline = None  # type: ignore  # AI-AGENT-REF: fallback when pipeline absent
 
 _log = get_logger(__name__)  # AI-AGENT-REF: central logger adapter
 
@@ -235,8 +235,8 @@ def _alpaca_diag_info() -> dict[str, object]:
             "shadow_mode": shadow,
             "cwd": os.getcwd(),
         }
-    except Exception as e:  # pragma: no cover – diag never fatal
-        return {"diag_error": str(e)}
+    except COMMON_EXC as e:  # pragma: no cover – diag never fatal
+        return {"diag_error": str(e)}  # AI-AGENT-REF: narrowed diag exception
 
 # --- path helpers (no imports of heavy deps) ---
 BASE_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -1282,13 +1282,13 @@ import portalocker
 # Bind HTTPError if available; fall back to generic Exception
 try:  # pragma: no cover
     from requests.exceptions import HTTPError  # type: ignore
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover  # AI-AGENT-REF: optional requests
     HTTPError = Exception
 
 # AI-AGENT-REF: optional schedule dependency
 try:  # pragma: no cover - optional dependency
     import schedule  # type: ignore
-except Exception:  # pragma: no cover - schedule may be absent in tests
+except ImportError:  # pragma: no cover - schedule may be absent in tests
     import types
     schedule = types.SimpleNamespace()
 
@@ -1369,12 +1369,12 @@ def _import_model_pipeline():  # AI-AGENT-REF: import helper for tests
         from ai_trading.pipeline import model_pipeline  # type: ignore
 
         return model_pipeline
-    except Exception as _pkg_err:  # pragma: no cover
+    except ImportError as _pkg_err:  # pragma: no cover  # AI-AGENT-REF: narrow import
         try:
             from pipeline import model_pipeline  # type: ignore
 
             return model_pipeline
-        except Exception as _legacy_err:  # pragma: no cover
+        except ImportError as _legacy_err:  # pragma: no cover
             logger.error("model_pipeline import failed: %s", _pkg_err)
             raise ImportError("model_pipeline import failed") from _legacy_err
 
@@ -1500,7 +1500,7 @@ BOT_MODE_ENV = "development"
 # AI-AGENT-REF: optional pybreaker dependency
 try:  # pragma: no cover - optional dependency
     import pybreaker  # type: ignore
-except Exception:  # pragma: no cover - fallback
+except ImportError:  # pragma: no cover - fallback  # AI-AGENT-REF: optional pybreaker
 
     class pybreaker:  # type: ignore
             class CircuitBreaker:

--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -28,7 +28,7 @@ from json import JSONDecodeError
 try:  # pragma: no cover
     import requests  # type: ignore
     RequestException = requests.exceptions.RequestException  # type: ignore[attr-defined]
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover  # AI-AGENT-REF: narrow requests import
     class RequestException(Exception):
         pass
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)
@@ -42,7 +42,7 @@ try:  # pragma: no cover - torch is optional
     from torch.utils.data import DataLoader, TensorDataset  # type: ignore
 
     TORCH_AVAILABLE = True
-except Exception:  # torch not installed or not importable on this host
+except (ImportError, OSError):  # torch not installed or not importable on this host
     torch = None  # type: ignore
     nn = None  # type: ignore
     DataLoader = TensorDataset = None  # type: ignore

--- a/ai_trading/monitoring/performance_dashboard.py
+++ b/ai_trading/monitoring/performance_dashboard.py
@@ -20,7 +20,7 @@ from json import JSONDecodeError
 try:  # pragma: no cover
     import requests  # type: ignore
     RequestException = requests.exceptions.RequestException  # type: ignore[attr-defined]
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover  # AI-AGENT-REF: narrow requests import
     class RequestException(Exception):
         pass
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)

--- a/ai_trading/portfolio/sizing.py
+++ b/ai_trading/portfolio/sizing.py
@@ -20,7 +20,7 @@ from ai_trading.logging import logger
 try:  # pragma: no cover
     import requests  # type: ignore
     RequestException = requests.exceptions.RequestException  # type: ignore[attr-defined]
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover  # AI-AGENT-REF: narrow requests import
     class RequestException(Exception):
         pass
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)

--- a/ai_trading/risk/circuit_breakers.py
+++ b/ai_trading/risk/circuit_breakers.py
@@ -19,7 +19,7 @@ from json import JSONDecodeError
 try:  # pragma: no cover
     import requests  # type: ignore
     RequestException = requests.exceptions.RequestException  # type: ignore[attr-defined]
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover  # AI-AGENT-REF: narrow requests import
     class RequestException(Exception):
         pass
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)

--- a/tools/audit_exceptions.py
+++ b/tools/audit_exceptions.py
@@ -13,12 +13,8 @@ from __future__ import annotations
 import argparse
 import ast
 import json
-import logging
 import pathlib
 import sys
-import textwrap
-
-logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
 
 def find_broad_handlers(path: pathlib.Path) -> list[dict]:
     try:
@@ -60,18 +56,7 @@ def main() -> int:
     for h in all_hits:
         report["by_file"].setdefault(h["file"], []).append(h)
 
-    sys.stdout.write(
-        json.dumps(report, separators=(",", ":"), sort_keys=True) + "\n"
-    )
-    logging.warning("Top offenders (first 10):")
-    for i, h in enumerate(all_hits[:10], 1):
-        logging.warning(
-            "%2d. %s:%s\n%s",
-            i,
-            h["file"],
-            h["line"],
-            textwrap.indent(h["snippet"], "    "),
-        )
+    print(json.dumps(report, separators=(",", ":"), sort_keys=True))
 
     if args.fail_over is not None and len(all_hits) > args.fail_over:
         return 2


### PR DESCRIPTION
## Summary
- use ImportError for optional dependency fallbacks across core modules
- tighten diagnostic exception handling and optional imports
- streamline audit_exceptions.py to emit single JSON line

## Testing
- `python tools/audit_exceptions.py --paths ai_trading/core/bot_engine.py ai_trading/meta_learning.py ai_trading/monitoring/performance_dashboard.py ai_trading/portfolio/sizing.py ai_trading/risk/circuit_breakers.py`
- `pytest -q` *(fails: logging teardown errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a39f9ab52883308e81c8f389b6703b