### PR TITLE
chore: lock dev deps and stabilize smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,29 @@
-# knobs
+# Defaults (configurable in CI)
 TOP_N ?= 5
 FAIL_ON_IMPORT_ERRORS ?= 0
 DISABLE_ENV_ASSERT ?= 0
 IMPORT_REPAIR_REPORT ?= artifacts/import-repair-report.md
 
-# ensure artifacts dir exists
+# Ensure artifact dir exists
 $(shell mkdir -p artifacts >/dev/null 2>&1)
 
-.PHONY: ensure-runtime legacy-fix test-collect-report ci-smoke
+.PHONY: ensure-runtime test-collect-report ci-smoke
 
+# Install runtime + dev (dev with --no-deps) unless SKIP_INSTALL=1
 ensure-runtime:
-	python -m pip install -r requirements.txt -c constraints.txt
-	python -m pip install -r requirements-dev.txt --no-deps -c constraints.txt
+	@echo "[install] runtime"
+	@python -m pip install -r requirements.txt -c constraints.txt
+	@echo "[install] dev (no-deps)"
+	@python -m pip install -r requirements-dev.txt --no-deps -c constraints.txt
 
-legacy-fix:
-	python tools/repair_test_imports.py --pkg ai_trading --tests tests --rewrite-map tools/static_import_rewrites.txt --report artifacts/import-repair-report.md --write || true
-	python tools/mark_legacy_tests.py --apply || true
-
-test-collect-report: legacy-fix
-	@echo "[collect] running pytest --collect-only"
-	@PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
-	pytest -q --collect-only || true
-	@echo "[harvest] writing $(IMPORT_REPAIR_REPORT)"
+# Collect-only + harvest, always write the artifact, exit 0 or 101
+test-collect-report:
+	@echo "[collect] pytest --collect-only"
+	@PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q --collect-only || true
+	@echo "[harvest] $(IMPORT_REPAIR_REPORT)"
 	@DISABLE_ENV_ASSERT=$(DISABLE_ENV_ASSERT) TOP_N=$(TOP_N) FAIL_ON_IMPORT_ERRORS=$(FAIL_ON_IMPORT_ERRORS) \
-	python tools/harvest_import_errors.py --report $(IMPORT_REPAIR_REPORT)
+  python tools/harvest_import_errors.py --report $(IMPORT_REPAIR_REPORT)
 
+# CI smoke convenience
 ci-smoke:
 	@bash tools/ci_smoke.sh

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,6 +22,14 @@ pydantic==2.8.2
 pandas==2.2.2
 pytest-xdist==3.6.1
 pytest-timeout==2.3.1
-pytest-asyncio==0.23.7
-freezegun==1.5.1
+pytest-asyncio==0.23.8
+freezegun==1.2.2
 requests-mock==1.12.1
+
+freezegun==1.2.2
+python-dateutil==2.9.0.post0
+pytest==8.3.2
+pytest-xdist==3.6.1
+execnet==2.1.1
+pytest-timeout==2.3.1
+pytest-asyncio==0.23.8

