### PR TITLE
chore: add optional dependency extras and skip tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,27 @@ description = "AI trading bot (lightweight testable build)"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "pandas>=1.5",
   "requests>=2.31",
 ]
 
 [project.optional-dependencies]
-ml = ["scikit-learn>=1.3"]
+pandas = [
+  "pandas>=2.0"
+]
+plot = [
+  "matplotlib>=3.7"
+]
+ml = [
+  "scikit-learn>=1.4",
+  "torch>=2.2 ; platform_system != 'Windows'"
+]
+ta = [
+  "ta>=0.11.0",
+  "TA-Lib>=0.4.26"
+]
+all = [
+  "ai-trading-bot[pandas,plot,ml,ta]"
+]
 test = ["pytest>=7.4", "pytest-cov>=4.1"]
 
 [build-system]

--- a/tests/data_fetcher/test_datetime_narrow_exceptions.py
+++ b/tests/data_fetcher/test_datetime_narrow_exceptions.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 import pytest
 import sys

--- a/tests/execution/test_fetch_minute_df_safe_empty.py
+++ b/tests/execution/test_fetch_minute_df_safe_empty.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 import pytest
 from ai_trading.core.bot_engine import DataFetchError, fetch_minute_df_safe

--- a/tests/helpers/asserts.py
+++ b/tests/helpers/asserts.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 
 
@@ -6,4 +8,3 @@ def assert_df_like(df: pd.DataFrame) -> None:
     assert isinstance(df, pd.DataFrame)
     # When offline, allow empty but with valid columns/index type
     assert hasattr(df, "columns")
-

--- a/tests/optdeps.py
+++ b/tests/optdeps.py
@@ -1,0 +1,14 @@
+import pytest
+
+HINT = {
+    "pandas":       'pip install "ai-trading-bot[pandas]"',
+    "matplotlib":   'pip install "ai-trading-bot[plot]"',
+    "sklearn":      'pip install "ai-trading-bot[ml]"',
+    "torch":        'pip install "ai-trading-bot[ml]"',
+    "ta":           'pip install "ai-trading-bot[ta]"',
+    "talib":        'pip install "ai-trading-bot[ta]"',
+}
+
+def require(pkg: str):
+    """Skip current test module unless `pkg` is importable, with a clear install hint."""
+    return pytest.importorskip(pkg, reason=f"Install with: {HINT.get(pkg, 'pip install ' + pkg)}")

--- a/tests/slow/test_meta_learning_heavy.py
+++ b/tests/slow/test_meta_learning_heavy.py
@@ -1,14 +1,14 @@
+from tests.optdeps import require
+require("pandas")
+require("sklearn")
+require("torch")
 import io
 import types
 
 import pandas as pd
 import pytest
-pytest.importorskip("sklearn", reason="Optional heavy dependency; slow suite")  # AI-AGENT-REF: guard sklearn
 import sklearn.linear_model
-try:
-    pytest.importorskip("torch", reason="Optional heavy dependency; slow suite")  # AI-AGENT-REF: guard torch
-except Exception:
-    pytest.skip("torch import failed", allow_module_level=True)
+import torch
 
 try:
     import pydantic_settings  # noqa: F401

--- a/tests/support/assert_df_like.py
+++ b/tests/support/assert_df_like.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 from pandas import DataFrame
 
 

--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import builtins
 import importlib
 import runpy

--- a/tests/test_alpaca_time_params.py
+++ b/tests/test_alpaca_time_params.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import datetime as dt
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 import types
 from unittest.mock import MagicMock, patch
@@ -66,4 +68,3 @@ def test_minute_normalized(mock_rest_cls):
     args, kwargs = mock_rest.get_bars.call_args
     assert kwargs["timeframe"] in ("1Min", "1Minute")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
-

