### PR TITLE
fix: robust data fetch and runtime model

### DIFF
--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -41,6 +41,21 @@ class DataFetchException(Exception):
     """Error raised when market data retrieval fails."""
 
 
+def _empty_bars_df() -> pd.DataFrame:
+    """Return an empty OHLCV DataFrame with UTC timestamps."""
+    cols = ["timestamp", "open", "high", "low", "close", "volume"]
+    df = pd.DataFrame(columns=cols)
+    df["timestamp"] = pd.to_datetime(df["timestamp"]).tz_localize("UTC")
+    return df
+
+
+def normalize_symbol_for_provider(symbol: str, provider: str) -> str:
+    """Return symbol normalized for the data provider."""
+    if provider.lower() == "yahoo":
+        return symbol.replace(".", "-")
+    return symbol
+
+
 # ---- datetime helpers ----
 def ensure_datetime(dt_or_str, *, tz: str | None = "UTC") -> datetime:
     """Return timezone-aware datetime in UTC."""  # AI-AGENT-REF
@@ -120,24 +135,111 @@ def last_minute_bar_age_seconds(now: datetime | None = None) -> int:
 
 
 # ---- data access stubs ----
+
+
+def _alpaca_get_bars(
+    client, symbol: str, start: pd.Timestamp, end: pd.Timestamp, timeframe: str = "1Day"
+) -> pd.DataFrame:
+    """Fetch bars via Alpaca SDK v2/v3 with a stable DataFrame format."""
+    try:
+        from alpaca.data.historical import StockHistoricalDataClient
+        from alpaca.data.requests import StockBarsRequest
+        from alpaca.data.timeframe import TimeFrame
+
+        _ = StockHistoricalDataClient  # referenced to satisfy linter
+        start = start.tz_convert("UTC") if start is not None else pd.Timestamp.utcnow().tz_localize("UTC") - pd.Timedelta(days=1)
+        end = end.tz_convert("UTC") if end is not None else pd.Timestamp.utcnow().tz_localize("UTC")
+        tf = TimeFrame.Day if timeframe.lower() in {"1d", "1day"} else TimeFrame.Minute
+        req = StockBarsRequest(
+            symbol_or_symbols=symbol,
+            start=start.to_pydatetime(),
+            end=end.to_pydatetime(),
+            timeframe=tf,
+            adjustment="all",
+            limit=10000,
+        )
+        resp = client.get_stock_bars(req)
+        df = getattr(resp, "df", None)
+        if df is None:
+            return _empty_bars_df()
+        if isinstance(df.index, pd.MultiIndex):
+            df = df.xs(symbol, level=0, drop_level=False).droplevel(0)
+        df = df.reset_index().rename(columns={"index": "timestamp"})
+        rename_map = {"t": "timestamp", "o": "open", "h": "high", "l": "low", "c": "close", "v": "volume"}
+        df = df.rename(columns=rename_map)
+        keep = ["timestamp", "open", "high", "low", "close", "volume"]
+        for k in keep:
+            if k not in df.columns:
+                df[k] = pd.NA
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        return df[keep].sort_values("timestamp")
+    except Exception:
+        raise
+
+
+def _yahoo_get_bars(
+    symbol: str, start: pd.Timestamp | None, end: pd.Timestamp | None, timeframe: str = "1Day"
+) -> pd.DataFrame:
+    """Fetch bars from Yahoo Finance if available."""
+    try:
+        import yfinance as yf  # type: ignore
+    except Exception:
+        return _empty_bars_df()
+
+    interval = "1d" if timeframe.lower() in {"1d", "1day"} else "1m"
+    sym = normalize_symbol_for_provider(symbol, "yahoo")
+    start = (start.tz_convert("UTC") if start is not None else None)
+    end = (end.tz_convert("UTC") if end is not None else None)
+    try:
+        df = yf.download(
+            sym,
+            start=start,
+            end=end,
+            interval=interval,
+            progress=False,
+        )
+    except Exception:
+        return _empty_bars_df()
+    if df is None or df.empty:
+        return _empty_bars_df()
+    df = df.reset_index()
+    df = df.rename(
+        columns={
+            "Date": "timestamp",
+            "Datetime": "timestamp",
+            "Open": "open",
+            "High": "high",
+            "Low": "low",
+            "Close": "close",
+            "Adj Close": "close",
+            "Volume": "volume",
+        }
+    )
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    keep = ["timestamp", "open", "high", "low", "close", "volume"]
+    for k in keep:
+        if k not in df.columns:
+            df[k] = pd.NA
+    return df[keep].sort_values("timestamp")
 def get_bars(symbol: str, timeframe: str, start, end, /, *, feed=None) -> pd.DataFrame:
     if start is not None:
         start = ensure_datetime(start)
     if end is not None:
         end = ensure_datetime(end)
     SAFE_EXC = COMMON_EXC + (DataFetchException,)
