### PR TITLE
refactor: narrow broad exceptions (batch 2)

### DIFF
--- a/ai_trading/backtesting/grid_runner.py
+++ b/ai_trading/backtesting/grid_runner.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     from joblib import Parallel, delayed  # type: ignore
-except Exception:
+except ImportError:
     Parallel = None
 
     def delayed(f):

--- a/ai_trading/data/splits.py
+++ b/ai_trading/data/splits.py
@@ -74,12 +74,12 @@ class PurgedGroupTimeSeriesSplit(BaseCrossValidator):
             else:
                 indices = np.arange(len(X))
                 n_samples = len(X)
-            
+
             # Convert to datetime index if possible
             if hasattr(X, 'index') and not isinstance(indices, pd.DatetimeIndex):
                 try:
                     indices = pd.to_datetime(indices)
-                except Exception as e:
+                except (ValueError, TypeError) as e:
                     from ai_trading.logging import logger
                     logger.debug("Datetime index cast failed; using positional indices: %s", e)
             
@@ -137,7 +137,7 @@ class PurgedGroupTimeSeriesSplit(BaseCrossValidator):
                 else:
                     logger.warning(f"Split {i}: insufficient data after purging")
                     
-        except Exception as e:
+        except (ValueError, TypeError, IndexError) as e:
             logger.error(f"Error in split generation: {e}")
             return
     
@@ -191,14 +191,14 @@ class PurgedGroupTimeSeriesSplit(BaseCrossValidator):
                         # only if it's well before the test period
                         if idx < test_start_idx - len(test_indices):
                             purged_train.append(idx)
-                except Exception:
+                except (IndexError, KeyError, ValueError, TypeError):
                     # If there's any issue with the time comparison,
                     # err on the side of caution and exclude
                     continue
             
             return np.array(purged_train)
             
-        except Exception as e:
+        except (KeyError, ValueError, IndexError, TypeError) as e:
             logger.error(f"Error in purging overlapping observations: {e}")
             return train_indices
     
@@ -295,7 +295,7 @@ def walkforward_splits(
         logger.info(f"Generated {len(splits)} walk-forward splits using {mode} mode")
         return splits
         
-    except Exception as e:
+    except (ValueError, TypeError) as e:
         logger.error(f"Error generating walk-forward splits: {e}")
         return []
 
@@ -346,6 +346,6 @@ def validate_no_leakage(
         logger.debug("No data leakage detected")
         return True
         
-    except Exception as e:
+    except (ValueError, TypeError) as e:
         logger.error(f"Error validating leakage: {e}")
         return False

--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -26,7 +26,7 @@ _log = logging.getLogger(__name__)
 def _optional_import(name: str):
     try:
         return importlib.import_module(name)
-    except Exception:
+    except ImportError:
         return None
 
 
@@ -647,7 +647,7 @@ class ExecutionEngine:
         bid, ask = (0.0, 0.0)
         try:
             bid, ask = self._latest_quote()
-        except Exception:
+        except (RuntimeError, ValueError):
             return quantity, False
         spread_pct = (ask - bid) / bid if bid else 0.0
         if spread_pct >= 0.01:

--- a/ai_trading/execution/reconcile.py
+++ b/ai_trading/execution/reconcile.py
@@ -223,7 +223,7 @@ class PositionReconciler:
                 actions.append(action)
                 self.logger.info(action)
 
-            except Exception as e:
+            except (RuntimeError, ValueError) as e:
                 error_action = f"Failed to sync position for {drift.symbol}: {e}"
                 actions.append(error_action)
                 self.logger.error(error_action)
@@ -270,7 +270,7 @@ class PositionReconciler:
                 actions.append(action)
                 self.logger.info(action)
 
-            except Exception as e:
+            except (RuntimeError, ValueError) as e:
                 error_action = f"Failed to fix order {drift.order_id}: {e}"
                 actions.append(error_action)
                 self.logger.error(error_action)
@@ -404,7 +404,7 @@ def reconcile_positions_and_orders() -> ReconciliationResult:
             position_drifts=[], order_drifts=[], timestamp=datetime.now(UTC)
         )
 
-    except Exception as e:
+    except (RuntimeError, ValueError) as e:
         logger.error(f"Error in reconciliation: {e}")
         return ReconciliationResult(
             position_drifts=[], order_drifts=[], timestamp=datetime.now(UTC)


### PR DESCRIPTION
## Summary
- narrow grid search fallback import to ImportError only
- restrict execution engine and reconciler to runtime/value errors for quote and sync failures
- tighten portfolio optimizer and data splitting to handle specific error types

## Testing
- `python tools/audit_exceptions.py --paths ai_trading | jq '.total'`
- `pytest --disable-warnings --maxfail=1` *(fails: logging error)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b8976f7883309a0967ce4e6af2bb