### PR TITLE
Canonicalize Alpaca timeframe/feed in daily HTTP fallback, eliminate stub leakage in logs, and add Settings.webhook_secret

### DIFF
--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from functools import lru_cache
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any
 
 from pydantic import Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from ai_trading.settings import _secret_to_str  # AI-AGENT-REF: centralized normalization
 
+from ai_trading.settings import _secret_to_str  # AI-AGENT-REF: centralized normalization
 
 TICKERS_FILE = os.getenv("AI_TRADER_TICKERS_FILE", "tickers.csv")
 TICKERS_CSV = os.getenv("AI_TRADER_TICKERS_CSV")  # optional literal CSV list
@@ -40,13 +40,15 @@ class Settings(BaseSettings):
     alpaca_secret_key: SecretStr = Field(
         default=SecretStr("test_secret"), alias="ALPACA_SECRET_KEY"
     )
-    redis_url: Optional[str] = Field(default=None, alias="REDIS_URL")
+    redis_url: str | None = Field(default=None, alias="REDIS_URL")  # AI-AGENT-REF: modern union
     # AI-AGENT-REF: include Alpaca base URL
     alpaca_base_url: str = Field(
         default="https://paper-api.alpaca.markets", alias="ALPACA_BASE_URL"
     )
     # Expose canonical env key; alias resolution handled by resolver
     trading_mode: str = Field(default="balanced", alias="TRADING_MODE")
+    # AI-AGENT-REF: secret used by webhook handlers
+    webhook_secret: str | None = Field(default=None, alias="WEBHOOK_SECRET")
 
     REGIME_MIN_ROWS: int = Field(200, alias="REGIME_MIN_ROWS")
     data_warmup_lookback_days: int = Field(60, alias="DATA_WARMUP_LOOKBACK_DAYS")

--- a/tests/test_bars_timeframe_feed_canonicalization.py
+++ b/tests/test_bars_timeframe_feed_canonicalization.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from ai_trading.data import bars as bars_mod
+
+
+def _dummy_callable():  # AI-AGENT-REF: simulate stub attribute
+    return None
+
+
+def test_canonicalizers_map_weird_values_to_safe_defaults():
+    assert bars_mod._to_timeframe_str(_dummy_callable) == "1Day"
+    assert bars_mod._to_timeframe_str("1m") == "1Min"
+    assert bars_mod._to_timeframe_str("1Min") == "1Min"
+    assert bars_mod._to_timeframe_str("DAY") == "1Day"
+
+    assert bars_mod._to_feed_str(_dummy_callable) == "sip"
+    assert bars_mod._to_feed_str("IEX") == "iex"
+    assert bars_mod._to_feed_str("sip") == "sip"
+
+
+def test_safe_get_stock_bars_uses_canonicalized_values(monkeypatch):
+    class Req:
+        timeframe = _dummy_callable
+        feed = _dummy_callable
+        start = None
+        end = None
+
+    captured: dict[str, str] = {}
+
+    def fake_http_get_bars(symbol, timeframe, start, end, *, feed=None):
+        captured["timeframe"] = timeframe
+        captured["feed"] = feed
+        return pd.DataFrame()
+
+    monkeypatch.setattr(bars_mod, "http_get_bars", fake_http_get_bars)
+
+    class DummyClient:
+        class _Resp:
+            df = pd.DataFrame()
+
+        def get_stock_bars(self, request):  # pragma: no cover - simple stub
+            return self._Resp()
+
+    bars_mod.safe_get_stock_bars(DummyClient(), Req(), symbol="SPY", context="DAILY")
+
+    assert captured["timeframe"] in {"1Day", "1Min"}
+    assert captured["feed"] in {"iex", "sip"}

--- a/tests/test_minute_fallback_debug_path.py
+++ b/tests/test_minute_fallback_debug_path.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from ai_trading.data import bars as bars_mod
+
+
+def test_minute_fallback_debug_path_emits_record(caplog):
+    caplog.set_level("DEBUG")
+    bars_mod.fetch_minute_fallback(None, "SPY", now_utc=bars_mod.now_utc())
+    records = [r for r in caplog.records if r.message == "DATA_FALLBACK_WINDOW_DEBUG"]
+    assert records, "expected debug window log"  # AI-AGENT-REF: ensure debug path coverage


### PR DESCRIPTION
## Summary
- normalize timeframe and feed strings in Alpaca bar fetcher to avoid stub leakage in logs and HTTP requests
- add optional `webhook_secret` setting with env alias
- test canonicalization helpers and minute fallback debug logging

## Testing
- `ruff check ai_trading/data/bars.py ai_trading/config/settings.py tests/test_bars_timeframe_feed_canonicalization.py tests/test_minute_fallback_debug_path.py`
- `mypy ai_trading/data/bars.py ai_trading/config/settings.py tests/test_bars_timeframe_feed_canonicalization.py tests/test_minute_fallback_debug_path.py`
- `pytest` *(fails: ImportError: cannot import name 'get_or_load' from 'ai_trading.market.cache')*
- `pytest tests/test_bars_timeframe_feed_canonicalization.py tests/test_minute_fallback_debug_path.py`


------
https://chatgpt.com/codex/tasks/task_e_68a690b17f248330a7b454483c4e63bd