### PR TITLE
feat: add retry to HTTP utils

### DIFF
--- a/tests/runtime/test_http_wrapped.py
+++ b/tests/runtime/test_http_wrapped.py
@@ -1,0 +1,32 @@
+import requests
+
+from ai_trading.utils import http
+from ai_trading.utils.timing import HTTP_TIMEOUT, clamp_timeout
+
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def test_wrapped_get_retries_and_parses(monkeypatch):
+    calls = []
+
+    def fake_request(self, method, url, **kwargs):
+        calls.append(kwargs)
+        assert kwargs["timeout"] == clamp_timeout(None, default_non_test=HTTP_TIMEOUT)
+        if len(calls) == 1:
+            raise requests.exceptions.RequestException("boom")
+        return DummyResp({"ok": True})
+
+    # Patch session.request used by wrapper
+    monkeypatch.setattr(requests.Session, "request", fake_request)
+    # Patch requests.get per requirement, though wrapper uses session
+    monkeypatch.setattr(requests, "get", lambda url, **kw: fake_request(None, "GET", url, **kw))
+
+    resp = http.get("https://example.com")
+    assert resp.json() == {"ok": True}
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- wrap HTTP requests with retry_call and clamped timeouts
- add runtime test covering retry on GET

## Testing
- `pytest -n auto --disable-warnings tests/runtime/test_http_wrapped.py -q`
- `pytest -n auto --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68a3b02541c88330b7645cdfe69fe5f1