### PR TITLE
Pre-sanitize daily bar datetimes, canonicalize minute fallback logs, clarify HTTP metric, add tests

### DIFF
--- a/tests/test_daily_sanitize_debug.py
+++ b/tests/test_daily_sanitize_debug.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import types
+
+import pandas as pd
+
+from ai_trading.core import bot_engine as be
+
+
+def test_callable_triggers_single_debug(monkeypatch, caplog):
+    caplog.set_level("DEBUG")
+
+    class DummyReq:
+        def __init__(self, **kwargs):
+            self.start = lambda: kwargs.get("start")
+            self.end = lambda: kwargs.get("end")
+            self.symbol_or_symbols = kwargs.get("symbol_or_symbols")
+            self.timeframe = kwargs.get("timeframe")
+            self.feed = kwargs.get("feed")
+
+    monkeypatch.setattr(be, "StockBarsRequest", DummyReq)
+    monkeypatch.setattr(be, "is_market_open", lambda: True)
+
+    class DummySettings:
+        alpaca_api_key = "k"
+        alpaca_secret_key_plain = "s"
+
+    monkeypatch.setattr(be, "get_settings", lambda: DummySettings)
+    monkeypatch.setattr(be, "StockHistoricalDataClient", lambda *a, **k: object())
+
+    def fake_safe(client, req, symbol, ctx):
+        return pd.DataFrame({"close": [1.0]}, index=[pd.Timestamp("2025-08-19", tz="UTC")])
+
+    monkeypatch.setattr(be, "safe_get_stock_bars", fake_safe)
+
+    fetcher = be.DataFetcher()
+    ctx = types.SimpleNamespace()
+    fetcher.get_daily_df(ctx, "SPY")
+
+    records = [r for r in caplog.records if r.message == "DAILY_BARS_INPUT_SANITIZED"]
+    assert len(records) == 1
+

--- a/tests/test_fallback_logging_payload.py
+++ b/tests/test_fallback_logging_payload.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from ai_trading.data.bars import (
+    _format_fallback_payload,
+    _log_fallback_window_debug,
+)
+from ai_trading.data.timeutils import nyse_session_utc
+
+
+def test_fallback_payload_is_canonical(caplog):
+    d = date(2025, 8, 20)
+    start_u, end_u = nyse_session_utc(d)
+    payload = _format_fallback_payload("1Min", "iex", start_u, end_u)
+    assert isinstance(payload, list) and len(payload) == 4
+    tf, feed, s, e = payload
+    assert tf == "1Min"
+    assert feed in {"iex", "sip"}
+    assert s.endswith("+00:00") or s.endswith("Z")
+    assert e.endswith("+00:00") or e.endswith("Z")
+    logger = logging.getLogger("test_fallback_payload")
+    with caplog.at_level("DEBUG"):
+        _log_fallback_window_debug(logger, d, start_u, end_u)
+    records = [r for r in caplog.records if r.message == "DATA_FALLBACK_WINDOW_DEBUG"]
+    assert len(records) == 1
+


### PR DESCRIPTION
## Summary
- canonical minute-fallback logging helper and ET↔UTC debug line
- add tests for fallback payload formatting and daily sanitize debug path

## Testing
- `ruff check ai_trading/core/bot_engine.py ai_trading/data/bars.py ai_trading/main.py` *(main.py reports existing import-order errors)*
- `ruff check tests/test_daily_sanitize_debug.py tests/test_fallback_logging_payload.py`
- `pytest -q tests/test_fallback_logging_payload.py::test_fallback_payload_is_canonical tests/test_daily_sanitize_debug.py::test_callable_triggers_single_debug`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `python -m ai_trading.main --iterations 2 --interval 1` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_68a687faf15883309ebd2f452aad9f5d