### PR TITLE
fix: make logging setup idempotent

### DIFF
--- a/tests/test_logging_queue_listener.py
+++ b/tests/test_logging_queue_listener.py
@@ -1,0 +1,17 @@
+"""Regression tests for QueueListener logging setup idempotency."""
+
+from ai_trading.logging import get_logger, setup_logging
+
+
+def test_setup_logging_idempotent_no_runtime_error():
+    """Multiple calls to setup_logging should not raise errors."""
+    setup_logging()
+    setup_logging()
+
+
+def test_logger_emits_after_setup():
+    """Logger should emit records after setup."""
+    setup_logging()
+    log = get_logger(__name__)
+    log.info("queue-listener-ok")
+


### PR DESCRIPTION
## Summary
- guard QueueListener thread to prevent reconfiguration and remove illegal daemon mutation
- add regression tests for repeated setup_logging calls

## Testing
- `python -m pytest -q tests/test_logging_queue_listener.py`
- `pytest -n auto --disable-warnings --import-mode=importlib` *(fails: NameError: name 'MockSignal' is not defined, AssertionError: Validation failed: ['No logging handlers configured'], AssertionError: expected call not found., Exception: boom, AttributeError: '_TClient' object has no attribute 'get_account')*
- `python - <<'PY'
from ai_trading.app import create_app
app = create_app()
print(app.url_map)
PY`
- `sudo systemctl restart ai-trading.service` *(fails: System has not been booted with systemd as init system (PID 1). Can't operate.)*
- `sudo journalctl -u ai-trading.service -n 200 --no-pager | egrep -i 'RuntimeError|Traceback' || echo 'No errors ✅'`
- `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:9001/health` *(fails: 000)*
- `python - <<'PY'
import py_compile, pathlib, sys
errs = []
for p in pathlib.Path('.').rglob('*.py'):
    try:
        py_compile.compile(str(p), doraise=True)
    except Exception as e:
        errs.append((str(p), e))
print('py_compile errors:', errs)
sys.exit(1 if errs else 0)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a3f8291fe08330a81421d5771f4747