--- a/docs/ci-import-errors.md
+++ b/docs/ci-import-errors.md
@@ -141,3 +141,5 @@ Knobs:
 • DISABLE_ENV_ASSERT (set to 1 when running on a non-canonical host)
 • IMPORT_REPAIR_REPORT (artifact path, default artifacts/import-repair-report.md)
 ```
+
+- `SKIP_INSTALL=1` can be set for ultra-fast smoke runs that **skip** `make ensure-runtime`; the smoke still writes/prints the report and returns 0/101 based on `FAIL_ON_IMPORT_ERRORS`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,11 +15,11 @@ pytest-cov==5.0.0
 coverage==7.6.1
 execnet==2.1.1  # AI-AGENT-REF: enable pytest-xdist
 pytest-timeout==2.3.1
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.8
 pluggy==1.5.*
 iniconfig==2.0.*
 requests-mock==1.12.1
-freezegun==1.5.1
+freezegun==1.2.2
 hypothesis>=6.100
 sortedcontainers==2.4.*
 
@@ -28,3 +28,14 @@ libcst==1.4.0
 
 # Infra & helpers
 packaging==24.1
+
+# test helpers that our tests import directly
+freezegun==1.2.2
+python-dateutil==2.9.0.post0  # freezegun runtime dep (since we install dev with --no-deps)
+
+# pytest stack (ensure all are direct to survive --no-deps)
+pytest==8.3.2
+pytest-xdist==3.6.1
+execnet==2.1.1
+pytest-timeout==2.3.1
+pytest-asyncio==0.23.8

--- a/tools/ci_smoke.sh
+++ b/tools/ci_smoke.sh
@@ -5,13 +5,20 @@ set -euo pipefail
 : "${FAIL_ON_IMPORT_ERRORS:=0}"
 : "${DISABLE_ENV_ASSERT:=0}"
 : "${IMPORT_REPAIR_REPORT:=artifacts/import-repair-report.md}"
+: "${SKIP_INSTALL:=0}"
 
 mkdir -p "$(dirname "$IMPORT_REPAIR_REPORT")"
 
-DISABLE_ENV_ASSERT="${DISABLE_ENV_ASSERT}" \
-TOP_N="${TOP_N}" \
-FAIL_ON_IMPORT_ERRORS="${FAIL_ON_IMPORT_ERRORS}" \
+if [[ "$SKIP_INSTALL" != "1" ]]; then
+  make ensure-runtime
+fi
+
+# run collect + harvest through the Makefile (it already exits 101 on errors)
+DISABLE_ENV_ASSERT="$DISABLE_ENV_ASSERT" \
+TOP_N="$TOP_N" \
+FAIL_ON_IMPORT_ERRORS="$FAIL_ON_IMPORT_ERRORS" \
 make test-collect-report || rc=$?
+
 rc=${rc:-0}
 
 echo "=== BEGIN import-repair-report (head -40) ==="

--- a/tools/static_import_rewrites.txt
+++ b/tools/static_import_rewrites.txt
@@ -1,12 +1,18 @@
-ai_trading.position.core -> ai_trading.position
-from ai_trading.position.core import -> from ai_trading.position import
-import ai_trading.position.core as -> import ai_trading.position as
-ai_trading.runtime.http_wrapped -> ai_trading.utils.http
-from ai_trading.runtime.http_wrapped import -> from ai_trading.utils.http import
-import ai_trading.runtime.http_wrapped as -> import ai_trading.utils.http as
-ai_trading.monitoring.performance_monitor -> ai_trading.monitoring.system_health
-from ai_trading.monitoring.performance_monitor import -> from ai_trading.monitoring.system_health import
-import ai_trading.monitoring.performance_monitor as -> import ai_trading.monitoring.system_health as
-# normalized utils re-exports (harmless if already correct)
-from ai_trading.utils.timing import -> from ai_trading.utils import
+# ---- position.core → position ----
+^(\s*)from\s+ai_trading\.position\.core(\s+import\b.*)$ -> \1from ai_trading.position\2
+^(\s*)import\s+ai_trading\.position\.core\s+as\s+([A-Za-z_][A-Za-z0-9_]*)\b -> \1import ai_trading.position as \2
+^(\s*)import\s+ai_trading\.position\.core\b -> \1import ai_trading.position
+ai_trading\.position\.core -> ai_trading.position
 
+# ---- runtime.http_wrapped → utils.http ----
+^(\s*)from\s+ai_trading\.runtime\.http_wrapped\s+import\s+(.*)$ -> \1from ai_trading.utils.http import \2
+^(\s*)import\s+ai_trading\.runtime\.http_wrapped\s+as\s+([A-Za-z_][A-Za-z0-9_]*)\b -> \1import ai_trading.utils.http as \2
+^(\s*)import\s+ai_trading\.runtime\.http_wrapped\b -> \1import ai_trading.utils.http
+ai_trading\.runtime\.http_wrapped -> ai_trading.utils.http
+
+# ---- monitoring.performance_monitor (purged) → system_health.snapshot_basic ----
+^(\s*)from\s+ai_trading\.monitoring\.performance_monitor\s+import\s+ResourceMonitor\b.*$ -> \1from ai_trading.monitoring.system_health import snapshot_basic
+ai_trading\.monitoring\.performance_monitor -> ai_trading.monitoring.system_health
+
+# ---- minor import cleanups (safe no-ops) ----
+^(\s*)from\s+ai_trading\.utils\.timing\s+import\s+(.*)$ -> \1from ai_trading.utils import \2


### PR DESCRIPTION
## Summary
- pin dev deps including transitive pytest & freezegun requirements
- tighten Makefile and ci smoke script for deterministic import reports
- expand static rewrite map for legacy shim cleanup

## Testing
- `make ensure-runtime`
- `python - <<'PY'
from ai_trading.utils import HTTP_TIMEOUT, clamp_timeout, sleep
print("OK", HTTP_TIMEOUT, clamp_timeout(None)); sleep(0.01)
PY`
- `python tools/repair_test_imports.py --pkg ai_trading --tests tests --rewrite-map tools/static_import_rewrites.txt --report /tmp/rewrites.md --write`
- `python tools/check_no_legacy_symbols.py`
- `SKIP_INSTALL=1 DISABLE_ENV_ASSERT=1 tools/ci_smoke.sh || echo "smoke_exit=$?"`
- `DISABLE_ENV_ASSERT=1 FAIL_ON_IMPORT_ERRORS=1 tools/ci_smoke.sh || echo "expected_nonzero"`
- `TOP_N=7 make test-collect-report || true`
- `TOP_N=7 DISABLE_ENV_ASSERT=1 make test-collect-report || true`
- `python tools/mark_legacy_tests.py --apply`
- `pytest -n auto --disable-warnings >/tmp/pytest.log || tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68aa5069b298833083451f0f15f7d717