### PR TITLE
Harden daily-bars datetime sanitization and fix ET timezone fallback

### DIFF
--- a/tests/test_daily_sanitization_retry.py
+++ b/tests/test_daily_sanitization_retry.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import ai_trading.core.bot_engine as be_mod
+from ai_trading.core.bot_engine import DataFetcher
+
+
+def test_daily_retry_handles_callable(monkeypatch):
+    # AI-AGENT-REF: ensure callable retry sanitization
+    calls = {"n": 0}
+    class Dummy:
+        alpaca_api_key = "k"
+        alpaca_secret_key_plain = "s"
+
+    monkeypatch.setattr(be_mod, "get_settings", lambda: Dummy())
+
+    def fake_safe_get_stock_bars(client, request, symbol, context):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TypeError("datetime argument was callable")
+        idx = pd.to_datetime(["2025-08-19T13:30:00Z"])
+        df = pd.DataFrame(
+            {
+                "open": [1.0],
+                "high": [1.0],
+                "low": [1.0],
+                "close": [1.0],
+                "volume": [0],
+                "symbol": [symbol],
+            },
+            index=idx,
+        )
+        return df
+
+    monkeypatch.setattr(be_mod, "safe_get_stock_bars", fake_safe_get_stock_bars)
+
+    df = DataFetcher().get_daily_df(None, "SPY")
+    assert calls["n"] == 2
+    assert df is not None
+

--- a/tests/test_datetime_wrappers.py
+++ b/tests/test_datetime_wrappers.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from ai_trading.data_fetcher import ensure_datetime
+
+
+def test_naive_et_is_converted_to_utc():
+    # AI-AGENT-REF: naive ET → UTC conversion
+    et_naive = datetime(2025, 8, 20, 9, 30)  # intended ET naive
+    dt_utc = ensure_datetime(et_naive)
+    assert dt_utc.tzinfo is timezone.utc
+    assert dt_utc.hour == 13 and dt_utc.minute == 30
+
+
+def test_callable_is_unwrapped():
+    # AI-AGENT-REF: callable handling
+    dt_utc = ensure_datetime(lambda: datetime(2025, 8, 20, 9, 30))
+    assert dt_utc.tzinfo is timezone.utc
+


### PR DESCRIPTION
## Summary
- unwrap callables and localize naive ET datetimes before UTC conversion
- default daily-bar retry window to previous NYSE session when sanitization fails
- add regression tests for callable handling and fallback sanitization

## Testing
- `ruff check ai_trading/core/bot_engine.py ai_trading/data_fetcher.py`
- `pytest tests/test_datetime_wrappers.py::test_naive_et_is_converted_to_utc tests/test_datetime_wrappers.py::test_callable_is_unwrapped tests/test_daily_sanitization_retry.py::test_daily_retry_handles_callable`
- `pytest -n auto --disable-warnings` *(fails: ImportError: cannot import name 'ensure_datetime' ...)*
- `python -m ai_trading.main --iterations 2 --interval 1` *(fails: Missing Alpaca API credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a674ca4ddc8330a97ec367bd5d7ac8