--- a/tests/test_alpha_quality.py
+++ b/tests/test_alpha_quality.py
@@ -4,6 +4,8 @@ Basic tests for the new alpha quality features.
 Tests cover data leakage prevention, walk-forward analysis,
 slippage calculations, and RL reward penalties.
 """
+from tests.optdeps import require
+require("pandas")
 
 from datetime import timedelta
 from unittest.mock import Mock

--- a/tests/test_backtest_smoke.py
+++ b/tests/test_backtest_smoke.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 from pathlib import Path
 
 import pandas as pd

--- a/tests/test_bars_fallback.py
+++ b/tests/test_bars_fallback.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 from ai_trading.data.bars import _resample_minutes_to_daily
 

--- a/tests/test_bars_timeframe_feed_canonicalization.py
+++ b/tests/test_bars_timeframe_feed_canonicalization.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from tests.optdeps import require
+require("pandas")
+
 import pandas as pd
 from ai_trading.data import bars as bars_mod
 

--- a/tests/test_batch_paths.py
+++ b/tests/test_batch_paths.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import types
 
 import ai_trading.core.bot_engine as be

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import inspect
 
 import numpy as np

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 import types
 from pathlib import Path

--- a/tests/test_bot_engine.py
+++ b/tests/test_bot_engine.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import numpy as np
 import pandas as pd
 

--- a/tests/test_bot_engine_edge_cases.py
+++ b/tests/test_bot_engine_edge_cases.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/test_bot_engine_unit.py
+++ b/tests/test_bot_engine_unit.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import types
 
 import joblib
@@ -117,5 +119,4 @@ def test_run_trading_cycle_empty_df_returns_no_orders():
     ctx = types.SimpleNamespace(api=None)
     df = pd.DataFrame({"price": []})
     assert run_trading_cycle(ctx, df) == []
-
 

--- a/tests/test_bot_extended.py
+++ b/tests/test_bot_extended.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 import types
 from pathlib import Path

--- a/tests/test_conf_size_curve.py
+++ b/tests/test_conf_size_curve.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("numpy")
 import numpy as np
 import pytest
 from ai_trading.strategies.performance_allocator import _compute_conf_multiplier
@@ -19,4 +21,3 @@ def test_monotonic_and_bounds(th, max_boost, gamma):
     assert all(b + 1e-12 >= a for a, b in zip(ys, ys[1:]))
     assert abs(ys[0] - 1.0) < 1e-6
     assert abs(ys[-1] - max_boost) < 1e-6
-

--- a/tests/test_critical_fixes.py
+++ b/tests/test_critical_fixes.py
@@ -7,6 +7,8 @@ Tests for the fixes addressing the critical issues:
 3. Process management enhancements
 4. Data validation functionality
 """
+from tests.optdeps import require
+require("pandas")
 
 from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch

--- a/tests/test_critical_fixes_focused.py
+++ b/tests/test_critical_fixes_focused.py
@@ -2,6 +2,8 @@
 """
 Focused test suite for the critical trading bot fixes per problem statement.
 """
+from tests.optdeps import require
+require("pandas")
 
 import csv
 import os
@@ -246,5 +248,4 @@ def test_rfc3339_timestamp_api_format():
     assert end_param.endswith('Z'), "End timestamp should end with 'Z'"
     assert 'T' in start_param, "Should contain ISO datetime separator 'T'"
     assert '+00:00' not in start_param, "Should not contain +00:00 offset"
-
 

--- a/tests/test_critical_fixes_implementation.py
+++ b/tests/test_critical_fixes_implementation.py
@@ -3,6 +3,8 @@
 Tests the thread safety, memory leak prevention, division by zero protection,
 and other critical fixes for production readiness.
 """
+from tests.optdeps import require
+require("pandas")
 
 import os
 import sys
@@ -327,4 +329,3 @@ if __name__ == "__main__":
     test_dependency_injection()
 
     test_performance_optimizations()
-

--- a/tests/test_critical_fixes_validation.py
+++ b/tests/test_critical_fixes_validation.py
@@ -3,6 +3,8 @@
 Critical fixes validation test for the AI trading bot.
 Tests the 5 major issues identified in the problem statement.
 """
+from tests.optdeps import require
+require("pandas")
 
 import os
 import sys

