### PR TITLE
Make smoke deterministic by running explicit test files; ensure tools/run_pytest.py honors & echoes targets; install minimal deps needed by smoke

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,3 +9,6 @@ ruff>=0.5
 pytest-timeout>=2.3
 pytest-asyncio>=0.23
 joblib>=1.4
+# AI-AGENT-REF: ensure config models import in smoke
+pydantic>=2.7
+pydantic-settings>=2.3

--- a/tools/ci_smoke.sh
+++ b/tools/ci_smoke.sh
@@ -56,7 +56,9 @@ fi
 # Targeted smoke run
 # -----------------
 export PYTEST_DISABLE_PLUGIN_AUTOLOAD=${PYTEST_DISABLE_PLUGIN_AUTOLOAD:-1}
-# Run explicit smoke tests only (no global collection)
+# AI-AGENT-REF: keep warnings quiet and avoid plugin autoload
+export PYTHONWARNINGS=${PYTHONWARNINGS:-ignore}
+echo "[ci_smoke] Running minimal smoke suite (3 files)"
 python tools/run_pytest.py --disable-warnings -q \
   tests/test_runner_smoke.py \
   tests/test_utils_timing.py \


### PR DESCRIPTION
## Summary
- add pydantic and pydantic-settings to dev dependencies for smoke
- ensure ci_smoke.sh disables plugin autoload, silences warnings, and runs explicit tests
- update run_pytest to echo exact command and honor explicit targets with optional xdist
- verify runner output in test_runner_smoke

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m ruff check tools/run_pytest.py tests/test_runner_smoke.py --select E9,F63,F7,F82`
- `bash tools/ci_smoke.sh`
- `pytest -n auto --disable-warnings` *(fails: ImportError: cannot import name 'DataFetchError' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa4480968833081bef90a9f5001e0