### PR TITLE
build: enhance test artifacts and legacy helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,56 +1,61 @@
 				## Central pytest knobs
 # AI-AGENT-REF: unify test harness
 export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
-PYTEST_PLUGINS    = -p xdist -p pytest_timeout -p pytest_asyncio
-PYTEST_FLAGS_BASE = -q -o log_cli=true -o log_cli_level=INFO
-PYTEST_NODES      = -n auto
-TIMEOUT_FLAGS     = --timeout=120 --timeout-method=thread
+PYTEST_PLUGINS ?= -p xdist -p pytest_timeout -p pytest_asyncio
+PYTEST_FLAGS_BASE ?= -q -o log_cli=true -o log_cli_level=INFO
+PYTEST_MARK_EXPR ?= -m "not legacy and not integration and not slow"
+PYTEST_NODES ?= -n auto
+TIMEOUT_FLAGS ?= --timeout=120 --timeout-method=thread
 WITH_RL ?= 0
 
-# Use the active shell's Python (typically your venv) everywhere.
-PYTHON ?= $(shell readlink -f $$(command -v python))
-PYTEST  = $(PYTHON) -m pytest
-IMPORT_REPAIR_REPORT ?= artifacts/import-repair-report.md
+# --- Defaults ---
+PYTHON ?= python                         # AI-AGENT-REF: default interpreter
+PYTEST ?= $(PYTHON) -m pytest
 TOP_N ?= 5
-FAIL_ON_IMPORT_ERRORS ?= 0
-DISABLE_ENV_ASSERT ?= 0
-MARK_EXPR ?= not legacy
+FAIL_ON_IMPORT_ERRORS ?=                 # AI-AGENT-REF: optional fail gate
+DISABLE_ENV_ASSERT ?=                    # AI-AGENT-REF: optional env assert skip
+IMPORT_REPAIR_REPORT ?= artifacts/import-repair-report.md
 
-.PHONY: test-collect extras-rl ensure-runtime test-collect-report test-core test-all repair-test-imports legacy-scan
+.PHONY: test-collect extras-rl ensure-runtime ensure-artifacts test-collect-report \
+        test-core test-all repair-test-imports legacy-scan legacy-mark fmt ci-smoke
 
 test-collect:
-	$(PYTEST) $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) --collect-only -m "$(MARK_EXPR)"
+	$(PYTEST) $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) --collect-only $(PYTEST_MARK_EXPR)
 
 extras-rl:
 	@if [ "$(WITH_RL)" = "1" ]; then \
-	        python -m pip install -r requirements-extras-rl.txt -c constraints.txt ; \
-	        echo "RL extras installed" ; \
+	python -m pip install -r requirements-extras-rl.txt -c constraints.txt ; \
+	echo "RL extras installed" ; \
 	else \
-	        echo "RL extras disabled (set WITH_RL=1 to enable)" ; \
+	echo "RL extras disabled (set WITH_RL=1 to enable)" ; \
         fi # AI-AGENT-REF: optional RL stack
 
 ensure-runtime:
-	@if [ "$(SKIP_INSTALL)" != "1" ]; then \
-		$(PYTHON) -m pip install -r requirements.txt -c constraints.txt ;\
-	fi
+	@if [ -z "$$SKIP_INSTALL" ]; then \
+	$(PYTHON) -m pip install -r requirements.txt -c constraints.txt; \
+	$(PYTHON) -m pip install -r requirements-dev.txt --no-deps -c constraints.txt; \
+	fi # AI-AGENT-REF: gate installs
+.PHONY: ensure-artifacts
+ensure-artifacts:
+	@mkdir -p $(dir $(IMPORT_REPAIR_REPORT))  # AI-AGENT-REF: ensure artifacts dir
 .PHONY: test-collect-report
 ## test-collect-report: ensure runtime deps, run pytest --collect-only, and
 ## harvest import errors into artifacts/import-repair-report.md with env header.
 ## Setting SKIP_INSTALL=1 bypasses the ensure-runtime step.
-test-collect-report: ensure-runtime
-	@mkdir -p $(dir $(IMPORT_REPAIR_REPORT))
-	$(PYTEST) $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) --collect-only \
-	  || true
+test-collect-report: ensure-runtime ensure-artifacts
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+	pytest -p xdist -p pytest_timeout -p pytest_asyncio --collect-only || true
 	DISABLE_ENV_ASSERT=$(DISABLE_ENV_ASSERT) \
-	  $(PYTHON) tools/harvest_import_errors.py --top $${TOP_N:-5} \
-	  $${FAIL_ON_IMPORT_ERRORS:+--fail-on-errors} \
-	  --out $(IMPORT_REPAIR_REPORT)
-	@echo "Wrote $(IMPORT_REPAIR_REPORT)"
+        $(PYTHON) tools/harvest_import_errors.py --top $(TOP_N) \
+        $(if $(FAIL_ON_IMPORT_ERRORS),--fail-on-errors,) \
+        --out "$(IMPORT_REPAIR_REPORT)"
+	@echo "Import report → $(IMPORT_REPAIR_REPORT)"  # AI-AGENT-REF: robust collector
 test-core:
-	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) -m "$(MARK_EXPR)" $(PYTEST_NODES) $(TIMEOUT_FLAGS)
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) $(PYTEST_MARK_EXPR) -n auto --timeout=120 --timeout-method=thread
 
 test-all:
