### PR TITLE
Finalize shim purge, harden imports, and make CI smoke deterministic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,29 @@
+# knobs
 TOP_N ?= 5
 FAIL_ON_IMPORT_ERRORS ?= 0
 DISABLE_ENV_ASSERT ?= 0
 IMPORT_REPAIR_REPORT ?= artifacts/import-repair-report.md
 
+# ensure artifacts dir exists
 $(shell mkdir -p artifacts >/dev/null 2>&1)
 
-test-collect-report:
-	@echo "[collect] pytest --collect-only"
-	@PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q --collect-only || true
-	@echo "[harvest] -> $(IMPORT_REPAIR_REPORT)"
+.PHONY: ensure-runtime legacy-fix test-collect-report ci-smoke
+
+ensure-runtime:
+	python -m pip install -r requirements.txt -c constraints.txt
+	python -m pip install -r requirements-dev.txt --no-deps -c constraints.txt
+
+legacy-fix:
+	python tools/repair_test_imports.py --pkg ai_trading --tests tests --rewrite-map tools/static_import_rewrites.txt --report artifacts/import-repair-report.md --write || true
+	python tools/mark_legacy_tests.py --apply || true
+
+test-collect-report: legacy-fix
+	@echo "[collect] running pytest --collect-only"
+	@PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+	pytest -q --collect-only || true
+	@echo "[harvest] writing $(IMPORT_REPAIR_REPORT)"
 	@DISABLE_ENV_ASSERT=$(DISABLE_ENV_ASSERT) TOP_N=$(TOP_N) FAIL_ON_IMPORT_ERRORS=$(FAIL_ON_IMPORT_ERRORS) \
-		python tools/harvest_import_errors.py --report $(IMPORT_REPAIR_REPORT)
+	python tools/harvest_import_errors.py --report $(IMPORT_REPAIR_REPORT)
 
 ci-smoke:
 	@bash tools/ci_smoke.sh
