### PR TITLE
Implement minute-cache freshness helpers and reintroduce weekly drawdown guard

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -1522,6 +1522,7 @@ class TradingConfig(BaseModel):
     signal_confirmation_bars: int = 2  # AI-AGENT-REF: bars to confirm signal
     delta_threshold: float = 0.02  # AI-AGENT-REF: price delta trigger
     max_drawdown_threshold: float = Field(_MAX_DRAWDOWN_THRESHOLD, ge=0, le=1)
+    weekly_drawdown_limit: float = Field(0.10, ge=0, le=1)  # AI-AGENT-REF: risk limit
     order_fill_rate_target: float = Field(_ORDER_FILL_RATE_TARGET, ge=0, le=1)
     mode_parameters: dict[str, float] | None = None
     sentiment_enhanced_caching: bool = _SENTIMENT_ENHANCED_CACHING

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -683,6 +683,9 @@ from ai_trading.settings import (
 
 # Initialize settings once for global use
 CFG = get_config_settings()
+# Backward-compat constants for risk thresholds used throughout this module
+# AI-AGENT-REF: restored weekly drawdown limit
+WEEKLY_DRAWDOWN_LIMIT = getattr(CFG, "weekly_drawdown_limit", 0.10)
 # AI-AGENT-REF: cached runtime settings for env aliases
 S = get_runtime_settings()
 SEED = get_seed_int()  # AI-AGENT-REF: deterministic seed from runtime settings


### PR DESCRIPTION
## Summary
- add in-memory minute cache helpers and refresh `get_minute_df` to populate it
- restore `WEEKLY_DRAWDOWN_LIMIT` constant from config
- expose `weekly_drawdown_limit` in `TradingConfig`

## Testing
- `python - <<'PY'
import compileall, sys
ok = compileall.compile_dir('.', maxlevels=20, quiet=1)
sys.exit(0 if ok else 1)
PY`
- `ruff check ai_trading/data_fetcher.py ai_trading/core/bot_engine.py ai_trading/config/management.py`
- `pytest -n auto --disable-warnings` *(fails: ImportError: The legacy 'ai_trading.tools' package is removed)*
- `python -m ai_trading --dry-run --interval 60 --iterations 1` *(fails: unrecognized arguments: --interval 60 --iterations 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f60b0ae08330a1395de48d71a444