### PR TITLE
Add missing TradingConfig fields and align Kelly default

### DIFF
--- a/ai_trading/risk/kelly.py
+++ b/ai_trading/risk/kelly.py
@@ -56,7 +56,8 @@ class KellyCriterion:
         if 'confidence_level' in kwargs:
             self.confidence_level = kwargs['confidence_level']
         elif min_sample_size is not None or max_fraction is not None:
-            self.confidence_level = 0.95
+            # AI-AGENT-REF: align legacy kwargs default to 0.90
+            self.confidence_level = 0.90
         else:
             self.confidence_level = self.config.confidence_level
         logger.info(f'KellyCriterion initialized with min_sample_size={self.min_sample_size}, max_fraction={self.max_fraction}, confidence_level={self.confidence_level}')

--- a/tests/test_institutional_kelly.py
+++ b/tests/test_institutional_kelly.py
@@ -23,7 +23,8 @@ class TestKellyCriterion:
         """Test Kelly Criterion initialization."""
         assert self.kelly.min_sample_size == 10
         assert self.kelly.max_fraction == 0.25
-        assert self.kelly.confidence_level == 0.95
+        # AI-AGENT-REF: default confidence now 0.90 when legacy kwargs used
+        assert self.kelly.confidence_level == 0.90
 
     def test_basic_kelly_calculation(self):
         """Test basic Kelly fraction calculation."""

--- a/tests/unit/test_trading_config_fields.py
+++ b/tests/unit/test_trading_config_fields.py
@@ -1,0 +1,21 @@
+# AI-AGENT-REF: validate new TradingConfig fields and env overrides
+from __future__ import annotations
+
+from ai_trading.config.management import TradingConfig
+
+
+def test_defaults_present():
+    cfg = TradingConfig()
+    assert cfg.kelly_fraction_max == 0.25
+    assert cfg.min_sample_size == 10
+    assert cfg.confidence_level == 0.90
+
+
+def test_env_overrides_and_defaults(monkeypatch):
+    monkeypatch.setenv('AI_TRADER_KELLY_FRACTION_MAX', '0.20')
+    monkeypatch.setenv('AI_TRADER_MIN_SAMPLE_SIZE', '12')
+    monkeypatch.setenv('AI_TRADER_CONFIDENCE_LEVEL', '0.85')
+    cfg = TradingConfig.from_env()
+    assert cfg.kelly_fraction_max == 0.20
+    assert cfg.min_sample_size == 12
+    assert cfg.confidence_level == 0.85


### PR DESCRIPTION
## Summary
- centralize Kelly and sampling config fields with env overrides
- default Kelly confidence level to 0.90 when using legacy kwargs
- cover new config fields and env overrides in tests

## Testing
- `python - <<'PY'
import py_compile, pathlib
[py_compile.compile(str(p), doraise=True) for p in pathlib.Path('.').rglob('*.py')]
print('py_compile OK')
PY`
- `pytest --disable-warnings tests/test_institutional_kelly.py::TestKellyCriterion::test_kelly_initialization tests/unit/test_trading_config_fields.py -q`
- `make smoke` *(fails: AssertionError in test_utils_timing, test_runner_smoke)*
- `make test-all` *(fails: 85 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68ab3ac548e08330ad1a80ab5d78d970