### PR TITLE
docs: align runtime docs with py312 and health endpoint

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -266,8 +266,10 @@ class RiskMetrics:
 #### Health Check Endpoint
 
 ```http
-GET /health
+GET http://127.0.0.1:9001/health
 ```
+
+Always returns JSON and must never 500.
 
 **Response:**
 ```json

--- a/DEPENDENCY_FIXES_SUMMARY.md
+++ b/DEPENDENCY_FIXES_SUMMARY.md
@@ -8,16 +8,16 @@ This document summarizes the fixes implemented to resolve the critical issues id
 
 **Problem**: `Failed to import Alpaca SDK: No module named 'alpaca_trade_api'`
 
-**Root Cause**: The codebase uses both `alpaca-py` (modern SDK) and `alpaca_trade_api` (legacy SDK), but only `alpaca-py` was listed in dependencies.
+**Root Cause**: Multiple Alpaca SDKs were mixed (`alpaca-py` and `alpaca_trade_api`).
 
 **Solution**:
-- Added `alpaca-trade-api>=3.1.0` to both `requirements.txt` and `pyproject.toml`
+- Standardized on `alpaca-trade-api>=3.1.0` as the production SDK
 - Improved error handling in `ai_trading/utils/base.py` with proper fallback to mock classes
 - Enhanced logging to distinguish between successful import and fallback usage
 
 **Files Modified**:
 - `requirements.txt`: Added alpaca-trade-api dependency
-- `pyproject.toml`: Added alpaca-trade-api dependency  
+- `pyproject.toml`: Added alpaca-trade-api dependency
 - `ai_trading/utils/base.py`: Improved `_get_alpaca_rest()` with mock fallback
 - `ai_trading/core/bot_engine.py`: Fixed empty try block for SDK imports
 
@@ -164,8 +164,7 @@ All changes maintain backward compatibility:
 To benefit from these fixes, ensure dependencies are installed:
 
 ```bash
-pip install -r requirements.txt
-# OR
+python -m pip install -U pip
 pip install -e .
 ```
 

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,12 +1,23 @@
 ## Deploying the AI Trading Bot (systemd)
 
+Target OS: **Ubuntu 24.04**.
+
 Use the canonical unit at `packaging/systemd/ai-trading.service`.
 
 ```bash
 sudo cp packaging/systemd/ai-trading.service /etc/systemd/system/ai-trading.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now ai-trading.service
+sudo systemctl restart ai-trading.service
+sudo systemctl status ai-trading.service
 ```
 
-Configure environment in `/home/aiuser/ai-trading-bot/.env` and ensure PATH in the unit points to your venv.
+Check logs and health:
+
+```bash
+journalctl -u ai-trading.service -n 200 --no-pager
+curl -s http://127.0.0.1:9001/health
+```
+
+Configure environment in `/home/aiuser/ai-trading-bot/.env` (loaded with `override=True` at startup) and ensure PATH in the unit points to your venv.
 

--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -1,6 +1,6 @@
 ## Logging Configuration
 
-The AI trading bot supports several logging configuration flags to control output verbosity and format:
+The AI trading bot supports several logging configuration flags to control output verbosity and format. Logger initialization is idempotent—calling the setup multiple times will not create duplicate handlers.
 
 ### Environment Variables
 

--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -166,15 +166,18 @@ All `try/except ImportError` blocks have been removed from:
 ### 2. Required Dependencies
 The following packages are now hard dependencies:
 - `pandas_market_calendars>=4.3`
-- `alpaca-py>=0.42.0`
 - `alpaca-trade-api>=3.1.0`
 - `hmmlearn>=0.3.0`
 - `psutil>=5.9.8`
 
 **Action Required**: Update your environment to install these packages:
 ```bash