-	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) -m "$(MARK_EXPR)" -k "not legacy" $(PYTEST_NODES) $(TIMEOUT_FLAGS)
+	pytest $(PYTEST_PLUGINS) $(PYTEST_FLAGS_BASE) $(PYTEST_MARK_EXPR) $(PYTEST_NODES) $(TIMEOUT_FLAGS)
 
 repair-test-imports:
 	bash tools/repair-test-imports.sh
@@ -58,3 +63,16 @@ repair-test-imports:
 .PHONY: legacy-scan
 legacy-scan:
 	python tools/check_no_legacy_symbols.py
+
+.PHONY: legacy-mark
+legacy-mark:
+	$(PYTHON) tools/mark_legacy_tests.py --apply  # AI-AGENT-REF: tag legacy tests
+
+.PHONY: fmt
+fmt:
+	$(PYTHON) -m ruff check --select I --fix .  # AI-AGENT-REF: import order
+	$(PYTHON) -m black .
+
+.PHONY: ci-smoke
+ci-smoke:
+	bash tools/ci_smoke.sh  # AI-AGENT-REF: CI smoke helper

--- a/docs/ci-import-errors.md
+++ b/docs/ci-import-errors.md
@@ -118,3 +118,13 @@ Troubleshooting
 Questions or tweaks? Ping the secondary reader (that’s me) and we’ll tune the
 harvester/Makefile as the suite evolves.
 
+### Quick knobs (recap)
+
+- `TOP_N` (default 5): how many unique import errors to print in CI logs.
+- `FAIL_ON_IMPORT_ERRORS=1`: cause `test-collect-report` to exit with code 101 if any import errors are found.
+- `DISABLE_ENV_ASSERT=1`: bypass the environment assertion in the harvester (useful on non-canonical hosts).
+- `SKIP_INSTALL=1`: **local only**; skips `pip install` in make targets (CI should not set this).
+
+### Legacy tests
+Run `make legacy-mark` to tag tests that still import legacy paths with `@pytest.mark.legacy`.
+Core test runs exclude them by default via `-m "not legacy ..."`. When you refactor or delete a legacy test, re-run `make legacy-mark` to keep tags consistent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ target-version = ["py311"]
 target-version = "py311"
 line-length = 100
 src = ["ai_trading", "trade_execution", "tests", "tools"]
-extend-exclude = ["**/.venv", "**/venv", "build", "dist", "notebooks", "artifacts"]
+extend-exclude = ["**/.venv", "**/venv", "build", "dist", "notebooks", "artifacts", "tools/static_import_rewrites.txt"]
 
 # Focus on safe mechanical families only.
 [tool.ruff.lint]

--- a/tools/ci_smoke.sh
+++ b/tools/ci_smoke.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# AI-AGENT-REF: CI smoke script
+# Run test-collect-report, print the first 40 lines of the artifact,
+# and exit 0/101 based on FAIL_ON_IMPORT_ERRORS.
+set -uo pipefail
+
+REPORT="${IMPORT_REPAIR_REPORT:-artifacts/import-repair-report.md}"
+TOP_N="${TOP_N:-5}"
+
+echo "==> CI smoke: make test-collect-report (TOP_N=${TOP_N}, FAIL_ON_IMPORT_ERRORS=${FAIL_ON_IMPORT_ERRORS:-}, DISABLE_ENV_ASSERT=${DISABLE_ENV_ASSERT:-})"
+status=0
+make test-collect-report || status=$?
+
+echo "==> Artifact preview (first 40 lines): ${REPORT}"
+if [[ -f "${REPORT}" ]]; then
+  sed -n '1,40p' "${REPORT}"
+else
+  echo "(artifact not found at ${REPORT})"
+fi
+
+# Normalize exit behaviour.
+if [[ -n "${FAIL_ON_IMPORT_ERRORS:-}" ]]; then
+  if [[ ${status} -eq 101 ]]; then
+    echo "==> Import errors found and FAIL_ON_IMPORT_ERRORS=1; exiting 101."
+    exit 101
+  elif [[ ${status} -eq 0 ]]; then
+    echo "==> No import errors detected; exiting 0."
+    exit 0
+  else
+    echo "==> Collector returned unexpected status ${status}; bubbling it up."
+    exit ${status}
+  fi
+else
+  echo "==> FAIL_ON_IMPORT_ERRORS not set; exiting 0 (collector status=${status})."
+  exit 0
+fi


### PR DESCRIPTION
## Summary
- harden test-collect-report with install guard, artifacts dir, and legacy targets
- exclude static rewrite map from ruff
- document knobs for import error harvesting and legacy tests

## Testing
- `pre-commit run --files Makefile pyproject.toml docs/ci-import-errors.md tools/ci_smoke.sh`
- `DISABLE_ENV_ASSERT=1 make test-collect-report`
- `FAIL_ON_IMPORT_ERRORS=1 DISABLE_ENV_ASSERT=1 make test-collect-report` (fails: 101)
- `make legacy-mark && rg -n '@pytest\.mark\.legacy' tests | wc -l`
- `pytest -n auto --disable-warnings` (fails: tests)


------
https://chatgpt.com/codex/tasks/task_e_68aa3a45506883309c4456eedcd7bf22