### PR TITLE
docs: document extras and improve opt-dep hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,41 @@ python --version  # Should output: Python 3.12.3
 python health_check.py
 ```
 
+### Install extras (feature sets)
+Some functionality depends on optional libraries. Install only what you need:
+
+```bash
+# Data wrangling & CSV/Parquet I/O
+pip install "ai-trading-bot[pandas]"
+
+# Plotting
+pip install "ai-trading-bot[plot]"
+
+# Machine learning (scikit-learn + PyTorch)
+pip install "ai-trading-bot[ml]"
+
+# Technical indicators (ta + TA-Lib)
+pip install "ai-trading-bot[ta]"
+
+# Everything
+pip install "ai-trading-bot[all]"
+```
+
+| Feature / Area       | Extra    | Packages (summary)           |
+|----------------------|----------|------------------------------|
+| DataFrames & I/O     | `pandas` | `pandas`                     |
+| Plotting             | `plot`   | `matplotlib`                 |
+| Machine Learning     | `ml`     | `scikit-learn`, `torch`      |
+| Technical Indicators | `ta`     | `ta`, `TA-Lib`               |
+
+> **Notes**
+> - **TA-Lib** may require system libraries/headers. See the TA-Lib docs for platform-specific instructions before installing `ai-trading-bot[ta]`.
+> - **PyTorch** wheels vary by CUDA/CPU and OS. If the default marker doesn’t suit your platform, follow the official instructions at [pytorch.org](https://pytorch.org) and/or install `torch` first, then `ai-trading-bot[ml]`.
+
+When a feature is used without its optional dependency, the code raises a helpful error like:
+
+> Missing optional dependency 'pandas'. Install with: `pip install "ai-trading-bot[pandas]"`
+
 ### Manual Installation
 
 If you prefer manual setup or encounter issues with the automated process:

--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -141,8 +141,7 @@ def _require_pandas(consumer: str = "this function"):
             "pandas",
             required=True,
             purpose=consumer,
-            extra="pip install pandas",
-        )
+        )  # AI-AGENT-REF: extras hint derived automatically
         return pd  # type: ignore[return-value]
     return pd
 

--- a/ai_trading/backtesting/grid_runner.py
+++ b/ai_trading/backtesting/grid_runner.py
@@ -8,8 +8,8 @@ from typing import Any
 from ai_trading.utils import optional_import, module_ok  # AI-AGENT-REF: unify optional deps
 
 _joblib = optional_import(
-    "joblib", purpose="parallel grid search", extra='pip install "ai-trading-bot[backtest]"'
-)
+    "joblib", purpose="parallel grid search", extra="backtest"
+)  # AI-AGENT-REF: extras hint uses key
 if module_ok(_joblib):  # joblib available
     Parallel = _joblib.Parallel
     delayed = _joblib.delayed

--- a/ai_trading/indicators.py
+++ b/ai_trading/indicators.py
@@ -10,8 +10,8 @@ from ai_trading.utils import optional_import, module_ok  # AI-AGENT-REF: unify o
 logger = logging.getLogger(__name__)
 
 _numba = optional_import(
-    "numba", purpose="speeding up indicators", extra='pip install "ai-trading-bot[fast]"'
-)
+    "numba", purpose="speeding up indicators", extra="fast"
+)  # AI-AGENT-REF: extras hint uses key
 _numba_jit = getattr(_numba, "jit", None) if module_ok(_numba) else None
 
 def jit(*args, **kwargs):

--- a/ai_trading/plotting/renderer.py
+++ b/ai_trading/plotting/renderer.py
@@ -20,18 +20,18 @@ OptionalDependencyError = _optdeps.OptionalDependencyError
 plt = optional_import(
     "matplotlib.pyplot",
     purpose="plotting results",
-    extra='pip install "ai-trading-bot[plot]"',
-)
+    extra="plot",
+)  # AI-AGENT-REF: extras hint uses key
 
 
 def render_equity_curve(series, *, title: str = "Equity") -> None:
     """Render a simple equity curve using matplotlib if available."""
     if not module_ok(plt):
         raise OptionalDependencyError(
-            name="matplotlib",
-            purpose="plotting",
-            extra='pip install "ai-trading-bot[plot]"',
-        )
+            "matplotlib",
+            feature="plotting",
+            extra="plot",
+        )  # AI-AGENT-REF: extras hint uses key
     plt.figure()
     plt.plot(series)
     plt.title(title)

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -19,8 +19,8 @@ from ai_trading.config import get_settings
 from ai_trading.exc import COMMON_EXC
 from ai_trading.utils import optional_import, module_ok  # AI-AGENT-REF: unify optional deps
 _mcal = optional_import(
-    "pandas_market_calendars", purpose="market calendars", extra='pip install "ai-trading-bot[cal]"'
-)
+    "pandas_market_calendars", purpose="market calendars", extra="cal"
+)  # AI-AGENT-REF: extras hint uses key
 mcal = _mcal if module_ok(_mcal) else None
 import numpy as np
 from ai_trading.monitoring.system_health import snapshot_basic

--- a/ai_trading/utils/optdeps.py
+++ b/ai_trading/utils/optdeps.py
@@ -4,55 +4,94 @@ from __future__ import annotations
 
 from importlib import import_module
 from types import ModuleType
-from typing import Any, Optional
-from dataclasses import dataclass
+from typing import Any, Mapping, Optional
 
 __all__ = ["optional_import", "module_ok", "OptionalDependencyError"]
 
 
-# AI-AGENT-REF: centralized optional dependency error
-@dataclass
+# AI-AGENT-REF: map modules to extras for install hints
+_EXTRAS_BY_PKG: Mapping[str, str] = {
+    "pandas": "pandas",
+    "matplotlib": "plot",
+    "sklearn": "ml",
+    "torch": "ml",
+    "ta": "ta",
+    "talib": "ta",
+}
+
+
+# AI-AGENT-REF: extras-aware optional dependency error
 class OptionalDependencyError(ImportError):
-    """Clear error for missing optional packages."""
+    def __init__(
+        self,
+        package: str,
+        *,
+        extra: Optional[str] = None,
+        feature: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        """Clear error for missing optional packages with install hint."""
 
-    name: str
-    purpose: Optional[str] = None
-    extra: Optional[str] = None
-
-    def __str__(self) -> str:  # pragma: no cover - trivial
-        bits = [f"Missing optional dependency: {self.name}."]
-        if self.purpose:
-            bits.append(f"Needed for: {self.purpose}.")
-        if self.extra:
-            bits.append(f"Install with: {self.extra}")
+        if message:
+            msg = message
         else:
-            bits.append(f"Try: pip install {self.name}")
-        return " ".join(bits)
+            if extra:
+                hint = (
+                    extra
+                    if extra.strip().startswith("pip ")
+                    else f'pip install "ai-trading-bot[{extra}]"'
+                )
+            else:
+                hint = f"pip install {package}"
+            suffix = f" for {feature}" if feature else ""
+            msg = f"Missing optional dependency '{package}'{suffix}. Install with: {hint}"
+        super().__init__(msg)
+        self.package = package
+        self.name = package  # back-compat
+        self.extra = extra
+        self.feature = feature
+        self.purpose = feature  # back-compat
 
 
+# AI-AGENT-REF: derive extras hints on optional imports
 def optional_import(
     name: str,
     *,
     required: bool = False,
     attr: Optional[str] = None,
-    purpose: Optional[str] = None,
+    message: Optional[str] = None,
     extra: Optional[str] = None,
+    feature: Optional[str] = None,
+    purpose: Optional[str] = None,
 ) -> Any | None:
     """Import a module (and optionally attribute) if available."""
 
+    feature = feature or purpose
     try:
         mod = import_module(name)
-    except Exception as e:  # ImportError / ModuleNotFoundError
+    except Exception:
         if required:
-            raise OptionalDependencyError(name=name, purpose=purpose, extra=extra) from e
+            resolved_extra = extra or _EXTRAS_BY_PKG.get(name)
+            raise OptionalDependencyError(
+                name,
+                extra=resolved_extra,
+                feature=feature,
+                message=message,
+            )
         return None
 
     if attr:
         try:
             return getattr(mod, attr)
-        except AttributeError as e:
+        except AttributeError:
             if required:
-                raise OptionalDependencyError(name=name, purpose=purpose, extra=extra) from e
+                resolved_extra = extra or _EXTRAS_BY_PKG.get(name)
+                raise OptionalDependencyError(
+                    name,
+                    extra=resolved_extra,
+                    feature=feature,
+                    message=message,
+                )
             return None
     return mod
 
@@ -60,3 +99,4 @@ def optional_import(
 def module_ok(mod: Optional[ModuleType | Any]) -> bool:
     """Return True if module/object is not None."""
     return mod is not None
+

--- a/tests/test_utils_optdeps.py
+++ b/tests/test_utils_optdeps.py
@@ -32,18 +32,28 @@ def test_optional_import_absent_module_returns_none():
 
 
 def test_required_raises_clear_message(monkeypatch):
+    # AI-AGENT-REF: ensure extras hint surfaces
     monkeypatch.setitem(sys.modules, "totally_missing_pkg", None)
     with pytest.raises(OptionalDependencyError) as ei:
         optional_import(
             "totally_missing_pkg",
             required=True,
             purpose="demo",
-            extra='pip install "ai-trading-bot[demo]"',
+            extra="demo",
         )
     msg = str(ei.value)
-    assert "Missing optional dependency: totally_missing_pkg." in msg
-    assert "Needed for: demo." in msg
+    assert "Missing optional dependency 'totally_missing_pkg'" in msg
+    assert "for demo" in msg
     assert 'Install with: pip install "ai-trading-bot[demo]"' in msg
+
+
+def test_auto_derives_extra(monkeypatch):
+    # AI-AGENT-REF: derive extras without explicit hint
+    monkeypatch.setitem(sys.modules, "pandas", None)
+    with pytest.raises(OptionalDependencyError) as ei:
+        optional_import("pandas", required=True)
+    msg = str(ei.value)
+    assert 'pip install "ai-trading-bot[pandas]"' in msg
 
 
 def test_render_equity_curve_handles_missing_matplotlib(monkeypatch):


### PR DESCRIPTION
## Summary
- document optional install extras in README with feature table and notes
- map packages to extras and emit extras-aware OptionalDependencyError hints
- test optional_import derives extras automatically

## Testing
- `python tools/pycompile_git.py`
- `SKIP_INSTALL=1 make smoke`
- `pytest -q tests/test_utils_optdeps.py`
- `python - <<'PY' ...` (manual OptionalDependencyError demo)


------
https://chatgpt.com/codex/tasks/task_e_68abb96ed95c83309b9b5dd587513422