### PR TITLE
feat: dedupe logger stream handlers

### DIFF
--- a/tests/test_sanitizing_logger_adapter.py
+++ b/tests/test_sanitizing_logger_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import ai_trading.logging as L
 from ai_trading.logging import SanitizingLoggerAdapter
 
 
@@ -32,7 +33,7 @@ def test_extra_key_collisions_are_prefixed():
             "hello",
             extra={
                 "levelname": "XLEVEL",  # reserved key collision
-                "msg": "XMSG",         # reserved key collision (message)
+                "message": "XMSG",      # reserved key collision (message)
                 "feed": "iex",          # a normal key for contrast
             },
         )
@@ -46,14 +47,12 @@ def test_extra_key_collisions_are_prefixed():
     assert rec.levelname == "INFO"
     assert rec.getMessage() == "hello"
 
-    # The extra values should appear under a *prefixed* key, not the reserved names
+    # The extra values should appear under the exact 'x_' prefix your adapter uses
     d = rec.__dict__
-    has_level_extra = any(
-        k != "levelname" and "levelname" in k and d[k] == "XLEVEL" for k in d
+    assert d.get("x_levelname") == "XLEVEL", (
+        f"Expected x_levelname='XLEVEL', got: {d.get('x_levelname')} (keys={list(d.keys())})"
     )
-    has_message_extra = any(
-        k != "msg" and "msg" in k and d[k] == "XMSG" for k in d
+    assert d.get("x_message") == "XMSG", (
+        f"Expected x_message='XMSG', got: {d.get('x_message')} (keys={list(d.keys())})"
     )
-    assert has_level_extra, f"Collision key 'levelname' was not prefixed: keys={list(d.keys())}"
-    assert has_message_extra, f"Collision key 'msg' was not prefixed: keys={list(d.keys())}"
 


### PR DESCRIPTION
## Summary
- expose `dedupe_stream_handlers` to remove duplicate StreamHandlers
- allow `validate_logging_setup` to operate on a given logger and optionally dedupe
- adjust logging tests to expect `x_`-prefixed keys and use new helper

## Testing
- `ruff check ai_trading/logging/__init__.py`
- `pytest -q tests/test_sanitizing_logger_adapter.py tests/test_validate_logging_setup_single_handler.py`
- `pytest -n auto --disable-warnings` *(fails: ImportError: cannot import name 'ensure_datetime' from 'ai_trading.data_fetcher', NameError: name 'MockConfigManager' is not defined, TypeError: int() argument must be a string, ImportError: cannot import name 'get_or_load' from 'ai_trading.fetch_contract', ImportError: cannot import name 'ensure_datetime' from 'ai_trading.data_fetcher')*

------
https://chatgpt.com/codex/tasks/task_e_68a6afcce76c8330a8069486509f0784