### PR TITLE
fix: normalize Alpaca timeframe inputs

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -40,9 +40,15 @@ from ai_trading.utils import health_check as _health_check
 from ai_trading.alpaca_api import ALPACA_AVAILABLE  # AI-AGENT-REF: canonical flag
 
 try:  # AI-AGENT-REF: optional Alpaca dependency
-    from alpaca_trade_api.rest import TimeFrame
+    from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
 except Exception:  # pragma: no cover
     TimeFrame = None  # type: ignore
+    class TimeFrameUnit:  # type: ignore
+        Minute = "Minute"
+        Hour = "Hour"
+        Day = "Day"
+        Week = "Week"
+        Month = "Month"
 
 # One place to define the common exception family (module-scoped)
 COMMON_EXC = (
@@ -1367,8 +1373,21 @@ class _TimeFrame:  # AI-AGENT-REF: safe constants when Alpaca SDK not installed
     Week = "Week"
     Month = "Month"
 
+    def __init__(self, amount, unit):
+        self.amount = amount
+        self.unit = unit
+
+
+class _TimeFrameUnit:
+    Minute = "Minute"
+    Hour = "Hour"
+    Day = "Day"
+    Week = "Week"
+    Month = "Month"
+
 # Expose shim under expected name
 TimeFrame = _TimeFrame
+TimeFrameUnit = _TimeFrameUnit
 
 # AI-AGENT-REF: beautifulsoup4 is a hard dependency in pyproject.toml
 from bs4 import BeautifulSoup
@@ -3503,7 +3522,7 @@ class DataFetcher:
         try:
             req = StockBarsRequest(
                 symbol_or_symbols=[symbol],
-                timeframe=TimeFrame.Day,
+                timeframe=TimeFrame(1, TimeFrameUnit.Day),
                 start=start_ts,
                 end=end_ts,
                 feed=_DEFAULT_FEED,
@@ -3934,7 +3953,7 @@ def prefetch_daily_data(
     try:
         req = StockBarsRequest(
             symbol_or_symbols=symbols,
-            timeframe=TimeFrame.Day,
+            timeframe=TimeFrame(1, TimeFrameUnit.Day),
             start=start_date,
             end=end_date,
             feed=_DEFAULT_FEED,
@@ -4012,7 +4031,7 @@ def prefetch_daily_data(
                     try:
                         req_sym = StockBarsRequest(
                             symbol_or_symbols=[sym],
-                            timeframe=TimeFrame.Day,
+                            timeframe=TimeFrame(1, TimeFrameUnit.Day),
                             start=start_date,
                             end=end_date,
                             feed=_DEFAULT_FEED,

--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -1,0 +1,51 @@
+import types
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ai_trading.alpaca_api import get_bars_df
+
+
+class _Resp:
+    def __init__(self, df):
+        self.df = df
+
+
+@patch("ai_trading.alpaca_api.TradeApiREST")
+def test_day_timeframe_normalized(mock_rest_cls):
+    mock_rest = MagicMock()
+    mock_rest.get_bars.return_value = _Resp(pd.DataFrame({"open": [1.0], "close": [1.1]}))
+    mock_rest_cls.return_value = mock_rest
+
+    df = get_bars_df("SPY", "Day", feed="iex", adjustment="all")
+    args, kwargs = mock_rest.get_bars.call_args
+    assert kwargs["timeframe"] in ("1Day", "1D")
+    assert not df.empty
+
+
+@patch("ai_trading.alpaca_api.TradeApiREST")
+def test_tf_object_normalized(mock_rest_cls):
+    from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
+
+    mock_rest = MagicMock()
+    mock_rest.get_bars.return_value = _Resp(pd.DataFrame({"open": [1.0], "close": [1.1]}))
+    mock_rest_cls.return_value = mock_rest
+
+    df = get_bars_df("SPY", TimeFrame(1, TimeFrameUnit.Day), feed="iex", adjustment="all")
+    args, kwargs = mock_rest.get_bars.call_args
+    assert kwargs["timeframe"] in ("1Day", "1D")
+    assert not df.empty
+
+
+@patch("ai_trading.alpaca_api.TradeApiREST")
+def test_minute_normalized(mock_rest_cls):
+    mock_rest = MagicMock()
+    mock_rest.get_bars.return_value = _Resp(pd.DataFrame({"open": [1.0], "close": [1.1]}))
+    mock_rest_cls.return_value = mock_rest
+
+    df = get_bars_df("SPY", "Minute", feed="iex", adjustment="all")
+    args, kwargs = mock_rest.get_bars.call_args
+    assert kwargs["timeframe"] in ("1Min", "1Minute")
+    assert not df.empty
+

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,2 @@
+# AI-AGENT-REF: ensure unique package namespace for unit tests
+

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,2 @@
+# AI-AGENT-REF: ensure unique package namespace for utils tests
+


### PR DESCRIPTION
## Summary
- normalize timeframe strings or `TimeFrame` objects to Alpaca REST forms before fetching bars
- log both raw and normalized timeframes on API failure
- use explicit `TimeFrame(1, TimeFrameUnit.Day)` when building `StockBarsRequest`
- add tests for timeframe normalization and package init files for test namespaces

## Testing
- `pytest` *(fails: ImportError: cannot import name 'get_or_load' from 'ai_trading.market.cache', AssertionError in centralized logging test, more)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c790e924833097b049b35b3d3b2b