--- a/tests/test_critical_trading_fixes.py
+++ b/tests/test_critical_trading_fixes.py
@@ -9,6 +9,8 @@ Tests the five main areas of improvement:
 4. Partial Order Management
 5. Order Status Monitoring
 """
+from tests.optdeps import require
+require("pandas")
 
 import csv
 import os

--- a/tests/test_critical_trading_issues.py
+++ b/tests/test_critical_trading_issues.py
@@ -3,6 +3,8 @@
 Critical trading bot issues test suite.
 Tests for order execution tracking, meta-learning log formats, liquidity management.
 """
+from tests.optdeps import require
+require("pandas")
 
 import csv
 import os

--- a/tests/test_daily_bars_datetime_sanitization.py
+++ b/tests/test_daily_bars_datetime_sanitization.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from tests.optdeps import require
+require("pandas")
+
 from datetime import UTC, datetime, timedelta
 
 import pandas as pd
@@ -52,4 +55,3 @@ def test_daily_request_sanitizes_inputs(monkeypatch):
 
     assert calls["n"] == 2
     assert result is None
-

--- a/tests/test_daily_sanitization_retry.py
+++ b/tests/test_daily_sanitization_retry.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from tests.optdeps import require
+require("pandas")
+
 import ai_trading.core.bot_engine as be_mod
 import pandas as pd
 from ai_trading.core.bot_engine import DataFetcher
@@ -37,4 +40,3 @@ def test_daily_retry_handles_callable(monkeypatch):
     df = DataFetcher().get_daily_df(None, "SPY")
     assert calls["n"] == 2
     assert df is not None
-

--- a/tests/test_daily_sanitize_debug.py
+++ b/tests/test_daily_sanitize_debug.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from tests.optdeps import require
+require("pandas")
+
 import types
 
 import pandas as pd
@@ -38,4 +41,3 @@ def test_callable_triggers_single_debug(monkeypatch, caplog):
 
     records = [r for r in caplog.records if r.message == "DAILY_BARS_INPUT_SANITIZED"]
     assert len(records) == 1
-

--- a/tests/test_data_cache.py
+++ b/tests/test_data_cache.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import time
 
 import pandas as pd

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import datetime
 import os
 import sys

--- a/tests/test_data_fetcher_datetime.py
+++ b/tests/test_data_fetcher_datetime.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 from datetime import UTC, datetime
 from pathlib import Path

--- a/tests/test_data_fetcher_extended.py
+++ b/tests/test_data_fetcher_extended.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import datetime
 import types
 

--- a/tests/test_data_fetcher_fallbacks.py
+++ b/tests/test_data_fetcher_fallbacks.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import datetime as dt
 
 import pandas as pd

--- a/tests/test_data_fetcher_init.py
+++ b/tests/test_data_fetcher_init.py
@@ -1,6 +1,8 @@
 """Tests for data_fetcher.build_fetcher initialization paths."""  # AI-AGENT-REF
-
 from __future__ import annotations
+
+from tests.optdeps import require
+require("pandas")
 
 import pandas as pd
 
@@ -68,4 +70,3 @@ def test_build_fetcher_offline_returns_empty_df(monkeypatch):
     df = fetcher.get_daily_df(object(), "SPY")
     assert isinstance(df, pd.DataFrame)
     assert df.empty
-

--- a/tests/test_data_fetcher_timezone.py
+++ b/tests/test_data_fetcher_timezone.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 import types
 from datetime import UTC, datetime
@@ -57,4 +59,3 @@ def test_yahoo_get_bars_accepts_various_datetime_types(monkeypatch):
         "1Day",
     )
     assert not df4.empty and df4["timestamp"].dt.tz is not None
-

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 from ai_trading.features import compute_macd, compute_macds, ensure_columns
 

--- a/tests/test_enhanced_signals.py
+++ b/tests/test_enhanced_signals.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import numpy as np
 import pandas as pd
 

--- a/tests/test_equity_curve.py
+++ b/tests/test_equity_curve.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 
 

--- a/tests/test_fallback_concurrency.py
+++ b/tests/test_fallback_concurrency.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import threading
 import time
 import types

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 import types
 