-pip install "ai-trading-bot[broker]" alpaca-py alpaca-trade-api hmmlearn psutil pandas_market_calendars
+python -m pip install -U pip
+pip install -e .
+pip install alpaca-trade-api hmmlearn psutil pandas_market_calendars
 ```
+
+If opting for `alpaca-py`, update broker modules, tests, and docs accordingly.
 
 ### 3. StrategyAllocator Changes
 The `_Stub` fallback in `ai_trading/core/bot_engine.py` has been removed.

--- a/SHIM_REMOVAL_STRATEGY.md
+++ b/SHIM_REMOVAL_STRATEGY.md
@@ -22,7 +22,7 @@ Files with import guards for core dependencies that should be hard requirements:
    - `scikit-learn` - Used in ML modules, should be hard dependency
 
 2. **Medium Priority - Domain Libraries**:
-   - `alpaca-py` / `alpaca-trade-api` - Core trading functionality
+   - `alpaca-trade-api` - Core trading functionality (use a single SDK)
    - `yfinance` - Market data (but could be optional with feature flags)
    - `flask` - Web interface (could be optional)
 
@@ -77,6 +77,10 @@ python tools/codemods/remove_import_guards.py
 - [ ] All Settings access uses get_settings() with lowercase fields
 - [ ] Package imports cleanly with hard dependencies
 - [ ] Core functionality tests pass
+
+## Production Guidance
+
+Runtime code must not use `optional_import(...)`. Reserve such helpers for research or development utilities and gate heavy imports inside function scope when rarely used.
 
 ## Risk Mitigation
 

--- a/SHIM_REMOVAL_SUMMARY.md
+++ b/SHIM_REMOVAL_SUMMARY.md
@@ -26,7 +26,6 @@ Confirmed these are properly declared in `pyproject.toml` as hard dependencies:
 - `beautifulsoup4>=4.11.1`
 - `tenacity==8.2.2`
 - `transformers==4.35.2`
-- `alpaca-py>=0.42.0`
 - `requests>=2.31,<3`
 
 ### ✅ Optional Feature Flags Added
@@ -80,6 +79,11 @@ The implementation carefully followed AGENTS.md guidance:
 - **Did not rewrite `bot_engine.py`** wholesale due to explicit warnings
 - **Used targeted, surgical changes** rather than bulk replacements
 - **Preserved critical production logic** in core execution paths
+
+### Production guidance
+
+- Use a single Alpaca SDK (`alpaca-trade-api`) in production. Switching to `alpaca-py` requires updating brokers, tests, and docs.
+- Avoid `optional_import(...)` in runtime code. Gate heavy, optional dependencies inside function scope instead of shimming imports.
 
 ### Feature Flag Approach
 Rather than removing all optional imports, converted them to explicit feature flags:

--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -4,6 +4,11 @@
 
 This comprehensive testing guide covers the complete testing framework for the AI Trading Bot, including unit tests, integration tests, performance tests, and testing best practices.
 
+```bash
+ruff check .
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
+```
+
 ## Table of Contents
 
 - [Testing Philosophy](#testing-philosophy)
@@ -1052,7 +1057,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        python -m pip install -U pip
+        pip install -e .
         pip install -r requirements-dev.txt
     
     - name: Run unit tests
@@ -1081,7 +1087,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        python -m pip install -U pip
+        pip install -e .
         pip install -r requirements-dev.txt
     
     - name: Run integration tests
@@ -1106,7 +1113,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        python -m pip install -U pip
+        pip install -e .
         pip install -r requirements-dev.txt
         pip install memory-profiler
     

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -25,7 +25,7 @@ Run this checklist before diving into detailed troubleshooting:
 
 ```bash
 # 1. Check service status
-sudo systemctl status ai-trading-scheduler
+sudo systemctl status ai-trading.service
 
 # 2. Verify configuration
 python validate_env.py
@@ -87,7 +87,8 @@ which python
 # Should point to venv/bin/python
 
 # Reinstall dependencies
-pip install -r requirements.txt
+python -m pip install -U pip
+pip install -e .
 
 # Check for missing environment variables
 python -c "
