### PR TITLE
fix: allocator context and data health fallback

### DIFF
--- a/ai_trading/core/protocols.py
+++ b/ai_trading/core/protocols.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+from typing import Protocol, Sequence, Mapping, Any
+
+
+class AllocatorProtocol(Protocol):
+    def allocate(self, signals: Sequence[Mapping[str, Any]], runtime: "BotRuntime") -> Mapping[str, Any]: ...

--- a/ai_trading/position/legacy_manager.py
+++ b/ai_trading/position/legacy_manager.py
@@ -1,15 +1,13 @@
 """Position holding and management logic for reducing churn."""
 
 import logging
-from ai_trading.exc import COMMON_EXC  # AI-AGENT-REF: narrow handler
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from threading import Lock
 
-# AI-AGENT-REF: numpy and pandas are hard dependencies
-import numpy as np
-import pandas as pd
+from ai_trading.exc import COMMON_EXC  # AI-AGENT-REF: narrow handler
 
+# AI-AGENT-REF: numpy and pandas are hard dependencies
 HAS_NUMPY = True
 HAS_PANDAS = True
 
@@ -85,11 +83,11 @@ class PositionManager:
             )
 
         except COMMON_EXC as exc:  # AI-AGENT-REF: narrow
-            self.logger.warning(
-                "Failed to initialize intelligent position manager: %s", exc
+            self.logger.info(
+                "Intelligent position manager not available: %s; using legacy",
+                exc,
             )
             self.use_intelligent_system = False
-            self.logger.info("FALLBACK_MODE | Using legacy position management logic")
 
     def should_hold_position(
         self, symbol: str, current_position, unrealized_pnl_pct: float, days_held: int

--- a/tests/test_healthcheck_minute_fallback.py
+++ b/tests/test_healthcheck_minute_fallback.py
@@ -1,0 +1,40 @@
+import logging
+from types import SimpleNamespace
+
+import pandas as pd
+
+from ai_trading.core import bot_engine
+
+
+def test_healthcheck_minute_fallback(monkeypatch, caplog):
+    ctx = SimpleNamespace()
+    ctx.data_fetcher = SimpleNamespace(get_daily_df=lambda ctx, sym: pd.DataFrame())
+    ctx.data_client = object()
+
+    def fake_safe_get_stock_bars(client, request, symbol, context=""):
+        rng = pd.date_range("2024-01-01", periods=390, freq="T", tz="UTC")
+        return pd.DataFrame(
+            {
+                "timestamp": rng,
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1.0,
+                "volume": 1.0,
+            }
+        )
+
+    class DummyRequest:
+        def __init__(self, *args, **kwargs):
+            self.feed = kwargs.get("feed")
+            self.timeframe = kwargs.get("timeframe")
+
+    monkeypatch.setattr(bot_engine, "safe_get_stock_bars", fake_safe_get_stock_bars)
+    monkeypatch.setattr(bot_engine, "StockBarsRequest", DummyRequest)
+    monkeypatch.setattr(bot_engine, "TimeFrame", lambda *a, **k: None)
+    monkeypatch.setattr(bot_engine, "TimeFrameUnit", SimpleNamespace(Minute=None))
+    monkeypatch.setattr(bot_engine, "is_market_open", lambda: True)
+
+    with caplog.at_level(logging.INFO):
+        bot_engine.data_source_health_check(ctx, ["AAPL"])
+    assert any("minute fallback ok" in r.message for r in caplog.records)

--- a/tests/test_run_strategy_no_signals.py
+++ b/tests/test_run_strategy_no_signals.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+import pandas as pd
+
+from ai_trading.core import bot_engine
+
+
+class DummyStrategy:
+    name = "dummy"
+
+    def generate_signals(self, ctx):
+        return []
+
+
+class FailAllocator:
+    def allocate(self, signals):  # pragma: no cover - should not be called
+        raise AssertionError("allocate should not be called")
+
+
+def test_run_strategy_no_signals(monkeypatch):
+    ctx = SimpleNamespace(
+        strategies=[DummyStrategy()],
+        allocator=FailAllocator(),
+        api=SimpleNamespace(list_open_positions=lambda: []),
+        data_fetcher=SimpleNamespace(
+            get_daily_df=lambda ctx, sym: pd.DataFrame(),
+            get_minute_df=lambda ctx, sym: pd.DataFrame(),
+        ),
+    )
+
+    monkeypatch.setattr(bot_engine, "RL_AGENT", None)
+    import ai_trading.signals as sig
+
+    monkeypatch.setattr(sig, "generate_position_hold_signals", lambda ctx, pos: [])
+    monkeypatch.setattr(sig, "enhance_signals_with_position_logic", lambda s, ctx, h: s)
+
+    bot_engine.run_multi_strategy(ctx)

--- a/tests/test_runtime_allocator.py
+++ b/tests/test_runtime_allocator.py
@@ -1,0 +1,11 @@
+from ai_trading.config.management import TradingConfig
+from ai_trading.core.bot_engine import get_allocator
+from ai_trading.core.runtime import BotRuntime
+
+
+def test_runtime_has_allocator_when_built():
+    cfg = TradingConfig()
+    rt = BotRuntime(cfg=cfg)
+    assert getattr(rt, "allocator", None) is None
+    rt.allocator = get_allocator()
+    assert rt.allocator is not None


### PR DESCRIPTION
## Summary
- add AllocatorProtocol and runtime allocator field with safe builder handling
- fallback to minute data in data health check and guard allocation when no signals
- quiet optional integrations (Finnhub, intelligent position manager, trade log)

## Testing
- `ruff check ai_trading/core/runtime.py ai_trading/core/bot_engine.py ai_trading/data_fetcher.py ai_trading/position/legacy_manager.py tests/test_runtime_allocator.py tests/test_healthcheck_minute_fallback.py tests/test_run_strategy_no_signals.py`
- `mypy ai_trading/core/runtime.py ai_trading/core/bot_engine.py ai_trading/data_fetcher.py ai_trading/position/legacy_manager.py tests/test_runtime_allocator.py tests/test_healthcheck_minute_fallback.py tests/test_run_strategy_no_signals.py`
- `pytest tests/test_runtime_allocator.py tests/test_healthcheck_minute_fallback.py tests/test_run_strategy_no_signals.py`


------
https://chatgpt.com/codex/tasks/task_e_68a621f3f06483309f07bf572db3e25c