### PR TITLE
refactor: narrow broad exceptions

### DIFF
--- a/ai_trading/rebalancer.py
+++ b/ai_trading/rebalancer.py
@@ -13,7 +13,7 @@ _log = logging.getLogger(__name__)
 try:  # AI-AGENT-REF: resilient Alpaca import
     from alpaca.common.exceptions import APIError  # type: ignore
     from alpaca.trading.client import TradingClient  # type: ignore  # noqa: F401
-except Exception:  # AI-AGENT-REF: fallback when SDK missing
+except ImportError:  # AI-AGENT-REF: optional Alpaca dependency
     TradingClient = None  # type: ignore
 
     class APIError(Exception):


### PR DESCRIPTION
## Summary
- narrow optional import error handling across rebalancer and risk engine
- tighten signals and alerting modules with targeted exception tuples

## Testing
- `python tools/audit_exceptions.py --paths ai_trading | jq '.total'`
- `pytest -n auto --disable-warnings -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b3e4d8a083309ea1b820915baf6d