### PR TITLE
feat: prepend env summary to import report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,18 @@ extras-rl:
 	        echo "RL extras disabled (set WITH_RL=1 to enable)" ; \
 	fi # AI-AGENT-REF: optional RL stack
 
-test-collect-report: extras-rl
-	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) --collect-only || true
-	python tools/harvest_import_errors.py --write artifacts/import-repair-report.md || true
+.PHONY: test-collect-report
+## test-collect-report: run pytest --collect-only to surface import errors,
+## then harvest them into artifacts/import-repair-report.md.
+## The harvester prepends a normalized environment line and
+## asserts the exact combo on Ubuntu 24.04 / CPython 3.12.3.
+test-collect-report:
+	@mkdir -p artifacts
+	@echo "==> pytest --collect-only (import probing)"
+	@pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) --collect-only || true
+	@echo "==> harvest import errors (with env assertion)"
+	@python tools/harvest_import_errors.py
+	@echo "==> wrote artifacts/import-repair-report.md"
 
 test-core:
 	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) $(PYTEST_MARK_EXPR) $(PYTEST_NODES) $(TIMEOUT_FLAGS)

--- a/tools/harvest_import_errors.py
+++ b/tools/harvest_import_errors.py
@@ -1,132 +1,168 @@
 #!/usr/bin/env python3
+"""Harvest import errors and emit a report with an env header."""
+
+# AI-AGENT-REF: new env summary + assertion logic
 from __future__ import annotations
-import argparse
+
 import os
 import re
-import subprocess
 import sys
-import pathlib
 import platform
-from packaging import tags
+import subprocess
+from pathlib import Path
+from typing import Dict, Tuple
+
+try:  # AI-AGENT-REF: optional packaging
+    from packaging.tags import sys_tags  # type: ignore
+except Exception:  # pragma: no cover - best effort
+    sys_tags = None
 
 
-# AI-AGENT-REF: read release metadata
-def _read_os_release() -> dict:
-    info: dict[str, str] = {}
+# AI-AGENT-REF: expected header on canonical host
+EXPECTED_ENV_LINE = (
+    "Ubuntu 24.04 | glibc 2.39 | CPython 3.12.3 | tag cp312-manylinux_2_39_x86_64"
+)
+
+
+# AI-AGENT-REF: robust os-release reader
+def _read_os_release() -> Dict[str, str]:
+    data: Dict[str, str] = {}
     try:
-        with open("/etc/os-release") as f:
+        with open("/etc/os-release", "r", encoding="utf-8") as f:
             for line in f:
-                if "=" in line:
-                    k, v = line.strip().split("=", 1)
-                    info[k] = v.strip().strip('"')
-    except FileNotFoundError:
+                line = line.strip()
+                if not line or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                data[k] = v.strip().strip('"')
+    except Exception:
         pass
-    return info
+    return data
 
 
-# AI-AGENT-REF: compute env line and components
-def _top_wheel_tag() -> str:
+# AI-AGENT-REF: glibc version with getconf fallback
+def _glibc_version() -> str:
+    _, ver = platform.libc_ver()
+    if ver:
+        return ver
     try:
-        first = str(next(tags.sys_tags()))
-        return first.replace("cp312-cp312", "cp312")
+        out = subprocess.check_output(
+            ["getconf", "GNU_LIBC_VERSION"], text=True
+        ).strip()
+        m = re.search(r"glibc\s+(\d+\.\d+)", out)
+        if m:
+            return m.group(1)
+    except Exception:
+        pass
+    return "unknown"
+
+
+# AI-AGENT-REF: normalize first wheel tag
+def _top_normalized_tag() -> str:
+    try:
+        if sys_tags is None:
+            return "unknown"
+        tag = str(next(sys_tags()))
+        return re.sub(r"^([^-]+)-[^-]+-", r"\1-", tag)
     except Exception:
         return "unknown"
 
 
