### PR TITLE
Narrow final non-boundary except Exception in core/bot_engine.py (import guard, bars summary)

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -58,7 +58,7 @@ from ai_trading.data.bars import (_ensure_df, safe_get_stock_bars, _create_empty
 
 try:  # AI-AGENT-REF: optional Alpaca trading client
     from alpaca.trading.client import TradingClient  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - optional dependency
     TradingClient = None  # type: ignore
 
 if os.getenv("BOT_SHOW_DEPRECATIONS", "").lower() in {"1", "true", "yes"}:
@@ -2463,7 +2463,7 @@ def _fetch_universe_bars_chunked(
     total_symbols = len(out)
     try:
         bars_loaded = sum(len(v) for v in out.values())
-    except Exception:
+    except (TypeError, AttributeError):  # AI-AGENT-REF: bars summary fallback
         bars_loaded = 0
     first_symbol = next(iter(out.keys()), None)
     _log.info(
@@ -2559,7 +2559,7 @@ def _fetch_intraday_bars_chunked(
     total_symbols = len(out)
     try:
         bars_loaded = sum(len(v) for v in out.values())
-    except Exception:
+    except (TypeError, AttributeError):  # AI-AGENT-REF: bars summary fallback
         bars_loaded = 0
     first_symbol = next(iter(out.keys()), None)
     _log.info(


### PR DESCRIPTION
## Summary
- narrow optional Alpaca trading client import guard to ImportError and ModuleNotFoundError
- restrict bars summary fallback to TypeError and AttributeError

## Testing
- `rg -n "except Exception" | rg -v "/tests/" | rg -v "__main__" || true`
- `python - <<'PY'
import py_compile, pathlib, sys
errs=[]
for p in pathlib.Path('.').rglob('*.py'):
    try: py_compile.compile(str(p), doraise=True)
    except Exception as e: errs.append((str(p), str(e)))
print('PY_COMPILE_ERRORS', len(errs))
for f,e in errs: print(f,'=>',e)
sys.exit(1 if errs else 0)
PY`
- `ruff check ai_trading/core/bot_engine.py --select=BLE001 --force-exclude`
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'freezegun')*

------
https://chatgpt.com/codex/tasks/task_e_68a93c05d8948330bb68c9fc83915854