### PR TITLE
Add cachetools (runtime) and torch (dev) to unblock pytest collection

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,3 +4,8 @@ portalocker==2.7.0
 alpaca-trade-api==3.2.0
 yfinance==0.2.37
 websockets==10.4
+
+# Add exact pins for newly introduced deps to preserve reproducibility
+cachetools==5.3.3
+# Torch CPU wheels are published on PyPI; pin to a stable 2.x release compatible with Py3.12
+torch==2.3.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,6 +30,16 @@ tenacity==8.5.0
 # Infra & helpers
 packaging==24.1
 
+# prior PR added scikit-learn/scipy stack and others
+# (left unchanged here)
+
+# Ensure test collection succeeds where torch is imported
+# CPU wheel from PyPI; no CUDA required for tests
+torch
+
+# Align dev env with runtime caching imports during tests
+cachetools>=5,<6
+
 # --- test/dev-time runtime deps required at import/collection ---
 # AI-AGENT-REF: add deps for test imports
 prometheus-client==0.20.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,6 @@ pydantic-settings>=2.2,<3
 # Deterministic calendars & time zones
 tzdata>=2024.1  # AI-AGENT-REF: ensure timezone data
 pandas-market-calendars>=4.4,<6  # AI-AGENT-REF: exchange calendars
+
+# Caching used by runtime fetcher/caching hooks
+cachetools>=5,<6


### PR DESCRIPTION
## Summary
- include cachetools in runtime requirements and pin in constraints
- add torch and cachetools to dev requirements and pin in constraints

## Testing
- `python -m pip install --upgrade pip`
- `python -m pip install -r requirements.txt -c constraints.txt`
- `python -m pip install -r requirements-dev.txt --no-deps -c constraints.txt`
- `python -m pip install torch==2.3.1 -c constraints.txt`
- `python - <<'PY'
import cachetools, torch; print('cachetools OK; torch OK')
PY`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist -p pytest_timeout -p pytest_asyncio -q --collect-only -o log_cli=true -o log_cli_level=INFO` *(fails: ModuleNotFoundError: No module named 'stable_baselines3')*

------
https://chatgpt.com/codex/tasks/task_e_68a9bda7680c83309a4488b4e15b8906