### PR TITLE
Install stable_baselines3 + gymnasium (and friends) to satisfy RL tests; keep runtime untouched

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -9,3 +9,16 @@ websockets==10.4
 cachetools==5.3.3
 # Torch CPU wheels are published on PyPI; pin to a stable 2.x release compatible with Py3.12
 torch==2.3.1
+
+# Keep prior pins intact; append deterministic pins for new dev deps
+stable-baselines3==2.3.2
+gymnasium==0.29.1
+cloudpickle==3.0.0
+tqdm==4.66.4
+matplotlib==3.9.2
+contourpy==1.3.3
+cycler==0.12.1
+fonttools==4.59.1
+kiwisolver==1.4.9
+pillow==11.3.0
+pyparsing==3.2.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -53,3 +53,16 @@ sortedcontainers==2.4.*
 scikit-learn==1.5.*
 scipy==1.13.*
 threadpoolctl==3.5.*
+
+# ==== RL / ML stack used by tests (dev-only) ====
+stable-baselines3==2.3.2
+gymnasium==0.29.1
+cloudpickle==3.0.0
+tqdm==4.66.4
+matplotlib==3.9.2
+contourpy==1.3.3
+cycler==0.12.1
+fonttools==4.59.1
+kiwisolver==1.4.9
+pillow==11.3.0
+pyparsing==3.2.3

--- a/tools/check_dev_deps.py
+++ b/tools/check_dev_deps.py
@@ -1,0 +1,25 @@
+"""Tiny sanity check for dev ML dependencies used by tests.
+Run: python tools/check_dev_deps.py
+Exits 0 if all imports succeed; prints a minimal status line.
+"""
+from __future__ import annotations
+
+import sys
+
+def main() -> int:
+    missing: list[str] = []
+    for name in ("stable_baselines3", "gymnasium", "cloudpickle", "tqdm"):
+        try:
+            __import__(name)
+        except Exception as e:  # precise intent: import-only verification
+            missing.append(f"{name}: {e}")
+    if missing:
+        print("MISSING:")
+        for m in missing:
+            print(" -", m)
+        return 1
+    print("dev-ml-deps: OK")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add RL testing stack (stable-baselines3, gymnasium, cloudpickle, tqdm, matplotlib) to dev requirements and constraints
- provide tooling to sanity-check ML dev dependencies

## Testing
- `python tools/check_dev_deps.py`
- `python - <<'PY'
import stable_baselines3 as sb3, gymnasium as gym
print('OK')
PY`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist -p pytest_timeout -p pytest_asyncio -q --collect-only`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist -p pytest_timeout -p pytest_asyncio -q -m "not integration and not slow" -n 2 --timeout=120 --timeout-method=thread`

------
https://chatgpt.com/codex/tasks/task_e_68a9c38eb3488330982c7ad357835927