### PR TITLE
fix: load pytest plugins under autoload disable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,13 @@ dev-deps:
 
 test-core:
 	@mkdir -p artifacts
-	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -n auto -q -m "not integration and not slow" --disable-warnings | tee artifacts/pytest-core.txt
+	# AI-AGENT-REF: load xdist and asyncio when autoload disabled
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist -p pytest_asyncio -n auto -q -m "not integration and not slow" --disable-warnings | tee artifacts/pytest-core.txt
 
 test-int:
 	@mkdir -p artifacts
-	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 RUN_INTEGRATION=1 pytest -n auto -q -m "integration" --disable-warnings | tee artifacts/pytest-integration.txt
+	# AI-AGENT-REF: load xdist and asyncio when autoload disabled
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 RUN_INTEGRATION=1 pytest -p xdist -p pytest_asyncio -n auto -q -m "integration" --disable-warnings | tee artifacts/pytest-integration.txt
 
 test-all:  ## Run lint, types, and unit tests
 	python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- explicitly load xdist and pytest_asyncio when plugin autoload is disabled for parallel tests

## Testing
- ⚠️ `make test-core` (255 failed, 428 passed, 54 skipped, 1 xfailed, 90 errors)
- ⚠️ `pytest -n auto --disable-warnings` (missing `coverage` module)
- ⚠️ `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist -p pytest_asyncio -n auto --disable-warnings` (255 failed, 428 passed, 72 skipped, 1 xfailed, 90 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a8ec19e54c83309c9292abdef7e414