### PR TITLE
Fix RiskEngine import crash from threading.Lock | None annotation; add import guard test

### DIFF
--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -1,3 +1,5 @@
+from __future__ import annotations  # AI-AGENT-REF: enable postponed evaluation of annotations
+
 import logging
 import os
 import random
@@ -82,7 +84,10 @@ MAX_DRAWDOWN = 0.05
 class RiskEngine:
     """Cross-strategy risk manager."""
 
-    _lock: threading.Lock | None = None
+    # NOTE: threading.Lock is a constructor (callable), not a type. Using it in a PEP 604 union
+    # triggers a runtime TypeError during class creation on Python 3.12. We annotate as object|None
+    # and instantiate with threading.Lock() in __init__/on-demand.
+    _lock: object | None = None  # AI-AGENT-REF: avoid TypeError from threading.Lock | None
 
     def __init__(self, cfg: TradingConfig | None = None) -> None:
         """Initialize the engine with an optional trading config."""

--- a/tests/unit/test_risk_engine_import.py
+++ b/tests/unit/test_risk_engine_import.py
@@ -1,0 +1,9 @@
+# AI-AGENT-REF: ensure RiskEngine imports without crash
+
+
+def test_import_risk_engine():
+    # Import must not raise on class creation
+    from ai_trading.risk.engine import RiskEngine  # noqa: F401
+
+    assert True
+


### PR DESCRIPTION
## Summary
- avoid `threading.Lock | None` runtime error by postponing annotations and using `object | None`
- add guard unit test to ensure `RiskEngine` imports without crash

## Testing
- `python - <<'PY'
from ai_trading.risk.engine import RiskEngine
r = RiskEngine()
print("OK")
PY`
- `python - <<'PY'
import py_compile, pathlib, sys
errs=[]
for p in pathlib.Path('.').rglob('*.py'):
    try:
        py_compile.compile(str(p), doraise=True)
    except Exception as e:
        errs.append((str(p), str(e)))
print("PY_COMPILE_ERRORS", len(errs))
for f,e in errs: print(f, '=>', e)
sys.exit(1 if errs else 0)
PY`
- `pytest -q tests/unit/test_risk_engine_import.py`
- `pytest -n auto --disable-warnings` *(fails: 265 failed, 401 passed, 68 skipped, 1 xfailed, 95 errors)*
- `sudo systemctl restart ai-trading.service` *(fails: System has not been booted with systemd as init system)*
- `sudo journalctl -u ai-trading.service -n 200 --no-pager` *(fails: No journal files were found)*

------
https://chatgpt.com/codex/tasks/task_e_68a91279b9688330923d5be04cae334a