@@ -118,6 +119,18 @@ except Exception as e:
     print(f'Configuration error: {e}')
 "
 ```
+
+### Module attribute errors
+
+**Error:** `module 'ai_trading.config.management' has no attribute 'get_env'` (or `reload_env`).
+
+**Fix:** Update to the latest code and ensure `ai_trading/config/management.py` exports both helpers.
+
+### Health endpoint returns 500
+
+**Symptoms:** `curl -s http://127.0.0.1:9001/health` shows 500 or non-JSON.
+
+**Fix:** The `/health` route must catch exceptions and return `{"ok": false}` on degradation. Verify no unhandled errors in the handler.
 
 ### 2. API Connection Failures
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -17,6 +17,10 @@ make validate-env
 
 # Run tests
 make test-all
+
+# Lint and tests directly
+ruff check .
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
 ```
 
 ## Dependency Management
@@ -37,7 +41,8 @@ make install
 make install-dev
 
 # Manual installation
-pip install -r requirements.txt
+python -m pip install -U pip
+pip install -e .
 pip install -r requirements-dev.txt
 ```
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,3 +1,18 @@
+## Operations
+
+Target OS: **Ubuntu 24.04**.
+
+### Service Management
+
+```bash
+sudo systemctl start ai-trading.service
+sudo systemctl stop ai-trading.service
+sudo systemctl restart ai-trading.service
+sudo systemctl status ai-trading.service
+journalctl -u ai-trading.service -n 200 --no-pager
+curl -s http://127.0.0.1:9001/health  # JSON, never 500
+```
+
 ### Paths & default files
 - Trade log file defaults to `<repo>/logs/trades.jsonl` when `TRADE_LOG_PATH` is not set. The directory is auto-created.
 - Empty model path disables ML quietly. Set `MODEL_PATH` to enable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,10 +25,11 @@ values in `hyperparams.json`.
 
 ## Development
 
-Install the dependencies listed in `requirements-dev.txt` which in turn
-includes `requirements.txt`:
+Install dependencies:
 
 ```bash
+python -m pip install -U pip
+pip install -e .
 pip install -r requirements-dev.txt
 ```
 
@@ -41,14 +42,18 @@ pytest
 
 ## Systemd Service
 
-A sample service file `ai-trading-scheduler.service` is provided. It calls `python -m ai_trading` inside the project virtual environment.
+A sample service file `ai-trading.service` is provided. It calls `python -m ai_trading` inside the project virtual environment.
 
 To use it:
 
 ```bash
-sudo cp ai-trading-scheduler.service /etc/systemd/system/
+sudo cp packaging/systemd/ai-trading.service /etc/systemd/system/
 sudo systemctl daemon-reload
-sudo systemctl enable --now ai-trading-scheduler.service
+sudo systemctl enable --now ai-trading.service
+sudo systemctl restart ai-trading.service
+sudo systemctl status ai-trading.service
+journalctl -u ai-trading.service -n 200 --no-pager
+curl -s http://127.0.0.1:9001/health
 ```
 
 The service writes to `logs/scheduler.log` (or `$BOT_LOG_FILE`). View logs with


### PR DESCRIPTION
## Summary
- replace AGENTS contract with updated runtime policy
- document py312 quickstart, config helpers, and zoneinfo usage
- refresh deployment, operations, and troubleshooting guides for ai-trading.service on :9001

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'numpy', AttributeError 'alpaca_trade_api.rest' has no attribute 'APIError')*
- `grep -RInE 'Python 3\.1[01]|py311' --include='*.md' .`
- `grep -RIn '\bpytz\b' --include='*.md' .`
- `grep -RInE '8081/health|HEALTHCHECK_PORT=8081' --include='*.md' .`
- `grep -RIn 'Ubuntu 22\.04' --include='*.md' .`
- `grep -RInE 'pip(3)? install -r requirements\.txt' --include='*.md' .`
- `grep -RInE 'alpaca\.trading|alpaca-py' --include='*.md' .`


------
https://chatgpt.com/codex/tasks/task_e_68acade8d5308330b11c1b54535c0313