### PR TITLE
UTC correctness, real signal scoring, and allocator confidence gate (config-driven)

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -1519,6 +1519,7 @@ class TradingConfig(BaseModel):
     min_confidence: float = Field(
         0.60, ge=0, le=1
     )  # AI-AGENT-REF: floor for ML signals
+    score_confidence_min: float = Field(0.60, ge=0, le=1)  # AI-AGENT-REF: allocator confidence gate
     signal_confirmation_bars: int = 2  # AI-AGENT-REF: bars to confirm signal
     delta_threshold: float = 0.02  # AI-AGENT-REF: price delta trigger
     max_drawdown_threshold: float = Field(_MAX_DRAWDOWN_THRESHOLD, ge=0, le=1)

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -377,7 +377,8 @@ def _is_market_open_now(cfg=None) -> bool:
     if cfg is not None:
         market_calendar = getattr(cfg, "market_calendar", "XNYS")
     cal = mcal.get_calendar(market_calendar)
-    now = pd.Timestamp.utcnow().tz_convert("UTC")
+    # AI-AGENT-REF: use timezone-aware UTC now to avoid naive timestamps
+    now = pd.Timestamp.now(tz="UTC")
     schedule = cal.schedule(start_date=now.date(), end_date=now.date())
     if schedule.empty:
         return False
@@ -5740,7 +5741,8 @@ def data_source_health_check(ctx: BotContext, symbols: Sequence[str]) -> None:
         return
     if len(missing) == len(symbols):
         try:
-            session = last_market_session(pd.Timestamp.utcnow().tz_convert("UTC"))  # AI-AGENT-REF: prior session window
+            # AI-AGENT-REF: compute prior session from aware UTC now
+            session = last_market_session(pd.Timestamp.now(tz="UTC"))  # AI-AGENT-REF: prior session window
             if session is not None:
                 start_ts = session.open.tz_convert("UTC")
                 end_ts = session.close.tz_convert("UTC")

--- a/ai_trading/portfolio/core.py
+++ b/ai_trading/portfolio/core.py
@@ -39,8 +39,10 @@ def get_latest_price(ctx, symbol: str) -> float | None:
     if price is not None:
         return price
 
