### PR TITLE
Stage 2.1: centralize exception types, remove a few broad catches, and wire retries on key I/O paths

### DIFF
--- a/ai_trading/exc.py
+++ b/ai_trading/exc.py
@@ -1,0 +1,36 @@
+# ruff: noqa
+from __future__ import annotations
+
+from json import JSONDecodeError
+
+# Optional requests import with safe fallbacks
+try:  # pragma: no cover
+    import requests  # type: ignore
+    RequestException = requests.exceptions.RequestException  # type: ignore[attr-defined]
+    try:  # pragma: no cover
+        from requests.exceptions import HTTPError  # type: ignore
+    except ImportError:  # pragma: no cover
+        HTTPError = Exception
+except ImportError:  # pragma: no cover
+    class RequestException(Exception): ...
+    HTTPError = Exception  # minimal fallback
+
+# A common family for “expected” programming/data/HTTP parse errors
+COMMON_EXC = (
+    TypeError,
+    ValueError,
+    KeyError,
+    JSONDecodeError,
+    RequestException,
+    TimeoutError,
+    ImportError,
+)
+
+# Transient network/IO-ish errors appropriate for retry backoff
+TRANSIENT_HTTP_EXC = (
+    RequestException,
+    HTTPError,
+    TimeoutError,
+    OSError,          # DNS / socket hiccups
+    ConnectionError,  # builtin
+)

--- a/ai_trading/tools/fetch_sample_universe.py
+++ b/ai_trading/tools/fetch_sample_universe.py
@@ -32,9 +32,9 @@ def run(symbols: list[str], timeout: float | None = None) -> int:
     with StageTimer(logger, "UNIVERSE_FETCH", universe_size=len(symbols)):
         results = http.map_get(urls, timeout=timeout)
     logger.info("HTTP_POOL_STATS", extra=http.pool_stats())
-    for (_url, code, _), sym in zip(results, symbols, strict=False):
-        if code != 200:
-            logger.error("fetch failed for %s status=%s", sym, code)
+    for (resp, err), sym in zip(results, symbols, strict=False):  # AI-AGENT-REF: Stage 2.1
+        if err or not resp or resp[1] != 200:
+            logger.error("fetch failed for %s", sym)
             failures += 1
     return 0 if failures == 0 else 1
 

--- a/ai_trading/utils/http.py
+++ b/ai_trading/utils/http.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json  # AI-AGENT-REF: JSON decode error handling
 import os
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -9,6 +8,12 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+from ai_trading.exc import (
+    JSONDecodeError,
+    RequestException,
+    HTTPError,
+    TRANSIENT_HTTP_EXC,
+)
 from ai_trading.logging import get_logger  # AI-AGENT-REF: centralized logging
 from ai_trading.utils.retry import retry_call  # AI-AGENT-REF: retry helper
 from ai_trading.utils.timing import HTTP_TIMEOUT, clamp_timeout  # AI-AGENT-REF: timeout clamp
@@ -18,14 +23,19 @@ _log = get_logger(__name__)
 _session = None
 _session_lock = threading.Lock()
 _pool_stats = {
-    "max_workers": int(os.getenv("HTTP_POOL_WORKERS", "8")),
+    "workers": int(os.getenv("HTTP_POOL_WORKERS", "8")),
+    "per_host": int(os.getenv("HTTP_MAX_PER_HOST", "6")),
+    "pool_maxsize": 32,
     "requests": 0,
     "responses": 0,
     "errors": 0,
 }
 
+# AI-AGENT-REF: Stage 2.1 build session with pooling metadata
 
 def _build_session() -> requests.Session:
+    _pool_stats["per_host"] = int(os.getenv("HTTP_MAX_PER_HOST", str(_pool_stats["per_host"])))
+    _pool_stats["workers"] = int(os.getenv("HTTP_POOL_WORKERS", str(_pool_stats["workers"])))
     s = requests.Session()
     retries = Retry(
         total=3,
@@ -34,11 +44,14 @@ def _build_session() -> requests.Session:
         allowed_methods=("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"),
         raise_on_status=False,
     )
