### PR TITLE
feat: add retry utility

### DIFF
--- a/ai_trading/utils/retry.py
+++ b/ai_trading/utils/retry.py
@@ -1,0 +1,67 @@
+"""Utility for retrying callables with bounded exponential backoff."""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+def _nowait_sleep(seconds: float) -> None:
+    """Sleep unless test flags indicate fast retry."""
+    if os.getenv("PYTEST_RUNNING") == "1" or os.getenv("FAST_RETRY_IN_TESTS") == "1":
+        return
+    time.sleep(seconds)
+
+
+def retry_call(
+    func: Callable[..., T],
+    *args: Any,
+    exceptions: type[Exception] | tuple[type[Exception], ...],
+    attempts: int = 3,
+    base_delay: float = 0.1,
+    max_delay: float = 2.0,
+    jitter: float = 0.1,
+    **kwargs: Any,
+) -> T:
+    """Call ``func`` with retries on specified ``exceptions``.
+
+    Applies exponential backoff with optional jitter between attempts. Sleep
+    calls are skipped during testing when ``PYTEST_RUNNING`` or
+    ``FAST_RETRY_IN_TESTS`` environment variables are set to ``"1"``.
+
+    Args:
+        func: Callable to execute.
+        *args: Positional arguments for ``func``.
+        exceptions: Exception type or tuple of types to trigger retry.
+        attempts: Maximum number of attempts.
+        base_delay: Initial delay between retries in seconds.
+        max_delay: Maximum delay cap in seconds.
+        jitter: Random jitter added to delay in seconds.
+        **kwargs: Keyword arguments for ``func``.
+
+    Returns:
+        Result of ``func`` if successful.
+
+    Raises:
+        The last caught exception if all attempts fail.
+    """
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+
+    for attempt in range(1, attempts + 1):
+        try:
+            return func(*args, **kwargs)
+        except exceptions as exc:
+            if attempt >= attempts:
+                raise exc
+            delay = min(max_delay, base_delay * (2 ** (attempt - 1)))
+            if jitter > 0:
+                delay += random.uniform(0, jitter)
+            _nowait_sleep(delay)
+    # Should never reach here
+    raise RuntimeError("Retry logic failed unexpectedly")

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,0 +1,65 @@
+"""Unit tests for retry_call utility."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from ai_trading.utils.retry import retry_call
+
+
+class _Flaky:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> str:
+        self.calls += 1
+        if self.calls < 3:
+            raise RuntimeError("fail")
+        return "ok"
+
+
+class _AlwaysFail:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> None:
+        self.calls += 1
+        raise ValueError("nope")
+
+
+@pytest.mark.unit
+def test_retry_eventually_succeeds() -> None:
+    flaky = _Flaky()
+    result = retry_call(flaky, exceptions=RuntimeError, attempts=3)
+    assert result == "ok"
+    assert flaky.calls == 3
+
+
+@pytest.mark.unit
+def test_retry_raises_after_exhaustion() -> None:
+    failing = _AlwaysFail()
+    with pytest.raises(ValueError):
+        retry_call(failing, exceptions=ValueError, attempts=3)
+    assert failing.calls == 3
+
+
+@pytest.mark.unit
+def test_fast_retry_skips_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FAST_RETRY_IN_TESTS", "1")
+
+    calls = {"n": 0}
+
+    def func() -> str:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise RuntimeError("boom")
+        return "done"
+
+    start = time.perf_counter()
+    result = retry_call(func, exceptions=RuntimeError, attempts=2, base_delay=0.5)
+    elapsed = time.perf_counter() - start
+    assert result == "done"
+    assert calls["n"] == 2
+    assert elapsed < 0.01


### PR DESCRIPTION
## Summary
- add generic retry_call with bounded backoff and jitter
- skip sleeps during tests with FAST_RETRY_IN_TESTS/PYTEST_RUNNING
- cover retry helper with unit tests

## Testing
- `pre-commit run --files ai_trading/utils/retry.py tests/unit/test_retry.py`
- `pytest tests/unit/test_retry.py`
- `pytest -n auto --disable-warnings` *(fails: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_68a3adf67f708330b8fe12abedaa10c1