### PR TITLE
fix: guard optional numba import and rewriter

### DIFF
--- a/ai_trading/indicators.py
+++ b/ai_trading/indicators.py
@@ -9,7 +9,7 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 try:
     from numba import jit as _numba_jit
-except (pd.errors.EmptyDataError, KeyError, ValueError, TypeError, ZeroDivisionError, OverflowError):
+except (ImportError, ModuleNotFoundError):  # AI-AGENT-REF: numba optional; fall back to pure-Python
     _numba_jit = None
 
 def jit(*args, **kwargs):

--- a/tests/unit/test_indicators_numba_optional.py
+++ b/tests/unit/test_indicators_numba_optional.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+
+
+def test_indicators_import_without_numba(monkeypatch):
+    """Ensure indicators module loads when numba is missing."""
+    # AI-AGENT-REF: simulate missing numba to test optional import path
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **kw):
+        if name == "numba":
+            raise ModuleNotFoundError("numba")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    # Reload module to hit guarded import
+    importlib.sys.modules.pop("ai_trading.indicators", None)
+    mod = importlib.import_module("ai_trading.indicators")
+
+    assert hasattr(mod, "jit")
+    assert getattr(mod, "_numba_jit", None) is None
+

--- a/tools/narrow_broad_excepts.py
+++ b/tools/narrow_broad_excepts.py
@@ -44,7 +44,11 @@ class Narrower(ast.NodeTransformer):
 
         def name(id_: str) -> ast.expr:
             return ast.Name(id=id_, ctx=ast.Load())
+        # Heuristics based on imports & content
         src_block = ast.get_source_segment(self.src, try_node) or ''
+        # AI-AGENT-REF: include import errors for guarded imports
+        if 'import ' in src_block:
+            excs.extend([name('ImportError'), name('ModuleNotFoundError')])
         if any((x in imps for x in {'pandas', 'pd'})):
             excs.append(ast.Attribute(value=ast.Attribute(value=name('pd'), attr='errors', ctx=ast.Load()), attr='EmptyDataError', ctx=ast.Load()))
             excs.extend([name('KeyError'), name('ValueError'), name('TypeError')])


### PR DESCRIPTION
## Summary
- handle missing numba with ImportError guard in indicators
- extend narrow_broad_excepts to inject ImportError for import blocks
- test indicators module loads when numba is absent

## Testing
- `python - <<'PY'
import py_compile, pathlib, sys
errs=[]
for p in pathlib.Path('.').rglob('*.py'):
    try: py_compile.compile(str(p), doraise=True)
    except Exception as e: errs.append((str(p), str(e)))
print('PY_COMPILE_ERRORS', len(errs))
for f,e in errs: print(f, '=>', e)
sys.exit(1 if errs else 0)
PY`
- `ruff check --select=BLE001 ai_trading/indicators.py tools/narrow_broad_excepts.py --force-exclude`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/unit/test_indicators_numba_optional.py`
- `pytest -n auto --disable-warnings` *(fails: 2 skipped, 41 errors; KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a93e90dd90833092a0fd9547fcd88c