### PR TITLE
Make smoke deterministic by running explicit test files and ensure tools/run_pytest.py honors targets

### DIFF
--- a/tools/ci_smoke.sh
+++ b/tools/ci_smoke.sh
@@ -56,7 +56,11 @@ fi
 # Targeted smoke run
 # -----------------
 export PYTEST_DISABLE_PLUGIN_AUTOLOAD=${PYTEST_DISABLE_PLUGIN_AUTOLOAD:-1}
-python tools/run_pytest.py --disable-warnings tests/test_runner_smoke.py tests/test_utils_timing.py -q
+# AI-AGENT-REF: run explicit smoke tests to prevent global collection
+python tools/run_pytest.py --disable-warnings -q \
+  tests/test_runner_smoke.py \
+  tests/test_utils_timing.py \
+  tests/test_trading_config_aliases.py
 
 echo "[ci_smoke] Completed."
 

--- a/tools/run_pytest.py
+++ b/tools/run_pytest.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
+"""Deterministic pytest runner used by CI smoke tests."""
+
 from __future__ import annotations
 
+import argparse
+import importlib.util as iu
 import logging
 import os
 import shlex
@@ -8,37 +12,71 @@ import subprocess
 import sys
 
 
-def has_xdist() -> bool:
-    try:
-        import xdist  # noqa: F401
+def build_parser() -> argparse.ArgumentParser:
+    """Create argument parser for the runner."""
+    p = argparse.ArgumentParser(description="Deterministic pytest runner")
+    p.add_argument(
+        "--disable-warnings",
+        action="store_true",
+        help="Silence warnings via -W ignore",
+    )
+    p.add_argument(
+        "--collect-only",
+        action="store_true",
+        help="Only collect tests",
+    )
+    p.add_argument(
+        "-k",
+        dest="keyword",
+        default=None,
+        help="pytest -k expression (optional)",
+    )
+    p.add_argument(
+        "-q",
+        dest="quiet",
+        action="store_true",
+        help="Quiet mode (pytest -q)",
+    )
+    # AI-AGENT-REF: allow explicit test targets to avoid global collection
+    p.add_argument(
+        "targets",
+        nargs="*",
+        help="Explicit test file/dir/node-id targets",
+    )
+    return p
 
-        return True
-    except Exception:
-        return False
+
+def build_pytest_cmd(args: argparse.Namespace) -> list[str]:
+    """Construct the pytest command based on parsed arguments."""
+    cmd = [sys.executable, "-m", "pytest", "-q"]
+    if args.disable_warnings:
+        # AI-AGENT-REF: map --disable-warnings to interpreter flag
+        cmd += ["-W", "ignore"]
+    if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1":
+        if iu.find_spec("xdist") is not None:
+            # AI-AGENT-REF: ensure xdist still loads when autoload is disabled
+            cmd += ["-p", "xdist.plugin", "-n", os.environ.get("PYTEST_XDIST_WORKERS", "auto")]
+        else:
+            # AI-AGENT-REF: explicitly disable xdist plugin if absent
+            cmd += ["-p", "no:xdist"]
+    else:
+        if iu.find_spec("xdist") is not None:
+            cmd += ["-n", os.environ.get("PYTEST_XDIST_WORKERS", "auto")]
+    if args.collect_only:
+        cmd += ["--collect-only"]
+    if args.keyword:
+        cmd += ["-k", args.keyword]
+    if args.targets:
+        # AI-AGENT-REF: append explicit targets last so pytest limits collection
+        cmd.extend(args.targets)
+    return cmd
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = list(argv or sys.argv[1:])
-
-    # AI-AGENT-REF: map --disable-warnings to interpreter flag
-    if "--disable-warnings" in args:
-        args.remove("--disable-warnings")
-        args[:0] = ["-W", "ignore"]
-
-    base = ["pytest", "-q"]
-
-    autoload_disabled = os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
-
-    # Add -n auto only when xdist is available
-    if has_xdist():
-        # AI-AGENT-REF: ensure xdist plugin is loaded when autoload is disabled
-        if autoload_disabled:
-            base.extend(["-p", "xdist.plugin"])
-        base.extend(["-n", os.environ.get("PYTEST_XDIST_WORKERS", "auto")])
-
-    cmd = base + args
-
-    logging.basicConfig(level=logging.INFO)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    cmd = build_pytest_cmd(args)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     logger = logging.getLogger("run_pytest")
     logger.info("[run_pytest] %s", " ".join(shlex.quote(c) for c in cmd))
     return subprocess.call(cmd)


### PR DESCRIPTION
## Summary
- run smoke script against explicit test files to avoid global collection
- allow run_pytest.py to accept explicit targets and disable xdist plugin when missing

## Testing
- `python - <<'PY'
import compileall, sys
sys.exit(0 if compileall.compile_dir('.', maxlevels=10, quiet=1) else 1)
PY`
- `DISABLE_ENV_ASSERT=1 SKIP_INSTALL=1 tools/ci_smoke.sh`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python tools/run_pytest.py --disable-warnings -q tests/test_runner_smoke.py tests/test_utils_timing.py tests/test_trading_config_aliases.py --collect-only`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python tools/run_pytest.py --disable-warnings -k __never__ --collect-only`
- `pytest -n auto --disable-warnings` *(fails: Plugin already registered under a different name: xdist)*

------
https://chatgpt.com/codex/tasks/task_e_68aa893958d08330b7a5512b4f5b3dd5