### PR TITLE
config: define missing data feed + risk fields on Settings; harden qty helper; no shims

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,6 @@
 ALPACA_API_KEY=your_alpaca_api_key_here
 ALPACA_SECRET_KEY=your_alpaca_secret_key_here
 ALPACA_BASE_URL=https://paper-api.alpaca.markets
-ALPACA_DATA_FEED=iex
-ALPACA_ADJUSTMENT=all
 DATA_LOOKBACK_DAYS_DAILY=200
 DATA_LOOKBACK_DAYS_MINUTE=5
 TZ=UTC
@@ -56,3 +54,17 @@ SEED=42
 
 # Log verbosity (true for debug mode)
 VERBOSE=false
+
+# ---- Risk Controls ----
+# Fraction of equity usable per cycle (0,1]; default 0.04 if unset
+CAPITAL_CAP=0.04
+
+# Max fraction of equity at risk per position (0,1]; default 0.05 if unset
+DOLLAR_RISK_LIMIT=0.05
+
+# ---- Market Data ----
+# Alpaca data feed: iex (free) or sip (subscription). Default: iex
+ALPACA_DATA_FEED=iex
+
+# Adjustments for bars: all | raw. Default: all
+ALPACA_ADJUSTMENT=all

--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -1,226 +1,33 @@
-from __future__ import annotations
-
 import os
 from functools import lru_cache
-from pathlib import Path
-from typing import Any
 
-from pydantic import Field, SecretStr
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-from ai_trading.settings import _secret_to_str  # AI-AGENT-REF: centralized normalization
+from ai_trading.settings import (
+    Settings,
+    _secret_to_str,
+    get_settings as _base_get_settings,
+)  # AI-AGENT-REF: canonical settings
 
 TICKERS_FILE = os.getenv("AI_TRADER_TICKERS_FILE", "tickers.csv")
-TICKERS_CSV = os.getenv("AI_TRADER_TICKERS_CSV")  # optional literal CSV list
-UNIVERSE_LIMIT = int(os.getenv("AI_TRADER_UNIVERSE_LIMIT", "0") or "0")  # 0 => no cap
-
 MODEL_PATH = os.getenv("AI_TRADER_MODEL_PATH")