--- a/tests/test_fetch_and_screen.py
+++ b/tests/test_fetch_and_screen.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import datetime as dt
 import sys
 import types

--- a/tests/test_fetch_contract.py
+++ b/tests/test_fetch_contract.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import os
 import sys
 import types
@@ -49,4 +51,3 @@ def test_get_bars_never_none(monkeypatch):
         "volume",
     ]
     assert str(result["timestamp"].dt.tz) == "UTC"
-

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -3,6 +3,8 @@
 Test script to validate the trading bot fixes.
 This script tests the expanded ticker portfolio and TA-Lib fallback handling.
 """
+from tests.optdeps import require
+require("pandas")
 
 import csv
 import os

--- a/tests/test_grid_sanity.py
+++ b/tests/test_grid_sanity.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 import types
 from pathlib import Path
@@ -265,4 +267,3 @@ def test_health_check_succeeds(monkeypatch):
     })
     ctx = DummyCtx(df)
     pre_trade_health_check(ctx, ["AAA"])
-

--- a/tests/test_healthcheck_minute_fallback.py
+++ b/tests/test_healthcheck_minute_fallback.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import logging
 from types import SimpleNamespace
 

--- a/tests/test_healthcheck_minute_fallback_handles_none.py
+++ b/tests/test_healthcheck_minute_fallback_handles_none.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 from ai_trading.core.bot_engine import _ensure_df
 
@@ -10,4 +12,3 @@ def test_ensure_df_none_and_dict():
     df = _ensure_df(d)
     assert isinstance(df, pd.DataFrame)
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
-

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 
 import pandas as pd
 
@@ -42,4 +44,3 @@ def test_vwap_calculation():
     volume = pd.Series([1000, 1100, 1200])
     vwap = calculate_vwap(high, low, close, volume)
     assert vwap.iloc[-1] > 0
-

--- a/tests/test_initial_rebalance.py
+++ b/tests/test_initial_rebalance.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import datetime
 import types
 

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 import types
 from pathlib import Path

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("numpy")
 import json
 import logging
 

--- a/tests/test_mean_reversion_extra.py
+++ b/tests/test_mean_reversion_extra.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 from ai_trading.strategies.mean_reversion import MeanReversionStrategy
 
@@ -33,5 +35,4 @@ def test_generate_invalid_stats(caplog):
     ctx.data_fetcher.df.loc[ctx.data_fetcher.df.index[-1], "close"] = float('nan')
     assert strat.generate(ctx) == []
     assert "invalid rolling" in caplog.text
-
 

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -1,12 +1,12 @@
+from tests.optdeps import require
+require("numpy")
+require("torch")
 import types
 
 import numpy as np
 import pytest
-try:
-    pytest.importorskip("torch", reason="Optional heavy dependency; guard at import time")
-    from torch import nn
-except Exception:
-    pytest.skip("torch import failed", allow_module_level=True)
+import torch
+from torch import nn
 
 np.random.seed(0)
 
@@ -159,7 +159,6 @@ def test_update_signal_weights_norm_zero(caplog):
 
 
 def test_portfolio_rl_trigger(monkeypatch):
-    torch = pytest.importorskip("torch")
     # AI-AGENT-REF: ensure real torch is loaded during tests
     # if not hasattr(torch, "nn") or not hasattr(torch.nn, "Parameter"):
     #     pytest.skip("torch stubs active")

--- a/tests/test_meta_learning_additional.py
+++ b/tests/test_meta_learning_additional.py
@@ -1,9 +1,11 @@
+from tests.optdeps import require
+require("numpy")
+require("sklearn")
 import types
 from pathlib import Path
 
 import numpy as np
 import pytest
-pytest.importorskip("sklearn", reason="Optional heavy dependency; guard at import time")  # AI-AGENT-REF: guard sklearn
 import sklearn.linear_model
 from ai_trading import meta_learning
 

--- a/tests/test_meta_learning_module.py
+++ b/tests/test_meta_learning_module.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("numpy")
 import json
 import sys
 from pathlib import Path

--- a/tests/test_metalearning_strategy.py
+++ b/tests/test_metalearning_strategy.py
@@ -2,6 +2,8 @@
 """
 Test suite for MetaLearning strategy.
 """
+from tests.optdeps import require
+require("pandas")
 
 import os
 from datetime import UTC, datetime, timedelta
@@ -302,4 +304,3 @@ if __name__ == '__main__':
 
     if success:
         prediction = strategy.predict_price_movement(mock_data)
-

--- a/tests/test_minute_fallback_none_safe.py
+++ b/tests/test_minute_fallback_none_safe.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import types
 
 import ai_trading.data.bars as data_bars

--- a/tests/test_ml_model_extra.py
+++ b/tests/test_ml_model_extra.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 from pathlib import Path
 

--- a/tests/test_ml_model_loading.py
+++ b/tests/test_ml_model_loading.py
@@ -1,10 +1,12 @@
+from tests.optdeps import require
+require("numpy")
+require("sklearn")
 import pickle
 import sys
 import types
 
 import numpy as np
 import pytest
-pytest.importorskip("sklearn", reason="Optional heavy dependency; guard at import time")  # AI-AGENT-REF: guard sklearn
 
 # AI-AGENT-REF: Replaced unsafe _raise_dynamic_exec_disabled() with direct imports from core module
 from ai_trading.core.bot_engine import _load_ml_model

--- a/tests/test_ml_model_validation.py
+++ b/tests/test_ml_model_validation.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 from pathlib import Path
 

--- a/tests/test_model_registry_roundtrip.py
+++ b/tests/test_model_registry_roundtrip.py
@@ -1,10 +1,12 @@
 """Test model registry register → latest_for → load_model workflow."""
+from tests.optdeps import require
+require("numpy")
+require("sklearn")
 
 import tempfile
 
 import numpy as np
 import pytest
-pytest.importorskip("sklearn", reason="Optional heavy dependency; guard at import time")  # AI-AGENT-REF: guard sklearn
 from ai_trading.model_registry import ModelRegistry
 from sklearn.linear_model import LinearRegression
 

--- a/tests/test_momentum_extra.py
+++ b/tests/test_momentum_extra.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 from ai_trading.strategies import momentum
 from ai_trading.strategies.momentum import MomentumStrategy

--- a/tests/test_moving_average_crossover_extra.py
+++ b/tests/test_moving_average_crossover_extra.py
@@ -1,4 +1,6 @@
 """Tests for moving average crossover strategy."""
+from tests.optdeps import require
+require("pandas")
 
 import pandas as pd
 from ai_trading.strategies.moving_average_crossover import (

--- a/tests/test_parallel_speed.py
+++ b/tests/test_parallel_speed.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import time
 
 import pandas as pd

--- a/tests/test_peak_performance.py
+++ b/tests/test_peak_performance.py
@@ -2,6 +2,8 @@
 """
 Tests for peak performance hardening modules.
 """
+from tests.optdeps import require
+require("pandas")
 
 from datetime import UTC, datetime
 

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import importlib
 import sys
 import types

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import types
 
 import pandas as pd

--- a/tests/test_predict_smoke.py
+++ b/tests/test_predict_smoke.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import importlib
 import sys
 import types

--- a/tests/test_price_snapshot_minute_fallback.py
+++ b/tests/test_price_snapshot_minute_fallback.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 from types import SimpleNamespace
 
 import pandas as pd
@@ -27,4 +29,3 @@ def test_price_snapshot_minute_fallback(monkeypatch):
 
     price = portfolio_core.get_latest_price(ctx, "SPY")
     assert price == 123.0
-

--- a/tests/test_production_fixes.py
+++ b/tests/test_production_fixes.py
@@ -8,6 +8,8 @@ This test suite validates the four main fixes:
 3. Market-aware data staleness thresholds
 4. Enhanced environment debugging capabilities
 """
