### PR TITLE
feat: bias sizing by confidence

### DIFF
--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -110,6 +110,17 @@ class Settings(BaseSettings):
     score_confidence_min: float | None = Field(
         default=None, alias="SCORE_CONFIDENCE_MIN"
     )  # AI-AGENT-REF: optional score confidence gate
+    # AI-AGENT-REF: confidence→size curve knobs (opt-in; 1.0 = disabled)
+    score_size_max_boost: float = Field(
+        1.0,
+        alias="SCORE_SIZE_MAX_BOOST",
+        description="Upper bound of raw size multiplier at confidence=1.0",
+    )
+    score_size_gamma: float = Field(
+        1.0,
+        alias="SCORE_SIZE_GAMMA",
+        description="Shape parameter: 1.0 linear, <1 concave, >1 convex",
+    )
     # Min model buy score
     buy_threshold: float = Field(default=0.4, env="AI_TRADER_BUY_THRESHOLD")
     # Max daily loss fraction before halt

--- a/tests/test_allocator_size_bias.py
+++ b/tests/test_allocator_size_bias.py
@@ -1,0 +1,42 @@
+import logging
+
+import pytest
+
+from ai_trading.strategies.performance_allocator import PerformanceBasedAllocator, _resolve_conf_threshold
+from ai_trading.config.management import TradingConfig
+from ai_trading.config.settings import get_settings
+from ai_trading.settings import get_settings as base_get_settings
+
+
+class Sig:
+    def __init__(self, sym: str, confidence: float, weight: float = 1.0):
+        self.symbol = sym
+        self.confidence = confidence
+        self.weight = weight
+
+
+@pytest.fixture
+def allocator():
+    return PerformanceBasedAllocator()
+
+
+def test_allocator_prefers_higher_conf_when_boost_enabled(monkeypatch, allocator, caplog):
+    monkeypatch.setenv("SCORE_SIZE_MAX_BOOST", "1.15")
+    monkeypatch.setenv("SCORE_SIZE_GAMMA", "1.0")
+    get_settings.cache_clear()  # AI-AGENT-REF: refresh after env change
+    base_get_settings.cache_clear()
+
+    cfg = TradingConfig(score_confidence_min=0.70)
+    th = _resolve_conf_threshold(cfg)
+
+    caplog.set_level(logging.INFO)
+    inputs = {"momentum": [Sig("A", th + 0.01), Sig("B", 0.95)]}
+
+    out = allocator.allocate(inputs, cfg)
+
+    items = list(out.get("momentum", []))
+    assert len(items) == 2
+    weights = {s.symbol: s.weight for s in items}
+    assert weights["B"] > weights["A"]
+
+

--- a/tests/test_conf_size_curve.py
+++ b/tests/test_conf_size_curve.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+
+from ai_trading.strategies.performance_allocator import _compute_conf_multiplier
+
+
+@pytest.mark.parametrize(
+    "th,max_boost,gamma",
+    [
+        (0.7, 1.15, 1.0),
+        (0.7, 1.25, 0.5),
+        (0.7, 1.10, 2.0),
+    ],
+)
+def test_monotonic_and_bounds(th, max_boost, gamma):
+    xs = np.linspace(th, 1.0, 50)
+    ys = [_compute_conf_multiplier(float(x), th, max_boost, gamma) for x in xs]
+    assert min(ys) >= 1.0 - 1e-9
+    assert max(ys) <= max_boost + 1e-9
+    assert all(b + 1e-12 >= a for a, b in zip(ys, ys[1:]))
+    assert abs(ys[0] - 1.0) < 1e-6
+    assert abs(ys[-1] - max_boost) < 1e-6
+


### PR DESCRIPTION
## Summary
- expose SCORE_SIZE_MAX_BOOST and SCORE_SIZE_GAMMA knobs
- scale raw signal weights by confidence before caps
- test confidence multiplier curve and allocator bias

## Testing
- `ruff check ai_trading/settings.py ai_trading/config/settings.py ai_trading/strategies/performance_allocator.py tests/test_conf_size_curve.py tests/test_allocator_size_bias.py`
- `pytest -n auto --disable-warnings` *(fails: ImportError: cannot import name 'ensure_datetime', Exception: boom, AssertionError: False)*
- `pytest tests/test_conf_size_curve.py tests/test_allocator_size_bias.py -n0`


------
https://chatgpt.com/codex/tasks/task_e_68a7c05a69048330b133411f96bd00ce