-def _env_line() -> tuple[str, str, str, str, str, str]:
-    """Return (line, os_id, ver, glibc_ver, py, tag)."""
+# AI-AGENT-REF: compute human-readable env line
+def compute_env_summary() -> Tuple[str, Dict[str, str]]:
     osr = _read_os_release()
-    os_id = osr.get("ID", "unknown").strip()
-    ver = osr.get("VERSION_ID", "?").strip()
-    libc, glibc_ver = platform.libc_ver()
-    py = f"{platform.python_implementation()} {sys.version.split()[0]}"
-    tag = _top_wheel_tag()
-    line = f"{os_id.capitalize()} {ver} | glibc {glibc_ver or '?'} | {py} | tag {tag}"
-    return line, os_id, ver, glibc_ver, py, tag
+    distro = (osr.get("ID") or "unknown").lower()
+    version = osr.get("VERSION_ID") or "unknown"
+    glibc = _glibc_version()
+    py_impl = platform.python_implementation()
+    py_ver = ".".join(platform.python_version_tuple())
+    tag = _top_normalized_tag()
+
+    distro_title = distro.capitalize()
+    env_line = f"{distro_title} {version} | glibc {glibc} | {py_impl} {py_ver} | tag {tag}"
+    parts = {
+        "distro": distro,
+        "version": version,
+        "glibc": glibc,
+        "py_impl": py_impl,
+        "py_ver": py_ver,
+        "tag": tag,
+    }
+    return env_line, parts
 
 
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-ART = ROOT / "artifacts"
-ART.mkdir(exist_ok=True)
+def main() -> None:
+    # AI-AGENT-REF: prepend env header and assert on canonical host
+    env_line, env_parts = compute_env_summary()
+    if (
+        env_parts["distro"] == "ubuntu"
+        and env_parts["version"].startswith("24.04")
+        and env_parts["py_impl"] == "CPython"
+        and env_parts["py_ver"] == "3.12.3"
+    ):
+        assert (
+            env_line == EXPECTED_ENV_LINE
+        ), f"Env summary mismatch: '{env_line}' != '{EXPECTED_ENV_LINE}'"
 
-parser = argparse.ArgumentParser(description="Harvest import errors")
-parser.add_argument("--write", type=str, help="Path to write report", default=None)
-args = parser.parse_args()
+    report_lines: list[str] = []
+    report_lines.append("# Import/Dependency Repair Report\n\n")
+    report_lines.append(f"**Environment:** {env_line}\n\n")
 
-cmd = [
-    sys.executable,
-    "-m",
-    "pytest",
-    "-p",
-    "xdist",
-    "-p",
-    "pytest_timeout",
-    "-p",
-    "pytest_asyncio",
-    "-q",
-    "--collect-only",
-    "-o",
-    "log_cli=true",
-    "-o",
-    "log_cli_level=INFO",
-]
-env = dict(os.environ)
-env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
-out = subprocess.run(cmd, cwd=ROOT, env=env, capture_output=True, text=True)
-text = out.stdout + "\n" + out.stderr
+    # AI-AGENT-REF: existing harvesting logic
+    root = Path(__file__).resolve().parents[1]
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-p",
+        "xdist",
+        "-p",
+        "pytest_timeout",
+        "-p",
+        "pytest_asyncio",
+        "-q",
+        "--collect-only",
+        "-o",
+        "log_cli=true",
+        "-o",
+        "log_cli_level=INFO",
+    ]
+    env = dict(os.environ)
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    out = subprocess.run(cmd, cwd=root, env=env, capture_output=True, text=True)
+    text = out.stdout + "\n" + out.stderr
 
-mod_not_found = re.findall(r"No module named ['\"]([^'\"]+)['\"]", text)
-import_errors = sorted(set(mod_not_found))
+    (root / "artifacts/test-collect.log").write_text(text, encoding="utf-8")
 
