### PR TITLE
feat: add env line to import error report

### DIFF
--- a/tools/harvest_import_errors.py
+++ b/tools/harvest_import_errors.py
@@ -6,6 +6,51 @@ import re
 import subprocess
 import sys
 import pathlib
+import platform
+from packaging import tags
+
+
+# AI-AGENT-REF: read release metadata
+def _read_os_release() -> dict:
+    info: dict[str, str] = {}
+    try:
+        with open("/etc/os-release") as f:
+            for line in f:
+                if "=" in line:
+                    k, v = line.strip().split("=", 1)
+                    info[k] = v.strip().strip('"')
+    except FileNotFoundError:
+        pass
+    return info
+
+
+# AI-AGENT-REF: compute env line
+def _compute_env_line() -> str:
+    """
+    Example:
+    Ubuntu 24.04 | glibc 2.39 | CPython 3.12.3 | tag cp312-manylinux_2_39_x86_64
+    """
+    osr = _read_os_release()
+    name = osr.get("NAME", "Linux")
+    ver = osr.get("VERSION_ID", "").strip()
+    distro = f"{name} {ver}".strip()
+
+    libc, libc_ver = platform.libc_ver()
+    if platform.system() == "Linux":
+        assert (
+            libc == "glibc" and libc_ver
+        ), "Expected glibc on Ubuntu; if using a musl-based image, update the harvester."
+
+    py = f"{platform.python_implementation()} {sys.version.split()[0]}"
+
+    try:
+        top = str(next(tags.sys_tags()))
+        top = top.replace("cp312-cp312-", "cp312-")
+    except Exception:
+        top = "unknown"
+
+    return f"{distro} | {libc} {libc_ver} | {py} | tag {top}"
+
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 ART = ROOT / "artifacts"
@@ -49,12 +94,11 @@ if is_rl_disabled:
     suppress = {"torch", "stable_baselines3", "gymnasium"}
     external = [m for m in external if m not in suppress]
 
+env_line = _compute_env_line()
+
 TEMPLATE = """# Import/Dependency Repair Report
 
-**Env**
-- Distro: Ubuntu 24.04 (glibc 2.39)
-- Python: CPython 3.12.3
-- Wheel tag: `cp312-manylinux_2_39_x86_64`
+**Env:** <!--ENV-->
 
 ## Summary
 - Internal import errors (unique): <!--ICOUNT-->
@@ -68,7 +112,8 @@ TEMPLATE = """# Import/Dependency Repair Report
 - Treat others as **external**; fix by adding pins to `requirements.txt` + `constraints.txt` (not to dev-only).
 """
 
-report = TEMPLATE.replace("<!--INTERNAL-->", "\n".join(f"- `{m}`" for m in internal) or "- none")
+report = TEMPLATE.replace("<!--ENV-->", env_line)
+report = report.replace("<!--INTERNAL-->", "\n".join(f"- `{m}`" for m in internal) or "- none")
 report = report.replace("<!--EXTERNAL-->", "\n".join(f"- `{m}`" for m in external) or "- none")
 report = report.replace("<!--ICOUNT-->", str(len(internal)))
 report = report.replace("<!--ECOUNT-->", str(len(external)))


### PR DESCRIPTION
## Summary
- compute dynamic environment line for harvest_import_errors report using `/etc/os-release`, `platform`, and `packaging.tags`
- assert glibc when running on Linux and prepend env summary to markdown output

## Testing
- `pre-commit run --files tools/harvest_import_errors.py` *(fails: repo-guard mutable default in unrelated file)*
- `SKIP=repo-guard pre-commit run --files tools/harvest_import_errors.py`
- `pytest -n auto --disable-warnings` *(fails: missing modules and runtime errors)*
- `make test-collect-report` *(fails: errors during collection, report still generated)*

------
https://chatgpt.com/codex/tasks/task_e_68aa097e5bd48330bfb8a81dc17a504b