-    start_iso = (pd.Timestamp.utcnow().normalize() - pd.Timedelta(days=1)).isoformat()
-    end_iso = (pd.Timestamp.utcnow() + pd.Timedelta(minutes=1)).isoformat()
+    # AI-AGENT-REF: use aware UTC now for minute fallback window
+    now_utc = pd.Timestamp.now(tz="UTC")
+    start_iso = (now_utc.normalize() - pd.Timedelta(days=1)).isoformat()
+    end_iso = (now_utc + pd.Timedelta(minutes=1)).isoformat()
     try:
         req = StockBarsRequest(
             symbol_or_symbols=[symbol],

--- a/ai_trading/strategy_allocator.py
+++ b/ai_trading/strategy_allocator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -13,20 +14,35 @@ class MockSignal:
 class StrategyAllocator:
     """Minimal allocator with confidence normalization hook for tests."""  # AI-AGENT-REF: test strategy allocator
 
+    # AI-AGENT-REF: resolve threshold via config chain
     @staticmethod
-    def _normalize_confidence(c: float) -> float:
-        """Clip confidence to [0,1]."""  # AI-AGENT-REF: normalization helper
-        return max(0.0, min(1.0, c))
+    def _resolve_conf_threshold(cfg) -> float:
+        for name in ("score_confidence_min", "min_confidence", "conf_threshold"):
+            v = getattr(cfg, name, None)
+            if isinstance(v, int | float) and 0 <= float(v) <= 1:
+                return float(v)
+        return 0.6
+
+    @staticmethod
+    def _normalize_confidence(x: float) -> float:
+        try:
+            return max(0.0, min(1.0, float(x)))
+        except (TypeError, ValueError):
+            return 0.0
+
+    def __init__(self, config: Any | None = None):
+        # AI-AGENT-REF: allow duck-typed config for tests
+        self.config = config or type("_Cfg", (), {"score_confidence_min": 0.6})()
 
     def allocate(self, signals_by_strategy: dict[str, list[MockSignal]]):
         out: list[MockSignal] = []
+        th = self._resolve_conf_threshold(self.config)
         for sigs in (signals_by_strategy or {}).values():
             for s in sigs or []:
-                out.append(
-                    MockSignal(
-                        s.symbol, s.action, self._normalize_confidence(s.confidence)
-                    )
-                )
+                c = self._normalize_confidence(getattr(s, "confidence", 0.0))
+                if c < th:
+                    continue
+                out.append(MockSignal(getattr(s, "symbol", ""), getattr(s, "action", "buy"), c))
         return out
 
 

--- a/scripts/check_feed.py
+++ b/scripts/check_feed.py
@@ -10,7 +10,8 @@ from ai_trading.data.bars import safe_get_stock_bars
 
 if __name__ == "__main__":  # pragma: no cover - manual use
     rt = build_runtime(SimpleNamespace())
-    now = pd.Timestamp.utcnow().tz_localize("UTC")
+    # AI-AGENT-REF: use timezone-aware UTC now for diagnostics
+    now = pd.Timestamp.now(tz="UTC")
     start = now - pd.Timedelta(days=120)
     client = getattr(
         rt,

--- a/tests/test_confidence_gate.py
+++ b/tests/test_confidence_gate.py
@@ -1,0 +1,26 @@
+import types
+
+
+def _resolve():
+    # AI-AGENT-REF: prefer minimal allocator, fallback to script version
+    try:
+        import ai_trading.strategy_allocator as s
+        return s
+    except Exception:
+        import scripts.strategy_allocator as s
+        return s
+
+
+def test_conf_gate_basic():
+    mod = _resolve()
+    Alloc = getattr(mod, "StrategyAllocator")
+    cfg = types.SimpleNamespace(score_confidence_min=0.7)
+    alloc = Alloc(config=cfg)
+
+    lo = types.SimpleNamespace(symbol="A", side="buy", action="buy", confidence=0.55)
+    hi = types.SimpleNamespace(symbol="B", side="buy", action="buy", confidence=0.85)
+
+    out = alloc.allocate({"s": [lo, hi]})
+    assert any(getattr(s, "symbol", "") == "B" for s in out)
+    assert not any(getattr(s, "symbol", "") == "A" for s in out)
+

--- a/tests/test_signals_scoring.py
+++ b/tests/test_signals_scoring.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pandas as pd
+
+from ai_trading import signals
+
+
+class _DummyProba:
+    # AI-AGENT-REF: stub model with predict_proba
+    def predict_proba(self, X):
+        n = len(X)
+        p1 = np.linspace(0.0, 1.0, n)
+        return np.c_[1.0 - p1, p1]
+
+
+def test_score_candidates_predict_proba():
+    X = pd.DataFrame({"a": [1, 2, 3]}, index=["r1", "r2", "r3"])
+    out = signals.score_candidates(X, _DummyProba())
+    assert "score" in out.columns
+    assert out["score"].between(0, 1).all()
+

--- a/tests/test_time_utc_now.py
+++ b/tests/test_time_utc_now.py
@@ -1,0 +1,9 @@
+import pandas as pd
+
+
+def test_now_is_aware_utc():
+    # AI-AGENT-REF: ensure timezone-aware UTC now
+    now_utc = pd.Timestamp.now(tz="UTC")
+    assert now_utc.tz is not None
+    assert str(now_utc.tz) in {"UTC", "+00:00"}
+


### PR DESCRIPTION
## Summary
- standardize UTC now usage across bot engine, portfolio fallbacks, and diagnostics
- implement real model-based scoring with [0,1] clamping
- add configurable allocator confidence gate driven by `score_confidence_min`

## Testing
- `ruff check ai_trading/core/bot_engine.py ai_trading/portfolio/core.py ai_trading/signals.py ai_trading/strategy_allocator.py scripts/strategy_allocator.py scripts/check_feed.py ai_trading/config/management.py`
- `pytest tests/test_time_utc_now.py tests/test_signals_scoring.py tests/test_confidence_gate.py -n auto --disable-warnings`
- `pytest -q tests/test_time_utc_now.py tests/test_signals_scoring.py tests/test_confidence_gate.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7ad12433c8330af0bb91a5f756acb