### PR TITLE
ensure repo modules and add alpaca submit_order

### DIFF
--- a/tools/run_pytest.py
+++ b/tools/run_pytest.py
@@ -9,6 +9,7 @@ import logging
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -68,12 +69,29 @@ def build_pytest_cmd(args: argparse.Namespace) -> list[str]:
     return cmd
 
 
+def _ensure_repo_on_path() -> None:
+    """Prepend repository root to sys.path and PYTHONPATH for deterministic imports."""
+    # AI-AGENT-REF: prepend repo root so smoke tests import workspace modules
+    repo_root = Path(__file__).resolve().parent.parent
+    repo_str = str(repo_root)
+    if repo_str not in sys.path:
+        sys.path.insert(0, repo_str)
+    existing = os.environ.get("PYTHONPATH", "")
+    os.environ["PYTHONPATH"] = repo_str if not existing else f"{repo_str}{os.pathsep}{existing}"
+    try:
+        import ai_trading  # type: ignore
+        print(f"[run_pytest] ai_trading path -> {Path(ai_trading.__file__).resolve()}")
+    except Exception as e:  # pragma: no cover - diagnostic only
+        print(f"[run_pytest] ai_trading not importable yet ({e}); pytest will handle it", file=sys.stderr)
+
+
 def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger = logging.getLogger("run_pytest")
+    _ensure_repo_on_path()
     parser = build_parser()
     args = parser.parse_args(argv)
     cmd = build_pytest_cmd(args)
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
-    logger = logging.getLogger("run_pytest")
     # AI-AGENT-REF: echo exact command for smoke test assertions
     logger.info("[run_pytest] %s", " ".join(cmd))
     return subprocess.call(cmd)


### PR DESCRIPTION
## Summary
- ensure tools/run_pytest.py prepends repo root and shows ai_trading import path
- add ai_trading.alpaca_api.submit_order with shadow mode, SDK/HTTP fallback, and HTTP error mapping

## Testing
- `python tools/pycompile_git.py`
- `SKIP_INSTALL=1 make smoke`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS="-p no:faulthandler -p no:randomly -p no:cov -m 'not integration and not slow and not requires_credentials' -k 'not slow'" python tools/run_pytest.py tests` *(fails: missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6516eb808330aae589bc39475c8b