+from tests.optdeps import require
+require("pandas")
 
 import os
 import sys

--- a/tests/test_property_based.py
+++ b/tests/test_property_based.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import sys
 from pathlib import Path
 

--- a/tests/test_regime_and_schema_guard.py
+++ b/tests/test_regime_and_schema_guard.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 import pytest
 

--- a/tests/test_regime_filters.py
+++ b/tests/test_regime_filters.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 import pytest
 

--- a/tests/test_resample_daily.py
+++ b/tests/test_resample_daily.py
@@ -1,4 +1,6 @@
 """Test minute-to-daily resampling fallback."""
+from tests.optdeps import require
+require("pandas")
 
 from datetime import UTC, datetime
 
@@ -43,4 +45,3 @@ def test_get_daily_bars_resamples_minutes(monkeypatch):
     assert not out.empty
     assert len(out) == 1
     assert float(out.iloc[0]["open"]) == 1
-

--- a/tests/test_retrain_smoke.py
+++ b/tests/test_retrain_smoke.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import importlib
 import sys
 import types

--- a/tests/test_risk_engine_additional.py
+++ b/tests/test_risk_engine_additional.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("numpy")
 
 import ai_trading.risk.engine as risk_engine  # AI-AGENT-REF: normalized import
 import numpy as np

