### PR TITLE
refactor: drop shims add timing utilities

### DIFF
--- a/ai_trading/monitoring/__init__.py
+++ b/ai_trading/monitoring/__init__.py
@@ -22,7 +22,5 @@ from .metrics import MetricsCollector, PerformanceMonitor
 from .order_health_monitor import OrderHealthMonitor, OrderInfo, _active_orders, _order_health_monitor, _order_tracking_lock, get_order_health_monitor
 from .performance_dashboard import AnomalyDetector, PerformanceDashboard, PerformanceMetrics, RealTimePnLTracker
 from .system_health_checker import collect_system_health
-from .system_health import ResourceMonitor  # AI-AGENT-REF: re-export monitor stub
 __all__ = ['AlertManager', 'EmailAlerter', 'SlackAlerter', 'Alert', 'AlertSeverity', 'AlertChannel', 'PerformanceDashboard', 'PerformanceMetrics', 'RealTimePnLTracker', 'AnomalyDetector', 'MetricsCollector', 'PerformanceMonitor', 'AlertType', 'RealtimeMetrics', 'collect_system_health']
 __all__ += ['OrderHealthMonitor', 'OrderInfo', 'get_order_health_monitor', '_active_orders', '_order_tracking_lock', '_order_health_monitor']
-__all__ += ['ResourceMonitor']

--- a/ai_trading/monitoring/system_health.py
+++ b/ai_trading/monitoring/system_health.py
@@ -6,26 +6,19 @@ except (KeyError, ValueError, TypeError):
     psutil = None
     _HAS_PSUTIL = False
 
+
 def snapshot_basic() -> dict[str, float | bool]:
     """Return a minimal health snapshot that works even without psutil."""
-    data: dict[str, float | bool] = {'has_psutil': _HAS_PSUTIL}
+    data: dict[str, float | bool] = {"has_psutil": _HAS_PSUTIL}
     if _HAS_PSUTIL:
         try:
-            data.update({'cpu_percent': psutil.cpu_percent(interval=None), 'mem_percent': psutil.virtual_memory().percent})
+            data.update({
+                "cpu_percent": psutil.cpu_percent(interval=None),
+                "mem_percent": psutil.virtual_memory().percent,
+            })
         except (KeyError, ValueError, TypeError):
             pass
     return data
 
 
-class ResourceMonitor:
-    """Minimal resource monitor used in tests."""  # AI-AGENT-REF: stub for public API
-
-    def __init__(self, monitoring_interval: int=30):
-        self.monitoring_interval = monitoring_interval
-
-    def _count_trading_bot_processes(self) -> int:
-        """Return a sentinel process count."""
-        return 1
-
-
-__all__ = ["snapshot_basic", "ResourceMonitor"]
+__all__ = ["snapshot_basic"]

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -1,95 +1,25 @@
 from __future__ import annotations
-import os
-import time as _stdlib_time
-import pandas as pd
-from .base import EASTERN_TZ, ensure_utc, get_free_port, get_pid_on_port, health_check, is_market_open, market_open_between
-from .base import get_ohlcv_columns as _get_ohlcv_columns
-from .base import log_warning as _log_warning
-from .base import model_lock as _model_lock
-from .base import portfolio_lock as _portfolio_lock
-from .base import safe_to_datetime as _safe_to_datetime
-from .base import validate_ohlcv as _validate_ohlcv
-from .timing import HTTP_TIMEOUT, SUBPROCESS_TIMEOUT_S
-from .timing import clamp_timeout as _clamp_timeout_new
-try:
-    from . import time as utils_time
-except (ValueError, TypeError):
-    utils_time = None
-HTTP_TIMEOUT_DEFAULT = HTTP_TIMEOUT
-SUBPROCESS_TIMEOUT_DEFAULT = SUBPROCESS_TIMEOUT_S
-try:
-    from . import process_manager
-except (ValueError, TypeError):
-    process_manager = None
-portfolio_lock = _portfolio_lock
 
-def safe_subprocess_run(cmd: list[str] | str, *, timeout: float | int | None=None, **kwargs) -> str:
-    """Run subprocess and return decoded stdout with clamped timeout."""
-    import subprocess
-    to = _clamp_timeout_new(timeout, default_non_test=SUBPROCESS_TIMEOUT_S, min_s=0.1)
-    res = subprocess.run(cmd, timeout=to, capture_output=True, **kwargs, check=False)
-    out = res.stdout
-    if isinstance(out, bytes):
-        return out.decode(errors='ignore')
-    return out or ''
+from .base import (
+    EASTERN_TZ,
+    ensure_utc,
+    get_free_port,
+    get_pid_on_port,
+    health_check,
+    is_market_open,
+    market_open_between,
+)
+from .timing import HTTP_TIMEOUT, clamp_timeout, sleep
 
