### PR TITLE
Unblock tests by restoring fetcher exports & dev deps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,9 @@ coverage==7.6.1
 execnet==2.1.1  # AI-AGENT-REF: enable pytest-xdist
 pytest-timeout==2.3.1
 pytest-asyncio==0.23.8
+# pytest core deps when installing with --no-deps
+pluggy==1.5.*
+iniconfig==2.0.*
 requests-mock==1.12.1
 freezegun==1.4.0
 
@@ -26,3 +29,17 @@ tenacity==8.5.0
 
 # Infra & helpers
 packaging==24.1
+
+# --- test/dev-time runtime deps required at import/collection ---
+# AI-AGENT-REF: add deps for test imports
+prometheus-client==0.20.*
+schedule==1.2.*
+ratelimit==2.2.*
+hypothesis==6.112.*
+sortedcontainers==2.4.*
+
+# Some ML-oriented tests/fixtures import sklearn at collection time.
+# Keeping this in dev requirements avoids bloating runtime images.
+scikit-learn==1.5.*
+scipy==1.13.*
+threadpoolctl==3.5.*


### PR DESCRIPTION
## Summary
- expose `warmup_cache`, `get_cache_stats`, and `_CACHE_STATS` from `ai_trading.data_fetcher`
- pin missing test-time packages like `prometheus-client`, `schedule`, `ratelimit`, `hypothesis`, and `scikit-learn` along with their required deps

## Testing
- `python -c "import prometheus_client, schedule, ratelimit, hypothesis; print('OK')"`
- `python -c "from ai_trading.data_fetcher import warmup_cache, get_cache_stats, _CACHE_STATS; print('OK')"`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist -p pytest_timeout -p pytest_asyncio -q -m 'not integration and not slow' -n 2 --timeout=120 --timeout-method=thread -o xdist.debug=1 -o log_cli=true -o log_cli_level=INFO tests` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_68a94ff3069c83308f39c0a2d55558b4