### PR TITLE
Harden pytest determinism & fix smoke dev-requirements path; add heavy test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SKIP_INSTALL ?= 0
 # Ensure artifact dir exists even on CI
 $(shell mkdir -p artifacts >/dev/null 2>&1)
 
-.PHONY: ensure-runtime test-collect-report ci-smoke smoke test test-all lint
+.PHONY: ensure-runtime test-collect-report ci-smoke smoke test test-all test-all-heavy lint
 
 ensure-runtime:
 ifeq ($(SKIP_INSTALL),0)
@@ -42,7 +42,13 @@ test: smoke
 
 # Run full test suite; disables common auto-loaded plugins for determinism
 test-all:
-	PYTEST_ADDOPTS="-p no:faulthandler -p no:randomly -p no:cov" \
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+	PYTEST_ADDOPTS="-p no:faulthandler -p no:randomly -p no:cov -m 'not integration and not slow and not requires_credentials'" \
+	python tools/run_pytest.py tests
+
+# Run everything, including slow/integration/credentials-marked tests, still without plugin autoload.
+test-all-heavy:
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
 	python tools/run_pytest.py tests
 
 lint:

--- a/tools/ci_smoke.sh
+++ b/tools/ci_smoke.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 
 # Install dev test dependencies unless explicitly skipped (xdist, psutil, ruff, etc.).
 if [ "${SKIP_INSTALL:-0}" != "1" ]; then
-  if [ -f "requirements/dev.txt" ]; then
+  if [ -f "requirements-dev.txt" ]; then
     python -m pip install --upgrade pip >/dev/null 2>&1 || true
-    python -m pip install -r requirements/dev.txt
+    python -m pip install -r requirements-dev.txt
   fi
 fi
 


### PR DESCRIPTION
## Summary
- fix ci smoke script to install dev requirements from the correct path
- disable pytest plugin autoload and heavy markers in test-all; add opt-in test-all-heavy target

## Testing
- `SKIP_INSTALL=1 make smoke`
- `SKIP_INSTALL=1 make test-all` *(fails: 280 failed, 48 errors)*
- `SKIP_INSTALL=1 make test-all-heavy` *(interrupted)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist.plugin -n auto --disable-warnings tests/test_runner_smoke.py tests/test_utils_timing.py tests/test_trading_config_aliases.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d0fa3748330b3231d6db2df5f00