### PR TITLE
Unify feed string mapping across data_fetcher and bars for perfect symmetry

### DIFF
--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -64,12 +64,16 @@ def _to_timeframe_str(tf: object) -> str:
 
 def _to_feed_str(feed: object) -> str:
     """Return canonical Alpaca feed string ("iex" or "sip").
-    Defaults to "sip" on ambiguity."""  # AI-AGENT-REF: feed canonicalization
+    Defaults to "sip" on ambiguity. Accepts slightly messy inputs."""  # AI-AGENT-REF: feed canonicalization
     try:
         s = str(feed).strip().lower()
     except Exception:  # noqa: BLE001
         return "sip"
-    return "iex" if s == "iex" else "sip"
+    if "iex" in s:
+        return "iex"
+    if "sip" in s:
+        return "sip"
+    return "sip"
 
 
 def _format_fallback_payload_df(

--- a/tests/test_data_fetcher_canonicalization.py
+++ b/tests/test_data_fetcher_canonicalization.py
@@ -17,7 +17,8 @@ def test_canonical_helpers() -> None:
 
     assert df._to_timeframe_str(Weird()) in {"1Day", "1Min"}
     assert df._to_feed_str("IEX") == "iex"
-    assert df._to_feed_str("sip") == "sip"
+    assert df._to_feed_str(" sip ") == "sip"
+    assert df._to_feed_str("iex-feed") == "iex"
     assert df._to_feed_str(object()) in {"sip", "iex"}
 
 


### PR DESCRIPTION
## Summary
- mirror feed substring canonicalization in `data_fetcher._to_feed_str`
- cover sloppy feed inputs (e.g. `" sip "`, `"iex-feed"`) in tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -n auto --disable-warnings tests/test_bars_timeframe_feed_canonicalization.py tests/test_data_fetcher_canonicalization.py tests/test_fallback_logging_payload.py tests/test_daily_sanitize_debug.py -q`
- `pytest -n auto --disable-warnings -q` *(fails: ImportError: cannot import name 'ensure_datetime', plus other test failures)*
- `python -m ai_trading.main` *(fails: No module named 'tenacity'; API start failure: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68a6988f6e6483308ec65dfe01db05dc