### PR TITLE
test: add logging sanitizer and setup tests

### DIFF
--- a/tests/test_sanitizing_logger_adapter.py
+++ b/tests/test_sanitizing_logger_adapter.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+
+from ai_trading.logging import SanitizingLoggerAdapter
+
+
+class _CaptureHandler(logging.Handler):
+    """Capture the last log record for assertions."""
+
+    def __init__(self):
+        super().__init__()
+        self.last: logging.LogRecord | None = None
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D401
+        self.last = record
+
+
+def test_extra_key_collisions_are_prefixed():
+    """Ensure reserved keys in extra dict are prefixed, preserving core fields."""
+    # Fresh, isolated logger
+    logger = logging.getLogger("ai_trading.tests.collisions")
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+
+    adapter = SanitizingLoggerAdapter(logger, {})
+    handler = _CaptureHandler()
+    logger.addHandler(handler)
+    try:
+        adapter.info(
+            "hello",
+            extra={
+                "levelname": "XLEVEL",  # reserved key collision
+                "msg": "XMSG",         # reserved key collision (message)
+                "feed": "iex",          # a normal key for contrast
+            },
+        )
+    finally:
+        logger.removeHandler(handler)
+
+    rec = handler.last
+    assert rec, "No log record captured"
+
+    # Standard fields must remain intact
+    assert rec.levelname == "INFO"
+    assert rec.getMessage() == "hello"
+
+    # The extra values should appear under a *prefixed* key, not the reserved names
+    d = rec.__dict__
+    has_level_extra = any(
+        k != "levelname" and "levelname" in k and d[k] == "XLEVEL" for k in d
+    )
+    has_message_extra = any(
+        k != "msg" and "msg" in k and d[k] == "XMSG" for k in d
+    )
+    assert has_level_extra, f"Collision key 'levelname' was not prefixed: keys={list(d.keys())}"
+    assert has_message_extra, f"Collision key 'msg' was not prefixed: keys={list(d.keys())}"
+

--- a/tests/test_validate_logging_setup_single_handler.py
+++ b/tests/test_validate_logging_setup_single_handler.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import inspect
+import logging
+import pytest
+
+import ai_trading.logging as L
+
+
+def test_validate_logging_setup_single_handler():
+    """Ensure validate_logging_setup() deduplicates handlers."""
+    if not hasattr(L, "validate_logging_setup"):
+        pytest.skip(
+            "validate_logging_setup() not present in ai_trading.logging; add it or adjust test."
+        )
+
+    sig = inspect.signature(L.validate_logging_setup)
+    if len(sig.parameters) != 1:
+        pytest.skip(
+            "validate_logging_setup() does not accept a logger argument; dedup test skipped."
+        )
+
+    # Use a dedicated logger name to avoid global handlers
+    logger = logging.getLogger("ai_trading.tests.single_handler")
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+
+    # Add two duplicate StreamHandlers deliberately
+    logger.addHandler(logging.StreamHandler())
+    logger.addHandler(logging.StreamHandler())
+    pre_count = sum(isinstance(h, logging.StreamHandler) for h in logger.handlers)
+    assert pre_count == 2, "Fixture assumption failed: expected two handlers"
+
+    count = L.validate_logging_setup(logger)  # expected to dedupe
+    post_count = sum(isinstance(h, logging.StreamHandler) for h in logger.handlers)
+    assert post_count == 1, f"Expected a single StreamHandler, found {post_count}"
+    if isinstance(count, int):
+        assert count == len(logger.handlers)
+


### PR DESCRIPTION
## Summary
- test that SanitizingLoggerAdapter prefixes reserved LogRecord keys
- add guard for validate_logging_setup to ensure single handler or skip

## Testing
- `pytest tests/test_sanitizing_logger_adapter.py tests/test_validate_logging_setup_single_handler.py -vv`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_68a6ad545f98833081e5df5e9f1d953e