### PR TITLE
refactor: add env helper and drop pytz

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -17,8 +17,6 @@ from ai_trading.utils.optdeps import optional_import  # AI-AGENT-REF: unify opti
 
 # Optional deps via helper keep imports lightweight
 pd = optional_import("pandas")  # -> module or None
-ZoneInfo = optional_import("zoneinfo", attr="ZoneInfo")
-_pytz = optional_import("pytz")
 TimeFrame = optional_import("alpaca_trade_api.rest", attr="TimeFrame")
 TimeFrameUnit = (
     optional_import("alpaca_trade_api.rest", attr="TimeFrameUnit")
@@ -33,24 +31,15 @@ RETRYABLE_HTTP_STATUSES = tuple(RETRY_HTTP_CODES)
 _UTC = timezone.utc  # AI-AGENT-REF: prefer stdlib UTC
 
 
-# AI-AGENT-REF: timezone fallback chain
-def _eastern_tz():
-    """Return America/New_York tzinfo with zoneinfo or pytz."""
-    if _pytz is not None:
-        try:
-            return _pytz.timezone("America/New_York")
-        except Exception:
-            pass
-    if ZoneInfo is not None:
-        try:
-            return ZoneInfo("America/New_York")
-        except Exception:
-            pass
-    _log.debug("Falling back to UTC tzinfo for EASTERN_TZ (pytz/zoneinfo unavailable)")
-    return timezone.utc
+from zoneinfo import ZoneInfo
 
 
-EASTERN_TZ = _eastern_tz()
+def eastern_tz() -> ZoneInfo:
+    """Return America/New_York tzinfo using stdlib zoneinfo (Py3.12)."""
+    return ZoneInfo("America/New_York")  # AI-AGENT-REF: rely solely on stdlib
+
+
+EASTERN_TZ = eastern_tz()
 HAS_PANDAS: bool = bool(pd is not None)  # AI-AGENT-REF: expose pandas availability
 
 def _is_intraday_unit(unit_tok: str) -> bool:

--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
-from typing import Optional, Dict, Any, Tuple
+from typing import Any, Callable, Dict, Optional, TypeVar
 
 # Authoritative runtime settings come from ai_trading.config.settings (which
 # re-exports _base_get_settings from ai_trading.settings in this repo).
@@ -10,11 +11,52 @@ from ai_trading.config.settings import get_settings
 # Single source of truth for capital sizing math.
 from ai_trading.utils.capital_scaling import derive_cap_from_settings as _derive_cap_from_settings
 
+T = TypeVar("T")
+
+
+def _to_bool(s: str) -> bool:
+    return s.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def get_env(
+    key: str,
+    default: Optional[str] = None,
+    *,
+    cast: Optional[Callable[[str], T]] = None,
+    required: bool = False,
+) -> T | str | None:
+    """Fetch an environment variable with optional casting and required check.
+
+    AI-AGENT-REF: typed env access helper
+    Assumes dotenv was already loaded by the top-level startup code.
+    """
+    raw = os.environ.get(key, default)
+    if raw is None:
+        if required:
+            raise RuntimeError(f"Missing required environment variable: {key}")
+        return None
+    if cast is None:
+        return raw
+    if cast is bool:
+        return _to_bool(str(raw))  # type: ignore[return-value]
+    try:
+        return cast(raw)  # type: ignore[misc]
+    except Exception as e:  # noqa: BLE001
+        raise RuntimeError(
+            f"Failed to cast env var {key!r}={raw!r} via {cast}: {e}"
+        ) from e
+
+
+# Canonical runtime seed used by risk/engine and anywhere else needing determinism.
+SEED: int = int(os.environ.get("SEED", "42"))  # AI-AGENT-REF: expose runtime seed
+
 
 __all__ = [
     "TradingConfig",
     "get_settings",
     "derive_cap_from_settings",
+    "get_env",
+    "SEED",
 ]
 
 
@@ -25,6 +67,7 @@ class TradingConfig:
     We do not guess new fields. Only fields observed in code/logs are exposed.
     Values are sourced from central settings via `from_env()`.
     """
+    seed: int = SEED  # AI-AGENT-REF: propagate runtime seed
     enable_finbert: bool = False
     # Legacy sizing knobs are optional; if absent, we read them from central settings.
     capital_cap: Optional[float] = None
@@ -36,6 +79,7 @@ class TradingConfig:
         s = get_settings()
         # We only materialize what's referenced in code/logs; everything else stays in `s`.
         return cls(
+            seed=SEED,
             enable_finbert=bool(getattr(s, "enable_finbert", False)),
             capital_cap=(getattr(s, "capital_cap", None)),
             dollar_risk_limit=(getattr(s, "dollar_risk_limit", None)),

--- a/ai_trading/utils/dependency_check.py
+++ b/ai_trading/utils/dependency_check.py
@@ -12,8 +12,8 @@ _CORE = [
     "numpy",
     "pandas",
     "pydantic",
-    "pytz",
 ]
+# AI-AGENT-REF: removed pytz; stdlib zoneinfo covers timezone needs
 
 
 def assert_core_dependencies() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ai-trading-bot"
 version = "0.0.0"
 description = "AI trading bot (lightweight testable build)"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
   "numpy==1.26.4",
   "pandas==2.2.2",
@@ -44,11 +44,11 @@ exclude = ["tests*", "scripts*", "artifacts*"]
 
 [tool.black]
 line-length = 120
-target-version = ["py311"]
+target-version = ["py312"]
 
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 line-length = 100
 src = ["ai_trading", "trade_execution", "tests", "tools"]
 extend-exclude = ["**/.venv", "**/venv", "build", "dist", "notebooks", "artifacts", "tools/static_import_rewrites.txt"]

--- a/scripts/check_feed.py
+++ b/scripts/check_feed.py
@@ -1,12 +1,12 @@
 """Small diagnostic to verify market data fetch."""
 from types import SimpleNamespace
 import pandas as pd
-import pytz
+from zoneinfo import ZoneInfo  # AI-AGENT-REF: use stdlib zoneinfo
 from ai_trading.core.runtime import build_runtime
 from ai_trading.data.bars import safe_get_stock_bars
 if __name__ == '__main__':
     rt = build_runtime(SimpleNamespace())
-    now = pd.Timestamp.now(tz='UTC')
+    now = pd.Timestamp.now(tz=ZoneInfo("UTC"))
     start = now - pd.Timedelta(days=120)
     client = getattr(rt, 'data_client', SimpleNamespace(get_stock_bars=lambda req: SimpleNamespace(df=pd.DataFrame())))
     df = safe_get_stock_bars(client, None, 'SPY', '1Day')

--- a/tests/institutional/test_live_trading.py
+++ b/tests/institutional/test_live_trading.py
@@ -10,7 +10,7 @@ import datetime as dt
 import os
 
 import pytest
-import pytz
+from zoneinfo import ZoneInfo  # AI-AGENT-REF: drop pytz for stdlib zoneinfo
 
 pytestmark = pytest.mark.alpaca
 
@@ -271,7 +271,7 @@ class TestTradingBotIntegration:
         """Test full system integration with all components."""
         if not (os.getenv('ALPACA_API_KEY_ID') and os.getenv('ALPACA_API_SECRET_KEY')):
             pytest.skip('ALPACA credentials required for integration test')
-        now = dt.datetime.now(pytz.timezone('US/Eastern'))
+        now = dt.datetime.now(ZoneInfo("America/New_York"))  # AI-AGENT-REF: use stdlib zoneinfo
         if now.weekday() >= 5 or not (dt.time(9, 30) <= now.time() <= dt.time(16, 0)):
             pytest.skip('Market closed')
         # This would test the integration of:

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -57,8 +57,7 @@ if not hasattr(sys.modules["pandas_market_calendars"], "get_calendar"):
     sys.modules["pandas_market_calendars"].get_calendar = MagicMock()
 
 mods = [
-    "pytz",
-    "tzlocal",
+    "tzlocal",  # AI-AGENT-REF: pytz no longer required
     "requests",
     "urllib3",
     "bs4",


### PR DESCRIPTION
## Summary
- add get_env helper and SEED constant in config management, including seed in TradingConfig
- target Python 3.12 for packaging and tooling
- switch remaining pytz usage to stdlib zoneinfo and drop pytz from dependency checks

## Testing
- `pytest -n auto --disable-warnings` *(fails: ModuleNotFoundError: No module named 'ai_trading.risk.engine', AttributeError: module 'ai_trading.alpaca_api' has no attribute 'DataFetchError', ImportError: cannot import name 'DataFetchError' from 'ai_trading.data')*

------
https://chatgpt.com/codex/tasks/task_e_68aca70684a8833092aa24a9161b221b