### PR TITLE
Enforce env-driven confidence gate in PerformanceAllocator + de-dup init banners

### DIFF
--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -21,6 +21,7 @@ from enum import Enum
 from typing import Any
 
 _log = logging.getLogger(__name__)
+from ai_trading.logging.emit_once import emit_once  # AI-AGENT-REF: dedupe init banners
 
 
 def _optional_import(name: str):
@@ -311,7 +312,7 @@ class OrderManager:
 
         self._idempotency_cache: OrderIdempotencyCache | None = None
 
-        _log.info("OrderManager initialized")
+        emit_once(_log, "ORDER_MANAGER_INIT", "info", "OrderManager initialized")  # AI-AGENT-REF: one-shot init log
 
     def _ensure_idempotency_cache(self) -> OrderIdempotencyCache:
         """Ensure idempotency cache is instantiated."""
@@ -650,7 +651,7 @@ class ExecutionEngine:
             "average_fill_time": 0.0,
         }
 
-        _log.info("ExecutionEngine initialized")
+        emit_once(_log, "EXECUTION_ENGINE_INIT", "info", "ExecutionEngine initialized")  # AI-AGENT-REF: one-shot init log
 
     def _assess_liquidity(self, symbol: str, quantity: int) -> tuple[int, bool]:
         """Assess liquidity and optionally adjust quantity."""

--- a/ai_trading/logging/emit_once.py
+++ b/ai_trading/logging/emit_once.py
@@ -1,0 +1,26 @@
+"""Helper to emit a log record only once per process."""
+
+from __future__ import annotations
+
+from logging import Logger
+import threading
+
+_emitted: set[str] = set()
+_lock = threading.Lock()
+
+
+def emit_once(logger: Logger, key: str, level: str, msg: str, **extra) -> bool:
+    """Emit ``msg`` at ``level`` only once per process keyed by ``key``."""
+    # AI-AGENT-REF: ensure initialization logs are de-duplicated
+    token = f"{logger.name}:{key}"
+    with _lock:
+        if token in _emitted:
+            return False
+        _emitted.add(token)
+    fn = getattr(logger, level.lower(), logger.info)
+    fn(msg, extra=extra or None)
+    return True
+
+
+__all__ = ["emit_once"]
+

--- a/ai_trading/risk/circuit_breakers.py
+++ b/ai_trading/risk/circuit_breakers.py
@@ -13,6 +13,7 @@ from typing import Any
 
 # Use the centralized logger as per AGENTS.md
 from ai_trading.logging import logger
+from ai_trading.logging.emit_once import emit_once  # AI-AGENT-REF: dedupe init log
 from json import JSONDecodeError
 
 # Consistent exception tuple without hard dependency on requests
@@ -84,9 +85,13 @@ class DrawdownCircuitBreaker:
         self.halt_timestamp = None
         self.reset_callbacks = []
 
-        logger.info(
-            f"DrawdownCircuitBreaker initialized with max_drawdown={self._safe_format_percentage(self.max_drawdown)}"
-        )
+        emit_once(
+            logger,
+            "DRAWDOWN_CB_INIT",
+            "info",
+            "DrawdownCircuitBreaker initialized",
+            max_drawdown=self._safe_format_percentage(self.max_drawdown),
+        )  # AI-AGENT-REF: emit init banner once
 
     def _safe_format_percentage(self, value) -> str:
         """

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -107,6 +107,9 @@ class Settings(BaseSettings):
     # Min confidence threshold
     # Confidence thresholds tuned to test expectations
     conf_threshold: float = Field(default=0.75, env="AI_TRADER_CONF_THRESHOLD")
+    score_confidence_min: float | None = Field(
+        default=None, alias="SCORE_CONFIDENCE_MIN"
+    )  # AI-AGENT-REF: optional score confidence gate
     # Min model buy score
     buy_threshold: float = Field(default=0.4, env="AI_TRADER_BUY_THRESHOLD")
     # Max daily loss fraction before halt

--- a/tests/test_emit_once.py
+++ b/tests/test_emit_once.py
@@ -1,0 +1,15 @@
+import logging
+
+from ai_trading.logging.emit_once import emit_once
+
+
+def test_emit_once_emits_only_first_time(caplog):
+    logger = logging.getLogger("ai_trading.test")
+    caplog.set_level(logging.INFO)
+
+    assert emit_once(logger, "UNIQUE_KEY", "info", "Hello") is True
+    assert emit_once(logger, "UNIQUE_KEY", "info", "Hello") is False
+
+    msgs = [r.message for r in caplog.records]
+    assert msgs.count("Hello") == 1
+

--- a/tests/test_performance_allocator_conf_gate.py
+++ b/tests/test_performance_allocator_conf_gate.py
@@ -1,0 +1,43 @@
+import logging
+import pytest
+
+from ai_trading.strategies.performance_allocator import (
+    PerformanceBasedAllocator,
+    _resolve_conf_threshold,
+)
+from ai_trading.config.management import TradingConfig
+from ai_trading.config.settings import get_settings
+
+
+class Sig:
+    def __init__(self, symbol: str, confidence: float):
+        self.symbol = symbol
+        self.confidence = confidence
+
+
+def test_threshold_resolution_prefers_trading_config(monkeypatch):
+    monkeypatch.setenv("SCORE_CONFIDENCE_MIN", "0.2")
+    get_settings.cache_clear()  # AI-AGENT-REF: refresh settings after env change
+    cfg = TradingConfig(score_confidence_min=0.75)
+    assert _resolve_conf_threshold(cfg) == pytest.approx(0.75)
+
+
+def test_allocator_confidence_gate_filters_and_logs(caplog):
+    caplog.set_level(logging.INFO)
+    alloc = PerformanceBasedAllocator()
+    cfg = TradingConfig(score_confidence_min=0.7)
+    inputs = {
+        "momentum": [Sig("AAPL", 0.65), Sig("MSFT", 0.71), Sig("NVDA", 0.90)],
+        "meanrev": [Sig("TSLA", 0.40), Sig("AMZN", 0.72)],
+    }
+
+    out = alloc.allocate(inputs, cfg)
+
+    kept_symbols = {s.symbol for xs in out.values() for s in xs}
+    assert kept_symbols == {"MSFT", "NVDA", "AMZN"}
+
+    drops = [rec for rec in caplog.records if rec.message == "CONFIDENCE_DROP"]
+    assert len(drops) >= 2
+    for rec in drops:
+        assert getattr(rec, "threshold", 0) == pytest.approx(0.7)
+


### PR DESCRIPTION
## Summary
- add optional SCORE_CONFIDENCE_MIN setting for allocator gate
- introduce emit_once helper and wrap circuit breaker & execution engine init logs
- filter low-confidence signals in PerformanceBasedAllocator
- add unit tests for confidence gating and one-shot logging

## Testing
- `ruff check ai_trading/settings.py ai_trading/logging/emit_once.py ai_trading/risk/circuit_breakers.py ai_trading/execution/engine.py ai_trading/strategies/performance_allocator.py tests/test_performance_allocator_conf_gate.py tests/test_emit_once.py --ignore I001,UP035,UP006,BLE001`
- `pytest -n auto --disable-warnings` *(fails: tests/test_alpaca_timeframe_mapping.py::test_tf_object_normalized, tests/test_critical_fixes_implementation.py::test_dependency_injection, tests/test_bot_extended.py::test_fetch_minute_df_safe_market_closed, tests/runtime/test_http_wrapped.py::test_wrapped_get_retries_and_parses, tests/test_config_validation_max_position_size.py::test_static_mode_nonpositive_is_autofixed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bd9c356483309d7c14f637b9bbc1