### PR TITLE
fix: export portfolio_lock and noop alpaca stub

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1301,7 +1301,19 @@ YFINANCE_AVAILABLE = has_yfinance()  # AI-AGENT-REF: cached provider availabilit
 # Production Alpaca SDK imports are performed lazily. Create harmless stand-ins
 # when the SDK is unavailable.
 class _AlpacaStub:  # AI-AGENT-REF: placeholder when Alpaca unavailable
-    pass
+    """Lightweight no-op stub used before lazy-importing real Alpaca classes.
+    Accepts any args/kwargs and safely no-ops attribute access/calls.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._args = args
+        self._kwargs = kwargs
+
+    def __getattr__(self, _name):  # return a no-op callable for any missing attr
+        def _noop(*args, **kwargs):
+            return None
+
+        return _noop
 
 
 class APIErrorStub(Exception):

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -9,6 +9,7 @@ from .base import (
     health_check,
     is_market_open,
     market_open_between,
+    portfolio_lock as _portfolio_lock,  # NEW: bring in the shared lock
 )
 from .base import (
     log_warning as _log_warning,
@@ -34,6 +35,10 @@ try:  # pragma: no cover
     from . import process_manager  # type: ignore
 except Exception:  # pragma: no cover
     process_manager = None  # type: ignore
+
+
+# Expose the concrete lock directly at the package level
+portfolio_lock = _portfolio_lock
 
 
 def safe_subprocess_run(
@@ -148,6 +153,7 @@ __all__ = [
     "health_check",
     "is_market_open",
     "market_open_between",
+    "portfolio_lock",     # NEW
     "psleep",
     "sleep_s",
     "sleep",

--- a/tests/runtime/test_alpaca_stub_no_typeerror.py
+++ b/tests/runtime/test_alpaca_stub_no_typeerror.py
@@ -1,0 +1,8 @@
+
+def test_alpaca_stub_accepts_args_and_noops():
+    # Import from bot_engine where the stub is defined/aliased
+    from ai_trading.core.bot_engine import _AlpacaStub  # private but stable for this test
+    stub = _AlpacaStub("key", "secret", base_url="https://example.com", paper=True)
+    # Should not raise; attribute/method access should no-op
+    assert stub is not None
+    assert stub.any_method(1, x=2) is None

--- a/tests/utils/test_portfolio_lock_export.py
+++ b/tests/utils/test_portfolio_lock_export.py
@@ -1,0 +1,9 @@
+import threading
+
+
+def test_portfolio_lock_is_exported_and_is_same_object():
+    from ai_trading.utils import portfolio_lock
+    from ai_trading.utils.base import portfolio_lock as base_lock
+    assert isinstance(portfolio_lock, type(threading.Lock()))
+    # same underlying object (identity), not a new lock
+    assert portfolio_lock is base_lock


### PR DESCRIPTION
## Summary
- expose `portfolio_lock` from `ai_trading.utils`
- allow `_AlpacaStub` to accept args and return no-op callables
- add regression tests for lock export and stub behavior

## Testing
- `pytest -n auto --disable-warnings tests/utils/test_portfolio_lock_export.py tests/runtime/test_alpaca_stub_no_typeerror.py`
- `pytest -n auto --disable-warnings` *(fails: import file mismatch)*
- `sudo systemctl restart ai-trading.service` *(fails: System has not been booted with systemd)*
- `sudo journalctl -u ai-trading.service -n 200 --no-pager | egrep -i 'health|lock|alpaca|failed|error'` *(fails: No journal files were found.)*
- `curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:9001/health` *(fails: 000)*

------
https://chatgpt.com/codex/tasks/task_e_68a499de2b048330806fa6ae59a66cc4