-
-imports-rewrite:
-	python tools/repair_test_imports.py --pkg ai_trading --tests tests \
-	  --rewrite-map tools/static_import_rewrites.txt \
-	  --report artifacts/import-repair-report.md --write

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .timing import HTTP_TIMEOUT, clamp_timeout, sleep  # re-export
+from .timing import HTTP_TIMEOUT, clamp_timeout, sleep  # re-export for public surface
 from .base import (
     EASTERN_TZ,
     ensure_utc,

--- a/constraints.txt
+++ b/constraints.txt
@@ -18,3 +18,10 @@ alpaca-py==0.42.0
 torch==2.3.1
 stable-baselines3==2.3.2
 gymnasium==0.29.1
+pydantic==2.8.2
+pandas==2.2.2
+pytest-xdist==3.6.1
+pytest-timeout==2.3.1
+pytest-asyncio==0.23.7
+freezegun==1.5.1
+requests-mock==1.12.1

--- a/docs/ci-import-errors.md
+++ b/docs/ci-import-errors.md
@@ -3,9 +3,9 @@
 This repo prints the **Top-N unique import errors** straight into CI logs and
 also writes a Markdown artifact for deeper triage.
 
-- **Make target:** `make test-collect-report`
-- **Artifact (default):** `artifacts/import-repair-report.md`
-- **Script:** `tools/harvest_import_errors.py` (prepends an Environment header)
+- **Make target:** `make test-collect-report` → writes `artifacts/import-repair-report.md`
+- **Smoke script:** `tools/ci_smoke.sh` → prints head -40 of the report and exits 0 or 101
+- **Harvester:** `tools/harvest_import_errors.py` (prepends an Environment header)
 
 ---
 
@@ -129,10 +129,10 @@ Core test runs exclude them by default via `-m "not legacy ..."`. When you refac
 ### Quick smoke
 
 ```bash
-# Print env header + Top-N in logs; return 0
+# Print env header + head -40 of report; return 0
 tools/ci_smoke.sh
 
-# Fail pipeline when import errors are present
+# Fail pipeline when import errors are present (exit 101)
 FAIL_ON_IMPORT_ERRORS=1 tools/ci_smoke.sh
 
 Knobs:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,11 +15,11 @@ pytest-cov==5.0.0
 coverage==7.6.1
 execnet==2.1.1  # AI-AGENT-REF: enable pytest-xdist
 pytest-timeout==2.3.1
-pytest-asyncio==0.23.8
+pytest-asyncio==0.23.7
 pluggy==1.5.*
 iniconfig==2.0.*
 requests-mock==1.12.1
-freezegun==1.4.0
+freezegun==1.5.1
 hypothesis>=6.100
 sortedcontainers==2.4.*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ beautifulsoup4>=4.12,<5
 lxml>=5,<6
 aiohttp>=3.9,<4
 # Explicit Pydantic v2 + settings
-pydantic>=2.7,<3
+pydantic==2.8.2
 pydantic-settings>=2.2,<3
 
 # Deterministic calendars & time zones
@@ -34,3 +34,4 @@ tenacity==8.5.0
 scikit-learn==1.5.1
 scipy==1.13.1
 threadpoolctl==3.5.0
+pandas==2.2.2

--- a/tests/runtime/test_http_wrapped.py
+++ b/tests/runtime/test_http_wrapped.py
@@ -1,6 +1,6 @@
 import requests
 from ai_trading.utils import http
-from ai_trading.utils.timing import HTTP_TIMEOUT, clamp_timeout
+from ai_trading.utils import HTTP_TIMEOUT, clamp_timeout
 
 
 class DummyResp:

--- a/tools/check_no_legacy_symbols.py
+++ b/tools/check_no_legacy_symbols.py
@@ -5,9 +5,9 @@ import re
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 BLOCKED = (
-    r"ai_trading\.monitoring\.performance_monitor",
-    r"\bResourceMonitor\b",
-    r"\bperformance_monitor\b",
+    "ai_trading.monitoring.performance_monitor",
+    "ResourceMonitor",
+    "performance_monitor",
     r"ai_trading\.position\.core",
     r"ai_trading\.runtime\.http_wrapped",
 )

--- a/tools/static_import_rewrites.txt
+++ b/tools/static_import_rewrites.txt
@@ -1,16 +1,12 @@
-# ai_trading.position.core → ai_trading.position
-from ai_trading.position.core import (.*) -> from ai_trading.position import \1
-from ai_trading.position.core import (.*) as (.*) -> from ai_trading.position import \1 as \2
-import ai_trading.position.core as (.*) -> import ai_trading.position as \1
-import ai_trading.position.core -> import ai_trading.position
+ai_trading.position.core -> ai_trading.position
+from ai_trading.position.core import -> from ai_trading.position import
+import ai_trading.position.core as -> import ai_trading.position as
+ai_trading.runtime.http_wrapped -> ai_trading.utils.http
+from ai_trading.runtime.http_wrapped import -> from ai_trading.utils.http import
+import ai_trading.runtime.http_wrapped as -> import ai_trading.utils.http as
+ai_trading.monitoring.performance_monitor -> ai_trading.monitoring.system_health
+from ai_trading.monitoring.performance_monitor import -> from ai_trading.monitoring.system_health import
+import ai_trading.monitoring.performance_monitor as -> import ai_trading.monitoring.system_health as
+# normalized utils re-exports (harmless if already correct)
+from ai_trading.utils.timing import -> from ai_trading.utils import
 
-# ai_trading.runtime.http_wrapped → ai_trading.utils.http
-from ai_trading.runtime.http_wrapped import (.*) -> from ai_trading.utils.http import \1
-from ai_trading.runtime.http_wrapped import (.*) as (.*) -> from ai_trading.utils.http import \1 as \2
-import ai_trading.runtime.http_wrapped as (.*) -> import ai_trading.utils.http as \1
-import ai_trading.runtime.http_wrapped -> import ai_trading.utils.http
-
-# monitoring shim module to system_health (module path only; no aliasing back to shim)
-from ai_trading.monitoring.performance_monitor import (.*) -> from ai_trading.monitoring.system_health import \1
-import ai_trading.monitoring.performance_monitor as (.*) -> import ai_trading.monitoring.system_health as \1
-import ai_trading.monitoring.performance_monitor -> import ai_trading.monitoring.system_health


### PR DESCRIPTION
## Summary
- Centralize timing helpers and re-export them so tests import from `ai_trading.utils` instead of the legacy path.
- Harden legacy-shim defenses with an updated blocklist and expanded static import rewrites; document deterministic CI smoke behavior.
- Pin missing dev/runtime dependencies and wire Makefile targets for stable collection and artifact printing.

## Testing
- `make ensure-runtime`【4f7dd5†L1-L24】
- `python - <<'PY' from ai_trading.utils import HTTP_TIMEOUT, clamp_timeout, sleep ... PY`【6aa2f6†L1-L2】
- `python tools/check_no_legacy_symbols.py`【2a3415†L1-L2】
- `DISABLE_ENV_ASSERT=1 tools/ci_smoke.sh`【a7716f†L1-L21】
- `DISABLE_ENV_ASSERT=1 FAIL_ON_IMPORT_ERRORS=1 tools/ci_smoke.sh` (expected non-zero)【adb4b9†L1-L24】
- `pytest -n auto --disable-warnings` (fails: ImportError and KeyboardInterrupt)【09505a†L1-L20】

------
https://chatgpt.com/codex/tasks/task_e_68aa4cce002483309f27553f8a511e75