### PR TITLE
Adopt repo-wide ruff config, make smoke lint critical-only, and add TradingConfig alias test

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,30 @@
+# Repo-wide Ruff configuration
+# Keep smoke fast and signal-rich; reserve strict style for full CI/dev runs.
+
+# Target & basics
+line-length = 100
+src = ["ai_trading", "tools", "tests"]
+target-version = "py312"
+
+# Ignore common non-source dirs
+exclude = [
+  ".git", ".venv", "venv", "dist", "build", "data", "logs", "notebooks", "docs/_build",
+]
+
+[lint]
+# Default selection is intentionally light; smoke uses --select to narrow further.
+# These are commonly useful project-wide without being noisy.
+select = [
+  "E9",   # Syntax errors
+  "F63",  # if/else misuse
+  "F7",   # forward references, etc.
+  "F82",  # undefined names from star imports
+]
+# We'll handle long lines, docstrings, annotations, and import style later.
+ignore = ["E501", "D", "ANN", "COM812", "ISC001", "ARG002", "B905"]
+
+[format]
+quote-style = "preserve"
+indent-style = "space"
+line-ending = "auto"
+

--- a/tests/test_trading_config_aliases.py
+++ b/tests/test_trading_config_aliases.py
@@ -1,0 +1,29 @@
+"""Pin the presence/behavior of TradingConfig aliases and tunables.
+
+This guards against future regressions where legacy names disappear or
+script-only knobs get dropped from the model surface.
+"""
+from __future__ import annotations
+
+from ai_trading.config.management import TradingConfig
+
+
+def test_trading_config_aliases_and_tunables_exist():
+    cfg = TradingConfig()
+
+    # Back-compat aliases map to canonical fields
+    assert cfg.max_correlation_exposure == cfg.sector_exposure_cap
+    assert cfg.max_drawdown == cfg.max_drawdown_threshold
+    assert cfg.stop_loss_multiplier == cfg.trailing_factor
+    assert cfg.take_profit_multiplier == cfg.take_profit_factor
+
+    # Script/optimizer tunables exist (may be None by default)
+    for name in (
+        "max_position_size_pct",
+        "max_var_95",
+        "min_profit_factor",
+        "min_sharpe_ratio",
+        "min_win_rate",
+    ):
+        assert hasattr(cfg, name), f"Missing tunable: {name}"
+

--- a/tools/ci_smoke.sh
+++ b/tools/ci_smoke.sh
@@ -26,7 +26,7 @@ then
   fi
   if [ -n "${PY_FILES}" ]; then
     set +e
-    python -m ruff check ${PY_FILES}
+    python -m ruff check --select E9,F63,F7,F82 ${PY_FILES}
     RUFF_STATUS=$?
     set -e
     if [ "${RUFF_STATUS}" -ne 0 ]; then


### PR DESCRIPTION
## Summary
- add repo-wide `.ruff.toml` with focused rules and excluded directories
- limit smoke linting to critical Ruff codes
- test `TradingConfig` aliases and tunables

## Testing
- `python - <<'PY'
import compileall, sys
sys.exit(0 if compileall.compile_dir('.', maxlevels=10, quiet=1) else 1)
PY`
- `DISABLE_ENV_ASSERT=1 SKIP_INSTALL=1 tools/ci_smoke.sh`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_runner_smoke.py tests/test_utils_timing.py tests/test_trading_config_aliases.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa84c642788330b0861687e1a5cd54