### PR TITLE
Narrow execution/simulator broad exceptions; harden import guard in execution package; add targeted tests

### DIFF
--- a/ai_trading/execution/__init__.py
+++ b/ai_trading/execution/__init__.py
@@ -64,14 +64,16 @@ from .position_reconciler import (
 )
 from .transaction_costs import estimate_cost
 
-try:  # AI-AGENT-REF: optional production engine when Alpaca deps missing
+try:  # AI-AGENT-REF: optional production engine when components are missing
     from .production_engine import (
         ExecutionResult,
         OrderRequest,
         ProductionExecutionCoordinator,
     )
-# noqa: BLE001 TODO: narrow exception
-except Exception:  # pragma: no cover
+except (ImportError, AttributeError):  # pragma: no cover
+    # Only import/attribute resolution failures are tolerated here. Runtime
+    # exceptions should surface from the production engine itself, not be
+    # swallowed at package import time.
     ExecutionResult = OrderRequest = ProductionExecutionCoordinator = None  # type: ignore
 
 # Export all execution classes

--- a/ai_trading/execution/algorithms.py
+++ b/ai_trading/execution/algorithms.py
@@ -100,8 +100,9 @@ class VWAPExecutor:
 
             return child_orders
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        # Only local math/input/runtime issues are tolerated here. Broker/API
+        # errors are handled inside OrderManager.
+        except (ValueError, TypeError, ZeroDivisionError, RuntimeError) as e:
             logger.error(f"Error in VWAP execution: {e}")
             return []
 
@@ -185,8 +186,8 @@ class TWAPExecutor:
             logger.info(f"TWAP execution completed: {len(child_orders)} orders")
             return child_orders
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        # Guard TWAP math edge cases; e.g., duration_minutes==0 can zero-divide.
+        except (ValueError, TypeError, ZeroDivisionError, RuntimeError) as e:
             logger.error(f"Error in TWAP execution: {e}")
             return []
 
@@ -274,8 +275,7 @@ class ImplementationShortfall:
             )
             return child_orders
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (ValueError, TypeError, ZeroDivisionError, RuntimeError) as e:
             logger.error(f"Error in Implementation Shortfall execution: {e}")
             return []
 
@@ -310,8 +310,7 @@ class ImplementationShortfall:
 
             return schedule
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (ValueError, TypeError, ZeroDivisionError, RuntimeError) as e:
             logger.error(f"Error calculating execution schedule: {e}")
             return [(total_quantity, self.urgency_factor)]
 

--- a/ai_trading/execution/simulator.py
+++ b/ai_trading/execution/simulator.py
@@ -84,8 +84,7 @@ class SlippageModel:
 
             return total_slippage
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (ValueError, TypeError, ZeroDivisionError) as e:
             logger.error(f"Error calculating slippage: {e}")
             return 0.0
 
@@ -119,8 +118,7 @@ class SlippageModel:
                 f"liquidity={liquidity:.2f}"
             )
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (ValueError, TypeError, ZeroDivisionError) as e:
             logger.error(f"Error updating market conditions: {e}")
 
 
@@ -214,8 +212,7 @@ class FillSimulator:
 
             return result
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (ValueError, TypeError, ZeroDivisionError) as e:
             logger.error(f"Error simulating fill: {e}")
             return {
                 "filled": False,
@@ -311,6 +308,5 @@ class FillSimulator:
                 f"Fill simulator updated: vol={volatility:.2f}, vol={volume:.2f}"
             )
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (ValueError, TypeError, ZeroDivisionError) as e:
             logger.error(f"Error updating fill simulator: {e}")

--- a/tests/unit/test_execution_algorithms_narrow.py
+++ b/tests/unit/test_execution_algorithms_narrow.py
@@ -1,0 +1,21 @@
+from ai_trading.execution.algorithms import TWAPExecutor
+from ai_trading.execution.engine import OrderManager
+from ai_trading.core.enums import OrderSide, OrderType
+
+
+class DummyOrderManager(OrderManager):
+    # Use OrderManager behavior; submit_order returns False/True safely.
+    pass
+
+
+def test_twap_zero_duration_returns_empty_list():
+    om = DummyOrderManager()
+    twap = TWAPExecutor(om)
+    orders = twap.execute_twap_order(
+        symbol="TEST",
+        side=OrderSide.BUY,
+        total_quantity=1000,
+        duration_minutes=0,  # triggers zero-division path before loop
+    )
+    assert orders == []
+

--- a/tests/unit/test_execution_simulator_narrow.py
+++ b/tests/unit/test_execution_simulator_narrow.py
@@ -1,0 +1,27 @@
+from ai_trading.execution.simulator import SlippageModel, FillSimulator
+from ai_trading.core.enums import OrderSide, OrderType
+
+
+def test_update_market_conditions_zero_liquidity_does_not_raise():
+    s = SlippageModel()
+    # Liquidity=0 would normally zero-divide; ensure our narrowed catch handles it.
+    s.update_market_conditions(volatility=0.5, liquidity=0.0)
+    assert True  # no exception
+
+
+def test_simulate_fill_negative_price_returns_fallback():
+    class FaultySlippageModel(SlippageModel):
+        def calculate_slippage(self, *args, **kwargs):  # type: ignore[override]
+            raise ValueError("math error")
+
+    fs = FillSimulator(slippage_model=FaultySlippageModel())
+    out = fs.simulate_fill(
+        symbol="TEST",
+        side=OrderSide.BUY,
+        order_type=OrderType.MARKET,
+        quantity=100,
+        price=-1.0,
+    )
+    assert out["filled"] is False
+    assert "Simulation error" in out.get("rejection_reason", "")
+


### PR DESCRIPTION
## Summary
- restrict execution package import guard to ImportError/AttributeError and clarify comment
- replace broad `except Exception` blocks in execution algorithms and simulator with targeted tuples
- add tests for TWAP zero-duration, simulator liquidity zero, and negative price fallback

## Testing
- `python - <<'PY'
import py_compile, pathlib, sys
errs=[]
for p in pathlib.Path('.').rglob('*.py'):
    try:
        py_compile.compile(str(p), doraise=True)
    except Exception as e:
        errs.append((str(p), str(e)))
print('PY_COMPILE_ERRORS', len(errs))
for f,e in errs: print(f, '=>', e)
sys.exit(1 if errs else 0)
PY`
- `pytest -q tests/unit/test_execution_algorithms_narrow.py tests/unit/test_execution_simulator_narrow.py`
- `ruff check ai_trading/execution/__init__.py ai_trading/execution/algorithms.py ai_trading/execution/simulator.py --force-exclude`


------
https://chatgpt.com/codex/tasks/task_e_68a917be67fc8330b00ee3c49a943540