### PR TITLE
fix: respect scheduler iteration precedence

### DIFF
--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -165,7 +165,8 @@ class Settings(BaseSettings):
     # AI-AGENT-REF: runtime defaults for deterministic behavior and loops
     seed: int | None = 42
     loop_interval_seconds: int = 60
-    iterations: int = 0  # 0 => run forever
+    # 0 => run forever; allow override via SCHEDULER_ITERATIONS
+    iterations: int = Field(default=0, env="SCHEDULER_ITERATIONS")  # AI-AGENT-REF: env override
     api_port: int | None = 9001
 
     # AI-AGENT-REF: optional Finnhub API config


### PR DESCRIPTION
## Summary
- parse integer env vars with helper `_get_int_env`
- honor `SCHEDULER_ITERATIONS` with CLI/env/settings precedence
- wire settings `iterations` to `SCHEDULER_ITERATIONS`

## Testing
- `pytest -q tests/test_additional_coverage.py::test_main_starts_api_thread -vv`
- `SCHEDULER_ITERATIONS=1 pytest -q tests/test_additional_coverage.py::test_main_starts_api_thread -vv`
- `SCHEDULER_ITERATIONS=1 pytest -q tests/test_additional_coverage.py::test_main_starts_api_thread -vv -- --iterations=2` *(fails: unrecognized arguments)*
- `make test-all` *(fails: 'unit' marker not found)*
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: cachetools)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f32396808330aa8b9bf265179ecb