-(ART / "test-collect.log").write_text(text, encoding="utf-8")
+    mod_not_found = re.findall(r"No module named ['\"]([^'\"]+)['\"]", text)
+    import_errors = sorted(set(mod_not_found))
+    internal = sorted(m for m in import_errors if m.startswith("ai_trading"))
+    external = sorted(m for m in import_errors if not m.startswith("ai_trading"))
+    if os.getenv("WITH_RL", "0") != "1":
+        suppress = {"torch", "stable_baselines3", "gymnasium"}
+        external = [m for m in external if m not in suppress]
 
-internal = sorted(m for m in import_errors if m.startswith("ai_trading"))
-external = sorted(m for m in import_errors if not m.startswith("ai_trading"))
-is_rl_disabled = os.getenv("WITH_RL", "0") != "1"
-if is_rl_disabled:
-    suppress = {"torch", "stable_baselines3", "gymnasium"}
-    external = [m for m in external if m not in suppress]
-
-env_line, os_id, ver, glibc_ver, py, tag = _env_line()
-
-TEMPLATE = """# Import/Dependency Repair Report
-
-## Summary
-- Internal import errors (unique): <!--ICOUNT-->
-<!--INTERNAL-->
-
-- External import errors (unique): <!--ECOUNT-->
-<!--EXTERNAL-->
-
-## Notes
-- Treat entries starting with `ai_trading.` as **internal**; fix by adding/renaming exports or updating the static rewrite map.
-- Treat others as **external**; fix by adding pins to `requirements.txt` + `constraints.txt` (not to dev-only).
-"""
-
-report = TEMPLATE
-report = report.replace("<!--INTERNAL-->", "\n".join(f"- `{m}`" for m in internal) or "- none")
-report = report.replace("<!--EXTERNAL-->", "\n".join(f"- `{m}`" for m in external) or "- none")
-report = report.replace("<!--ICOUNT-->", str(len(internal)))
-report = report.replace("<!--ECOUNT-->", str(len(external)))
-
-header = f"**Environment:** {env_line}\n\n"
-report = header + report
-
-if (
-    os_id == "ubuntu"
-    and ver.startswith("24.04")
-    and py.startswith("CPython 3.12.3")
-    and "manylinux_2_39_x86_64" in tag
-):
-    expected = (
-        "Ubuntu 24.04 | glibc 2.39 | CPython 3.12.3 | tag cp312-manylinux_2_39_x86_64"
+    report_lines.append("## Summary\n")
+    report_lines.append(f"- Internal import errors (unique): {len(internal)}\n")
+    report_lines.extend(f"- `{m}`\n" for m in internal) if internal else report_lines.append("- none\n")
+    report_lines.append("\n")
+    report_lines.append(f"- External import errors (unique): {len(external)}\n")
+    report_lines.extend(f"- `{m}`\n" for m in external) if external else report_lines.append("- none\n")
+    report_lines.append("\n## Notes\n")
+    report_lines.append(
+        "- Treat entries starting with `ai_trading.` as **internal**; fix by adding/renaming exports or updating the static rewrite map.\n"
     )
-    assert env_line == expected, f"env line mismatch: {env_line!r} != {expected!r}"
+    report_lines.append(
+        "- Treat others as **external**; fix by adding pins to `requirements.txt` + `constraints.txt` (not to dev-only).\n"
+    )
 
-if args.write:
-    (ROOT / args.write).write_text(report, encoding="utf-8")
-else:
-    print(report)
+    out_path = Path("artifacts/import-repair-report.md")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("".join(report_lines), encoding="utf-8")
 
-# AI-AGENT-REF: harvest import errors deterministically
-sys.exit(out.returncode if internal or external else 0)
+    sys.exit(out.returncode if internal or external else 0)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    main()
+


### PR DESCRIPTION
## Summary
- add robust env summary and assertion to harvest_import_errors
- wire Makefile target to generate import report after pytest collect

## Testing
- `python tools/harvest_import_errors.py; head -n 5 artifacts/import-repair-report.md`
- `make test-collect-report` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'ai_trading.utils.timing')*

------
https://chatgpt.com/codex/tasks/task_e_68aa109b8ac48330b1a00d4634a17d0a