### PR TITLE
TradingConfig back-compat aliases + script tunables; keep current smoke/runner stable

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -780,6 +780,22 @@ class TradingConfig(BaseModel):
     max_trades_per_day: int = 100
     volume_threshold: int = 50000
     seed: int = 42
+    # AI-AGENT-REF: add optional script tunables for exploratory scripts
+    max_position_size_pct: float | None = Field(
+        default=None, description="Optional cap on position size as percent of equity"
+    )
+    max_var_95: float | None = Field(
+        default=None, description="Optional 95% VaR limit for risk scripts"
+    )
+    min_profit_factor: float | None = Field(
+        default=None, description="Minimum profit factor for optimizers"
+    )
+    min_sharpe_ratio: float | None = Field(
+        default=None, description="Minimum Sharpe ratio threshold"
+    )
+    min_win_rate: float | None = Field(
+        default=None, description="Minimum win rate requirement"
+    )
     entry_start_offset_min: int = 0
     entry_end_offset_min: int = 390
 
@@ -801,6 +817,27 @@ class TradingConfig(BaseModel):
         if self.take_profit_factor < 1.0:
             raise ValueError('take_profit_factor must be >= 1.0')
         return self
+
+    # AI-AGENT-REF: expose back-compat aliases for older scripts
+    @property
+    def max_correlation_exposure(self) -> float:
+        """Backward-compatible alias for sector_exposure_cap."""
+        return self.sector_exposure_cap
+
+    @property
+    def max_drawdown(self) -> float:
+        """Backward-compatible alias for max_drawdown_threshold."""
+        return self.max_drawdown_threshold
+
+    @property
+    def stop_loss_multiplier(self) -> float:
+        """Backward-compatible alias for trailing_factor."""
+        return self.trailing_factor
+
+    @property
+    def take_profit_multiplier(self) -> float:
+        """Backward-compatible alias for take_profit_factor."""
+        return self.take_profit_factor
 
     @classmethod
     def from_env(cls, mode: Literal['conservative', 'balanced', 'aggressive'] | None=None, **overrides) -> 'TradingConfig':


### PR DESCRIPTION
## Summary
- expose back-compat aliases on `TradingConfig` for legacy field names
- add optional script tunables used by demo/optimization flows

## Testing
- `python - <<'PY'
import compileall, sys
sys.exit(0 if compileall.compile_dir('.', maxlevels=10, quiet=1) else 1)
PY`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_runner_smoke.py tests/test_utils_timing.py`
- `DISABLE_ENV_ASSERT=1 SKIP_INSTALL=1 tools/ci_smoke.sh`
- `python - <<'PY'
import types, sys, importlib.util
config_pkg = types.ModuleType('ai_trading.config')
config_pkg.__path__ = []
config_pkg.MAX_DRAWDOWN_THRESHOLD = 0.08
config_pkg.MODE_PARAMETERS = {}
config_pkg.ORDER_FILL_RATE_TARGET = 0.8
config_pkg.SENTIMENT_ENHANCED_CACHING = False
config_pkg.SENTIMENT_RECOVERY_TIMEOUT_SECS = 0
sys.modules['ai_trading.config'] = config_pkg
aliases_mod = types.ModuleType('ai_trading.config.aliases')
aliases_mod.resolve_trading_mode = lambda mode: mode
sys.modules['ai_trading.config.aliases'] = aliases_mod
creds_mod = types.ModuleType('ai_trading.config.alpaca_creds')
creds_mod.resolve_alpaca_credentials = lambda: {'API_KEY':'','SECRET_KEY':'','BASE_URL':''}
sys.modules['ai_trading.config.alpaca_creds'] = creds_mod
settings_mod = types.ModuleType('ai_trading.config.settings')
class Settings: ...
settings_mod.Settings = Settings
settings_mod.get_settings = lambda: Settings()
sys.modules['ai_trading.config.settings'] = settings_mod
spec = importlib.util.spec_from_file_location('ai_trading.config.management','ai_trading/config/management.py')
module = importlib.util.module_from_spec(spec)
sys.modules['ai_trading.config.management'] = module
spec.loader.exec_module(module)
TradingConfig = module.TradingConfig
cfg = TradingConfig()
assert cfg.max_correlation_exposure == cfg.sector_exposure_cap
assert cfg.max_drawdown == cfg.max_drawdown_threshold
assert cfg.stop_loss_multiplier == cfg.trailing_factor
assert cfg.take_profit_multiplier == cfg.take_profit_factor
for name in ["max_position_size_pct","max_var_95","min_profit_factor","min_sharpe_ratio","min_win_rate"]:
    getattr(cfg, name)
print("OK")
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aa801c19688330b14ad9425c03c170