### PR TITLE
Harden env validator & sizing fallback; robust Alpaca position fallback; enforce UTC datetimes

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -38,6 +38,7 @@ from ai_trading.net.http import (
 )  # AI-AGENT-REF: retrying HTTP session
 from ai_trading.position_sizing import (
     resolve_max_position_size,
+    _resolve_max_position_size,
 )  # AI-AGENT-REF: dynamic max position sizing
 
 
@@ -159,22 +160,12 @@ def _validate_runtime_config(cfg, tcfg) -> None:
             # AI-AGENT-REF: dynamic resolver will handle later
             pass
         else:
-            fallback, meta = resolve_max_position_size(cfg, tcfg, force_refresh=True)
+            eq = getattr(tcfg, "equity", getattr(cfg, "equity", None))
+            fallback = _resolve_max_position_size(max_pos, cap, eq)
             try:
                 setattr(tcfg, "max_position_size", float(fallback))
             except (AttributeError, TypeError):
                 pass
-            logger.info(
-                "CONFIG_AUTOFIX",
-                extra={
-                    "field": "max_position_size",
-                    "given": max_pos,
-                    "fallback": float(fallback),
-                    "reason": "derived_equity_cap",
-                    "equity": meta.get("equity"),
-                    "capital_cap": meta.get("capital_cap"),
-                },
-            )
 
     base_url = str(getattr(cfg, "alpaca_base_url", ""))
     paper = bool(getattr(cfg, "paper", True))

--- a/ai_trading/utils/time.py
+++ b/ai_trading/utils/time.py
@@ -1,8 +1,12 @@
-"""Time utilities for timezone-aware datetime operations."""
+from __future__ import annotations
 
 from datetime import UTC, datetime
 
 
-def now_utc():
-    """Get current UTC time as timezone-aware datetime."""
+def utcnow() -> datetime:
+    """Repository-standard UTC now (timezone-aware)."""  # AI-AGENT-REF
     return datetime.now(UTC)
+
+
+# Back-compat alias
+now_utc = utcnow

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+
+target-version = "py311"
+
+[lint]
+select = ["E9", "F63", "F7", "F82", "BLE001", "DTZ005"]
+

--- a/tests/test_broker_alpaca.py
+++ b/tests/test_broker_alpaca.py
@@ -1,6 +1,9 @@
 from ai_trading.broker.alpaca import AlpacaBroker
 
 
+from ai_trading.broker.alpaca import APIError
+
+
 class FakeClient:
     def __init__(self, positions):
         self._positions = positions
@@ -12,7 +15,7 @@ class FakeClient:
         for p in self._positions:
             if p.symbol == symbol:
                 return p
-        raise Exception("not found")
+        raise APIError({"code": 404, "message": "not found"}, None)
 
 
 class Obj:

--- a/tests/test_config_validation_max_position_size.py
+++ b/tests/test_config_validation_max_position_size.py
@@ -20,14 +20,14 @@ def test_static_mode_nonpositive_is_autofixed(caplog):
         max_position_size=0.0,
     )
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO, logger="ai_trading.position_sizing"):
         main._validate_runtime_config(cfg, tcfg)
 
-    assert getattr(tcfg, "max_position_size", 0.0) == 9000.0
+    assert getattr(tcfg, "max_position_size", 0.0) == 8000.0
 
     assert any(
         r.__dict__.get("field") == "max_position_size"
-        and r.__dict__.get("reason") == "nonpositive"
+        and r.__dict__.get("reason") == "derived_equity_cap"
         for r in caplog.records
     )
 

--- a/validate_env.py
+++ b/validate_env.py
@@ -1,8 +1,16 @@
 
 from __future__ import annotations
 
-# Simple CLI pass-through to ai_trading.tools.env_validate (single source of truth)
-from ai_trading.tools.env_validate import _main  # AI-AGENT-REF
+import importlib.util
+from pathlib import Path
+
+# AI-AGENT-REF: Load env_validate without importing deprecated package
+_MOD_PATH = Path(__file__).parent / "ai_trading" / "tools" / "env_validate.py"
+_spec = importlib.util.spec_from_file_location("_env_validate", _MOD_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader  # keep mypy happy
+_spec.loader.exec_module(_mod)
+_main = _mod.main
 
 if __name__ == "__main__":
     raise SystemExit(_main())


### PR DESCRIPTION
## Summary
- ensure env validator exits non-zero only when required Alpaca keys missing and use structured logging
- derive nonpositive max position size from capital cap and equity with CONFIG_AUTOFIX logging
- add resilient Alpaca get_open_position using SDK first then REST
- centralize UTC time with utcnow helper and narrow Ruff rules

## Testing
- `ruff check --select E9,F63,F7,F82,BLE001,DTZ005 ai_trading/broker/alpaca.py ai_trading/main.py ai_trading/position_sizing.py ai_trading/tools/env_validate.py ai_trading/utils/time.py tests/test_broker_alpaca.py tests/test_config_validation_max_position_size.py validate_env.py`
- `mypy ai_trading`
- `pytest tests/test_additional_coverage.py::test_validate_env_main -q`
- `pytest tests/test_config_validation_max_position_size.py::test_static_mode_nonpositive_is_autofixed -q`
- `pytest tests/test_broker_alpaca.py::test_get_open_position_uses_sdk_then_falls_back -q`
- `pytest -n auto --disable-warnings -q` *(fails: ImportError in tests/institutional/test_live_trading.py, etc.)*
- `make test-all` *(fails: NameError in tests/test_institutional_kelly.py, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f8fc26d08330ad734c4101864409