### PR TITLE
fix: robust timeframe stub and close price

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1320,12 +1320,22 @@ class APIErrorStub(Exception):
     pass
 
 
+# Assign lightweight stubs for Alpaca SDK types; keep TimeFrame separate for constants.
 StockHistoricalDataClient = Quote = StockBarsRequest = StockLatestQuoteRequest = (
-    TimeFrame
-) = TradingClient = OrderSide = OrderStatus = TimeInForce = Order = (
-    MarketOrderRequest
-) = _AlpacaStub  # type: ignore
+    TradingClient
+) = OrderSide = OrderStatus = TimeInForce = Order = MarketOrderRequest = _AlpacaStub  # type: ignore
 APIError = APIErrorStub
+
+# Minimal enum-like shim so code can reference TimeFrame.Day etc.
+class _TimeFrame:  # AI-AGENT-REF: safe constants when Alpaca SDK not installed
+    Day = "Day"
+    Minute = "Minute"
+    Hour = "Hour"
+    Week = "Week"
+    Month = "Month"
+
+# Expose shim under expected name
+TimeFrame = _TimeFrame
 
 # AI-AGENT-REF: beautifulsoup4 is a hard dependency in pyproject.toml
 from bs4 import BeautifulSoup

--- a/tests/test_stubs_and_prices.py
+++ b/tests/test_stubs_and_prices.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+
+def test_timeframe_has_basic_members():
+    from ai_trading.core.bot_engine import TimeFrame
+
+    assert hasattr(TimeFrame, "Day")
+    assert hasattr(TimeFrame, "Minute")
+    assert hasattr(TimeFrame, "Hour")
+
+
+def test_get_latest_close_handles_empty_and_variants():
+    from ai_trading.utils.base import get_latest_close
+
+    df_empty = pd.DataFrame(columns=["close"])
+    assert get_latest_close(df_empty) == 0.0
+
+    df_alt = pd.DataFrame({"Close": [None, "nan", 101.5]})
+    assert get_latest_close(df_alt) == 101.5
+
+    df_ok = pd.DataFrame({"close": [99.0, 100.0, float("nan")]})
+    assert get_latest_close(df_ok) == 100.0


### PR DESCRIPTION
## Summary
- add minimal TimeFrame shim when Alpaca SDK missing
- harden get_latest_close for missing/invalid data
- skip symbols with invalid closes in portfolio weights
- add tests for TimeFrame stub and close extraction

## Testing
- `pre-commit run --files ai_trading/core/bot_engine.py ai_trading/utils/base.py ai_trading/portfolio/core.py tests/test_stubs_and_prices.py` *(fails: repo-guard mutable default in ai_trading/broker/alpaca.py)*
- `pytest -n auto --disable-warnings` *(fails: import mismatch in tests/utils/test_retry.py)*
- `pytest tests/test_stubs_and_prices.py -n auto --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a4a0c22638833082c1f4ba5121d607