### PR TITLE
Central logging normalization helpers; apply to data-fetch hot path (timeframe/feed canonicalization)

### DIFF
--- a/ai_trading/logging/normalize.py
+++ b/ai_trading/logging/normalize.py
@@ -1,0 +1,56 @@
+"""Central helpers to canonicalize logging payload fields."""  # AI-AGENT-REF: shared normalization utilities
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping  # AI-AGENT-REF: type hints for helpers
+from typing import Any
+
+
+def _as_lower_str(value: Any) -> str:
+    try:
+        return str(value).strip().lower()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def canon_timeframe(value: Any) -> str:
+    """Return canonical timeframe string: "1Min" or "1Day".
+
+    Accepts strings, enums, or odd callables (from stubs). Defaults to "1Day".
+    """  # AI-AGENT-REF: unify timeframe normalization
+
+    s = _as_lower_str(value)
+    if s in {"1min", "1m", "minute", "1 minute"}:
+        return "1Min"
+    if s in {"1day", "1d", "day", "1 day"}:
+        return "1Day"
+    if "min" in s:
+        return "1Min"
+    if "day" in s:
+        return "1Day"
+    return "1Day"
+
+
+def canon_feed(value: Any) -> str:
+    """Return canonical feed: "iex" or "sip". Defaults to "sip" on ambiguity."""  # AI-AGENT-REF: unify feed normalization
+
+    s = _as_lower_str(value)
+    if "iex" in s:
+        return "iex"
+    if "sip" in s:
+        return "sip"
+    return "sip"
+
+
+def normalize_extra(extra: Mapping[str, Any] | None) -> dict:
+    """Return a copy of `extra` with canonical feed/timeframe if present."""  # AI-AGENT-REF: ensure logging extras use canonical values
+
+    if extra is None:
+        return {}
+    out: MutableMapping[str, Any] = dict(extra)
+    if "feed" in out:
+        out["feed"] = canon_feed(out["feed"])  # type: ignore[index]
+    if "timeframe" in out:
+        out["timeframe"] = canon_timeframe(out["timeframe"])  # type: ignore[index]
+    return dict(out)
+


### PR DESCRIPTION
## Summary
- add `logging.normalize` module for canonical feed/timeframe mapping
- wire `data_fetcher` to centralized helpers and normalize logging extras

## Testing
- `ruff check ai_trading/logging/normalize.py ai_trading/data_fetcher.py`
- `pytest -n auto --disable-warnings` *(fails: test_tf_object_normalized, test_fetch_minute_df_safe_market_closed, test_dependency_injection, test_wrapped_get_retries_and_parses, test_alpaca_api_format_compatibility)*
- `pytest tests/test_data_fetcher_canonicalization.py tests/test_redact.py -q`
- `python -m ai_trading.main --iterations 1 --interval 1` *(fails: Missing Alpaca API credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a69d8e75808330b6d7b6a645565572