### PR TITLE
fix: robust minute fallback and remove import cycle

### DIFF
--- a/ai_trading/data/__init__.py
+++ b/ai_trading/data/__init__.py
@@ -5,6 +5,20 @@ This module provides data labeling, splitting, and preprocessing
 capabilities for machine learning model training.
 """
 
-from .bars import (_ensure_df, safe_get_stock_bars, StockBarsRequest, TimeFrame, TimeFrameUnit)
+from .bars import (
+    StockBarsRequest,
+    TimeFrame,
+    TimeFrameUnit,
+    _ensure_df,
+    empty_bars_dataframe,
+    safe_get_stock_bars,
+)
 
-__all__ = ['_ensure_df', 'safe_get_stock_bars', 'StockBarsRequest', 'TimeFrame', 'TimeFrameUnit']
+__all__ = [
+    "_ensure_df",
+    "empty_bars_dataframe",
+    "safe_get_stock_bars",
+    "StockBarsRequest",
+    "TimeFrame",
+    "TimeFrameUnit",
+]

--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -1,33 +1,55 @@
 from __future__ import annotations
+
 from typing import Any
+
 import pandas as pd
 
+from ai_trading.data_fetcher import (
+    get_bars as http_get_bars,
+)  # AI-AGENT-REF: fallback helpers
+from ai_trading.data_fetcher import (
+    get_minute_df,
+)
 from ai_trading.logging import get_logger
+
 _log = get_logger(__name__)
 
 # Light, local Alpaca shims so this module never needs bot_engine
 try:
     from alpaca.data.requests import StockBarsRequest  # type: ignore
-except Exception:  # pragma: no cover
+except Exception:  # pragma: no cover  # noqa: BLE001
+
     class StockBarsRequest:  # type: ignore
         pass
 
+
 try:
     from alpaca.data.timeframe import TimeFrame, TimeFrameUnit  # type: ignore
-except Exception:  # pragma: no cover
+except Exception:  # pragma: no cover  # noqa: BLE001
+
     class TimeFrame:  # type: ignore
         def __init__(self, n: int, unit: Any) -> None:
             self.n = n
             self.unit = unit
+
     class TimeFrameUnit:  # type: ignore
         Day = "Day"
         Minute = "Minute"
 
+
 # Keep exception scope narrow and local
 COMMON_EXC = (
-    ValueError, KeyError, AttributeError, TypeError, RuntimeError,
-    ImportError, OSError, ConnectionError, TimeoutError,
+    ValueError,
+    KeyError,
+    AttributeError,
+    TypeError,
+    RuntimeError,
+    ImportError,
+    OSError,
+    ConnectionError,
+    TimeoutError,
 )
+
 
 def _ensure_df(obj: Any) -> pd.DataFrame:
     """Best-effort conversion to DataFrame, never raises."""
@@ -40,14 +62,29 @@ def _ensure_df(obj: Any) -> pd.DataFrame:
             df = getattr(obj, "df", None)
             return df if isinstance(df, pd.DataFrame) else pd.DataFrame()
         return pd.DataFrame(obj) if obj is not None else pd.DataFrame()
-    except Exception:
+    except Exception:  # noqa: BLE001
         return pd.DataFrame()
 
-def _create_empty_bars_dataframe() -> pd.DataFrame:
-    cols = ["open", "high", "low", "close", "volume", "trade_count", "vwap"]
-    return pd.DataFrame(columns=cols)
 
-def safe_get_stock_bars(client: Any, request: StockBarsRequest, symbol: str, context: str = "") -> pd.DataFrame:
+def empty_bars_dataframe() -> pd.DataFrame:
+    cols = ["open", "high", "low", "close", "volume", "trade_count", "vwap"]
+    return pd.DataFrame(columns=cols)  # AI-AGENT-REF: shared empty DataFrame
+
+
+def _create_empty_bars_dataframe() -> pd.DataFrame:
+    return empty_bars_dataframe()
+
+
+def _is_minute_timeframe(tf) -> bool:
+    try:
+        return str(tf).lower() in ("1min", "1m", "minute", "1 minute")
+    except Exception:  # noqa: BLE001
+        return False  # AI-AGENT-REF: broad but safe
+
+
+def safe_get_stock_bars(
+    client: Any, request: StockBarsRequest, symbol: str, context: str = ""
+) -> pd.DataFrame:
     """
     Safely fetch stock bars via Alpaca client and always return a DataFrame.
     This is a faithful move of the original implementation from bot_engine,
