### PR TITLE
Harden logging + HTTP retries; add normalization tests

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import os
 import threading
 import time  # AI-AGENT-REF: tests patch main.time.sleep
@@ -100,7 +99,7 @@ from typing import Any
 config: Any | None = None
 
 
-logger = logging.getLogger(__name__)
+# AI-AGENT-REF: structured logger already bound via get_logger(__name__); avoid rebinding
 
 _SHUTDOWN = threading.Event()  # AI-AGENT-REF: signal-triggered shutdown flag
 

--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -41,7 +41,7 @@ def build_retrying_session(
         read=total_retries,
         backoff_factor=backoff_factor,
         status_forcelist=status_forcelist,
-        allowed_methods=("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"),
+        allowed_methods=frozenset({"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"}),  # AI-AGENT-REF: frozenset for urllib3 compatibility
         raise_on_status=False,
     )
     adapter = HTTPAdapter(

--- a/tests/test_logging_normalize.py
+++ b/tests/test_logging_normalize.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from ai_trading.logging.normalize import (
+    canon_feed,
+    canon_timeframe,
+    normalize_extra,
+)
+
+
+def _fn_stub():  # AI-AGENT-REF: stub function to mimic leakage
+    pass
+
+
+def test_canon_timeframe_basic():
+    assert canon_timeframe("1m") == "1Min"
+    assert canon_timeframe("1Min") == "1Min"
+    assert canon_timeframe("1day") == "1Day"
+    assert canon_timeframe("1Day") == "1Day"
+
+
+def test_canon_timeframe_odd_values():
+    # AI-AGENT-REF: odd inputs fallback to Day
+    assert canon_timeframe(_fn_stub) == "1Day"
+    assert canon_timeframe(None) == "1Day"
+
+
+def test_canon_feed_basic():
+    assert canon_feed("IEX") == "iex"
+    assert canon_feed("sip") == "sip"
+
+
+def test_normalize_extra_applies_canonicalization():
+    e = normalize_extra({"feed": _fn_stub, "timeframe": _fn_stub})
+    assert e["feed"] in {"iex", "sip"}
+    assert e["timeframe"] in {"1Min", "1Day"}
+

--- a/tests/test_net_http_timeout.py
+++ b/tests/test_net_http_timeout.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import types
+
+import requests
+
+from ai_trading.net.http import TimeoutSession, build_retrying_session
+
+
+def test_timeoutsession_injects_default_timeout(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, url, **kwargs):  # AI-AGENT-REF: capture timeout
+        captured.update(kwargs)
+        return types.SimpleNamespace(ok=True)
+
+    monkeypatch.setattr(requests.Session, "request", fake_request, raising=True)
+
+    s = TimeoutSession(default_timeout=(5.0, 10.0))
+    s.request("GET", "http://unit.test")
+    assert captured["timeout"] == (5.0, 10.0)
+
+    captured.clear()
+    s.request("GET", "http://unit.test", timeout=1.23)
+    assert captured["timeout"] == 1.23
+
+
+def test_build_retrying_session_defaults(monkeypatch):
+    captured = {}
+
+    def fake_request(self, method, url, **kwargs):  # AI-AGENT-REF: capture timeout
+        captured.update(kwargs)
+        return types.SimpleNamespace(ok=True)
+
+    monkeypatch.setattr(requests.Session, "request", fake_request, raising=True)
+
+    s = build_retrying_session(connect_timeout=2.0, read_timeout=3.0)
+    s.request("GET", "http://unit.test")
+    assert captured["timeout"] == (2.0, 3.0)
+

--- a/tests/test_signal_handlers_logging.py
+++ b/tests/test_signal_handlers_logging.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import signal as _signal
+import types
+
+import ai_trading.main as main
+
+
+def test_install_signal_handlers_logs_service_signal(monkeypatch):
+    calls = []
+
+    def fake_info(msg, *args, **kwargs):  # AI-AGENT-REF: capture SERVICE_SIGNAL
+        calls.append((msg, args, kwargs))
+
+    monkeypatch.setattr(main, "logger", types.SimpleNamespace(info=fake_info))
+
+    installed = {}
+
+    def fake_signal(sig, handler):  # AI-AGENT-REF: record handler
+        installed[sig] = handler
+
+    monkeypatch.setattr(_signal, "signal", fake_signal)
+
+    main._install_signal_handlers()
+    assert _signal.SIGINT in installed and _signal.SIGTERM in installed
+
+    handler = installed[_signal.SIGINT]
+    handler(_signal.SIGINT, None)
+
+    assert any(call[0] == "SERVICE_SIGNAL" for call in calls)
+


### PR DESCRIPTION
## Summary
- keep structured logger from the start without rebinding
- use frozenset for urllib3 Retry allowed methods
- add tests for logging normalization, HTTP timeout injection, signal handler logging, and minute fallback canonicalization

## Testing
- `ruff check ai_trading/main.py ai_trading/net/http.py tests/test_healthcheck_minute_fallback.py tests/test_logging_normalize.py tests/test_net_http_timeout.py tests/test_signal_handlers_logging.py`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'cachetools')*


------
https://chatgpt.com/codex/tasks/task_e_68a6abfb4b1483308b86c072ed24c8c1