### PR TITLE
fix: handle empty market data fallbacks

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -2061,8 +2061,9 @@ def fetch_minute_df_safe(symbol: str) -> pd.DataFrame:
         df = get_minute_df(symbol, start_dt, now_utc)
 
     if df.empty:
-        _log.error(f"Fetch failed: empty DataFrame for {symbol}")
-        raise DataFetchError(f"No data for {symbol}")
+        _log.info("Fetch skipped: empty DataFrame after fallbacks | %s", symbol)  # AI-AGENT-REF
+        _log.info("SKIP_NO_DATA | %s", symbol)
+        return pd.DataFrame()
 
     # Check data freshness before proceeding with trading logic
     try:

--- a/tests/test_data_fetcher_fallbacks.py
+++ b/tests/test_data_fetcher_fallbacks.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import datetime as dt
+
+from ai_trading import data_fetcher as dfetch
+
+
+def _fake_yf(symbol, period=None, start=None, end=None, interval="1m", **_):
+    idx = pd.date_range(end=dt.datetime.now(dt.timezone.utc), periods=5, freq="1min")
+    return pd.DataFrame(
+        {
+            "Open": [1, 2, 3, 4, 5],
+            "High": [2, 3, 4, 5, 6],
+            "Low": [0, 1, 2, 3, 4],
+            "Close": [1.5] * 5,
+            "Volume": [100] * 5,
+        },
+        index=idx,
+    )
+
+
+def test_minute_fallback_on_empty(monkeypatch):
+    """Minute bars fall back to Yahoo when Alpaca yields empty."""  # AI-AGENT-REF
+    monkeypatch.setattr(dfetch, "_fetch_bars", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(dfetch.yf, "download", _fake_yf)
+    now = dt.datetime.now(dt.timezone.utc)
+    df = dfetch.get_minute_df("ABBV", now - dt.timedelta(days=5), now)
+    assert not df.empty
+    assert {"open", "high", "low", "close", "volume"}.issubset({c.lower() for c in df.columns})
+
+
+def test_minute_fallback_on_exception(monkeypatch):
+    """Minute bars fall back to Yahoo when Alpaca errors."""  # AI-AGENT-REF
+    def _boom(*_, **__):
+        raise ValueError("json error")
+
+    monkeypatch.setattr(dfetch, "_fetch_bars", _boom)
+    monkeypatch.setattr(dfetch, "fh_fetcher", None)
+    monkeypatch.setattr(dfetch.yf, "download", _fake_yf)
+    now = dt.datetime.now(dt.timezone.utc)
+    df = dfetch.get_minute_df("MSFT", now - dt.timedelta(days=1), now)
+    assert not df.empty
+
+
+def test_daily_fallback_on_empty(monkeypatch):
+    """Daily bars fall back to Yahoo when Alpaca yields empty."""  # AI-AGENT-REF
+    monkeypatch.setattr(dfetch, "get_bars", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(dfetch.yf, "download", _fake_yf)
+    now = dt.datetime.now(dt.timezone.utc)
+    df = dfetch.get_bars_df("SPY", now - dt.timedelta(days=30), now, timeframe="1D")
+    assert not df.empty


### PR DESCRIPTION
## Summary
- retry alternate Alpaca feed and raise on empty bars
- add Yahoo Finance fallback for minute and daily bars
- soften empty-data logging in fetch_minute_df_safe
- add tests covering minute/daily fallback scenarios

## Testing
- `pip install pandas yfinance`
- `pip install pydantic`
- `pip install pytest-xdist`
- `pip install python-dotenv`
- `pip install joblib`
- `pip install portalocker`
- `pip install cachetools`
- `pytest -n auto --disable-warnings` *(fails: ImportError: The legacy 'ai_trading.tools' package is removed. Use 'ai_trading.tools.env_validate' explicitly.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6136333408330a709913bfca200d6