### PR TITLE
refactor: use central canonicalizers in bars

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -19,42 +19,19 @@ from ai_trading.logging.empty_policy import (
 from ai_trading.logging.empty_policy import (
     should_emit as _empty_should_emit,
 )
+from ai_trading.logging.normalize import (  # AI-AGENT-REF: central canonicalizers
+    canon_feed as _canon_feed,
+)
+from ai_trading.logging.normalize import (
+    canon_timeframe as _canon_tf,
+)
 from ai_trading.utils.time import now_utc
 
 from .timeutils import ensure_utc_datetime, expected_regular_minutes
 
 _log = get_logger(__name__)
 
-# AI-AGENT-REF: canonicalize timeframe and feed to avoid stub leakage
-def _to_timeframe_str(tf: object) -> str:
-    """Return canonical timeframe string ("1Min" or "1Day")."""
-    try:
-        s = str(tf).strip().lower()
-    except Exception:  # noqa: BLE001
-        return "1Day"
-    if s in {"1min", "1m", "minute", "1 minute"}:
-        return "1Min"
-    if s in {"1day", "1d", "day", "1 day"}:
-        return "1Day"
-    if "min" in s:
-        return "1Min"
-    if "day" in s:
-        return "1Day"
-    return "1Day"
-
-
-# AI-AGENT-REF: normalize feed names
-def _to_feed_str(feed: object) -> str:
-    """Return canonical feed name ("iex" or "sip")."""
-    try:
-        s = str(feed).strip().lower()
-    except Exception:  # noqa: BLE001
-        return "sip"
-    if "iex" in s:
-        return "iex"
-    if "sip" in s:
-        return "sip"
-    return "sip"
+"""AI-AGENT-REF: canonicalizers moved to ai_trading.logging.normalize"""
 # AI-AGENT-REF: canonical fallback payload builder
 def _format_fallback_payload(tf_str: str, feed_str: str, start_utc: datetime, end_utc: datetime) -> list[str]:
     s = start_utc.astimezone(UTC).isoformat()
@@ -176,11 +153,11 @@ def safe_get_stock_bars(
                     symbol,
                     start_dt,
                     end_dt,
-                    feed=_to_feed_str(getattr(request, "feed", None)),
+                    feed=_canon_feed(getattr(request, "feed", None)),  # AI-AGENT-REF: central feed
                 )
             else:
-                tf_str = _to_timeframe_str(getattr(request, "timeframe", ""))
-                feed_str = _to_feed_str(getattr(request, "feed", None))
+                tf_str = _canon_tf(getattr(request, "timeframe", ""))  # AI-AGENT-REF
+                feed_str = _canon_feed(getattr(request, "feed", None))
                 df = http_get_bars(
                     symbol,
                     tf_str,
@@ -206,9 +183,9 @@ def safe_get_stock_bars(
         _key = (
             symbol,
             str(context),
+            _canon_feed(getattr(request, "feed", None)),  # AI-AGENT-REF
+            _canon_tf(getattr(request, "timeframe", "")),
             _now.date().isoformat(),
-            _to_feed_str(getattr(request, "feed", None)),
-            _to_timeframe_str(getattr(request, "timeframe", "")),
         )
         if _empty_should_emit(_key, _now):
             lvl = _empty_classify(is_market_open=False)
@@ -219,8 +196,8 @@ def safe_get_stock_bars(
                 extra={
                     "symbol": symbol,
                     "context": context,
-                    "feed": _to_feed_str(getattr(request, "feed", None)),
-                    "timeframe": _to_timeframe_str(getattr(request, "timeframe", "")),
+                    "feed": _canon_feed(getattr(request, "feed", None)),
+                    "timeframe": _canon_tf(getattr(request, "timeframe", "")),
                     "occurrences": cnt,
                 },
             )
@@ -236,11 +213,11 @@ def safe_get_stock_bars(
                     symbol,
                     start_dt,
                     end_dt,
-                    feed=_to_feed_str(getattr(request, "feed", None)),
+                    feed=_canon_feed(getattr(request, "feed", None)),
                 )
             )
-        tf_str = _to_timeframe_str(getattr(request, "timeframe", ""))
-        feed_str = _to_feed_str(getattr(request, "feed", None))
+        tf_str = _canon_tf(getattr(request, "timeframe", ""))
+        feed_str = _canon_feed(getattr(request, "feed", None))
         df = http_get_bars(symbol, tf_str, start_dt, end_dt, feed=feed_str)
         return _ensure_df(df)  # AI-AGENT-REF: HTTP/Yahoo fallback on exception
 

--- a/tests/test_bars_timeframe_feed_canonicalization.py
+++ b/tests/test_bars_timeframe_feed_canonicalization.py
@@ -4,20 +4,28 @@ import pandas as pd
 
 from ai_trading.data import bars as bars_mod
 
+# AI-AGENT-REF: test central helpers
+from ai_trading.logging.normalize import (
+    canon_feed as _canon_feed,
+)
+from ai_trading.logging.normalize import (
+    canon_timeframe as _canon_tf,
+)
+
 
 def _dummy_callable():  # AI-AGENT-REF: simulate stub attribute
     return None
 
 
 def test_canonicalizers_map_weird_values_to_safe_defaults():
-    assert bars_mod._to_timeframe_str(_dummy_callable) == "1Day"
-    assert bars_mod._to_timeframe_str("1m") == "1Min"
-    assert bars_mod._to_timeframe_str("1Min") == "1Min"
-    assert bars_mod._to_timeframe_str("DAY") == "1Day"
+    assert _canon_tf(_dummy_callable) == "1Day"
+    assert _canon_tf("1m") == "1Min"
+    assert _canon_tf("1Min") == "1Min"
+    assert _canon_tf("DAY") == "1Day"
 
-    assert bars_mod._to_feed_str(_dummy_callable) == "sip"
-    assert bars_mod._to_feed_str("IEX") == "iex"
-    assert bars_mod._to_feed_str("sip") == "sip"
+    assert _canon_feed(_dummy_callable) == "sip"
+    assert _canon_feed("IEX") == "iex"
+    assert _canon_feed("sip") == "sip"
 
 
 def test_safe_get_stock_bars_uses_canonicalized_values(monkeypatch):


### PR DESCRIPTION
## Summary
- import canon_timeframe and canon_feed from logging.normalize and drop local helpers
- update bars logging to use canon_timeframe/canon_feed
- adjust bars canonicalization test to target shared helpers

## Testing
- `ruff check ai_trading/data/bars.py tests/test_bars_timeframe_feed_canonicalization.py`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError, ImportError, AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a1e04f148330a6d4f123aa6aa4fc