-MODEL_MODULE = os.getenv("AI_TRADER_MODEL_MODULE")
-
-
-def model_config_source() -> str:
-    """Return 'path', 'module', or ''."""
-    if MODEL_PATH:
-        return "path"
-    if MODEL_MODULE:
-        return "module"
-    return ""
-
-
-class Settings(BaseSettings):
-    """Minimal project settings for tests and CI."""
-
-    env: str = Field(default="test", alias="APP_ENV")
-    # AI-AGENT-REF: allow market calendar override via droplet .env
-    market_calendar: str = Field(default="XNYS", alias="MARKET_CALENDAR")
-    data_provider: str = Field(default="mock", alias="DATA_PROVIDER")
-    log_level: str = Field(default="INFO", alias="LOG_LEVEL")
-    enable_memory_optimization: bool = Field(default=True)
-    alpaca_api_key: str = Field(default="test_key", alias="ALPACA_API_KEY")
-    alpaca_secret_key: SecretStr = Field(
-        default=SecretStr("test_secret"), alias="ALPACA_SECRET_KEY"
-    )
-    redis_url: str | None = Field(default=None, alias="REDIS_URL")  # AI-AGENT-REF: modern union
-    # AI-AGENT-REF: include Alpaca base URL
-    alpaca_base_url: str = Field(
-        default="https://paper-api.alpaca.markets", alias="ALPACA_BASE_URL"
-    )
-    # Expose canonical env key; alias resolution handled by resolver
-    trading_mode: str = Field(default="balanced", alias="TRADING_MODE")
-    # AI-AGENT-REF: secret used by webhook handlers
-    webhook_secret: str | None = Field(default=None, alias="WEBHOOK_SECRET")
-
-    REGIME_MIN_ROWS: int = Field(200, alias="REGIME_MIN_ROWS")
-    data_warmup_lookback_days: int = Field(60, alias="DATA_WARMUP_LOOKBACK_DAYS")
-    disable_daily_retrain: bool = Field(False, alias="DISABLE_DAILY_RETRAIN")
-    enable_sklearn: bool = Field(False, alias="ENABLE_SKLEARN")
-    intraday_lookback_minutes: int = Field(120, alias="INTRADAY_LOOKBACK_MINUTES")
-    enable_numba_optimization: bool = Field(False, alias="ENABLE_NUMBA_OPTIMIZATION")
-    alpaca_data_feed: str | None = Field(default="iex", alias="ALPACA_DATA_FEED")
-    alpaca_adjustment: str = Field("all", alias="ALPACA_ADJUSTMENT")
-    data_lookback_days_daily: int = Field(200, alias="DATA_LOOKBACK_DAYS_DAILY")
-    data_lookback_days_minute: int = Field(5, alias="DATA_LOOKBACK_DAYS_MINUTE")
-    scheduler_sleep_seconds: int = Field(60, alias="SCHEDULER_SLEEP_SECONDS")
-    # Feature flags and thresholds
-    data_cache_enable: bool = Field(True, env="AI_TRADER_DATA_CACHE_ENABLE")
-    enable_plotting: bool = Field(False, env="AI_TRADER_ENABLE_PLOTTING")
-    position_size_min_usd: float = Field(
-        0.0, env="AI_TRADER_POSITION_SIZE_MIN_USD"
-    )
-    volume_threshold: float = Field(0.0, env="AI_TRADER_VOLUME_THRESHOLD")
-
-    # --- Added fields to support runtime modules and tests ---
-    # Portfolio-level feature flag (clustering, risk sizing)
-    ENABLE_PORTFOLIO_FEATURES: bool = Field(
-        False, alias="ENABLE_PORTFOLIO_FEATURES"
-    )
-
-    # Cache configuration
-    data_cache_ttl_seconds: int = Field(
-        300, env="AI_TRADER_DATA_CACHE_TTL_SECONDS"
-    )
-    data_cache_dir: str = Field(
-        default=str(Path.home() / ".cache" / "ai_trader"),
-        env="AI_TRADER_DATA_CACHE_DIR",
-    )
-    data_cache_disk_enable: bool = Field(
-        True, env="AI_TRADER_DATA_CACHE_DISK_ENABLE"
-    )
-
-    # Batch fallback worker pool size
-    batch_fallback_workers: int = Field(4, alias="BATCH_FALLBACK_WORKERS")
-
-    # Pre-trade lookback days for safety checks
-    pretrade_lookback_days: int = Field(120, alias="PRETRADE_LOOKBACK_DAYS")
-
-    # Meta-learning and trade logging
-    enable_reinforcement_learning: bool = Field(
-        False, alias="ENABLE_REINFORCEMENT_LEARNING"
-    )
-    trade_log_file: str = Field("trades.csv", alias="TRADE_LOG_FILE")
-
-    # Portfolio rebalancer controls
-    rebalance_sleep_seconds: int = Field(60, alias="REBALANCE_SLEEP_SECONDS")
-
-    # Sentiment API (optional)
-    sentiment_api_key: str | None = Field(
-        default=None, alias="SENTIMENT_API_KEY"
-    )
-    sentiment_api_url: str | None = Field(
-        default=None, alias="SENTIMENT_API_URL"
-    )
-
-    # Logging
-    log_compact_json: bool = Field(False, alias="LOG_COMPACT_JSON")
-
-    # AI-AGENT-REF: add missing runtime config fields for trading loop
-    # Operational toggles and thresholds
-    testing: bool = Field(False, alias="TESTING")
-    shadow_mode: bool = Field(False, alias="SHADOW_MODE")
-    log_market_fetch: bool = Field(True, alias="LOG_MARKET_FETCH")
-    healthcheck_port: int = Field(9001, alias="HEALTHCHECK_PORT")
-    min_health_rows: int = Field(120, alias="MIN_HEALTH_ROWS")
-    metrics_enabled: bool = Field(False, alias="METRICS_ENABLED")
-
-    # Data pipeline/cache controls
-    market_cache_enabled: bool = Field(False, alias="MARKET_CACHE_ENABLED")
-    minute_cache_ttl: int = Field(60, alias="MINUTE_CACHE_TTL")
-    data_sanitize_enabled: bool = Field(True, alias="DATA_SANITIZE_ENABLED")
-    liquidity_checks_enabled: bool = Field(True, alias="LIQUIDITY_CHECKS_ENABLED")
-    corp_actions_enabled: bool = Field(True, alias="CORP_ACTIONS_ENABLED")
-
-    # Risk & position caps
-    max_open_positions: int = Field(10, alias="MAX_OPEN_POSITIONS")
-    max_portfolio_positions: int = Field(10, alias="MAX_PORTFOLIO_POSITIONS")
-    sector_exposure_cap: float = Field(0.33, alias="SECTOR_EXPOSURE_CAP")
-    max_drawdown_threshold: float = Field(0.08, alias="MAX_DRAWDOWN_THRESHOLD")
-    weekly_drawdown_limit: float = Field(0.10, alias="WEEKLY_DRAWDOWN_LIMIT")
-    disaster_dd_limit: float = Field(0.25, alias="DISASTER_DD_LIMIT")
-
-    # Strategy/ML thresholds
-    ml_confidence_threshold: float = Field(0.5, alias="ML_CONFIDENCE_THRESHOLD")
-    volume_spike_threshold: float = Field(1.5, alias="VOLUME_SPIKE_THRESHOLD")
-    pyramid_levels: int = Field(0, alias="PYRAMID_LEVELS")
-    sgd_params: dict[str, Any] = Field(default_factory=dict, alias="SGD_PARAMS")
-
-    # Trade execution/behavior
-    force_trades: bool = Field(False, alias="FORCE_TRADES")
-    sizing_enabled: bool = Field(True, alias="SIZING_ENABLED")
-
-    # AI-AGENT-REF: rebalancer defaults
-    rebalance_interval_min: int = Field(
-        15,
-        env="AI_TRADER_REBALANCE_INTERVAL_MIN",
-        description="How often (minutes) to consider portfolio rebalancing.",
-    )
-    rebalance_on_fill: bool = Field(
-        True,
-        env="AI_TRADER_REBALANCE_ON_FILL",
-        description="Trigger a rebalance pass after order fills.",
-    )
-    rebalance_max_trades_per_cycle: int = Field(
-        10,
-        env="AI_TRADER_REBALANCE_MAX_TRADES_PER_CYCLE",
-        description="Safety cap to limit rebalance churn.",
-    )
-
-    # AI-AGENT-REF: runtime defaults for deterministic behavior and loops
-    seed: int | None = 42
-    loop_interval_seconds: int = 60
-    # 0 => run forever; allow override via SCHEDULER_ITERATIONS
-    iterations: int = Field(default=0, env="SCHEDULER_ITERATIONS")  # AI-AGENT-REF: env override
-    api_port: int | None = 9001
-
-    # AI-AGENT-REF: optional Finnhub API config
-    # --- Finnhub (optional; tests may reference these) ---
-    finnhub_api_key: str | None = Field(
-        default=None,
-        alias="FINNHUB_API_KEY",
-        description="Finnhub API key; optional for local/dev & tests",
-    )
-    finnhub_base_url: str = Field(
-        default="https://finnhub.io/api/v1",
-        alias="FINNHUB_BASE_URL",
-        description="Finnhub REST base URL",
-    )
-
-    model_config = SettingsConfigDict(
-        env_prefix="AI_TRADING_",
-        case_sensitive=False,
-        extra="ignore",
-    )
-
-    @property
-    def alpaca_secret_key_plain(self) -> str:
-        return _secret_to_str(self.alpaca_secret_key) or ""
-
-    @property
-    def alpaca_headers(self) -> dict[str, str]:
-        """Canonical Alpaca auth headers as plain strings."""  # AI-AGENT-REF: standard header builder
-        return {
-            "APCA-API-KEY-ID": self.alpaca_api_key or "",
-            "APCA-API-SECRET-KEY": self.alpaca_secret_key_plain or "",
-        }
-
-    @property
-    def scheduler_iterations(self) -> int:
-        """Back-compat alias used by main.py and tests."""
-        return self.iterations
 
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:
-    return Settings()
+    """Return cached Settings instance."""  # AI-AGENT-REF: simple wrapper
+    return _base_get_settings()
 
 
-# AI-AGENT-REF: return mapping of broker keys with optional Finnhub
 def broker_keys(s: Settings | None = None) -> dict[str, str]:
+    """Return broker credential mapping."""  # AI-AGENT-REF: key extractor
     s = s or get_settings()
     keys = {
-        "ALPACA_API_KEY": s.alpaca_api_key,
-        "ALPACA_SECRET_KEY": s.alpaca_secret_key_plain,
+        "ALPACA_API_KEY": getattr(s, "alpaca_api_key", ""),
+        "ALPACA_SECRET_KEY": _secret_to_str(getattr(s, "alpaca_secret_key", None)) or "",
     }
-    if s.finnhub_api_key:
+    if getattr(s, "finnhub_api_key", None):
         keys["finnhub"] = s.finnhub_api_key
     return keys
+
+
+__all__ = ["Settings", "get_settings", "broker_keys"]
 

--- a/tests/test_settings_bridge.py
+++ b/tests/test_settings_bridge.py
@@ -5,6 +5,6 @@ from ai_trading.config.settings import get_settings as modern_get
 
 
 def test_settings_bridge_alias():
-    """Legacy get_settings should reference modern config."""  # AI-AGENT-REF
-    assert legacy_get is modern_get
+    """Legacy and modern helpers return the same instance."""  # AI-AGENT-REF
+    assert legacy_get() is modern_get()
 


### PR DESCRIPTION
## Summary
- add alpaca_data_feed, alpaca_adjustment, capital_cap, dollar_risk_limit to Settings with strict validation and sane defaults
- remove ad-hoc aliasing in config/settings; get_settings() returns a cached Settings instance
- guard _current_qty against missing positions (return 0)
- document CAPITAL_CAP, DOLLAR_RISK_LIMIT, ALPACA_DATA_FEED, ALPACA_ADJUSTMENT in .env.example

## Testing
- `pytest -n auto --disable-warnings` *(fails: tests/test_alpaca_timeframe_mapping.py::test_tf_object_normalized, tests/test_critical_fixes_implementation.py::test_dependency_injection, tests/test_bot_extended.py::test_fetch_minute_df_safe_market_closed, tests/runtime/test_http_wrapped.py::test_wrapped_get_retries_and_parses, tests/test_config_validation_max_position_size.py::test_static_mode_nonpositive_is_autofixed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7953a9cf883309a16dd06468c0773