### PR TITLE
fix: break data circular imports and guard datetime

### DIFF
--- a/ai_trading/data/__init__.py
+++ b/ai_trading/data/__init__.py
@@ -1,24 +1,12 @@
 """
-Data processing and labeling modules for AI trading.
+Lightweight package initializer for ai_trading.data.
 
-This module provides data labeling, splitting, and preprocessing
-capabilities for machine learning model training.
+Intentionally avoids importing heavy submodules at import time to prevent
+circular imports (e.g., data_fetcher <-> data.bars via package __init__).
+
+Import explicitly from submodules instead, for example:
+    from ai_trading.data.bars import safe_get_stock_bars, empty_bars_dataframe
+    from ai_trading.data.timeutils import ensure_utc_datetime, previous_business_day
+    from ai_trading.data.universe import load_tickers
 """
-
-from .bars import (
-    StockBarsRequest,
-    TimeFrame,
-    TimeFrameUnit,
-    _ensure_df,
-    empty_bars_dataframe,
-    safe_get_stock_bars,
-)
-
-__all__ = [
-    "_ensure_df",
-    "empty_bars_dataframe",
-    "safe_get_stock_bars",
-    "StockBarsRequest",
-    "TimeFrame",
-    "TimeFrameUnit",
-]
+__all__ = []

--- a/tests/test_data_init_no_circular.py
+++ b/tests/test_data_init_no_circular.py
@@ -1,0 +1,11 @@
+import importlib
+import sys
+
+
+def test_import_timeutils_does_not_import_bars():
+    sys.modules.pop("ai_trading.data.bars", None)
+    import ai_trading.data.timeutils  # noqa: F401
+    assert "ai_trading.data.bars" not in sys.modules
+    import ai_trading.data.bars as bars
+    df = bars.empty_bars_dataframe()
+    assert df.empty

--- a/tests/test_ensure_utc_datetime_callables.py
+++ b/tests/test_ensure_utc_datetime_callables.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from ai_trading.data.timeutils import ensure_utc_datetime
+
+
+def test_callable_rejected():
+    def cb():
+        return datetime.now(timezone.utc)
+
+    with pytest.raises(TypeError):
+        ensure_utc_datetime(cb)
+
+
+def test_callable_allowed():
+    dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+
+    def cb():
+        return dt
+
+    out = ensure_utc_datetime(cb, allow_callables=True)
+    assert out == dt

--- a/tests/test_minute_fallback_none_safe.py
+++ b/tests/test_minute_fallback_none_safe.py
@@ -1,0 +1,25 @@
+import types
+import pandas as pd
+
+import ai_trading.data.bars as data_bars
+from ai_trading.data.bars import safe_get_stock_bars, TimeFrame, TimeFrameUnit
+
+
+def test_minute_fallback_none_safe(monkeypatch):
+    class Client:
+        def get_stock_bars(self, request):
+            class Resp:
+                df = pd.DataFrame()
+            return Resp()
+
+    monkeypatch.setattr(data_bars, "get_minute_df", lambda *a, **k: None)
+
+    req = types.SimpleNamespace(
+        symbol_or_symbols=["SPY"],
+        timeframe="1Min",
+        start=None,
+        end=None,
+        feed="iex",
+    )
+    df = safe_get_stock_bars(Client(), req, "SPY", "TEST")
+    assert df.empty

--- a/tests/test_universe_csv.py
+++ b/tests/test_universe_csv.py
@@ -22,7 +22,7 @@ def test_packaged_exists_without_env(monkeypatch):
 
 def test_missing_returns_empty(monkeypatch):
     monkeypatch.setenv("AI_TRADER_TICKERS_CSV", "/nonexistent.csv")
-    from ai_trading.data import universe as U
+    import ai_trading.data.universe as U
     orig = U.locate_tickers_csv
     U.locate_tickers_csv = lambda: None
     try:


### PR DESCRIPTION
## Summary
- make ai_trading.data package lightweight to avoid circular imports
- harden ensure_utc_datetime and bar fetch fallbacks against callables and None payloads
- add regression tests for data init, callable datetime, and minute fallback

## Testing
- `pytest tests/test_data_init_no_circular.py tests/test_ensure_utc_datetime_callables.py tests/test_minute_fallback_none_safe.py -n auto --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a648e438ac8330b55f8cf7497f1419