### PR TITLE
Pre-sanitize daily bars and clarify HTTP pool metric

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -370,7 +370,10 @@ def main(argv: list[str] | None = None) -> None:
                 logger.exception("run_cycle failed")
             count += 1
 
-            logger.info("HTTP_POOL_STATS", extra=http_utils.pool_stats())
+            # AI-AGENT-REF: clarify pool stats origin
+            _pool_stats = http_utils.pool_stats()
+            _pool_stats["transport"] = "requests"
+            logger.info("REQUESTS_POOL_STATS", extra=_pool_stats)
             logger.info(
                 "CYCLE_TIMING",
                 extra={


### PR DESCRIPTION
## Summary
- sanitize daily bar request datetimes up front to avoid noisy retries
- label pool stats as REQUESTS_POOL_STATS and tag transport="requests"

## Testing
- `ruff check ai_trading/core/bot_engine.py ai_trading/main.py` *(fails: import-order, blind-except)*
- `PYTHONPATH=/tmp:$PYTHONPATH pytest -q tests/test_daily_bars_datetime_sanitization.py tests/test_data_fetcher_timezone.py tests/test_critical_datetime_fixes.py` *(pass)*
- `PYTHONPATH=/tmp:$PYTHONPATH pytest -n auto --disable-warnings` *(fails: missing modules, runtime errors)*
- `PYTHONPATH=/tmp:$PYTHONPATH python -m ai_trading.main --iterations 2 --interval 1` *(fails: missing Alpaca credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a68465e1608330892e03bedbcdd766