### PR TITLE
Dynamic MAX_POSITION_SIZE (AUTO mode via Alpaca equity × capital_cap) + caching, clamps, logs, and tests

### DIFF
--- a/ai_trading/position_sizing.py
+++ b/ai_trading/position_sizing.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from math import floor
+from typing import Any
+
+from ai_trading.logging import get_logger  # AI-AGENT-REF: structured logging
+from ai_trading.net.http import get_global_session
+
+_log = get_logger(__name__)
+
+
+@dataclass
+class _Cache:
+    value: float | None = None
+    ts: datetime | None = None
+
+
+_CACHE = _Cache()
+
+
+def _now_utc() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _should_refresh(ttl_seconds: float) -> bool:
+    if _CACHE.ts is None:
+        return True
+    return _now_utc() - _CACHE.ts >= timedelta(seconds=ttl_seconds)
+
+
+def _coerce_float(val: Any, default: float = 0.0) -> float:
+    try:
+        return float(val)
+    except Exception:  # noqa: BLE001
+        return default
+
+
+def _clamp(val: float, vmin: float | None, vmax: float | None) -> float:
+    if vmin is not None:
+        val = max(val, vmin)
+    if vmax is not None:
+        val = min(val, vmax)
+    return val
+
+
+def _fallback_max_size(cfg, tcfg) -> float:
+    for name in ("max_position_size_fallback", "max_position_size_default"):
+        v = getattr(tcfg, name, None)
+        if v is not None:
+            return _coerce_float(v, 8000.0)
+    v = getattr(cfg, "default_max_position_size", None)
+    if v is not None:
+        return _coerce_float(v, 8000.0)
+    return 8000.0
+
+
+def _get_equity_from_alpaca(cfg) -> float:
+    """Fetch account equity from Alpaca /v2/account.
+
+    Returns 0.0 on any error (caller will fallback).
+    """  # AI-AGENT-REF: external equity fetch
+    try:
+        base = str(getattr(cfg, "alpaca_base_url", "")).rstrip("/")
+        url = f"{base}/v2/account"
+        key = getattr(cfg, "alpaca_api_key", None)
+        secret = getattr(cfg, "alpaca_secret_key_plain", None)
+        if not key or not secret or not base:
+            return 0.0
+        s = get_global_session()
+        resp = s.get(
+            url,
+            headers={
+                "APCA-API-KEY-ID": key,
+                "APCA-API-SECRET-KEY": secret,
+            },
+        )
+        if getattr(resp, "status_code", 0) != 200:
+            return 0.0
+        data = resp.json()  # type: ignore[no-any-return]
+        eq = _coerce_float(data.get("equity"), 0.0)
+        return eq
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def resolve_max_position_size(cfg, tcfg, *, force_refresh: bool = False) -> tuple[float, dict[str, Any]]:
+    """Resolve max_position_size according to mode and settings."""  # AI-AGENT-REF: AUTO sizing resolver
+    mode = str(getattr(tcfg, "max_position_mode", getattr(cfg, "max_position_mode", "STATIC"))).upper()
+    ttl = float(getattr(tcfg, "dynamic_size_refresh_secs", getattr(cfg, "dynamic_size_refresh_secs", 3600.0)))
+    cap = _coerce_float(getattr(tcfg, "capital_cap", 0.0), 0.0)
+    vmin = getattr(tcfg, "max_position_size_min", None)
+    vmax = getattr(tcfg, "max_position_size_max", None)
+
+    if mode != "AUTO":  # Static path
+        cur = _coerce_float(getattr(tcfg, "max_position_size", 0.0), 0.0)
+        if cur <= 0.0:
+            cur = _fallback_max_size(cfg, tcfg)
+        _CACHE.value, _CACHE.ts = cur, _now_utc()
+        return cur, {
+            "mode": mode,
+            "source": "static",
+            "capital_cap": cap,
+            "refreshed_at": _CACHE.ts.isoformat(),
+        }
+
+    if not force_refresh and not _should_refresh(ttl) and _CACHE.value is not None:
+        return _CACHE.value, {
+            "mode": mode,
+            "source": "cache",
+            "capital_cap": cap,
+            "refreshed_at": (_CACHE.ts or _now_utc()).isoformat(),
+        }
+
+    eq = _get_equity_from_alpaca(cfg)
+    if eq <= 0.0 or cap <= 0.0:
+        fb = _fallback_max_size(cfg, tcfg)
+        val = _clamp(fb, vmin, vmax)
+        _CACHE.value, _CACHE.ts = val, _now_utc()
+        return val, {
+            "mode": mode,
+            "source": "fallback",
+            "equity": eq,
+            "capital_cap": cap,
+            "clamp_min": vmin,
+            "clamp_max": vmax,
+            "refreshed_at": _CACHE.ts.isoformat(),
+        }
+
+    computed = float(floor(eq * cap))
+    val = _clamp(computed, _coerce_float(vmin, None) if vmin is not None else None,
+                 _coerce_float(vmax, None) if vmax is not None else None)
+    if val <= 0.0:
+        val = _fallback_max_size(cfg, tcfg)
+    _CACHE.value, _CACHE.ts = val, _now_utc()
+    return val, {
+        "mode": mode,
+        "source": "alpaca",
+        "equity": eq,
+        "capital_cap": cap,
+        "computed": computed,
+        "clamp_min": vmin,
+        "clamp_max": vmax,
+        "refreshed_at": _CACHE.ts.isoformat(),
+    }
+

