### PR TITLE
Unblock test collection on Ubuntu 24.04 and surface import errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,26 @@
 # AI-AGENT-REF: unify test harness
 export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
 PYTEST_PLUGINS    := -p xdist -p pytest_timeout -p pytest_asyncio
-PYTEST_FLAGS_BASE := -q -o log_cli=true -o log_cli_level=INFO
+PYTEST_FLAGS      := -q -o log_cli=true -o log_cli_level=INFO
 PYTEST_MARK_EXPR  := -m "not integration and not slow"
 PYTEST_NODES      := -n auto
 TIMEOUT_FLAGS     := --timeout=120 --timeout-method=thread
 
-.PHONY: test-collect test-core test-all repair-test-imports
+.PHONY: test-collect test-collect-report test-core test-all repair-test-imports
 
 test-collect:
-	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) --collect-only
+	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS) --collect-only
 
 test-core:
-	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) $(PYTEST_MARK_EXPR) $(PYTEST_NODES) $(TIMEOUT_FLAGS)
+	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS) $(PYTEST_MARK_EXPR) $(PYTEST_NODES) $(TIMEOUT_FLAGS)
 
 test-all:
-	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) $(PYTEST_NODES) $(TIMEOUT_FLAGS)
+	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS) $(PYTEST_NODES) $(TIMEOUT_FLAGS)
+
+test-collect-report:
+	# AI-AGENT-REF: generate import error report
+	python tools/collect_import_errors.py || true
+	@echo "Report written to artifacts/import-repair-report.md"
 
 repair-test-imports:
 	bash tools/repair-test-imports.sh

--- a/ai_trading/position/api.py
+++ b/ai_trading/position/api.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
-from collections.abc import Mapping
-
-
-class Allocator(Protocol):
-    def allocate(self, cash: float, prices: Mapping[str, float]) -> Mapping[str, float]: ...
+from .market_regime import MarketRegime, detect_market_regime
 
 
 @dataclass(frozen=True)
 class Allocation:
-    quantities: Mapping[str, float]
-    cash_left: float = 0.0
+    cash_pct: float
+    risk_pct: float = 0.0
+
+
+class Allocator(Protocol):
+    def allocate(self, regime: MarketRegime) -> Allocation: ...
+# AI-AGENT-REF: allocation protocol surface

--- a/ai_trading/position/market_regime.py
+++ b/ai_trading/position/market_regime.py
@@ -1,21 +1,15 @@
 from __future__ import annotations
-from enum import Enum
-from collections.abc import Iterable
+from enum import Enum, auto
 
 
-class MarketRegime(str, Enum):
-    BULL = "bull"
-    BEAR = "bear"
-    SIDEWAYS = "sideways"
-    VOLATILE = "volatile"
-    UNKNOWN = "unknown"
+class MarketRegime(Enum):
+    UNKNOWN = auto()
+    BULL = auto()
+    BEAR = auto()
+    SIDEWAYS = auto()
 
 
-def detect_market_regime(
-    prices: Iterable[float] | None = None,
-) -> MarketRegime:
-    """
-    Minimal placeholder for tests that import the symbol.
-    Does not implement strategy logic; returns UNKNOWN by default.
-    """
+def detect_market_regime(*_args, **_kwargs) -> MarketRegime:
+    """Placeholder to keep imports stable during tests."""
     return MarketRegime.UNKNOWN
+# AI-AGENT-REF: stable market regime enum for test imports

--- a/artifacts/import-repair-report.md
+++ b/artifacts/import-repair-report.md
@@ -1,23 +1,15 @@
 # Import/Dependency Repair Report
 
-- **OS:** Ubuntu 24.04 (glibc 2.39)
-- **Python:** CPython 3.12.3 (x86_64)
-- **Wheel tag:** cp312-manylinux_2_39_x86_64
-- **Commit:** <!-- fill in -->
-- **Date:** <!-- fill in -->
+**Env**
+- Distro: Ubuntu 24.04 (glibc 2.39)
+- Python: CPython 3.12.3
+- Wheel tag: `cp312-manylinux_2_39_x86_64`
 
 ## Summary
-- Test files collected: <!-- fill in -->
-- Import errors: <!-- fill in -->
-- Internal missing modules: <!-- list -->
-- External missing packages: <!-- list -->
-- Skipped (optional/vendor): <!-- list -->
+- Remaining import errors (unique): <!--COUNT-->
+- Modules:
+<!--IMPORT_ERRORS-->
 
-## External packages newly added
-- <!-- e.g., scikit-learn==1.5.2, scipy==1.13.1, ... -->
-
-## Internal modules restored/stubbed
-- `ai_trading.position.MarketRegime` (enum + placeholder detector)
-- `ai_trading.position.Allocator` / `Allocation` (light protocol)
-- `ai_trading.monitoring.performance_monitor.ResourceMonitor`
-- `ai_trading.risk.short_selling.validate_short_selling`
+## Notes
+- Treat entries starting with `ai_trading.` as **internal**; fix by adding/renaming exports or updating the static rewrite map.
+- Treat others as **external**; fix by adding pins to `requirements.txt` + `constraints.txt` (not to dev-only).

--- a/tools/collect_import_errors.py
+++ b/tools/collect_import_errors.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import os
+import re
+import subprocess
+import sys
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+ART = ROOT / "artifacts"
+ART.mkdir(exist_ok=True)
+
+cmd = [
+    sys.executable, "-m", "pytest",
+    "-p", "xdist", "-p", "pytest_timeout", "-p", "pytest_asyncio",
+    "-q", "--collect-only", "-o", "log_cli=true", "-o", "log_cli_level=INFO",
+]
+env = dict(os.environ)
+env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+out = subprocess.run(cmd, cwd=ROOT, env=env, capture_output=True, text=True)
+text = out.stdout + "\n" + out.stderr
+
+mod_not_found = re.findall(r"No module named ['\"]([^'\"]+)['\"]", text)
+import_errors = sorted(set(mod_not_found))
+
+payload = {
+    "status": out.returncode,
+    "import_errors": import_errors,
+    "raw_log_path": "artifacts/test-collect.log",
+}
+(ART / "test-collect.log").write_text(text, encoding="utf-8")
+(ART / "import-errors.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+tmpl_path = ROOT / "artifacts" / "import-repair-report.md"
+tmpl = tmpl_path.read_text(encoding="utf-8")
+report = tmpl.replace("<!--IMPORT_ERRORS-->", "\n".join(f"- `{m}`" for m in import_errors))
+report = report.replace("<!--COUNT-->", str(len(import_errors)))
+tmpl_path.write_text(report, encoding="utf-8")
+
+print(json.dumps(payload, indent=2))
+# AI-AGENT-REF: harvest import errors deterministically
+sys.exit(out.returncode if import_errors else 0)


### PR DESCRIPTION
## Summary
- finalize ai_trading.position API with MarketRegime enum, detection stub, and allocation protocol
- add import-error harvesting script with Makefile target and report template

## Testing
- `python -m pip install -r requirements.txt -c constraints.txt`
- `python -m pip install -r requirements-dev.txt --no-deps -c constraints.txt`
- `python - <<'PY'\nfrom ai_trading.position import MarketRegime, detect_market_regime, Allocation, Allocator\nprint('OK:', MarketRegime.UNKNOWN, callable(detect_market_regime))\nPY`
- `make test-collect-report`


------
https://chatgpt.com/codex/tasks/task_e_68a9fb8fab4883308e9cb7e378e8b22f