### PR TITLE
Narrow exception handlers for data fetcher and main

### DIFF
--- a/tests/runtime/test_exception_narrowing_df_main.py
+++ b/tests/runtime/test_exception_narrowing_df_main.py
@@ -1,0 +1,41 @@
+import inspect
+import re
+import ai_trading.data_fetcher as df_mod
+import ai_trading.main as main_mod
+
+
+def _source(mod):
+    return inspect.getsource(mod)
+
+
+def test_data_fetcher_has_importerror_for_optional_imports():
+    src = _source(df_mod)
+    # yfinance optional import
+    assert "except ImportError" in src
+    # http/requests optional transport import
+    assert "HTTP_INIT_FALLBACK" in src and "except ImportError" in src
+
+
+def test_data_fetcher_json_decode_is_valueerror_only():
+    src = _source(df_mod)
+    # The JSON decode guard around resp.json() should not be broad
+    assert re.search(r"resp\.json\(\)\n\s*except ValueError:\n\s*payload\s*=\s*\{\}", src)
+
+
+def test_main_get_int_env_narrows_to_valueerror():
+    # ensure _get_int_env uses ValueError not Exception
+    src = _source(main_mod)
+    assert "def _get_int_env" in src
+    assert "except ValueError" in src
+
+
+def test_main_validate_runtime_config_wrapper_is_valueerror():
+    src = _source(main_mod)
+    assert "RUNTIME_CONFIG_INVALID" in src
+    assert "except ValueError" in src
+
+
+def test_start_api_with_signal_uses_specific_errors():
+    src = _source(main_mod)
+    assert "def start_api_with_signal" in src
+    assert "except (OSError, RuntimeError) as e" in src


### PR DESCRIPTION
## Summary
- narrow optional-import catchers and pandas fallbacks in `data_fetcher`
- tighten env parsing and API thread startup errors in `main`
- add regression tests enforcing narrowed exception handlers

## Testing
- `ruff check --force-exclude --select BLE001 ai_trading/data_fetcher.py ai_trading/main.py tests/runtime/test_exception_narrowing_df_main.py`
- `pytest -n auto --disable-warnings -q` *(fails: test_alpaca_timeframe_mapping.py::test_tf_object_normalized, test_regime_fallback_warns_but_continues, test_critical_datetime_fixes.py::TestSentimentCaching::test_sentiment_cache_rate_limit_handling, test_bot_extended.py::test_fetch_minute_df_safe_market_closed, test_config_validation_max_position_size.py::test_static_mode_nonpositive_is_autofixed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d64607b0833087f89439bc05cd3d