### PR TITLE
Stabilize test environment: align pins with Alpaca, fix asyncio teardown, and re-run full suite

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+addopts = -ra
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+filterwarnings =
+    error
+    ignore:::pkg_resources
+    ignore::DeprecationWarning
+    ignore::UserWarning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,6 @@ black==24.8.0
 
 # Typing
 mypy==1.11.1
-types-requests==2.32.0.20240712
-types-python-dateutil==2.9.0.20240316
 types-setuptools==70.3.0.20240710
 
 # Tests
@@ -14,6 +12,7 @@ pytest-xdist==3.6.1
 pytest-cov==5.0.0
 execnet==2.1.1  # AI-AGENT-REF: enable pytest-xdist
 pytest-timeout==2.3.1
+pytest-asyncio==0.23.8
 requests-mock==1.12.1
 freezegun==1.4.0
 
@@ -25,5 +24,3 @@ tenacity==8.5.0
 
 # Infra & helpers
 packaging==24.1
-requests==2.32.3
-cachetools>=5.0  # AI-AGENT-REF: required for tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 # Core production dependencies
 # AI-AGENT-REF: pin NumPy to 1.x for pandas-ta compatibility
 numpy==1.26.4
-tzlocal>=5.2,<6
+tzlocal==4.3
 requests>=2.31,<3
-urllib3>=1.26,<2  # AI-AGENT-REF: align with Alpaca SDK
+urllib3==1.26.20  # AI-AGENT-REF: align with Alpaca SDK
 certifi>=2023.7.22
 charset-normalizer>=3.2,<4
 idna>=3.4,<4
 psutil>=5.9,<6
-portalocker>=2.8.2
+portalocker==2.7.0
 alpaca-trade-api>=3.0,<4  # AI-AGENT-REF: include Alpaca SDK
 joblib>=1.3,<2
 Flask>=3,<4


### PR DESCRIPTION
## Summary
- Pin tzlocal, portalocker, and urllib3 to Alpaca-compatible versions
- Remove conflicting dev runtime deps and add pytest-asyncio
- Harden test harness: disable plugin auto-load, add sequential run target, and add global asyncio/clock fixtures

## Testing
- `make test-core-seq` *(fails: 5 skipped, 18 deselected, 71 errors)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio -p xdist -n auto -q -m "not integration and not slow" --disable-warnings` *(fails: 263 failed, 599 passed, 48 skipped, 1 xfailed, 37 errors)*
- `ruff check .` *(fails: Found 73 errors)*
- `mypy ai_trading`

------
https://chatgpt.com/codex/tasks/task_e_68a8e76811dc83309f53d7d2d5033d0a