### PR TITLE
fix: refine data fetcher and PnL lock

### DIFF
--- a/ai_trading/predict.py
+++ b/ai_trading/predict.py
@@ -15,8 +15,9 @@ except Exception:  # noqa: BLE001
 @lru_cache(maxsize=1024)
 def predict(path: str):
     """Minimal prediction interface used in tests."""  # AI-AGENT-REF
-    import pandas as pd
     import importlib
+
+    import pandas as pd
 
     df = pd.read_csv(path)
     retrain = importlib.import_module("retrain")
@@ -41,7 +42,7 @@ def fetch_sentiment(symbol: str) -> float:
     try:
         import requests
 
-        resp = requests.get(f"https://example.com/{symbol}")
+        resp = requests.get(f"https://example.com/{symbol}", timeout=10)
         resp.raise_for_status()
         data = resp.json()
         score = float(data.get("score", 0.0))
@@ -66,4 +67,3 @@ __all__ = [
     "_sentiment_cache",
     "_CACHETOOLS_AVAILABLE",
 ]
-


### PR DESCRIPTION
## Summary
- prevent self-deadlock in PnL attribution with RLock
- implement lightweight data fetcher utilities and fallbacks
- add request timeouts and misc stubs for tests

## Testing
- `pre-commit run --files ai_trading/execution/pnl_attributor.py ai_trading/data_fetcher.py ai_trading/broker/alpaca.py ai_trading/predict.py`
- `pytest tests/test_enhanced_execution_debugging.py::TestPnLAttribution::test_position_snapshot_pnl_attribution -q`
- `pytest tests/runtime/test_http_wrapped.py::test_wrapped_get_retries_and_parses -q`
- `pytest tests/test_data_fetcher.py::test_finnhub_403_yfinance -q`
- `pytest tests/test_data_fetcher.py::test_fetch_bars_retry_invalid_feed -q`
- `pytest tests/test_data_fetcher.py::test_empty_bars_handled -q`
- `pytest tests/test_data_fetcher.py::test_fetch_bars_empty_uses_last_bar -q`
- `pytest tests/test_data_fetcher_datetime.py::test_ensure_datetime_none -q`
- `pytest tests/test_data_fetcher_timezone.py::test_yahoo_get_bars_accepts_various_datetime_types -q`


------
https://chatgpt.com/codex/tasks/task_e_68a557b1e5708330b77d9ee86025c421