### PR TITLE
Narrow broad exceptions in regime detection, feature pipeline, risk metrics, and DB connection (tests included)

### DIFF
--- a/ai_trading/database/connection.py
+++ b/ai_trading/database/connection.py
@@ -56,8 +56,12 @@ class DatabaseManager:
                 logger.info("Database connection established successfully")
                 return True
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            TimeoutError,
+            ConnectionError,
+            OSError,
+            RuntimeError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Failed to connect to database: {e}")
             return False
 
@@ -74,8 +78,12 @@ class DatabaseManager:
                 self._is_connected = False
                 logger.info("Database connection closed successfully")
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            TimeoutError,
+            ConnectionError,
+            OSError,
+            RuntimeError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error disconnecting from database: {e}")
 
     def is_healthy(self) -> bool:
@@ -88,8 +96,12 @@ class DatabaseManager:
             # In production: SELECT 1
             return True
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            TimeoutError,
+            ConnectionError,
+            OSError,
+            RuntimeError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Database health check failed: {e}")
             return False
 
@@ -130,8 +142,12 @@ class DatabaseManager:
             logger.debug(f"Database session {session_id} created")
             yield session
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            TimeoutError,
+            ConnectionError,
+            OSError,
+            RuntimeError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Database session error: {e}")
             if session:
                 session.rollback()
@@ -144,8 +160,12 @@ class DatabaseManager:
                     with self._connection_lock:
                         self._connections.pop(session_id, None)
                     logger.debug(f"Database session {session_id} closed")
-                # noqa: BLE001 TODO: narrow exception
-                except Exception as e:
+                except (
+                    TimeoutError,
+                    ConnectionError,
+                    OSError,
+                    RuntimeError,
+                ) as e:  # AI-AGENT-REF: narrow exception
                     logger.error(f"Error closing session {session_id}: {e}")
 
 
@@ -258,8 +278,12 @@ def initialize_database(connection_string: str | None = None, **kwargs) -> bool:
     try:
         _db_manager = DatabaseManager(connection_string, **kwargs)
         return _db_manager.connect()
-    # noqa: BLE001 TODO: narrow exception
-    except Exception as e:
+    except (
+        TimeoutError,
+        ConnectionError,
+        OSError,
+        RuntimeError,
+    ) as e:  # AI-AGENT-REF: narrow exception
         logger.error(f"Failed to initialize database: {e}")
         return False
 

--- a/ai_trading/features/pipeline.py
+++ b/ai_trading/features/pipeline.py
@@ -15,6 +15,8 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import RobustScaler, StandardScaler
 
+sklearn_available = True  # AI-AGENT-REF: indicate sklearn is installed
+
 # Use the centralized logger as per AGENTS.md
 from ai_trading.logging import logger
 
@@ -105,8 +107,12 @@ class BuildFeatures(BaseEstimator, TransformerMixin):
             logger.debug("BuildFeatures fitted successfully")
             return self
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            KeyError,
+            ValueError,
+            TypeError,
+            pd.errors.EmptyDataError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error fitting BuildFeatures: {e}")
             raise
 
@@ -160,8 +166,12 @@ class BuildFeatures(BaseEstimator, TransformerMixin):
             )
             return features
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            KeyError,
+            ValueError,
+            TypeError,
+            pd.errors.EmptyDataError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error transforming features: {e}")
             raise
 
@@ -189,8 +199,12 @@ class BuildFeatures(BaseEstimator, TransformerMixin):
 
             return features
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            KeyError,
+            ValueError,
+            TypeError,
+            pd.errors.EmptyDataError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error adding return features: {e}")
             return features
 
@@ -226,8 +240,12 @@ class BuildFeatures(BaseEstimator, TransformerMixin):
 
             return features
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            KeyError,
+            ValueError,
+            TypeError,
+            pd.errors.EmptyDataError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error adding volatility features: {e}")
             return features
 
@@ -264,8 +282,12 @@ class BuildFeatures(BaseEstimator, TransformerMixin):
 
             return features
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            KeyError,
+            ValueError,
+            TypeError,
+            pd.errors.EmptyDataError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error adding volume features: {e}")
             return features
 
@@ -326,8 +348,12 @@ class BuildFeatures(BaseEstimator, TransformerMixin):
 
             return features
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            KeyError,
+            ValueError,
+            TypeError,
+            pd.errors.EmptyDataError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error adding regime features: {e}")
             return features
 