-    adapter = HTTPAdapter(pool_connections=32, pool_maxsize=32, max_retries=retries)
+    adapter = HTTPAdapter(
+        pool_connections=_pool_stats["per_host"],
+        pool_maxsize=_pool_stats["pool_maxsize"],
+        max_retries=retries,
+    )
     s.mount("http://", adapter)
     s.mount("https://", adapter)
     return s
-
 
 def _get_session() -> requests.Session:
     global _session
@@ -48,17 +61,14 @@ def _get_session() -> requests.Session:
                 _session = _build_session()
     return _session
 
-
 def _with_timeout(kwargs: dict) -> dict:
     """Ensure a clamped timeout is always provided."""
     # AI-AGENT-REF: unify timeout handling
     kwargs["timeout"] = clamp_timeout(kwargs.get("timeout"), default_non_test=HTTP_TIMEOUT)
     return kwargs
 
-
 def _retry_config() -> tuple[int, float, float, float]:
-    """Load retry knobs from settings if available."""
-    # AI-AGENT-REF: optional configuration
+    """Load retry knobs from settings if available."""  # AI-AGENT-REF: Stage 2.1
     attempts, base, max_delay, jitter = 3, 0.1, 2.0, 0.1
     try:  # Lazy import to avoid heavy config at import time
         from ai_trading.config import get_settings  # type: ignore
@@ -68,18 +78,17 @@ def _retry_config() -> tuple[int, float, float, float]:
         base = float(getattr(s, "RETRY_BASE_DELAY", base))
         max_delay = float(getattr(s, "RETRY_MAX_DELAY", max_delay))
         jitter = float(getattr(s, "RETRY_JITTER", jitter))
-    except Exception:  # pragma: no cover - settings optional
+    except (AttributeError, TypeError, ValueError, ImportError):  # pragma: no cover - settings optional
         pass
     return attempts, base, max_delay, jitter
-
 
 def request(method: str, url: str, **kwargs) -> requests.Response:
     sess = _get_session()
     kwargs = _with_timeout(kwargs)
     attempts, base, max_delay, jitter = _retry_config()
     excs = (
-        requests.exceptions.RequestException,
-        json.JSONDecodeError,
+        RequestException,
+        JSONDecodeError,
         TimeoutError,
         OSError,
     )
@@ -109,47 +118,39 @@ def request(method: str, url: str, **kwargs) -> requests.Response:
         )
         _pool_stats["responses"] += 1
         return resp
-    except Exception:
+    except excs:  # AI-AGENT-REF: Stage 2.1 narrow stats capture
         _pool_stats["errors"] += 1
         raise
-
 
 def get(url: str, **kwargs) -> requests.Response:
     return request("GET", url, **kwargs)
 
-
 def post(url: str, **kwargs) -> requests.Response:
     return request("POST", url, **kwargs)
-
 
 def put(url: str, **kwargs) -> requests.Response:
     return request("PUT", url, **kwargs)
 
-
 def pool_stats() -> dict:
     return dict(_pool_stats)
 
-
 def _fetch_one(url: str, timeout: float | None = None) -> tuple[str, int, bytes]:
-    try:
-        r = get(url, timeout=timeout)
-        return (url, r.status_code, r.content)
-    except Exception:
-        return (url, 599, b"")
+    r = get(url, timeout=timeout)
+    return (url, r.status_code, r.content)
 
-
-def map_get(urls: list[str], *, timeout: float | None = None) -> list[tuple[str, int, bytes]]:
-    """Concurrent GET for a list of URLs. Returns list of (url, status_code, body)."""
+def map_get(urls: list[str], *, timeout: float | None = None) -> list[tuple[tuple[str, int, bytes] | None, Exception | None]]:
+    """Concurrent GET for a list of URLs."""  # AI-AGENT-REF: Stage 2.1
     if not urls:
         return []
-    max_workers = _pool_stats["max_workers"]
-    out: list[tuple[str, int, bytes]] = [("", 0, b"")] * len(urls)
-    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+    workers = _pool_stats["workers"]
+    SAFE_EXC = TRANSIENT_HTTP_EXC + (ValueError, TypeError, JSONDecodeError)
+    results: list[tuple[tuple[str, int, bytes] | None, Exception | None]] = [(None, None)] * len(urls)
+    with ThreadPoolExecutor(max_workers=workers) as ex:
         future_to_idx = {ex.submit(_fetch_one, url, timeout): i for i, url in enumerate(urls)}
         for fut in as_completed(future_to_idx):
             i = future_to_idx[fut]
             try:
