### PR TITLE
Load xdist via ini at parse-time and declare minimal dev deps to stop psutil import failures

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
-addopts = -ra
+# AI-AGENT-REF: preload xdist at parse time so `-n` works when autoload is off
+addopts = -ra -p xdist.plugin
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 filterwarnings =

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,7 @@
+# AI-AGENT-REF: minimal dev/test dependencies for reliable raw pytest runs
+pytest>=7.4
+pytest-xdist>=3.6
+psutil>=5.9
+freezegun>=1.4
+tenacity>=8.2
+cachetools>=5.3

--- a/tests/test_runner_smoke.py
+++ b/tests/test_runner_smoke.py
@@ -1,0 +1,49 @@
+"""Smoke-test the pytest runner's echoed command."""
+from __future__ import annotations
+
+import importlib.util as iu
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _first_echo_line(text: str) -> str:
+    for line in text.splitlines():
+        idx = line.find("[run_pytest]")
+        if idx != -1:
+            return line[idx:]
+    raise AssertionError("runner did not echo a '[run_pytest]' line; got:\n" + text)
+
+
+def test_runner_echo_contains_core_flags():
+    env = os.environ.copy()
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    root = Path(__file__).resolve().parents[1]
+    script = root / "tools" / "run_pytest.py"
+    args = [
+        sys.executable,
+        str(script),
+        "--disable-warnings",
+        "--collect-only",
+        "-k",
+        "__never__",
+    ]
+
+    proc = subprocess.run(
+        args, capture_output=True, text=True, env=env, cwd=root
+    )
+
+    echo = _first_echo_line(proc.stderr)
+
+    assert "pytest -q" in echo
+    assert " -W ignore" in echo
+
+    xdist_present = iu.find_spec("xdist") is not None
+    if xdist_present:
+        assert "xdist.plugin" in echo, echo
+        assert " -n " in echo or echo.endswith(" -n")
+    else:
+        assert "xdist.plugin" not in echo
+        assert " -n " not in echo
+

--- a/tests/test_utils_timing.py
+++ b/tests/test_utils_timing.py
@@ -1,0 +1,24 @@
+"""Sanity checks for centralized timing helpers exported by ai_trading.utils."""
+from __future__ import annotations
+
+from time import perf_counter
+
+import pytest
+
+from ai_trading.utils import HTTP_TIMEOUT, clamp_timeout, sleep
+
+
+def test_timing_exports_exist_and_behave():
+    assert isinstance(HTTP_TIMEOUT, int | float)
+    assert HTTP_TIMEOUT > 0
+
+    assert clamp_timeout(None) == pytest.approx(float(HTTP_TIMEOUT))
+    assert clamp_timeout(0.0) >= 0.0
+    assert clamp_timeout(-1.0) >= 0.0
+
+    t0 = perf_counter()
+    sleep(0.001)
+    dt = perf_counter() - t0
+    assert dt >= 0.0
+    assert dt < max(0.25, HTTP_TIMEOUT)
+

--- a/tools/ci_smoke.sh
+++ b/tools/ci_smoke.sh
@@ -7,6 +7,14 @@ set -euo pipefail
 : "${SKIP_INSTALL:=0}"
 : "${IMPORT_REPAIR_REPORT:=artifacts/import-repair-report.md}"
 
+# AI-AGENT-REF: ensure dev deps present for raw pytest use
+if [ "${SKIP_INSTALL:-0}" != "1" ]; then
+  if [ -f "requirements/dev.txt" ]; then
+    python -m pip install --upgrade pip >/dev/null 2>&1 || true
+    python -m pip install -r requirements/dev.txt
+  fi
+fi
+
 mkdir -p "$(dirname "$IMPORT_REPAIR_REPORT")"
 
 TOP_N="$TOP_N" \


### PR DESCRIPTION
## Summary
- preload `pytest-xdist` via `pytest.ini` so `-n` works even when plugin autoload is disabled
- add minimal `requirements/dev.txt` for tests and ensure `ci_smoke.sh` installs it by default
- add regression tests for the pytest runner echo and utility timing helpers

## Testing
- `python - <<'PY'
import compileall, sys
sys.exit(0 if compileall.compile_dir('.', maxlevels=10, quiet=1) else 1)
PY`
- `python -m ruff check tests/test_runner_smoke.py tests/test_utils_timing.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runner_smoke.py tests/test_utils_timing.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python tools/run_pytest.py --disable-warnings --collect-only -k __never__` *(fails: non-zero exit after echo)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -n auto --disable-warnings` *(fails: 134 failed, 67 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa730168448330a2492236fce1bcfe