@@ -380,8 +406,12 @@ def create_feature_pipeline(
         logger.info(f"Created feature pipeline with {len(pipeline_steps)} steps")
         return pipeline
 
-    # noqa: BLE001 TODO: narrow exception
-    except Exception as e:
+    except (
+        KeyError,
+        ValueError,
+        TypeError,
+        pd.errors.EmptyDataError,
+    ) as e:  # AI-AGENT-REF: narrow exception
         logger.error(f"Error creating feature pipeline: {e}")
         raise
 
@@ -434,7 +464,11 @@ def validate_pipeline_no_leakage(
         logger.debug("Pipeline validation passed - no obvious leakage detected")
         return True
 
-    # noqa: BLE001 TODO: narrow exception
-    except Exception as e:
+    except (
+        KeyError,
+        ValueError,
+        TypeError,
+        pd.errors.EmptyDataError,
+    ) as e:  # AI-AGENT-REF: narrow exception
         logger.error(f"Error validating pipeline: {e}")
         return False

--- a/ai_trading/risk/metrics.py
+++ b/ai_trading/risk/metrics.py
@@ -50,8 +50,13 @@ class RiskMetricsCalculator:
 
             return var
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating VaR: {e}")
             return 0.0
 
@@ -83,8 +88,13 @@ class RiskMetricsCalculator:
 
             return es
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating Expected Shortfall: {e}")
             return 0.0
 
@@ -109,8 +119,13 @@ class RiskMetricsCalculator:
             sharpe = mean_excess / std_excess * (252**0.5)
             return sharpe
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating Sharpe ratio: {e}")
             return 0.0
 
@@ -141,8 +156,13 @@ class RiskMetricsCalculator:
             sortino = mean_excess / downside_deviation * (252**0.5)
             return sortino
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating Sortino ratio: {e}")
             return 0.0
 
@@ -240,8 +260,13 @@ class DrawdownAnalyzer:
 
             return stats
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating drawdowns: {e}")
             return {}
 
@@ -268,8 +293,13 @@ class DrawdownAnalyzer:
             drawdown = (peak_value - current_value) / peak_value
             return True, drawdown
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error checking drawdown status: {e}")
             return False, 0.0
 
@@ -300,7 +330,12 @@ class DrawdownAnalyzer:
 
             return None  # Not recovered yet
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating recovery time: {e}")
             return None

--- a/ai_trading/strategies/regime_detector.py
+++ b/ai_trading/strategies/regime_detector.py
@@ -16,11 +16,9 @@ import numpy as np
 
 # Use the centralized logger as per AGENTS.md
 from ai_trading.logging import logger
-
-NUMPY_AVAILABLE = True
-
 from ai_trading.risk.adaptive_sizing import MarketRegime, VolatilityRegime
 
+NUMPY_AVAILABLE = True
 ENHANCED_REGIMES_AVAILABLE = True
 
 
@@ -210,8 +208,14 @@ class RegimeDetector:
 
             return regime, metrics
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+            np.linalg.LinAlgError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error detecting market regime: {e}")
             return self._fallback_regime_detection()
 
@@ -272,8 +276,14 @@ class RegimeDetector:
 
             return adjusted_thresholds
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+            np.linalg.LinAlgError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating dynamic thresholds: {e}")
             # Return conservative defaults
             return TradingThresholds(0.03, 0.5, 1.5, 0.03, 3.0)
@@ -331,8 +341,14 @@ class RegimeDetector:
 
             return trend_strength, direction
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+            np.linalg.LinAlgError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating trend metrics: {e}")
             return 0.0, TrendDirection.SIDEWAYS
 
@@ -379,8 +395,14 @@ class RegimeDetector:
 
             return percentile, regime
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+            np.linalg.LinAlgError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating volatility regime: {e}")
             return 0.5, VolatilityRegime.NORMAL
 
@@ -406,8 +428,14 @@ class RegimeDetector:
 
             return momentum
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+            np.linalg.LinAlgError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating momentum: {e}")
             return 0.0
 
@@ -432,8 +460,14 @@ class RegimeDetector:
             avg_correlation = statistics.mean(correlations)
             return min(1.0, max(0.0, avg_correlation))
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+            np.linalg.LinAlgError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error calculating correlation environment: {e}")
             return 0.3
 
@@ -449,8 +483,7 @@ class RegimeDetector:
 
             return None
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception:
+        except (ValueError, TypeError, KeyError):  # AI-AGENT-REF: narrow exception
             return None
 
     def _calculate_regime_confidence(
@@ -474,8 +507,14 @@ class RegimeDetector:
 
             return max(0.0, min(1.0, confidence))
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+            np.linalg.LinAlgError,
+        ):  # AI-AGENT-REF: narrow exception
             return 0.5
 
     def _classify_market_regime(self, metrics: RegimeMetrics) -> MarketRegime:
@@ -520,8 +559,14 @@ class RegimeDetector:
             # Default to normal
             return MarketRegime.NORMAL
 
-        # noqa: BLE001 TODO: narrow exception
-        except Exception as e:
+        except (
+            ValueError,
+            TypeError,
+            ZeroDivisionError,
+            OverflowError,
+            statistics.StatisticsError,
+            np.linalg.LinAlgError,
+        ) as e:  # AI-AGENT-REF: narrow exception
             logger.error(f"Error classifying market regime: {e}")
             return MarketRegime.NORMAL
 

--- a/tests/unit/test_db_connection_narrowing.py
+++ b/tests/unit/test_db_connection_narrowing.py
@@ -1,0 +1,18 @@
+"""Tests for narrowed exceptions in database connection."""
+
+from __future__ import annotations
+
+import time
+
+from ai_trading.database.connection import DatabaseManager
+
+
+def test_connect_handles_timeouterror(monkeypatch) -> None:
+    """TimeoutError during connect should return False."""  # AI-AGENT-REF: narrow exception test
+    db = DatabaseManager("sqlite:///:memory:")
+
+    def boom(_):
+        raise TimeoutError("sleep timeout")
+
+    monkeypatch.setattr(time, "sleep", boom)
+    assert db.connect() is False

--- a/tests/unit/test_features_pipeline_narrowing.py
+++ b/tests/unit/test_features_pipeline_narrowing.py
@@ -1,0 +1,17 @@
+"""Tests for narrowed exceptions in feature pipeline."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ai_trading.features.pipeline import BuildFeatures
+
+
+def test_transform_raises_value_error_on_bad_input() -> None:
+    """Non-DataFrame input should raise ValueError."""  # AI-AGENT-REF: narrow exception test
+    bf = BuildFeatures(include_regime=True, include_volatility=True)
+    X = pd.DataFrame({"close": [1, 2, 3]})
+    bf.fit(X)
+    with pytest.raises(ValueError):
+        bf.transform("bad")

--- a/tests/unit/test_regime_detector_narrowing.py
+++ b/tests/unit/test_regime_detector_narrowing.py
@@ -1,0 +1,15 @@
+"""Tests for narrowed exceptions in RegimeDetector."""
+
+from __future__ import annotations
+
+from ai_trading.strategies.regime_detector import RegimeDetector
+from ai_trading.risk.adaptive_sizing import MarketRegime
+
+
+def test_detect_current_regime_handles_type_error() -> None:
+    """Ensure TypeError is caught and fallback regime is returned."""  # AI-AGENT-REF: narrow exception test
+    rd = RegimeDetector()
+    market_data = {"prices": {"SPY": [1] * 70}, "returns": {"SPY": None}}
+    regime, metrics = rd.detect_current_regime(market_data, index_symbol="SPY")
+    assert isinstance(regime, MarketRegime)
+    assert hasattr(metrics, "trend_strength")

--- a/tests/unit/test_risk_metrics_narrowing.py
+++ b/tests/unit/test_risk_metrics_narrowing.py
@@ -1,0 +1,12 @@
+"""Tests for narrowed exceptions in risk metrics."""
+
+from __future__ import annotations
+
+from ai_trading.risk.metrics import RiskMetricsCalculator
+
+
+def test_var_handles_bad_values_gracefully() -> None:
+    """Invalid returns should return 0.0 instead of raising."""  # AI-AGENT-REF: narrow exception test
+    rmc = RiskMetricsCalculator()
+    returns = ["bad", None, {}]  # type: ignore
+    assert rmc.calculate_var(returns, confidence_level=0.95) == 0.0


### PR DESCRIPTION
## Summary
- replace broad `except Exception` blocks with specific exception tuples across regime detection, feature pipeline, risk metrics, and database connection modules
- add targeted unit tests exercising TypeError, ValueError and TimeoutError paths

## Testing
- `python - <<'PY'
import py_compile, pathlib, sys
errs=[]
for p in pathlib.Path('.').rglob('*.py'):
    try:
        py_compile.compile(str(p), doraise=True)
    except Exception as e:
        errs.append((str(p), str(e)))
print('PY_COMPILE_ERRORS', len(errs))
for f,e in errs:
    print(f, '=>', e)
sys.exit(1 if errs else 0)
PY`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError and other errors)*
- `pytest -q tests/unit/test_regime_detector_narrowing.py tests/unit/test_features_pipeline_narrowing.py tests/unit/test_risk_metrics_narrowing.py tests/unit/test_db_connection_narrowing.py`
- `ruff check ai_trading/strategies/regime_detector.py ai_trading/features/pipeline.py ai_trading/risk/metrics.py ai_trading/database/connection.py tests/unit/test_regime_detector_narrowing.py tests/unit/test_features_pipeline_narrowing.py tests/unit/test_risk_metrics_narrowing.py tests/unit/test_db_connection_narrowing.py --force-exclude`


------
https://chatgpt.com/codex/tasks/task_e_68a92c84d7e08330b9753e4b0ee08c45