### PR TITLE
refactor: finalize shim purge

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -11680,7 +11680,7 @@ def start_metrics_server(default_port: int = 9200) -> None:
             try:
                 resp = http.get(
                     f"http://localhost:{default_port}",
-                    timeout=clamp_timeout(2, default_non_test=HTTP_TIMEOUT),
+                    timeout=clamp_timeout(2),
                 )
                 if resp.ok:
                     _log.info("Metrics port %d already serving; reusing", default_port)

--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -27,7 +27,7 @@ def psleep(_=None) -> None:
 
 def clamp_timeout(df):
     """Benchmark-friendly helper returning input."""
-    _ = _clamp_timeout(1.0, min_s=0.1, max_s=10.0, default_non_test=1.0)
+    _ = _clamp_timeout(1.0)
     return df
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
@@ -91,7 +91,7 @@ def _fetch_api(url: str, retries: int=3, delay: float=1.0) -> dict:
     """Fetch JSON from an API with simple retry logic and backoff."""
     for attempt in range(1, retries + 1):
         try:
-            resp = http.get(url, timeout=_clamp_timeout(5, min_s=0.5, default_non_test=5))
+            resp = http.get(url, timeout=_clamp_timeout(5))
             resp.raise_for_status()
             return resp.json()
         except requests.exceptions.RequestException as exc:

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .timing import HTTP_TIMEOUT, clamp_timeout, sleep
+from .timing import HTTP_TIMEOUT, clamp_timeout, sleep  # re-export
 from .base import (
     EASTERN_TZ,
     ensure_utc,

--- a/ai_trading/utils/http.py
+++ b/ai_trading/utils/http.py
@@ -56,7 +56,7 @@ def _get_session() -> requests.Session:
 
 def _with_timeout(kwargs: dict) -> dict:
     """Ensure a clamped timeout is always provided."""
-    kwargs["timeout"] = clamp_timeout(kwargs.get("timeout"), default_non_test=HTTP_TIMEOUT)
+    kwargs["timeout"] = clamp_timeout(kwargs.get("timeout"))
     return kwargs
 
 
@@ -123,11 +123,11 @@ def request_json(
     status_forcelist = status_forcelist or {429, 500, 502, 503, 504}
     if isinstance(timeout, tuple):
         to = (
-            clamp_timeout(timeout[0], default_non_test=HTTP_TIMEOUT),
-            clamp_timeout(timeout[1], default_non_test=HTTP_TIMEOUT),
+            clamp_timeout(timeout[0]),
+            clamp_timeout(timeout[1]),
         )
     else:
-        t = clamp_timeout(timeout, default_non_test=HTTP_TIMEOUT)
+        t = clamp_timeout(timeout)
         to = (t, t)
 
     def _fetch() -> requests.Response:

--- a/ai_trading/utils/timing.py
+++ b/ai_trading/utils/timing.py
@@ -1,21 +1,23 @@
 from __future__ import annotations
 
 import time
+from typing import Optional
 
-# Default HTTP timeout (seconds)
+# Default HTTP timeout used by runtime unless overridden
 HTTP_TIMEOUT: float = 10.0
 
 
-def clamp_timeout(value: float | None) -> float:
-    """Return a sane timeout (value if positive else default)."""
+def clamp_timeout(value: Optional[float]) -> float:
+    """Return a sane timeout, falling back to HTTP_TIMEOUT when None/invalid."""
     try:
-        if value is not None and float(value) > 0:
-            return float(value)
+        if value is None:
+            return HTTP_TIMEOUT
+        v = float(value)
+        return v if v > 0 else HTTP_TIMEOUT
     except Exception:
-        pass
-    return HTTP_TIMEOUT
+        return HTTP_TIMEOUT
 
 
 def sleep(seconds: float) -> None:
-    """Thin wrapper for testability / monkeypatching."""
-    time.sleep(max(0.0, float(seconds)))
+    """Small wrapper for testability and central control."""
+    time.sleep(float(seconds))

--- a/tests/runtime/test_http_wrapped.py
+++ b/tests/runtime/test_http_wrapped.py
@@ -1,14 +1,6 @@
 import requests
 from ai_trading.utils import http
-
-try:
-    from ai_trading.utils.timing import HTTP_TIMEOUT, clamp_timeout  # preferred
-except Exception:  # AI-AGENT-REF: provide test-local timing helpers
-    HTTP_TIMEOUT = 10.0
-
-    def clamp_timeout(value, *, default_non_test=0.75, min_s=0.05, max_s=15.0):
-        val = default_non_test if value is None else float(value)
-        return max(min_s, min(max_s, val))
+from ai_trading.utils.timing import HTTP_TIMEOUT, clamp_timeout
 
 
 class DummyResp:
@@ -24,7 +16,7 @@ def test_wrapped_get_retries_and_parses(monkeypatch):
 
     def fake_request(self, method, url, **kwargs):
         calls.append(kwargs)
-        assert kwargs["timeout"] == clamp_timeout(None, default_non_test=HTTP_TIMEOUT)
+        assert kwargs["timeout"] == clamp_timeout(None)
         if len(calls) == 1:
             raise requests.exceptions.RequestException("boom")
         return DummyResp({"ok": True})

--- a/tools/check_no_legacy_symbols.py
+++ b/tools/check_no_legacy_symbols.py
@@ -4,18 +4,19 @@ import pathlib
 import re
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
-bad = [
-    r"\bResourceMonitor\b",
-    r"\bperformance_monitor\b",
-    r"\bposition\.core\b",
-    r"\bhttp_wrapped\b",
-]
-rx = re.compile("|".join(bad))
+BLOCKED = (
+    "ai_trading.monitoring.performance_monitor",
+    "ResourceMonitor",
+    "performance_monitor",
+    r"ai_trading\.position\.core",
+    r"ai_trading\.runtime\.http_wrapped",
+)
+rx = re.compile("|".join(BLOCKED))
 violations = []
 for p in ROOT.rglob("*.py"):
     if p.parts[0] == ".venv" or "/venv/" in str(p):
         continue
-    if p.name in {"mark_legacy_tests.py", "repair_test_imports.py"} and p.parent.name == "tools":
+    if p.name in {"mark_legacy_tests.py", "repair_test_imports.py", "check_no_legacy_symbols.py"} and p.parent.name == "tools":
         continue
     text = p.read_text(encoding="utf-8", errors="ignore")
     if rx.search(text):

--- a/tools/ci_smoke.sh
+++ b/tools/ci_smoke.sh
@@ -3,28 +3,19 @@ set -euo pipefail
 
 : "${TOP_N:=5}"
 : "${FAIL_ON_IMPORT_ERRORS:=0}"
-: "${DISABLE_ENV_ASSERT:=}"
+: "${DISABLE_ENV_ASSERT:=0}"
 : "${IMPORT_REPAIR_REPORT:=artifacts/import-repair-report.md}"
 
-# Run collect + harvest (never hard-fail the make; we control the exit below)
+mkdir -p "$(dirname "$IMPORT_REPAIR_REPORT")"
+
 DISABLE_ENV_ASSERT="${DISABLE_ENV_ASSERT}" \
-  make test-collect-report TOP_N="${TOP_N}" \
-       FAIL_ON_IMPORT_ERRORS="${FAIL_ON_IMPORT_ERRORS}" \
-       IMPORT_REPAIR_REPORT="${IMPORT_REPAIR_REPORT}" || true
+TOP_N="${TOP_N}" \
+FAIL_ON_IMPORT_ERRORS="${FAIL_ON_IMPORT_ERRORS}" \
+make test-collect-report || rc=$?
+rc=${rc:-0}
 
-echo "---- Import-Repair Report (head -n 40) ----"
-if [[ -f "${IMPORT_REPAIR_REPORT}" ]]; then
-  head -n 40 "${IMPORT_REPAIR_REPORT}"
-else
-  echo "Report not found at ${IMPORT_REPAIR_REPORT}"
-fi
-echo "-------------------------------------------"
+echo "=== BEGIN import-repair-report (head -40) ==="
+head -n 40 "$IMPORT_REPAIR_REPORT" || true
+echo "=== END import-repair-report ==="
 
-# Exit decision mirrors harvester's --fail-on-errors behavior
-if [[ "${FAIL_ON_IMPORT_ERRORS}" == "1" ]]; then
-  # If the report has a 'Remaining import errors' section with a nonzero count, exit 101
-  if grep -qE '^- Remaining import errors \(unique\): [1-9][0-9]*' "${IMPORT_REPAIR_REPORT}" 2>/dev/null; then
-    exit 101
-  fi
-fi
-exit 0
+exit "$rc"

--- a/tools/mark_legacy_tests.py
+++ b/tools/mark_legacy_tests.py
@@ -1,70 +1,35 @@
+#!/usr/bin/env python
 from __future__ import annotations
-import argparse
-import re
-from pathlib import Path
+import argparse, pathlib, re
 
-LEGACY_PATTERNS = [
-    r"\bai_trading\.monitoring\.performance_monitor\b",
-    r"\bResourceMonitor\b",
-    r"\bai_trading\.position\.core\b",
-    r"\bai_trading\.runtime\.http_wrapped\b",
-]
+LEGACY_PATTERNS = (
+    r"ai_trading\.monitoring\.performance_monitor",
+    r"ai_trading\.position\.core",
+    r"ai_trading\.runtime\.http_wrapped",
+)
 
-HEADER = "import pytest\npytestmark = pytest.mark.legacy  # added by mark_legacy_tests\n"
+DECORATOR = "@pytest.mark.legacy\n"
+IMPORT = "import pytest\n"
 
-def has_marker(text: str) -> bool:
-    return "pytestmark = pytest.mark.legacy" in text
-
-def insert_header(text: str) -> str:
-    # Insert after shebang or encoding or initial docstring if present, else at top.
-    lines = text.splitlines(True)
-    idx = 0
-    while idx < len(lines) and (lines[idx].startswith("#!") or "coding" in lines[idx]):
-        idx += 1
-    if idx < len(lines) and lines[idx].lstrip().startswith(('"""', "'''")):
-        quote = lines[idx].strip()[:3]
-        idx += 1
-        while idx < len(lines) and quote not in lines[idx]:
-            idx += 1
-        if idx < len(lines):
-            idx += 1
-    return "".join(lines[:idx] + [HEADER] + lines[idx:])
-
-def matches_legacy(text: str) -> bool:
-    pat = re.compile("|".join(f"(?:{p})" for p in LEGACY_PATTERNS))
-    return bool(pat.search(text))
-
-def unmark(text: str) -> str:
-    return text.replace(HEADER, "")
-
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--root", default="tests", help="directory to scan")
-    ap.add_argument("--apply", action="store_true", help="write markers to files")
-    ap.add_argument("--undo", action="store_true", help="remove previously added markers")
-    args = ap.parse_args()
-
-    root = Path(args.root)
-    changed = 0
-    for p in root.rglob("test_*.py"):
-        txt = p.read_text(encoding="utf-8", errors="ignore")
-        if args.undo:
-            new = unmark(txt)
-            if new != txt:
-                p.write_text(new, encoding="utf-8")
-                changed += 1
-            continue
-
-        if not matches_legacy(txt):
-            continue
-        if has_marker(txt):
-            continue
-        if args.apply:
-            p.write_text(insert_header(txt), encoding="utf-8")
-        changed += 1
-
-    print(("Marked" if args.apply else "Would mark") if not args.undo else "Unmarked", changed, "files.")
-    return 0
+def process(path: pathlib.Path) -> bool:
+    txt = path.read_text(encoding="utf-8")
+    if not re.search("|".join(LEGACY_PATTERNS), txt):
+        return False
+    if "pytest.mark.legacy" in txt:
+        return False
+    if "import pytest" not in txt:
+        txt = IMPORT + txt
+    txt = re.sub(r"(?m)^(def |class )", DECORATOR + r"\1", txt, count=1)
+    path.write_text(txt, encoding="utf-8")
+    return True
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("root", nargs="?", default="tests")
+    args = ap.parse_args()
+    changed = 0
+    for p in pathlib.Path(args.root).rglob("test_*.py"):
+        if args.apply:
+            changed += bool(process(p))
+    print(f"legacy-marked: {changed}")

--- a/tools/static_import_rewrites.txt
+++ b/tools/static_import_rewrites.txt
@@ -1,3 +1,20 @@
-ai_trading.position.core:ai_trading.position
-ai_trading.monitoring.performance_monitor:ai_trading.monitoring.system_health
-ai_trading.runtime.http_wrapped:ai_trading.utils.http
+# ---- Position core → Position (module collapsed) ----
+\bfrom\s+ai_trading\.position\.core\s+import\s+  =>  from ai_trading.position import 
+\bimport\s+ai_trading\.position\.core\s+as\s+     =>  import ai_trading.position as 
+\bimport\s+ai_trading\.position\.core\b           =>  import ai_trading.position
+\bfrom\s+ai_trading\.position\s+import\s+core\s+as\s+(\w+)  =>  import ai_trading.position as \1
+
+# ---- http_wrapped → utils.http ----
+\bfrom\s+ai_trading\.runtime\.http_wrapped\s+import\s+  =>  from ai_trading.utils.http import 
+\bimport\s+ai_trading\.runtime\.http_wrapped\s+as\s+     =>  import ai_trading.utils.http as 
+\bimport\s+ai_trading\.runtime\.http_wrapped\b           =>  import ai_trading.utils.http
+
+# ---- Stray runtime.http → utils.http (seen in fixtures) ----
+\bfrom\s+ai_trading\.runtime\.http\s+import\s+  =>  from ai_trading.utils.http import 
+\bimport\s+ai_trading\.runtime\.http\s+as\s+     =>  import ai_trading.utils.http as 
+\bimport\s+ai_trading\.runtime\.http\b           =>  import ai_trading.utils.http
+
+# ---- performance_monitor → system_health (module only; no shims) ----
+\bfrom\s+ai_trading\.monitoring\.performance_monitor\s+import\s+  =>  from ai_trading.monitoring.system_health import 
+\bimport\s+ai_trading\.monitoring\.performance_monitor\s+as\s+     =>  import ai_trading.monitoring.system_health as 
+\bimport\s+ai_trading\.monitoring\.performance_monitor\b           =>  import ai_trading.monitoring.system_health


### PR DESCRIPTION
## Summary
- add timing helpers and re-export via utils
- remove legacy shim symbols and strengthen blocklist
- add deterministic CI smoke wrapper and expand static import rewrites

## Testing
- `python - <<'PY'
from ai_trading.utils import HTTP_TIMEOUT, clamp_timeout, sleep
print("OK", HTTP_TIMEOUT, clamp_timeout(None)); sleep(0.01)
PY`
- `python tools/check_no_legacy_symbols.py`
- `python tools/mark_legacy_tests.py --apply`
- `DISABLE_ENV_ASSERT=1 SKIP_INSTALL=1 tools/ci_smoke.sh || echo "nonzero_exit=$?"`
- `DISABLE_ENV_ASSERT=1 FAIL_ON_IMPORT_ERRORS=1 tools/ci_smoke.sh || echo "expected_nonzero"`
- `pytest -n auto --disable-warnings >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68aa4617f1d083309879811850341930