--- a/tests/test_risk_engine_module.py
+++ b/tests/test_risk_engine_module.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("numpy")
 import sys
 import types
 from pathlib import Path

--- a/tests/test_risk_new.py
+++ b/tests/test_risk_new.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import ai_trading.risk.engine as risk_engine  # AI-AGENT-REF: normalized import
 import pandas as pd
 

--- a/tests/test_rl_features.py
+++ b/tests/test_rl_features.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import numpy as np
 import pandas as pd
 from ai_trading.rl_trading.features import FeatureConfig, compute_features

--- a/tests/test_rl_module.py
+++ b/tests/test_rl_module.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("numpy")
 import ai_trading.rl_trading.inference as inf
 import ai_trading.rl_trading.train as train_mod
 import numpy as np

--- a/tests/test_run_strategy_no_signals.py
+++ b/tests/test_run_strategy_no_signals.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 from types import SimpleNamespace
 
 import pandas as pd

--- a/tests/test_safety_fallbacks.py
+++ b/tests/test_safety_fallbacks.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import os
 
 import pandas as pd

--- a/tests/test_short_selling_implementation.py
+++ b/tests/test_short_selling_implementation.py
@@ -3,6 +3,8 @@
 Focused test for short selling implementation.
 Tests the specific changes needed to enable short selling capability.
 """
+from tests.optdeps import require
+require("pandas")
 
 import os
 import sys

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import importlib
 import sys
 import types
@@ -88,4 +90,3 @@ def test_composite_signal_confidence(monkeypatch):
     assert final == 1
     assert conf == pytest.approx(2.6)
     assert 'ml' in label
-

--- a/tests/test_signals_multi_horizon.py
+++ b/tests/test_signals_multi_horizon.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 from ai_trading.indicators import (
     compute_atr,

--- a/tests/test_signals_scoring.py
+++ b/tests/test_signals_scoring.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import numpy as np
 import pandas as pd
 from ai_trading import signals
@@ -16,4 +18,3 @@ def test_score_candidates_predict_proba():
     out = signals.score_candidates(X, _DummyProba())
     assert "score" in out.columns
     assert out["score"].between(0, 1).all()
-

--- a/tests/test_skip_logic.py
+++ b/tests/test_skip_logic.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import types
 
 import pandas as pd

--- a/tests/test_slippage.py
+++ b/tests/test_slippage.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 
 

--- a/tests/test_staleness_guard.py
+++ b/tests/test_staleness_guard.py
@@ -1,6 +1,8 @@
 """
 Tests for data staleness guard functionality.
 """
+from tests.optdeps import require
+require("pandas")
 import datetime
 from unittest.mock import Mock
 

--- a/tests/test_strategy_components.py
+++ b/tests/test_strategy_components.py
@@ -4,6 +4,8 @@ Test for advanced strategy components - multi-timeframe analysis and regime dete
 Tests the functionality of the new strategy modules without requiring
 full market data or external dependencies.
 """
+from tests.optdeps import require
+require("pandas")
 
 import asyncio
 import os

