### PR TITLE
Ensure ai_trading.utils.sleep is synchronous and measurable; fix smoke timing

### DIFF
--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
 # timing helpers for public surface  # AI-AGENT-REF: re-export
-from .timing import HTTP_TIMEOUT, clamp_timeout, sleep
+from .timing import HTTP_TIMEOUT, clamp_timeout, sleep as _timing_sleep
+
+def sleep(seconds: float) -> None:
+    """Synchronous sleep (non-negative), guaranteed to call timing.sleep.
+
+    We intentionally wrap instead of aliasing so that any prior alias/stub in
+    this module cannot shadow the real implementation.
+    """
+    # AI-AGENT-REF: hard bind sleep to timing.sleep
+    _timing_sleep(seconds)
 from .base import (
     EASTERN_TZ,
     ensure_utc,

--- a/tests/unit/test_sleep_binding.py
+++ b/tests/unit/test_sleep_binding.py
@@ -1,0 +1,13 @@
+from time import perf_counter
+
+from ai_trading.utils import sleep
+
+
+def test_utils_sleep_is_measurable():
+    start = perf_counter()
+    sleep(0.01)
+    elapsed = perf_counter() - start
+    # The same threshold used in the smoke timing test
+    assert elapsed >= 0.009
+    # AI-AGENT-REF: ensure sleep wrapper blocks
+


### PR DESCRIPTION
## Summary
- hard bind `ai_trading.utils.sleep` to the real timing wrapper
- add regression test verifying `utils.sleep` blocks for at least 9ms

## Testing
- `python tools/pycompile_git.py`
- `SKIP_INSTALL=1 make smoke`
- `pytest -n auto --disable-warnings tests/test_utils_timing.py tests/test_runner_smoke.py tests/unit/test_sleep_binding.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab58b62bc0833098b623c67b626ee7