### PR TITLE
Stop double registration of xdist: remove ini preloading and guard runner injection

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
-# AI-AGENT-REF: preload xdist at parse time so `-n` works when autoload is off
-addopts = -ra -p xdist.plugin
+# AI-AGENT-REF: drop xdist preload; runner injects when autoload is disabled
+addopts = -ra
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 filterwarnings =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,16 +8,7 @@ local test vendor stubs so imports like
 work during test collection. This is idempotent and does not affect runtime.
 """
 import os
-os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")  # AI-AGENT-REF: disable plugin autoload
 import sys as _sys
-
-# AI-AGENT-REF: explicitly load xdist plugin when available
-try:
-    import importlib.util as _util
-    _xdist_present = bool(_util.find_spec("xdist"))
-except Exception:  # pragma: no cover - absence or lookup issue
-    _xdist_present = False
-pytest_plugins = ["xdist.plugin"] if _xdist_present else []
 
 import importlib as _importlib
 

--- a/tools/run_pytest.py
+++ b/tools/run_pytest.py
@@ -53,15 +53,11 @@ def build_pytest_cmd(args: argparse.Namespace) -> list[str]:
         # AI-AGENT-REF: map --disable-warnings to interpreter flag
         cmd += ["-W", "ignore"]
     if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1":
-        if iu.find_spec("xdist") is not None:
-            # AI-AGENT-REF: ensure xdist still loads when autoload is disabled
+        addopts = os.environ.get("PYTEST_ADDOPTS", "")
+        xdist_requested = "-p xdist.plugin" in addopts or "xdist.plugin" in addopts
+        if iu.find_spec("xdist") is not None and not xdist_requested:
+            # AI-AGENT-REF: load xdist only when autoload is off and not already requested
             cmd += ["-p", "xdist.plugin", "-n", os.environ.get("PYTEST_XDIST_WORKERS", "auto")]
-        else:
-            # AI-AGENT-REF: explicitly disable xdist plugin if absent
-            cmd += ["-p", "no:xdist"]
-    else:
-        if iu.find_spec("xdist") is not None:
-            cmd += ["-n", os.environ.get("PYTEST_XDIST_WORKERS", "auto")]
     if args.collect_only:
         cmd += ["--collect-only"]
     if args.keyword:


### PR DESCRIPTION
## Summary
- drop xdist preloading from pytest.ini to avoid duplicate plugin registration
- only inject xdist in runner when autoload is disabled and user hasn't requested it
- stop forcing xdist plugin loading in tests' conftest

## Testing
- `python - <<'PY'
import compileall, sys
success = compileall.compile_dir('.', maxlevels=10, quiet=1)
print('compile', 'ok' if success else 'fail')
PY`
- `pytest -n auto --disable-warnings -q` *(fails: ImportError: cannot import name 'DataFetchError')*
- `DISABLE_ENV_ASSERT=1 SKIP_INSTALL=1 tools/ci_smoke.sh` *(passes)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python tools/run_pytest.py --disable-warnings -q tests/test_runner_smoke.py tests/test_utils_timing.py tests/test_trading_config_aliases.py --collect-only`

------
https://chatgpt.com/codex/tasks/task_e_68aa8bfdbe548330848ffba73e67e95e