### PR TITLE
Fix sleep shadowing crash and sanitize daily bar dates

### DIFF
--- a/tests/test_daily_bars_datetime_sanitization.py
+++ b/tests/test_daily_bars_datetime_sanitization.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pandas as pd
+
+from ai_trading.core import bot_engine as be
+
+
+def test_daily_request_sanitizes_inputs(monkeypatch):
+    fetcher = be.DataFetcher()
+    symbol = "SPY"
+
+    # Skip market-open logic
+    monkeypatch.setattr(be, "is_market_open", lambda: True)
+
+    class DummySettings:
+        alpaca_api_key = "k"
+        alpaca_secret_key_plain = "s"
+
+    monkeypatch.setattr(be, "get_settings", lambda: DummySettings)
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(be, "StockHistoricalDataClient", DummyClient)
+
+    class DummyRequest:
+        def __init__(self, symbol_or_symbols, timeframe, start, end, feed):
+            self.symbol_or_symbols = symbol_or_symbols
+            self.timeframe = timeframe
+            # Store as mixed types to test sanitization
+            self.start = start.strftime("%Y-%m-%d")  # str
+            self.end = (end - timedelta(days=1)).date()  # date
+            self.feed = feed
+
+    monkeypatch.setattr(be, "StockBarsRequest", DummyRequest)
+
+    calls = {"n": 0}
+
+    def fake_safe_get_stock_bars(client, req, sym, ctx):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TypeError("datetime argument was callable")
+        assert isinstance(req.start, datetime) and req.start.tzinfo is UTC
+        assert isinstance(req.end, datetime) and req.end.tzinfo is UTC
+        return pd.DataFrame()  # empty => function returns None
+
+    monkeypatch.setattr(be, "safe_get_stock_bars", fake_safe_get_stock_bars)
+
+    result = fetcher.get_daily_df(object(), symbol)
+
+    assert calls["n"] == 2
+    assert result is None
+

--- a/tests/test_utils_sleep_shadowing.py
+++ b/tests/test_utils_sleep_shadowing.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_sleep_uses_stdlib(monkeypatch):
+    utils = importlib.import_module("ai_trading.utils")
+
+    slept = {"count": 0}
+
+    def fake_sleep(_):
+        slept["count"] += 1
+
+    real_time = importlib.import_module("time")
+    monkeypatch.setattr(real_time, "sleep", fake_sleep)
+
+    utils.psleep(0)
+    utils.sleep_s(0)
+    utils.sleep(0)
+
+    assert slept["count"] == 3
+


### PR DESCRIPTION
## Summary
- alias stdlib `time` so sleep helpers can’t be shadowed by the package’s own `time` module
- retry daily bar fetch with sanitized UTC datetimes when Alpaca raises a callable datetime `TypeError`
- add regression tests for sleep aliasing and daily-bar datetime handling

## Testing
- `ruff check ai_trading/utils/__init__.py ai_trading/core/bot_engine.py`
- `pytest -q tests/test_utils_sleep_shadowing.py::test_sleep_uses_stdlib tests/test_daily_bars_datetime_sanitization.py::test_daily_request_sanitizes_inputs`
- `python -m ai_trading.main --iterations 2 --interval 1` *(fails: Missing Alpaca API credentials)*

## Audit Cleanup Report
- Runtime Mock* classes: **50**
- Import guards: **131**
- `__getattr__` definitions: **17**
- Dynamic `exec`: **0**
- Dynamic `eval`: **0**
- Root-level `metrics_logger` imports: **0**
- Files failing `py_compile`: **0**


------
https://chatgpt.com/codex/tasks/task_e_68a651fb6a7883308d05d6ae2eb85a11