--- a/tests/test_stubs_and_prices.py
+++ b/tests/test_stubs_and_prices.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 
 

--- a/tests/test_time_utc_now.py
+++ b/tests/test_time_utc_now.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 
 
@@ -6,4 +8,3 @@ def test_now_is_aware_utc():
     now_utc = pd.Timestamp.now(tz="UTC")
     assert now_utc.tz is not None
     assert str(now_utc.tz) in {"UTC", "+00:00"}
-

--- a/tests/test_trade_logic.py
+++ b/tests/test_trade_logic.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 from ai_trading.trade_logic import (
     compute_order_price,

--- a/tests/test_universe_csv.py
+++ b/tests/test_universe_csv.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("pandas")
 import pandas as pd
 from ai_trading.data.universe import load_universe, locate_tickers_csv
 

--- a/tests/test_yf_auto_adjust_and_cache.py
+++ b/tests/test_yf_auto_adjust_and_cache.py
@@ -1,4 +1,6 @@
 """Ensure yfinance fallback sets auto_adjust and TzCache."""
+from tests.optdeps import require
+require("pandas")
 
 import sys
 import types
@@ -32,4 +34,3 @@ def test_yfinance_auto_adjust_and_cache(monkeypatch):
 
     assert calls["auto_adjust"] is True
     assert calls["cache_called"] is True
-

--- a/tests/unit/test_data_fetcher_http.py
+++ b/tests/unit/test_data_fetcher_http.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from tests.optdeps import require
+require("pandas")
+
 import json
 from datetime import UTC, datetime, timedelta
 
@@ -118,4 +121,3 @@ def test_empty_bars_fallback(monkeypatch: pytest.MonkeyPatch):
     out = df.get_bars("TEST", timeframe="1Min", start=start, end=end, feed="iex", adjustment="raw")
     assert isinstance(out, pd.DataFrame) and not out.empty
     assert calls["count"] >= 2
-

--- a/tests/unit/test_features_pipeline_narrowing.py
+++ b/tests/unit/test_features_pipeline_narrowing.py
@@ -1,6 +1,8 @@
 """Tests for narrowed exceptions in feature pipeline."""
-
 from __future__ import annotations
+
+from tests.optdeps import require
+require("pandas")
 
 import pandas as pd
 import pytest

--- a/tests/unit/test_obv_vectorized.py
+++ b/tests/unit/test_obv_vectorized.py
@@ -1,3 +1,5 @@
+from tests.optdeps import require
+require("numpy")
 import numpy as np
 from ai_trading.indicators import obv as obv_vec
 
@@ -24,4 +26,3 @@ def test_obv_vectorized_matches_reference_loop():
         assert got.shape == ref.shape
         # exact equality holds for OBV semantics
         assert np.allclose(got, ref, atol=0.0)
-

--- a/tests/unit/test_sanitize_edges.py
+++ b/tests/unit/test_sanitize_edges.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from tests.optdeps import require
+require("pandas")
+
 import pandas as pd
 
 from ai_trading.data.sanitize import DataSanitizer, SanitizationConfig
@@ -33,4 +36,3 @@ def test_sanitize_flags_negative_prices_and_low_volume():
     assert report["original_count"] == 5
     assert 0 <= report["cleaned_count"] <= 5
     assert report["rejected_count"] >= 1
-


### PR DESCRIPTION
## Summary
- add packaging extras for pandas, plotting, ml, ta and aggregated all
- introduce `tests/optdeps.require` helper and guard tests using optional libraries
- ensure tests requiring optional libs skip with install hints when deps missing

## Testing
- `python tools/pycompile_git.py`
- `SKIP_INSTALL=1 make smoke`
- `pytest -q tests/test_backtest_smoke.py`
- `pytest -q tests/test_meta_learning.py`
- `pytest -q tests/slow/test_meta_learning_heavy.py`
- `pytest -n auto --disable-warnings` *(fails: unrecognized arguments -n)*

------
https://chatgpt.com/codex/tasks/task_e_68abb707ff5083309a3cca61830fabce