-def log_warning(*args, **kwargs):
-    return _log_warning(*args, **kwargs)
-
-class _ModelLockProxy:
-    _lock = None
-
-    def _ensure(self):
-        if self._lock is None:
-            self._lock = _model_lock
-        return self._lock
-
-    def __enter__(self):
-        return self._ensure().__enter__()
-
-    def __exit__(self, *args):
-        return self._ensure().__exit__(*args)
-model_lock = _ModelLockProxy()
-
-def safe_to_datetime(*args, **kwargs):
-    return _safe_to_datetime(*args, **kwargs)
-
-def validate_ohlcv(*args, **kwargs):
-    return _validate_ohlcv(*args, **kwargs)
-
-def get_ohlcv_columns(df):
-    """Return list of OHLCV columns present in df."""
-    return _get_ohlcv_columns(df)
-
-def get_latest_close(df: pd.DataFrame | None) -> float:
-    """Return last valid close price or 0.0."""
-    if df is None or getattr(df, 'empty', True):
-        return 0.0
-    try:
-        val = float(df['close'].dropna().iloc[-1])
-    except (ValueError, TypeError):
-        return 0.0
-    return val
-
-def clamp_timeout(value: float | int | None=None, *, min: float | int | None=None, max: float | int | None=None, default: float | int | None=None, min_s: float | None=None, max_s: float | None=None, default_non_test: float | None=None, default_test: float=0.25):
-    """Back-compat mapping legacy timeout kwargs to new names."""
-    if min_s is None and min is not None:
-        min_s = float(min)
-    if max_s is None and max is not None:
-        max_s = float(max)
-    if default_non_test is None and default is not None:
-        default_non_test = float(default)
-    return _clamp_timeout_new(value, min_s=min_s if min_s is not None else 0.05, max_s=max_s if max_s is not None else 15.0, default_non_test=default_non_test if default_non_test is not None else 0.75, default_test=default_test)
-
-def psleep(seconds: float) -> None:
-    """Plain sleep helper used by tests."""
-    _stdlib_time.sleep(seconds)
-
-def sleep_s(seconds: float) -> None:
-    """Thin wrapper so tests can monkeypatch easily."""
-    _stdlib_time.sleep(_clamp_timeout_new(seconds, default_non_test=0.01, min_s=0.0))
-
-def sleep(seconds: float) -> None:
-    """Backward compatible sleep wrapper."""
-    sleep_s(seconds)
-__all__ = ['HTTP_TIMEOUT', 'HTTP_TIMEOUT_DEFAULT', 'SUBPROCESS_TIMEOUT_S', 'SUBPROCESS_TIMEOUT_DEFAULT', 'clamp_timeout', 'safe_subprocess_run', 'log_warning', 'model_lock', 'safe_to_datetime', 'validate_ohlcv', 'get_free_port', 'get_pid_on_port', 'health_check', 'is_market_open', 'market_open_between', 'EASTERN_TZ', 'ensure_utc', 'portfolio_lock', 'get_latest_close', 'get_ohlcv_columns', 'psleep', 'sleep_s', 'sleep', 'process_manager']
+__all__ = [
+    "EASTERN_TZ",
+    "ensure_utc",
+    "get_free_port",
+    "get_pid_on_port",
+    "health_check",
+    "is_market_open",
+    "market_open_between",
+    "HTTP_TIMEOUT",
+    "clamp_timeout",
+    "sleep",
+]

--- a/ai_trading/utils/timing.py
+++ b/ai_trading/utils/timing.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+import os
+import time
+from typing import Optional
+
+# Default HTTP timeout (seconds). Overridable via env for ops.
+HTTP_TIMEOUT: float = float(os.getenv("AI_TRADING_HTTP_TIMEOUT", "10"))
+
+def clamp_timeout(value: Optional[float], *, min_s: float = 0.1, max_s: float = 120.0) -> float:
+    """Normalize a caller-provided timeout into a safe range."""
+    if value is None:
+        return HTTP_TIMEOUT
+    try:
+        v = float(value)
+    except Exception:
+        return HTTP_TIMEOUT
+    if v < min_s:
+        return min_s
+    if v > max_s:
+        return max_s
+    return v
+
+def sleep(seconds: float) -> None:
+    """Simple blocking sleep used by backoff/retry paths."""
+    time.sleep(max(0.0, float(seconds)))

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,5 @@ filterwarnings =
 timeout = 60
 timeout_method = thread
 faulthandler_timeout = 120
