### PR TITLE
fix: export robust sleep in utils

### DIFF
--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -1,8 +1,62 @@
 from __future__ import annotations
 
-# timing helpers for public surface  # AI-AGENT-REF: re-export
-from .timing import HTTP_TIMEOUT, clamp_timeout, sleep  # AI-AGENT-REF: robust sleep
-from .base import (
+"""
+ai_trading.utils (package)
+Ensures deterministic, measurable sleep for tests and workers.
+"""
+
+import os as _os
+from time import perf_counter as _pc, sleep as _os_sleep
+from typing import Union as _Union
+
+# Re-export existing timing utilities from the local timing module
+try:
+    from .timing import (  # type: ignore
+        HTTP_TIMEOUT as HTTP_TIMEOUT,
+        clamp_timeout as clamp_timeout,
+        perf_counter as perf_counter,
+        sleep as _orig_sleep,
+    )
+except Exception:  # pragma: no cover - very defensive
+    HTTP_TIMEOUT = 10.0  # type: ignore[assignment]
+
+    def clamp_timeout(x):  # type: ignore[no-redef]
+        return float(HTTP_TIMEOUT) if (x is None or float(x) < 0) else float(x)
+
+    perf_counter = _pc  # type: ignore[assignment]
+    _orig_sleep = None  # type: ignore[assignment]
+
+
+def _robust_sleep(seconds: _Union[int, float]) -> None:
+    """Block for ~seconds ensuring measurable delay."""  # AI-AGENT-REF: deterministic sleep
+    s = float(seconds)
+    if s <= 0.0:
+        return
+    start = _pc()
+    spin_cap = min(0.050, s)
+    while True:
+        if (_pc() - start) >= spin_cap:
+            break
+    remaining = s - (_pc() - start)
+    if remaining > 0.0:
+        _os_sleep(remaining)
+    while (_pc() - start) < s:
+        pass
+
+
+_force_local = str(_os.getenv("AI_TRADING_FORCE_LOCAL_SLEEP", "1")).lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+if _force_local or _orig_sleep is None:
+    sleep = _robust_sleep  # type: ignore[assignment]
+else:
+    sleep = _orig_sleep  # type: ignore[assignment]
+
+
+from .base import (  # noqa: E402
     EASTERN_TZ,
     ensure_utc,
     get_free_port,
@@ -26,6 +80,7 @@ from . import http  # noqa: F401
 __all__ = [
     "HTTP_TIMEOUT",
     "clamp_timeout",
+    "perf_counter",
     "sleep",
     "EASTERN_TZ",
     "ensure_utc",
@@ -44,3 +99,4 @@ __all__ = [
     "SUBPROCESS_TIMEOUT_DEFAULT",
     "safe_subprocess_run",
 ]
+


### PR DESCRIPTION
## Summary
- prefer `_robust_sleep` when importing `ai_trading.utils`
- expose `perf_counter` and timing helpers from package

## Testing
- `python tools/pycompile_git.py`
- `SKIP_INSTALL=1 make smoke`
- `pytest -n auto --disable-warnings` *(fails: import errors and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ab80fa6088833089ffa38cc901c63d