### PR TITLE
Narrow hot-path broad exceptions and vectorize OBV; document data_fetcher import guard

### DIFF
--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -12,7 +12,11 @@ from pandas.errors import OutOfBoundsDatetime  # AI-AGENT-REF: datetime bounds
 
 try:  # pragma: no cover - optional configuration module
     from ai_trading.config import get_settings
-except Exception:  # AI-AGENT-REF: fallback when config dependencies missing
+except Exception:
+    # NOTE: This guard is intentionally broad because configuration modules may
+    # raise non-ImportError exceptions during import (e.g., validation errors)
+    # before the logger is available. We provide a minimal fallback to keep the
+    # data layer usable in constrained environments (tests, tooling, dry-runs).
     def get_settings():  # type: ignore
         return None
 from ai_trading.data.timeutils import (

--- a/tests/unit/test_capital_scaling_narrow.py
+++ b/tests/unit/test_capital_scaling_narrow.py
@@ -1,0 +1,50 @@
+import types
+from ai_trading.capital_scaling import update_if_present, capital_scale
+
+
+class DummyRuntime:
+    pass
+
+
+def test_update_if_present_calls_update_then_reads_scale():
+    rt = DummyRuntime()
+    state = {"updated": False, "scale": 0.42}
+
+    class Scaler:
+        def update(self, runtime, equity):
+            state["updated"] = True
+            # returns None by design in this module; caller should then read current_scale()
+        def current_scale(self):
+            return state["scale"]
+
+    rt.capital_scaler = Scaler()
+    val = update_if_present(rt, equity=1000.0)
+    assert state["updated"] is True
+    assert abs(val - 0.42) < 1e-12
+
+
+def test_update_if_present_narrowed_exceptions_return_one():
+    rt = DummyRuntime()
+
+    class BadScaler:
+        def update(self, runtime, equity):
+            raise TypeError("boom")
+        def current_scale(self):  # pragma: no cover - not reached
+            return 2.0
+
+    rt.capital_scaler = BadScaler()
+    val = update_if_present(rt, equity=1.0)
+    assert val == 1.0
+
+
+def test_capital_scale_narrowed_exceptions_return_one():
+    rt = DummyRuntime()
+
+    class BadScaler:
+        def current_scale(self):
+            raise AttributeError("nope")
+
+    rt.capital_scaler = BadScaler()
+    val = capital_scale(rt)
+    assert val == 1.0
+

--- a/tests/unit/test_obv_vectorized.py
+++ b/tests/unit/test_obv_vectorized.py
@@ -1,0 +1,27 @@
+import numpy as np
+from ai_trading.indicators import obv as obv_vec
+
+
+def obv_loop(closes: np.ndarray, volumes: np.ndarray) -> np.ndarray:
+    obv_vals = [0.0]
+    for i in range(1, len(closes)):
+        if closes[i] > closes[i - 1]:
+            obv_vals.append(obv_vals[-1] + volumes[i])
+        elif closes[i] < closes[i - 1]:
+            obv_vals.append(obv_vals[-1] - volumes[i])
+        else:
+            obv_vals.append(obv_vals[-1])
+    return np.asarray(obv_vals, dtype=float)
+
+
+def test_obv_vectorized_matches_reference_loop():
+    rng = np.random.default_rng(123)
+    for n in (1, 2, 5, 10, 256, 1024):
+        closes = rng.normal(size=n).cumsum()  # realistic random walk
+        volumes = rng.integers(low=1, high=1000, size=n).astype(float)
+        ref = obv_loop(closes, volumes)
+        got = obv_vec(closes, volumes)
+        assert got.shape == ref.shape
+        # exact equality holds for OBV semantics
+        assert np.allclose(got, ref, atol=0.0)
+


### PR DESCRIPTION
## Summary
- narrow capital scaler exception handling and read scale after update
- vectorize OBV computation
- document broad import guard in `data_fetcher`

## Testing
- `python - <<'PY'
import py_compile, pathlib, sys
errs=[]
for p in pathlib.Path('.').rglob('*.py'):
    try:
        py_compile.compile(str(p), doraise=True)
    except Exception as e:
        errs.append((str(p), str(e)))
print('PY_COMPILE_ERRORS', len(errs))
for f,e in errs: print(f, '=>', e)
sys.exit(1 if errs else 0)
PY`
- `pytest -q tests/unit/test_capital_scaling_narrow.py tests/unit/test_obv_vectorized.py`
- `ruff check ai_trading/capital_scaling.py ai_trading/indicators.py ai_trading/data_fetcher.py --force-exclude`
- `python - <<'PY'
from ai_trading.capital_scaling import update_if_present, capital_scale
class R: pass
r=R()
class S:
    def __init__(self): self.k=1
    def update(self, runtime, eq): self.k+=1
    def current_scale(self): return 0.5
r.capital_scaler=S()
print('update_if_present=', update_if_present(r, 1000.0))
print('capital_scale=', capital_scale(r))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a913dfa5b88330b4ef54cbd2dcb6ea