@@ -58,7 +95,22 @@ def safe_get_stock_bars(client: Any, request: StockBarsRequest, symbol: str, con
         df = getattr(response, "df", None)
         if df is None or df.empty:
             _log.warning("ALPACA_BARS_EMPTY", extra={"symbol": symbol, "context": context})
-            return _create_empty_bars_dataframe()
+            if _is_minute_timeframe(getattr(request, "timeframe", "")):
+                df = get_minute_df(
+                    symbol,
+                    getattr(request, "start", None),
+                    getattr(request, "end", None),
+                    feed=getattr(request, "feed", None),
+                )
+            else:
+                df = http_get_bars(
+                    symbol,
+                    str(getattr(request, "timeframe", "")),
+                    getattr(request, "start", None),
+                    getattr(request, "end", None),
+                    feed=getattr(request, "feed", None) or "sip",
+                )
+            return _ensure_df(df)  # AI-AGENT-REF: fallback to robust fetchers
 
         # If MultiIndex (symbol, ts), select the symbol level
         if isinstance(df.index, pd.MultiIndex):
@@ -74,11 +126,33 @@ def safe_get_stock_bars(client: Any, request: StockBarsRequest, symbol: str, con
 
         _log.warning(
             "ALPACA_PARSE_EMPTY",
-            extra={"symbol": symbol, "context": context,
-                   "feed": getattr(request, "feed", None),
-                   "timeframe": getattr(request, "timeframe", None)}
+            extra={
+                "symbol": symbol,
+                "context": context,
+                "feed": getattr(request, "feed", None),
+                "timeframe": getattr(request, "timeframe", None),
+            },
         )
         return pd.DataFrame()
     except COMMON_EXC as e:
-        _log.error("ALPACA_BARS_FETCH_FAILED", extra={"symbol": symbol, "context": context, "error": str(e)})
-        return _create_empty_bars_dataframe()
+        _log.error(
+            "ALPACA_BARS_FETCH_FAILED",
+            extra={"symbol": symbol, "context": context, "error": str(e)},
+        )
+        if _is_minute_timeframe(getattr(request, "timeframe", "")):
+            return _ensure_df(
+                get_minute_df(
+                    symbol,
+                    getattr(request, "start", None),
+                    getattr(request, "end", None),
+                    feed=getattr(request, "feed", None),
+                )
+            )
+        df = http_get_bars(
+            symbol,
+            str(getattr(request, "timeframe", "")),
+            getattr(request, "start", None),
+            getattr(request, "end", None),
+            feed=getattr(request, "feed", None) or "sip",
+        )
+        return _ensure_df(df)  # AI-AGENT-REF: HTTP/Yahoo fallback on exception

--- a/scripts/check_feed.py
+++ b/scripts/check_feed.py
@@ -1,18 +1,22 @@
 """Small diagnostic to verify market data fetch."""
 
-import pandas as pd, datetime as dt, pytz  # noqa: F401
 from types import SimpleNamespace
 
-from ai_trading.core.bot_engine import safe_get_stock_bars
-from ai_trading.core.runtime import build_runtime
+import pandas as pd  # noqa: F401
+import pytz  # noqa: F401
 
+from ai_trading.core.runtime import build_runtime
+from ai_trading.data.bars import safe_get_stock_bars
 
 if __name__ == "__main__":  # pragma: no cover - manual use
     rt = build_runtime(SimpleNamespace())
     now = pd.Timestamp.utcnow().tz_localize("UTC")
     start = now - pd.Timedelta(days=120)
-    client = getattr(rt, "data_client", SimpleNamespace(get_stock_bars=lambda req: SimpleNamespace(df=pd.DataFrame())))
+    client = getattr(
+        rt,
+        "data_client",
+        SimpleNamespace(get_stock_bars=lambda req: SimpleNamespace(df=pd.DataFrame())),
+    )
     df = safe_get_stock_bars(client, None, "SPY", "1Day")
     print("rows:", len(df), "cols:", list(df.columns))
     print(df.tail(3))
-

--- a/tests/test_healthcheck_minute_fallback.py
+++ b/tests/test_healthcheck_minute_fallback.py
@@ -3,38 +3,40 @@ from types import SimpleNamespace
 
 import pandas as pd
 
+import ai_trading.data.bars as data_bars
+import ai_trading.data_fetcher as data_fetcher
 from ai_trading.core import bot_engine
 
 
-def test_healthcheck_minute_fallback(monkeypatch, caplog):
+def test_minute_fallback_uses_http_yahoo(monkeypatch, caplog):
     ctx = SimpleNamespace()
     ctx.data_fetcher = SimpleNamespace(get_daily_df=lambda ctx, sym: pd.DataFrame())
     ctx.data_client = object()
 
-    def fake_safe_get_stock_bars(client, request, symbol, context=""):
-        rng = pd.date_range("2024-01-01", periods=390, freq="T", tz="UTC")
-        return pd.DataFrame(
-            {
-                "timestamp": rng,
-                "open": 1.0,
-                "high": 1.0,
-                "low": 1.0,
-                "close": 1.0,
-                "volume": 1.0,
-            }
-        )
+    session = SimpleNamespace(
+        open=pd.Timestamp("2024-01-01 09:30", tz="UTC"),
+        close=pd.Timestamp("2024-01-01 16:00", tz="UTC"),
+    )
+    monkeypatch.setattr(bot_engine, "last_market_session", lambda _: session)
 
-    class DummyRequest:
-        def __init__(self, *args, **kwargs):
-            self.feed = kwargs.get("feed")
-            self.timeframe = kwargs.get("timeframe")
+    def boom(*args, **kwargs):
+        raise AttributeError("'NoneType' object has no attribute 'get'")
 
-    monkeypatch.setattr(bot_engine, "safe_get_stock_bars", fake_safe_get_stock_bars)
-    monkeypatch.setattr(bot_engine, "StockBarsRequest", DummyRequest)
-    monkeypatch.setattr(bot_engine, "TimeFrame", lambda *a, **k: None)
-    monkeypatch.setattr(bot_engine, "TimeFrameUnit", SimpleNamespace(Minute=None))
-    monkeypatch.setattr(bot_engine, "is_market_open", lambda: True)
+    monkeypatch.setattr(data_bars, "safe_get_stock_bars", boom)
+
+    called = {}
+
+    def fake_get_minute_df(symbol, start, end, feed=None):
+        called["called"] = True
+        rng = pd.date_range("2024-01-01 09:30", periods=390, freq="T", tz="UTC")
+        return pd.DataFrame({"timestamp": rng, "close": 1.0})
+
+    monkeypatch.setattr(data_fetcher, "get_minute_df", fake_get_minute_df)
+    monkeypatch.setattr(bot_engine, "get_minute_df", data_fetcher.get_minute_df)
 
     with caplog.at_level(logging.INFO):
         bot_engine.data_source_health_check(ctx, ["AAPL"])
-    assert any("minute fallback ok" in r.message for r in caplog.records)
+
+    assert called.get("called")
+    record = next(r for r in caplog.records if "minute fallback ok" in r.message)
+    assert record.rows >= 300


### PR DESCRIPTION
## Summary
- centralize bar helpers and remove circular import via `ai_trading.data.bars`
- add last-market-session window and resilient minute fallback
- test minute fallback path and Alpaca SDK failure scenario

## Testing
- `ruff check . -q` *(fails: Import block is un-sorted or un-formatted, etc.)*
- `ruff check ai_trading/core/bot_engine.py ai_trading/data/__init__.py ai_trading/data/bars.py ai_trading/market/calendars.py ai_trading/portfolio/core.py scripts/check_feed.py tests/test_healthcheck_minute_fallback.py -q`
- `ruff format ai_trading/core/bot_engine.py ai_trading/data/__init__.py ai_trading/data/bars.py ai_trading/market/calendars.py ai_trading/portfolio/core.py scripts/check_feed.py tests/test_healthcheck_minute_fallback.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_68a6379f19c0833094a8cdb9bb76e0c2