### PR TITLE
Fix undefined ctx in parallel symbol processing; silence yfinance auto-adjust/TzCache noise; keep Yahoo fallback stable

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -11879,6 +11879,9 @@ def _process_symbols(
     processed: list[str] = []
     row_counts: dict[str, int] = {}
 
+    # AI-AGENT-REF: bind lazy context for trade helpers
+    ctx = get_ctx()
+
     if not hasattr(state, "trade_cooldowns"):
         state.trade_cooldowns = {}
     if not hasattr(state, "last_trade_direction"):

--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -182,6 +182,14 @@ def _yahoo_get_bars(
     """Fetch bars from Yahoo Finance if available."""
     try:
         import yfinance as yf  # type: ignore
+        # AI-AGENT-REF: route yfinance TzCache to writable dir to silence warnings
+        try:
+            import tempfile, os as _os
+            _tz_dir = _os.getenv("YFINANCE_TZCACHE") or _os.path.join(tempfile.gettempdir(), "py-yfinance")
+            if hasattr(yf, "set_tz_cache_location"):
+                yf.set_tz_cache_location(_tz_dir)
+        except Exception:  # noqa: BLE001
+            pass
     except Exception:  # noqa: BLE001
         return _empty_bars_df()
 
@@ -196,6 +204,7 @@ def _yahoo_get_bars(
             end=end,
             interval=interval,
             progress=False,
+            auto_adjust=True,  # AI-AGENT-REF: fix noisy auto_adjust default change
         )
     except Exception:  # noqa: BLE001
         return _empty_bars_df()

--- a/tests/test_yf_auto_adjust_and_cache.py
+++ b/tests/test_yf_auto_adjust_and_cache.py
@@ -1,0 +1,35 @@
+"""Ensure yfinance fallback sets auto_adjust and TzCache."""
+
+import sys
+import types
+from datetime import UTC, datetime
+
+
+def test_yfinance_auto_adjust_and_cache(monkeypatch):
+    calls = {"auto_adjust": None, "cache_called": False}
+
+    fake = types.SimpleNamespace()
+
+    def set_tz_cache_location(path):  # AI-AGENT-REF: track tz cache invocation
+        calls["cache_called"] = True
+
+    def download(*args, auto_adjust=None, **kwargs):  # AI-AGENT-REF: capture auto_adjust
+        calls["auto_adjust"] = auto_adjust
+        import pandas as pd
+
+        return pd.DataFrame(
+            {"Open": [1.0], "High": [1.0], "Low": [1.0], "Close": [1.0], "Volume": [100]},
+            index=pd.date_range(datetime(2025, 8, 1, tzinfo=UTC), periods=1, name="Date"),
+        )
+
+    fake.set_tz_cache_location = set_tz_cache_location
+    fake.download = download
+    monkeypatch.setitem(sys.modules, "yfinance", fake)
+
+    from ai_trading.data_fetcher import _yahoo_get_bars
+
+    _ = _yahoo_get_bars("SPY", datetime(2025, 8, 1, tzinfo=UTC), datetime(2025, 8, 2, tzinfo=UTC), "1Day")
+
+    assert calls["auto_adjust"] is True
+    assert calls["cache_called"] is True
+


### PR DESCRIPTION
## Summary
- bind lazy bot context inside `_process_symbols` so threads can call `_safe_trade`
- configure yfinance to use a writable TzCache directory and set `auto_adjust=True`
- add test verifying Yahoo fallback passes `auto_adjust` and configures TzCache

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 ai_trading/core/bot_engine.py ai_trading/data_fetcher.py tests/test_yf_auto_adjust_and_cache.py`
- `pytest -n auto --disable-warnings` *(fails: ImportError: cannot import name 'get_or_load' from 'ai_trading.market.cache', plus 4 other failures)*
- `pytest tests/test_yf_auto_adjust_and_cache.py -q`
- `python -m ai_trading.__main__ --symbols ABBV,ABT,ACN,ADBE,AMD` *(fails: Alpaca credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ddda8ef88330b63b672cb82b668f