### PR TITLE
Add alpaca-py to dev requirements and extend import checks

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -66,3 +66,7 @@ fonttools==4.59.1
 kiwisolver==1.4.9
 pillow==11.3.0
 pyparsing==3.2.3
+
+# Broker/SDK for tests that import modern Alpaca SDK
+# Dev-only to satisfy test-time imports without altering runtime deps
+alpaca-py


### PR DESCRIPTION
## Summary
- add `alpaca-py` for test-time Alpaca SDK imports
- extend dev dependency checker to cover Alpaca SDKs and core test deps

## Testing
- `python tools/check_dev_deps.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist -p pytest_timeout -p pytest_asyncio -q --collect-only -o log_cli=true -o log_cli_level=INFO` *(fails: ModuleNotFoundError: No module named 'ai_trading.position.core')*

------
https://chatgpt.com/codex/tasks/task_e_68a9c8ad7bb88330931282e006fa50f8