### PR TITLE
Restore ai_trading.utils back-compat exports; implement safe subprocess helpers; add make test-all + smoke targets

### DIFF
--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -10,6 +10,14 @@ from .base import (
     health_check,
     is_market_open,
     market_open_between,
+    # back-compat exports used by ai_trading.core.bot_engine
+    log_warning,
+    model_lock,
+    safe_to_datetime,
+    validate_ohlcv,
+    # subprocess helpers for git hash retrieval
+    SUBPROCESS_TIMEOUT_DEFAULT,
+    safe_subprocess_run,
 )
 
 # Keep submodules importable as ai_trading.utils.http, etc.
@@ -27,4 +35,12 @@ __all__ = [
     "is_market_open",
     "market_open_between",
     "http",
+    # back-compat (engine)
+    "log_warning",
+    "model_lock",
+    "safe_to_datetime",
+    "validate_ohlcv",
+    # subprocess helper
+    "SUBPROCESS_TIMEOUT_DEFAULT",
+    "safe_subprocess_run",
 ]

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -3,6 +3,7 @@ import datetime as dt
 import logging
 import os
 import random
+import subprocess
 import socket
 import threading
 import time
@@ -31,6 +32,21 @@ DataFrame = pd.DataFrame
 Series = pd.Series
 Index = pd.Index
 SUBPROCESS_TIMEOUT_S = 5.0
+
+# Back-compat alias expected by ai_trading.core.bot_engine.get_git_hash()
+SUBPROCESS_TIMEOUT_DEFAULT = SUBPROCESS_TIMEOUT_S
+
+def safe_subprocess_run(cmd: list[str] | tuple[str, ...], timeout: float | int | None = None) -> str:
+    """Run a subprocess safely and return stdout text.
+
+    Returns an empty string on any failure so callers can degrade gracefully.
+    """
+    try:
+        t = float(timeout) if timeout is not None else SUBPROCESS_TIMEOUT_DEFAULT
+        res = subprocess.run(list(cmd), timeout=t, check=True, capture_output=True)
+        return (res.stdout or b"").decode(errors="ignore").strip()
+    except Exception:
+        return ""
 
 def get_ohlcv_columns(df) -> list[str]:
     cols = [str(c).lower() for c in getattr(df, 'columns', [])]


### PR DESCRIPTION
## Summary
- re-export legacy helpers and subprocess utilities from `ai_trading.utils`
- add safe `safe_subprocess_run` and `SUBPROCESS_TIMEOUT_DEFAULT`
- wire up deterministic `smoke`/`test-all` Makefile targets

## Testing
- `python - <<'PY'
from ai_trading.utils import log_warning, model_lock, safe_to_datetime, validate_ohlcv
from ai_trading.utils import SUBPROCESS_TIMEOUT_DEFAULT, safe_subprocess_run
print('OK')
PY`
- `python -m py_compile $(git ls-files '*.py')`
- `SKIP_INSTALL=1 make smoke`
- `SKIP_INSTALL=1 make test-all` *(fails: collection errors)*
- `pytest -n auto --disable-warnings` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ab33cfe8648330b4cf01f126bb051f