### PR TITLE
chore: add audit exceptions gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,7 @@ PY
           ruff check .
           ruff format --check .
           mypy ai_trading
+      - name: Audit exceptions
+        run: make audit-exceptions
       - name: Tests
         run: pytest -q -n auto --maxfail=1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,6 +64,9 @@ jobs:
           chmod +x scripts/quick_verify.sh
           ./scripts/quick_verify.sh
 
+      - name: Audit exceptions
+        run: make audit-exceptions
+
       - name: Run tests
         run: |
           pytest -q -n auto --disable-warnings

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init test lint verify test-all contract
+.PHONY: init test lint verify test-all contract audit-exceptions
 
 init:
 	python tools/check_python_version.py
@@ -28,6 +28,9 @@ verify:
 	@if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 	chmod +x scripts/quick_verify.sh
 	./scripts/quick_verify.sh
+
+audit-exceptions:
+	python tools/audit_exceptions.py --paths ai_trading --fail-over 12
 
 # === Import-time config hygiene helpers ===
 


### PR DESCRIPTION
## Summary
- add `audit-exceptions` make target to run broad-exception auditor with a threshold of 12
- invoke new target in CI before tests

## Testing
- `make -s audit-exceptions >/tmp/audit.json` *(fails: broad exception count 506 > 12)*
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'portalocker')*


------
https://chatgpt.com/codex/tasks/task_e_68a3bd25dec48330875b894006af30d9