### PR TITLE
Config validation: autofix nonpositive MAX_POSITION_SIZE

### DIFF
--- a/tests/test_config_validation_max_position_size.py
+++ b/tests/test_config_validation_max_position_size.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import logging
+
+import ai_trading.main as main
+
+
+def test_static_mode_nonpositive_is_autofixed(caplog):
+    cfg = SimpleNamespace(
+        trading_mode="balanced",
+        alpaca_base_url="https://paper-api.alpaca.markets",
+        paper=True,
+        default_max_position_size=9000.0,
+    )
+    tcfg = SimpleNamespace(
+        capital_cap=0.04,
+        dollar_risk_limit=0.05,
+        max_position_mode="STATIC",
+        max_position_size=0.0,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        main._validate_runtime_config(cfg, tcfg)
+
+    assert getattr(tcfg, "max_position_size", 0.0) == 9000.0
+
+    assert any(
+        r.__dict__.get("field") == "max_position_size"
+        and r.__dict__.get("reason") == "nonpositive"
+        for r in caplog.records
+    )
+
+
+def test_auto_mode_nonpositive_is_permitted(caplog):
+    cfg = SimpleNamespace(
+        trading_mode="balanced",
+        alpaca_base_url="https://paper-api.alpaca.markets",
+        paper=True,
+    )
+    tcfg = SimpleNamespace(
+        capital_cap=0.04,
+        dollar_risk_limit=0.05,
+        max_position_mode="AUTO",
+        max_position_size=0.0,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        main._validate_runtime_config(cfg, tcfg)
+
+    assert not any(r.getMessage() == "CONFIG_AUTOFIX" for r in caplog.records)


### PR DESCRIPTION
## Summary
- allow nonpositive MAX_POSITION_SIZE when max_position_mode=AUTO
- autofix nonpositive max_position_size in STATIC mode and warn
- add tests covering both AUTO and STATIC handling

## Testing
- `pytest -n0 tests/test_config_validation_max_position_size.py -q`
- `pytest -n auto --disable-warnings` *(fails: 5 failed, 102 passed, 6 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a73507afdc83308f5fc8106213c8a3