-    try:
-        if feed and hasattr(feed, "get_bars"):
-            return retry_call(
-                lambda: feed.get_bars(symbol, timeframe, start, end) or pd.DataFrame(),
+    if feed is not None:
+        try:
+            df = retry_call(
+                lambda: _alpaca_get_bars(feed, symbol, start, end, timeframe),
                 exceptions=TRANSIENT_HTTP_EXC,
             )
-    except SAFE_EXC as exc:  # AI-AGENT-REF: Stage 2.1 narrow catch
-        _log.info(f"feed.get_bars error {exc.__class__.__name__}", exc_info=True)
-    except AttributeError:
-        pass
-    cols = ["Open", "High", "Low", "Close", "Volume"]
-    return pd.DataFrame(columns=cols)
+            if df is not None and not df.empty:
+                return df
+        except SAFE_EXC as exc:  # AI-AGENT-REF: Stage 2.1 narrow catch
+            _log.info(f"feed.get_bars error {exc.__class__.__name__}", exc_info=True)
+        except AttributeError:
+            pass
+    return _yahoo_get_bars(symbol, start, end, timeframe)
 
 
 def get_bars_batch(

--- a/ai_trading/data_validation.py
+++ b/ai_trading/data_validation.py
@@ -12,7 +12,20 @@ __all__ = [
     "get_stale_symbols",
     "validate_trading_data",
     "emergency_data_check",
+    "is_valid_ohlcv",
 ]
+
+
+REQUIRED_PRICE_COLS = ("open", "high", "low", "close", "volume")
+
+
+def is_valid_ohlcv(df: pd.DataFrame, min_rows: int = 50) -> bool:
+    """Return True if ``df`` has required OHLCV columns and rows."""
+    if df is None or df.empty:
+        return False
+    if not set(REQUIRED_PRICE_COLS).issubset(df.columns):
+        return False
+    return len(df) >= min_rows
 
 
 def check_data_freshness(

--- a/ai_trading/exc.py
+++ b/ai_trading/exc.py
@@ -12,7 +12,8 @@ try:  # pragma: no cover
     except ImportError:  # pragma: no cover
         HTTPError = Exception
 except ImportError:  # pragma: no cover
-    class RequestException(Exception): ...
+    class RequestException(Exception):
+        pass
     HTTPError = Exception  # minimal fallback
 
 # A common family for “expected” programming/data/HTTP parse errors
@@ -34,3 +35,11 @@ TRANSIENT_HTTP_EXC = (
     OSError,          # DNS / socket hiccups
     ConnectionError,  # builtin
 )
+
+
+class DataFeedUnavailable(RuntimeError):
+    """Raised when required market data is unavailable."""
+
+
+class InvalidBarsError(ValueError):
+    """Raised when bar data is invalid or missing."""

--- a/scripts/check_feed.py
+++ b/scripts/check_feed.py
@@ -1,0 +1,18 @@
+"""Small diagnostic to verify market data fetch."""
+
+import pandas as pd, datetime as dt, pytz  # noqa: F401
+from types import SimpleNamespace
+
+from ai_trading.core.bot_engine import safe_get_stock_bars
+from ai_trading.core.runtime import build_runtime
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    rt = build_runtime(SimpleNamespace())
+    now = pd.Timestamp.utcnow().tz_localize("UTC")
+    start = now - pd.Timedelta(days=120)
+    client = getattr(rt, "data_client", SimpleNamespace(get_stock_bars=lambda req: SimpleNamespace(df=pd.DataFrame())))
+    df = safe_get_stock_bars(client, None, "SPY", "1Day")
+    print("rows:", len(df), "cols:", list(df.columns))
+    print(df.tail(3))
+

--- a/tests/test_fetch_contract.py
+++ b/tests/test_fetch_contract.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+
+import pandas as pd
+
+os.environ.setdefault("ALPACA_API_KEY", "dummy")
+os.environ.setdefault("ALPACA_SECRET_KEY", "dummy")
+dotenv_stub = types.ModuleType("dotenv")
+dotenv_stub.load_dotenv = lambda *a, **k: None
+dotenv_stub.dotenv_values = lambda *a, **k: {}
+dotenv_stub.find_dotenv = lambda *a, **k: ""
+sys.modules["dotenv"] = dotenv_stub
+
+from ai_trading import data_fetcher
+
+
+class DummyClient:
+    pass
+
+
+def test_get_bars_never_none(monkeypatch):
+    now = pd.Timestamp("2024-01-01", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "timestamp": [now],
+            "open": [1.0],
+            "high": [2.0],
+            "low": [0.5],
+            "close": [1.5],
+            "volume": [100],
+        }
+    )
+    monkeypatch.setattr(
+        data_fetcher,
+        "_alpaca_get_bars",
+        lambda client, symbol, start, end, timeframe="1Day": df,
+    )
+    result = data_fetcher.get_bars(
+        "AAPL", "1Day", now - pd.Timedelta(days=1), now, feed=DummyClient()
+    )
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.columns) == [
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+    assert str(result["timestamp"].dt.tz) == "UTC"
+

--- a/tests/test_runtime_model.py
+++ b/tests/test_runtime_model.py
@@ -1,0 +1,12 @@
+from types import SimpleNamespace
+
+from ai_trading.core.runtime import build_runtime, NullAlphaModel
+
+
+def test_runtime_has_model():
+    cfg = SimpleNamespace()
+    runtime = build_runtime(cfg)
+    assert hasattr(runtime, "model")
+    assert callable(getattr(runtime.model, "predict", None))
+    assert isinstance(runtime.model, NullAlphaModel)
+


### PR DESCRIPTION
## Summary
- ensure runtime always exposes a `model` with safe `NullAlphaModel`
- harden bar fetching across Alpaca/Yahoo and add outage canary
- add smoke tests and feed diagnostic script

## Testing
- `pytest tests/test_fetch_contract.py tests/test_runtime_model.py -q`
- `PYTHONPATH=. python scripts/check_feed.py`
- `PYTHONPATH=. python -m ai_trading.runner --iterations 1 --interval 60` *(fails: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68a4afbee36c8330b6f512fc208be43e