### PR TITLE
Load xdist explicitly in tests to support pytest -n when plugin autoload is disabled

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,15 @@ work during test collection. This is idempotent and does not affect runtime.
 import os
 os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")  # AI-AGENT-REF: disable plugin autoload
 import sys as _sys
+
+# AI-AGENT-REF: explicitly load xdist plugin when available
+try:
+    import importlib.util as _util
+    _xdist_present = bool(_util.find_spec("xdist"))
+except Exception:  # pragma: no cover - absence or lookup issue
+    _xdist_present = False
+pytest_plugins = ["xdist.plugin"] if _xdist_present else []
+
 import importlib as _importlib
 
 try:


### PR DESCRIPTION
## Summary
- explicitly load the xdist plugin from tests so `pytest -n auto` works when plugin autoloading is disabled

## Testing
- `python - <<'PY'
import compileall, sys
sys.exit(0 if compileall.compile_dir('.', maxlevels=10, quiet=1) else 1)
PY`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -n auto --disable-warnings -q` *(fails: unrecognized arguments: -n)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python tools/run_pytest.py --disable-warnings -k smoke` *(fails: ModuleNotFoundError: No module named 'psutil')*
- `python - <<'PY'
import ai_trading as t
from ai_trading import ExecutionEngine
assert hasattr(t, 'alpaca_api')
print('OK surface:', t.alpaca_api.__name__, ExecutionEngine.__name__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aa70ea2b64833097d1dda509e08c05