### PR TITLE
fix: expose alpaca_api and guard optional deps

### DIFF
--- a/ai_trading/__init__.py
+++ b/ai_trading/__init__.py
@@ -1,11 +1,34 @@
 """ai_trading public API.
 
 Keep imports *lazy* to avoid optional deps at import-time (e.g., Alpaca).
+Expose a **minimal, explicit allowlist** of submodules and symbols that are
+safe to import from the package root for tests and CLI users.
 """
 from importlib import import_module as _import_module
-__all__ = ['config', 'logging', 'utils']
 
-def __getattr__(name: str):
-    if name in {'config', 'logging', 'utils'}:
+# AI-AGENT-REF: public surface allowlist
+_PUBLIC_MODULES = {
+    'config', 'logging', 'utils',
+    'alpaca_api', 'data_validation', 'indicators', 'rebalancer', 'audit',
+    'core', 'strategy_allocator', 'predict', 'meta_learning', 'data_fetcher',
+    'signals', 'settings', 'runner', 'portfolio', 'app', 'ml_model',
+    'paths', 'main', 'position_sizing', 'capital_scaling', 'indicator_manager',
+    'execution', 'production_system', 'trade_logic',
+}
+
+_PUBLIC_SYMBOLS = {
+    'ExecutionEngine': 'ai_trading.execution.engine:ExecutionEngine',
+}
+
+__all__ = sorted(set(_PUBLIC_MODULES) | set(_PUBLIC_SYMBOLS))
+
+
+def __getattr__(name: str):  # pragma: no cover - thin lazy loader
+    if name in _PUBLIC_MODULES:
         return _import_module(f'ai_trading.{name}')
+    target = _PUBLIC_SYMBOLS.get(name)
+    if target:
+        mod_name, _, sym = target.partition(':')
+        return getattr(_import_module(mod_name), sym)
     raise AttributeError(name)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,15 @@ from datetime import datetime, timezone
 import pathlib
 
 import pytest
-from freezegun import freeze_time
+try:
+    # Optional dev dependency. Provide a benign fallback for smoke/collect.
+    from freezegun import freeze_time  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    from contextlib import contextmanager
+
+    @contextmanager
+    def freeze_time(*_a, **_k):  # AI-AGENT-REF: no-op when freezegun missing
+        yield
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_retry_idempotency_integration.py
+++ b/tests/test_retry_idempotency_integration.py
@@ -7,6 +7,8 @@ import pytest
 
 sys.path.insert(0, '/tmp')
 
+# Skip when tenacity isn't installed (CI smoke with SKIP_INSTALL=1)
+pytest.importorskip("tenacity")
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 pytestmark = pytest.mark.integration

--- a/tests/test_tenacity_import.py
+++ b/tests/test_tenacity_import.py
@@ -1,4 +1,8 @@
 """Test to ensure real tenacity package is imported from PyPI."""
+import pytest
+
+# Skip when tenacity isn't installed (CI smoke with SKIP_INSTALL=1)
+pytest.importorskip("tenacity")
 
 import inspect
 


### PR DESCRIPTION
## Summary
- expand ai_trading public API to lazily expose alpaca_api and other safe modules
- provide no-op freeze_time when freezegun is absent
- skip tenacity tests when dependency missing

## Testing
- `python - <<'PY'
import compileall, sys
ok = compileall.compile_dir('.', maxlevels=10, quiet=1)
print('compileall:', ok)
PY`
- `python - <<'PY'
from importlib import import_module
import ai_trading as t
assert hasattr(t, "alpaca_api"), "root should expose alpaca_api"
assert t.alpaca_api.__name__.endswith("alpaca_api")
from ai_trading import ExecutionEngine
print("OK surface:", t.alpaca_api, ExecutionEngine)
PY`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 SKIP_INSTALL=1 FAIL_ON_IMPORT_ERRORS=0 python tools/run_pytest.py --collect-only -q`
- `python - <<'PY'
import importlib.util
print("xdist:", "OK" if importlib.util.find_spec("xdist") else "MISS")
PY`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -n auto --disable-warnings >/tmp/pytest.log && tail -n 20 /tmp/pytest.log` *(fails: unrecognized arguments: -n)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6ddfa9dc8330a2283cd8df20ce4e