--- a/tests/test_dynamic_position_sizing.py
+++ b/tests/test_dynamic_position_sizing.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from ai_trading.net.http import get_global_session
+from ai_trading.position_sizing import resolve_max_position_size
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _stub_session(monkeypatch, status: int, payload: dict) -> None:
+    sess = get_global_session()
+
+    def fake_get(url, headers=None):  # noqa: D401
+        return _Resp(status, payload)
+
+    monkeypatch.setattr(sess, "get", fake_get, raising=True)
+
+
+def test_auto_mode_resolves_from_equity_and_capital_cap(monkeypatch, caplog):
+    cfg = SimpleNamespace(
+        alpaca_base_url="https://paper-api.alpaca.markets",
+        alpaca_api_key="k",
+        alpaca_secret_key_plain="s",
+        max_position_mode="AUTO",
+    )
+    tcfg = SimpleNamespace(
+        capital_cap=0.04,
+        max_position_mode="AUTO",
+        dynamic_size_refresh_secs=3600,
+    )
+
+    _stub_session(monkeypatch, 200, {"equity": "100000.00"})
+
+    with caplog.at_level(logging.INFO):
+        size, meta = resolve_max_position_size(cfg, tcfg, force_refresh=True)
+
+    assert size == 4000.0
+    assert meta["source"] in {"alpaca", "cache"}
+
+
+def test_auto_mode_fallback_on_error(monkeypatch, caplog):
+    cfg = SimpleNamespace(
+        alpaca_base_url="https://paper-api.alpaca.markets",
+        alpaca_api_key="k",
+        alpaca_secret_key_plain="s",
+        default_max_position_size=9000.0,
+        max_position_mode="AUTO",
+    )
+    tcfg = SimpleNamespace(
+        capital_cap=0.04,
+        max_position_mode="AUTO",
+        dynamic_size_refresh_secs=3600,
+    )
+
+    _stub_session(monkeypatch, 500, {})
+
+    with caplog.at_level(logging.WARNING):
+        size, meta = resolve_max_position_size(cfg, tcfg, force_refresh=True)
+
+    assert size == 9000.0
+    assert meta["source"] == "fallback"
+


### PR DESCRIPTION
## Summary
- add `position_sizing.resolve_max_position_size` for AUTO sizing from Alpaca equity with caching and clamps
- wire AUTO sizing into startup banner and periodic refresh in main loop
- cover AUTO and fallback behaviours with unit tests

## Testing
- `ruff check ai_trading/position_sizing.py ai_trading/main.py tests/test_dynamic_position_sizing.py`
- `pytest -q tests/test_dynamic_position_sizing.py`
- `pytest -n auto --disable-warnings` *(fails: ImportError: cannot import name 'ensure_datetime' from 'ai_trading.data_fetcher' (unknown location); AssertionError: assert True is False; TypeError: int() argument must be a string, a bytes-like object or a real number, not 'FieldInfo'; TypeError: 'Mock' object is not iterable; ImportError: cannot import name 'get_or_load' from 'ai_trading.market.cache')*

------
https://chatgpt.com/codex/tasks/task_e_68a72f9c7a34833092c35224476648a1