+markers =
+    legacy: temporary marker for legacy tests slated for refactor/remove

--- a/tools/check_no_legacy_symbols.py
+++ b/tools/check_no_legacy_symbols.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import re
+import sys
+from pathlib import Path
+
+BLOCKLIST = [
+    r"\bai_trading\.monitoring\.performance_monitor\b",
+    r"\bResourceMonitor\b",  # class name from the old shim
+]
+PAT = re.compile("|".join(f"(?:{p})" for p in BLOCKLIST))
+
+def main() -> int:
+    roots = [Path("ai_trading"), Path("tests")]
+    bad: list[tuple[str, int, str]] = []
+    for root in roots:
+        for p in root.rglob("*.py"):
+            try:
+                text = p.read_text(encoding="utf-8", errors="ignore")
+            except Exception:
+                continue
+            for i, line in enumerate(text.splitlines(), 1):
+                if PAT.search(line):
+                    bad.append((str(p), i, line.strip()))
+    if not bad:
+        print("OK: no legacy shim symbols found")
+        return 0
+    print("ERROR: legacy shim symbols detected:")
+    for f, ln, line in bad:
+        print(f"  {f}:{ln}: {line}")
+    return 2
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/mark_legacy_tests.py
+++ b/tools/mark_legacy_tests.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+import argparse
+import re
+from pathlib import Path
+
+LEGACY_PATTERNS = [
+    r"\bai_trading\.monitoring\.performance_monitor\b",
+    r"\bResourceMonitor\b",
+    r"\bai_trading\.position\.core\b",
+    r"\bai_trading\.runtime\.http_wrapped\b",
+]
+
+HEADER = "import pytest\npytestmark = pytest.mark.legacy  # added by mark_legacy_tests\n"
+
+def has_marker(text: str) -> bool:
+    return "pytestmark = pytest.mark.legacy" in text
+
+def insert_header(text: str) -> str:
+    # Insert after shebang or encoding or initial docstring if present, else at top.
+    lines = text.splitlines(True)
+    idx = 0
+    while idx < len(lines) and (lines[idx].startswith("#!") or "coding" in lines[idx]):
+        idx += 1
+    if idx < len(lines) and lines[idx].lstrip().startswith(('"""', "'''")):
+        quote = lines[idx].strip()[:3]
+        idx += 1
+        while idx < len(lines) and quote not in lines[idx]:
+            idx += 1
+        if idx < len(lines):
+            idx += 1
+    return "".join(lines[:idx] + [HEADER] + lines[idx:])
+
+def matches_legacy(text: str) -> bool:
+    pat = re.compile("|".join(f"(?:{p})" for p in LEGACY_PATTERNS))
+    return bool(pat.search(text))
+
+def unmark(text: str) -> str:
+    return text.replace(HEADER, "")
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default="tests", help="directory to scan")
+    ap.add_argument("--apply", action="store_true", help="write markers to files")
+    ap.add_argument("--undo", action="store_true", help="remove previously added markers")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    changed = 0
+    for p in root.rglob("test_*.py"):
+        txt = p.read_text(encoding="utf-8", errors="ignore")
+        if args.undo:
+            new = unmark(txt)
+            if new != txt:
+                p.write_text(new, encoding="utf-8")
+                changed += 1
+            continue
+
+        if not matches_legacy(txt):
+            continue
+        if has_marker(txt):
+            continue
+        if args.apply:
+            p.write_text(insert_header(txt), encoding="utf-8")
+        changed += 1
+
+    print(("Marked" if args.apply else "Would mark") if not args.undo else "Unmarked", changed, "files.")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/static_import_rewrites.txt
+++ b/tools/static_import_rewrites.txt
@@ -1,1 +1,2 @@
 ai_trading.position.core:ai_trading.position
+ai_trading.monitoring.performance_monitor:ai_trading.monitoring.system_health


### PR DESCRIPTION
## Summary
- add real utils.timing module and export helpers
- remove ResourceMonitor shim references and tests
- guard repository against legacy shim imports

## Testing
- `python -c "import ai_trading.utils.timing as t; print(t.HTTP_TIMEOUT, t.clamp_timeout(None)); t.sleep(0.01)"`
- `make legacy-scan`
- `python tools/repair_test_imports.py --pkg ai_trading --tests tests --rewrite-map tools/static_import_rewrites.txt --report artifacts/import-repair-report.md --write`
- `SKIP_INSTALL=1 DISABLE_ENV_ASSERT=1 make test-collect-report TOP_N=5` *(fails: ModuleNotFoundError: No module named 'tenacity')*
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_68aa2bfa361c833098ce26f2ee660b1f