### PR TITLE
build: enforce urllib3 runtime pins

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,6 @@
+urllib3==1.26.20
+tzlocal==4.3
+portalocker==2.7.0
 alpaca-trade-api==3.2.0
 yfinance==0.2.37
 websockets==10.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+# Keep dev tools only; no runtime libs or stubs that can fight pins.
 # Lint & format
 ruff==0.5.6
 black==24.8.0
@@ -10,6 +11,7 @@ types-setuptools==70.3.0.20240710
 pytest==8.3.2
 pytest-xdist==3.6.1
 pytest-cov==5.0.0
+coverage==7.6.1
 execnet==2.1.1  # AI-AGENT-REF: enable pytest-xdist
 pytest-timeout==2.3.1
 pytest-asyncio==0.23.8


### PR DESCRIPTION
## Summary
- drop stub leakage and install dev tools with pinned runtime constraints
- add coverage and doc comment to dev requirements
- pin urllib3, tzlocal, and portalocker via constraints

## Testing
- `make test-all`
- `pip check`
- `pytest -n auto --disable-warnings` *(fails: missing modules and import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ed815bf88330ba20b38eb9cbc223