### PR TITLE
feat: harden Alpaca data fallbacks and position API

### DIFF
--- a/tests/test_bars_fallback.py
+++ b/tests/test_bars_fallback.py
@@ -1,0 +1,21 @@
+import pandas as pd
+from ai_trading.data.bars import _resample_minutes_to_daily
+
+
+def test_resample_minute_to_daily_basic():
+    idx = pd.date_range(
+        "2025-08-19 13:30", periods=390 * 2, freq="1min", tz="America/New_York"
+    )
+    df = pd.DataFrame(
+        {
+            "open": 100.0,
+            "high": 101.0,
+            "low": 99.0,
+            "close": 100.5,
+            "volume": 1000,
+        },
+        index=idx.tz_convert("UTC"),
+    )
+    out = _resample_minutes_to_daily(df)
+    assert not out.empty
+    assert set(["open", "high", "low", "close", "volume"]).issubset(out.columns)

--- a/tests/test_broker_alpaca.py
+++ b/tests/test_broker_alpaca.py
@@ -1,0 +1,40 @@
+from ai_trading.broker.alpaca import AlpacaBroker
+
+
+class FakeClient:
+    def __init__(self, positions):
+        self._positions = positions
+
+    def list_positions(self):
+        return self._positions
+
+    def get_position(self, symbol):
+        for p in self._positions:
+            if p.symbol == symbol:
+                return p
+        raise Exception("not found")
+
+
+class Obj:
+    def __init__(self, symbol, qty, avg_entry_price):
+        self.symbol = symbol
+        self.qty = qty
+        self.avg_entry_price = avg_entry_price
+
+
+def test_list_open_positions_returns_objects():
+    broker = AlpacaBroker.__new__(AlpacaBroker)
+    broker._api = FakeClient([Obj("AAPL", "10", "150.0")])
+    broker._is_new = False
+    out = broker.list_open_positions()
+    assert out and hasattr(out[0], "symbol") and hasattr(out[0], "qty")
+
+
+def test_get_open_position_uses_sdk_then_falls_back():
+    broker = AlpacaBroker.__new__(AlpacaBroker)
+    broker._api = FakeClient([Obj("MSFT", "5", "300.0")])
+    broker._is_new = False
+    pos = broker.get_open_position("MSFT")
+    assert pos and pos.symbol == "MSFT" and int(pos.qty) == 5
+    none = broker.get_open_position("NVDA")
+    assert none is None


### PR DESCRIPTION
## Summary
- add get_open_position helper and return objects from list_open_positions
- resample minute bars when daily data is empty and log FinBERT-disabled once
- add unit tests for broker position helpers and minute resample utility

## Testing
- `pytest -n auto --disable-warnings` *(fails: ImportError: cannot import name 'ensure_datetime' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a74d8841048330bbff278f8afb5079