### PR TITLE
Break runtime-protocols import cycle, add git-aware pycompile

### DIFF
--- a/ai_trading/core/protocols.py
+++ b/ai_trading/core/protocols.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 from collections.abc import Mapping, Sequence
-from typing import Any, Protocol
-from .runtime import BotRuntime
+from typing import Any, Protocol, TYPE_CHECKING  # AI-AGENT-REF: add TYPE_CHECKING to break cycle
+
+if TYPE_CHECKING:  # AI-AGENT-REF: avoid runtime import cycle
+    from .runtime import BotRuntime
 
 
 class AllocatorProtocol(Protocol):
-    def allocate(self, signals: Sequence[Mapping[str, Any]], runtime: BotRuntime) -> Mapping[str, Any]:
+    def allocate(self, signals: Sequence[Mapping[str, Any]], runtime: 'BotRuntime') -> Mapping[str, Any]:  # AI-AGENT-REF: forward ref to runtime
         """Allocate positions based on signals."""
         raise NotImplementedError  # AI-AGENT-REF: remove placeholder ellipsis
 

--- a/tools/ci_smoke.sh
+++ b/tools/ci_smoke.sh
@@ -11,6 +11,9 @@ if [ "${SKIP_INSTALL:-0}" != "1" ]; then
   fi
 fi
 
+# Syntax check on tracked sources only
+python tools/pycompile_git.py  # AI-AGENT-REF: git-aware py_compile
+
 # -----------------
 # Python lint (ruff) — non-blocking in smoke
 # -----------------

--- a/tools/pycompile_git.py
+++ b/tools/pycompile_git.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import os, sys, subprocess, py_compile
+
+# AI-AGENT-REF: compile only tracked Python files
+
+def git_ls_files() -> list[str]:
+    """Return tracked Python files or empty list on failure."""  # AI-AGENT-REF: avoid .git traversal
+    try:
+        out = subprocess.check_output(["git", "ls-files", "*.py"], text=True)
+        return [line.strip() for line in out.splitlines() if line.strip()]
+    except Exception:
+        return []
+
+def fallback_walk(root: str) -> list[str]:
+    """Fallback tree walk excluding common non-source dirs."""
+    skip = {".git", "__pycache__", "venv", ".venv", ".tox"}
+    paths: list[str] = []
+    for d, dirs, files in os.walk(root):
+        if os.path.basename(d) in skip:
+            dirs[:] = []
+            continue
+        for f in files:
+            if f.endswith(".py"):
+                paths.append(os.path.join(d, f))
+    return paths
+
+def main() -> int:
+    files = git_ls_files() or fallback_walk(".")
+    for p in files:
+        try:
+            py_compile.compile(p, doraise=True)
+        except py_compile.PyCompileError as e:
+            sys.stderr.write(str(e) + "\n")
+            return 1
+    print("py_compile OK (git-aware)")
+    return 0
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- avoid core.runtime and protocols circular import by gating runtime type hints with `TYPE_CHECKING`
- add git-aware `pycompile` script and run it in smoke pipeline

## Testing
- `python tools/pycompile_git.py`
- `SKIP_INSTALL=1 make smoke`
- `pytest -n auto --disable-warnings` *(fails: missing modules / many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ab544065d083309c6ab14e5c662680