### PR TITLE
feat: retry alpaca broker calls

### DIFF
--- a/tests/runtime/test_alpaca_wrapped.py
+++ b/tests/runtime/test_alpaca_wrapped.py
@@ -1,0 +1,27 @@
+import pytest
+
+pytest.importorskip("alpaca")
+
+from ai_trading.broker.alpaca import AlpacaBroker, APIError
+
+
+class DummyClient:
+    def submit_order(self, **_):  # type: ignore[override]
+        return {"ok": True}
+
+
+def test_submit_order_retries(monkeypatch):
+    client = DummyClient()
+    calls = {"n": 0}
+
+    def flaky(**_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise APIError("boom")
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "submit_order", flaky)
+    broker = AlpacaBroker(client)
+    resp = broker.submit_order(symbol="AAPL", qty=1, side="buy")
+    assert resp == {"ok": True}
+    assert calls["n"] == 2


### PR DESCRIPTION
## Summary
- wrap Alpaca broker account, position, order actions with retry_call using settings-driven knobs
- add skip-friendly test ensuring submit_order retries once on transient APIError

## Testing
- `pytest tests/runtime/test_alpaca_wrapped.py -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68a3b1f596008330a5a6ed3d8a8f0004