### PR TITLE
Fix startup crash from unsafe float casts; normalize Makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,43 +27,43 @@ dev-deps:
 .PHONY: test-core test-int test-all test-core-seq test-core-1p test-collect test-debug
 
 test-core:
-        @mkdir -p artifacts
-        # AI-AGENT-REF: load xdist, asyncio, timeout when autoload disabled
-        PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest \
-                -p xdist -p pytest_asyncio -p pytest_timeout \
-                -n auto \
-                -m "not integration and not slow" \
-                -q --disable-warnings \
-                | tee artifacts/pytest-core.txt
+	@mkdir -p artifacts
+	# AI-AGENT-REF: load xdist, asyncio, timeout when autoload disabled
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest \
+	        -p xdist -p pytest_asyncio -p pytest_timeout \
+	        -n auto \
+	        -m "not integration and not slow" \
+	        -q --disable-warnings \
+	        | tee artifacts/pytest-core.txt
 
 .PHONY: test-core-1p
 test-core-1p:
-        @mkdir -p artifacts
-        # AI-AGENT-REF: single process verbose debug
-        PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest \
-                -p pytest_asyncio -p pytest_timeout -p no:xdist \
-                -m "not integration and not slow" \
-                -vv -s --maxfail=1 \
-                | tee artifacts/pytest-core-1p.txt
+	@mkdir -p artifacts
+	# AI-AGENT-REF: single process verbose debug
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest \
+	        -p pytest_asyncio -p pytest_timeout -p no:xdist \
+	        -m "not integration and not slow" \
+	        -vv -s --maxfail=1 \
+	        | tee artifacts/pytest-core-1p.txt
 
 .PHONY: test-collect
 test-collect:
-        @mkdir -p artifacts
-        # AI-AGENT-REF: collect-only run
-        PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest \
-                -p pytest_asyncio -p pytest_timeout -p no:xdist \
-                -m "not integration and not slow" \
-                --collect-only -q \
-                | tee artifacts/pytest-collect.txt
+	@mkdir -p artifacts
+	# AI-AGENT-REF: collect-only run
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest \
+	        -p pytest_asyncio -p pytest_timeout -p no:xdist \
+	        -m "not integration and not slow" \
+	        --collect-only -q \
+	        | tee artifacts/pytest-collect.txt
 
 .PHONY: test-debug
 test-debug:
-        @mkdir -p artifacts
-        # AI-AGENT-REF: trace active plugins/config
-        PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest \
-                -p xdist -p pytest_asyncio -p pytest_timeout \
-                --trace-config -q \
-                | tee artifacts/pytest-trace-config.txt
+	@mkdir -p artifacts
+	# AI-AGENT-REF: trace active plugins/config
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest \
+	        -p xdist -p pytest_asyncio -p pytest_timeout \
+	        --trace-config -q \
+	        | tee artifacts/pytest-trace-config.txt
 
 test-int:
 	@mkdir -p artifacts

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -122,6 +122,14 @@ def _get_int_env(var: str, default: int | None = None) -> int | None:
         return default
 
 
+def _as_float(val, default: float = 0.0) -> float:
+    """Best-effort float conversion that tolerates None/str."""
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return float(default)
+
+
 def _install_signal_handlers() -> None:
     """Install SIGINT/SIGTERM handlers."""  # AI-AGENT-REF
 
@@ -144,9 +152,9 @@ def _validate_runtime_config(cfg, tcfg) -> None:
     if mode not in {"aggressive", "balanced", "conservative"}:
         errors.append(f"TRADING_MODE invalid: {mode}")
 
-    cap = float(getattr(tcfg, "capital_cap", 0.0))
-    risk = float(getattr(tcfg, "dollar_risk_limit", 0.0))
-    max_pos = float(getattr(tcfg, "max_position_size", 0.0))
+    cap = _as_float(getattr(tcfg, "capital_cap", 0.0), 0.0)
+    risk = _as_float(getattr(tcfg, "dollar_risk_limit", 0.0), 0.0)
+    max_pos = _as_float(getattr(tcfg, "max_position_size", None), 0.0)
     mp_mode = str(
         getattr(tcfg, "max_position_mode", getattr(cfg, "max_position_mode", "STATIC"))
     ).upper()  # AI-AGENT-REF: allow AUTO vs STATIC handling
@@ -407,10 +415,10 @@ def main(argv: list[str] | None = None) -> None:
         "mode": getattr(config, "trading_mode", "balanced"),
         "paper": getattr(config, "paper", True),
         "alpaca_base_url": getattr(config, "alpaca_base_url", ""),
-        "capital_cap": float(getattr(S, "capital_cap", 0.0)),
-        "dollar_risk_limit": float(getattr(S, "dollar_risk_limit", 0.0)),
+        "capital_cap": _as_float(getattr(S, "capital_cap", 0.0), 0.0),
+        "dollar_risk_limit": _as_float(getattr(S, "dollar_risk_limit", 0.0), 0.0),
         "max_position_mode": str(getattr(S, "max_position_mode", getattr(config, "max_position_mode", "STATIC"))).upper(),
-        "max_position_size": float(getattr(S, "max_position_size", 0.0)),
+        "max_position_size": _as_float(getattr(S, "max_position_size", None), 0.0),
     }
     logger.info("STARTUP_BANNER", extra=_redact(banner))
 


### PR DESCRIPTION
## Summary
- add _as_float helper and use for capital, risk, and max position size
- log startup banner safely when values are missing
- replace space-indented Makefile recipes with tabs for test targets

## Testing
- `python -m py_compile ai_trading/main.py`
- `make test-collect` *(fails: 92 errors during collection)*
- `make test-core` *(fails: 286 failed, 318 passed, 54 skipped, 1 xfailed, 106 errors)*
- `make test-all` *(terminated early)*
- `python -m ai_trading` *(startup logs without TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68a905d9549c8330a8ab78458c1e9702