### PR TITLE
fix: add minute fallback and stop hook

### DIFF
--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -685,6 +685,23 @@ class ExecutionEngine:
                     removed += 1
         return removed
 
+    # AI-AGENT-REF: safe stop check hook
+    def check_stops(self) -> None:
+        """
+        Safety hook invoked after each cycle. It should never raise.
+        For now: best-effort inspection of open positions; no-op if unsupported.
+        """
+        try:
+            broker = getattr(self, "broker", None) or getattr(self, "broker_interface", None)
+            if broker is None or not hasattr(broker, "list_positions"):
+                _log.debug("check_stops: no broker/list_positions; skipping")
+                return
+
+            positions = broker.list_positions() or []
+            _log.debug("check_stops: inspected %d positions", len(positions))
+        except Exception as e:
+            _log.info("check_stops: suppressed exception: %s", e)
+
     # AI-AGENT-REF: expose short selling validation hook
     def _validate_short_selling(self, symbol: str, qty: float, price: float) -> None:
         from ai_trading.risk.short_selling import validate_short_selling

--- a/tests/test_execution_engine_check_stops.py
+++ b/tests/test_execution_engine_check_stops.py
@@ -1,0 +1,13 @@
+from ai_trading.execution.engine import ExecutionEngine
+
+
+class DummyBroker:
+    def list_positions(self):
+        return []
+
+
+def test_check_stops_noop():
+    eng = ExecutionEngine()
+    eng.broker = DummyBroker()
+    eng.check_stops()  # should not raise
+

--- a/tests/test_healthcheck_minute_fallback_handles_none.py
+++ b/tests/test_healthcheck_minute_fallback_handles_none.py
@@ -1,0 +1,12 @@
+import pandas as pd
+
+from ai_trading.core.bot_engine import _ensure_df
+
+
+def test_ensure_df_none_and_dict():
+    assert _ensure_df(None).empty
+    d = {"close": [1, 2, 3]}
+    df = _ensure_df(d)
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+

--- a/tests/test_price_snapshot_minute_fallback.py
+++ b/tests/test_price_snapshot_minute_fallback.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from types import SimpleNamespace
+
+from ai_trading.portfolio import core as portfolio_core
+
+
+def test_price_snapshot_minute_fallback(monkeypatch):
+    ctx = SimpleNamespace(
+        data_fetcher=SimpleNamespace(get_daily_df=lambda ctx, s: pd.DataFrame()),
+        data_client=object(),
+    )
+
+    def fake_safe_get_stock_bars(client, request, symbol, context=""):
+        return pd.DataFrame({"timestamp": [pd.Timestamp.utcnow()], "close": [123.0]})
+
+    class DummyRequest:
+        def __init__(self, *args, **kwargs):
+            self.feed = kwargs.get("feed")
+            self.timeframe = kwargs.get("timeframe")
+
+    monkeypatch.setattr(portfolio_core, "safe_get_stock_bars", fake_safe_get_stock_bars)
+    monkeypatch.setattr(portfolio_core, "StockBarsRequest", DummyRequest)
+    monkeypatch.setattr(portfolio_core, "TimeFrame", lambda *a, **k: None)
+    monkeypatch.setattr(portfolio_core, "TimeFrameUnit", SimpleNamespace(Minute=None))
+
+    price = portfolio_core.get_latest_price(ctx, "SPY")
+    assert price == 123.0
+


### PR DESCRIPTION
## Summary
- add `_ensure_df` helper and harden data health minute fallback
- add `ExecutionEngine.check_stops` and guard call in trading loop
- use minute bars for price snapshot when daily data is empty

## Testing
- `pytest tests/test_healthcheck_minute_fallback_handles_none.py tests/test_execution_engine_check_stops.py tests/test_price_snapshot_minute_fallback.py -n auto --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a626e40d5083308df7a35a4df299bb