-                out[i] = fut.result()
-            except Exception:
-                out[i] = (urls[i], 599, b"")
-    return out
+                results[i] = (fut.result(), None)
+            except SAFE_EXC as e:  # AI-AGENT-REF: Stage 2.1 narrowed catch
+                results[i] = (None, e)
+    return results

--- a/tests/test_http_pooling.py
+++ b/tests/test_http_pooling.py
@@ -17,10 +17,10 @@ def test_pool_config_defaults(monkeypatch):
 
 
 def test_host_semaphore_respects_env(monkeypatch):
-    def fake_get(self, url, timeout=None, headers=None):
+    def fake_get(url, timeout=None, headers=None):
         return DummyResp()
 
-    monkeypatch.setattr(requests.Session, "get", fake_get, raising=False)
+    monkeypatch.setattr(H, "get", fake_get)
     monkeypatch.setenv("HTTP_MAX_PER_HOST", "3")
     _ = H.map_get(["https://example.com"])
     assert H.pool_stats()["per_host"] == 3

--- a/tests/test_universe_fetch_pooling.py
+++ b/tests/test_universe_fetch_pooling.py
@@ -9,7 +9,7 @@ def test_universe_fetch_pooling(monkeypatch):
     def fake_map_get(urls, timeout=None, headers=None):
         calls['count'] = calls.get('count', 0) + 1
         calls['len'] = len(urls)
-        return [(u, 200, f"BODY{i}".encode()) for i, u in enumerate(urls)]
+        return [((u, 200, f"BODY{i}".encode()), None) for i, u in enumerate(urls)]
 
     monkeypatch.setattr(http, "map_get", fake_map_get)
     monkeypatch.setattr(data_fetcher, "_parse_bars", lambda s, c, b: b.decode())

--- a/tests/unit/test_broker_alpaca_import_narrowing.py
+++ b/tests/unit/test_broker_alpaca_import_narrowing.py
@@ -1,0 +1,9 @@
+import importlib
+import sys
+
+
+def test_alpaca_import_without_requests(monkeypatch):
+    monkeypatch.setitem(sys.modules, "requests", None)
+    mod = importlib.reload(importlib.import_module("ai_trading.broker.alpaca"))
+    assert hasattr(mod, "AlpacaBroker")
+    assert "TradingClient" in mod.__all__

--- a/tests/unit/test_http_retry_narrowing.py
+++ b/tests/unit/test_http_retry_narrowing.py
@@ -1,0 +1,27 @@
+import json
+from json import JSONDecodeError
+
+from ai_trading.utils import http
+
+
+class DummyResp:
+    status_code = 200
+    content = b"{}"
+
+    def json(self):
+        return json.loads(self.content)
+
+
+def test_map_get_aggregates_decode_error(monkeypatch):
+    def fake_get(url, timeout=None):
+        if url == "bad":
+            raise JSONDecodeError("bad", "doc", 0)
+        return DummyResp()
+
+    monkeypatch.setattr(http, "get", fake_get)
+    urls = ["ok", "bad"]
+    results = http.map_get(urls)
+    good, error = results[0], results[1]
+    assert good[0] == ("ok", 200, b"{}")
+    assert error[0] is None
+    assert isinstance(error[1], JSONDecodeError)


### PR DESCRIPTION
## Summary
- centralize common and transient exception families in new `exc.py`
- narrow HTTP pool error handling and expose aggregator results and stats cleanly
- harden Alpaca broker imports with ImportError guards and unified retry logic
- wrap data fetcher feeds with retry_call and tidy tests for new behaviors

## Testing
- `pytest tests/unit/test_http_retry_narrowing.py tests/unit/test_broker_alpaca_import_narrowing.py -q`
- `python tools/audit_exceptions.py --paths ai_trading | head -c 1000`


------
https://chatgpt.com/codex/tasks/task_e_68a3c87d64ac8330933de0d69fc9b9c3