### PR TITLE
refactor: centralize env loading

### DIFF
--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -4,19 +4,19 @@ This script fetches daily OHLCV bars for a predefined list of tickers and
 stores them as CSV files under ``data/``. Existing files are left untouched.
 """
 from __future__ import annotations
-import os
 from pathlib import Path
 import pandas as pd
 from ai_trading.utils.base import _get_alpaca_rest
 from alpaca_trade_api import TimeFrame
-from dotenv import load_dotenv
+from ai_trading.env import ensure_dotenv_loaded
+from ai_trading.config.management import get_env
 
 def main() -> None:
     """Fetch bars for each symbol and save to ``data`` directory."""
-    load_dotenv(dotenv_path='.env', override=True)
-    api_key = os.getenv('ALPACA_API_KEY')
-    secret_key = os.getenv('ALPACA_SECRET_KEY')
-    base_url = os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
+    ensure_dotenv_loaded()
+    api_key = get_env('ALPACA_API_KEY')
+    secret_key = get_env('ALPACA_SECRET_KEY')
+    base_url = get_env('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
     api = _get_alpaca_rest()(api_key, secret_key, base_url)
     symbols = ['AAPL', 'MSFT', 'GOOG', 'AMZN', 'NVDA', 'TSLA', 'META']
     start = '2023-01-01'

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -13,11 +13,6 @@ pytestmark = pytest.mark.usefixtures("default_env")
 req_mod = types.ModuleType("requests")
 req_mod.post = lambda *a, **k: None
 sys.modules.setdefault("requests", req_mod)
-for _m in ["dotenv"]:
-    mod = types.ModuleType(_m)
-    if _m == "dotenv":
-        mod.load_dotenv = lambda *a, **k: None
-    sys.modules.setdefault(_m, mod)
 
 try:
     from ai_trading import alpaca_api  # AI-AGENT-REF: canonical import

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -22,15 +22,11 @@ mods = [
     "alpaca.data.timeframe",
     "alpaca_trade_api.rest",
     "alpaca.common.exceptions",
-    "dotenv",
     "finnhub",
 ]
 for m in mods:
     sys.modules.setdefault(m, types.ModuleType(m))
 sys.modules.setdefault("alpaca_trade_api", types.ModuleType("alpaca_trade_api"))
-sys.modules["dotenv"] = types.ModuleType("dotenv")
-sys.modules["dotenv"].load_dotenv = lambda *a, **k: None
-sys.modules["dotenv"].dotenv_values = lambda *a, **k: {}
 
 
 class _FakeREST:

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -7,9 +7,6 @@ import pandas as pd
 import pytest
 from ai_trading.features import build_features_pipeline
 
-dotenv_stub = types.ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-sys.modules.setdefault("dotenv", dotenv_stub)
 ps_stub = types.ModuleType("pydantic_settings")
 ps_stub.BaseSettings = object
 ps_stub.SettingsConfigDict = dict

--- a/tests/test_fetch_contract.py
+++ b/tests/test_fetch_contract.py
@@ -8,11 +8,6 @@ import pandas as pd
 
 os.environ.setdefault("ALPACA_API_KEY", "dummy")
 os.environ.setdefault("ALPACA_SECRET_KEY", "dummy")
-dotenv_stub = types.ModuleType("dotenv")
-dotenv_stub.load_dotenv = lambda *a, **k: None
-dotenv_stub.dotenv_values = lambda *a, **k: {}
-dotenv_stub.find_dotenv = lambda *a, **k: ""
-sys.modules["dotenv"] = dotenv_stub
 
 from ai_trading import data_fetcher
 

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -77,7 +77,6 @@ mods = [
     "alpaca.data.requests",
     "alpaca.data.timeframe",
     "alpaca.common.exceptions",
-    "dotenv",
     "finnhub",
     "sklearn.ensemble",
     "sklearn.linear_model",
@@ -106,7 +105,6 @@ if "torch" in sys.modules:
     torch_nn.Softmax = lambda *a, **k: None
     sys.modules["torch.nn"] = torch_nn
 
-sys.modules["dotenv"].load_dotenv = lambda *a, **k: None
 req_mod = types.ModuleType("requests")
 sys.modules["requests"] = req_mod
 exc_mod = types.ModuleType("requests.exceptions")

--- a/tests/test_systemd_startup.py
+++ b/tests/test_systemd_startup.py
@@ -116,10 +116,9 @@ APCA_API_BASE_URL=https://api.alpaca.markets
             # Test ALPACA schema
             test_script = f'''
 import os
-from dotenv import load_dotenv
-load_dotenv("{alpaca_env_path}", override=True)
+from ai_trading.config.management import _resolve_alpaca_env, reload_env
+reload_env("{alpaca_env_path}", override=True)
 
-from ai_trading.config.management import _resolve_alpaca_env
 api_key, secret_key, base_url = _resolve_alpaca_env()
 
 assert api_key == "test_alpaca_key_from_env"
@@ -139,14 +138,13 @@ print("✓ ALPACA schema with .env file works")
             # Test APCA schema
             test_script = f'''
 import os
-from dotenv import load_dotenv
-load_dotenv("{apca_env_path}", override=True)
+from ai_trading.config.management import _resolve_alpaca_env, reload_env
+reload_env("{apca_env_path}", override=True)
 
-from ai_trading.config.management import _resolve_alpaca_env
 api_key, secret_key, base_url = _resolve_alpaca_env()
 
 assert api_key == "test_apca_key_from_env"
-assert secret_key == "test_apca_secret_from_env"  
+assert secret_key == "test_apca_secret_from_env"
 assert base_url == "https://api.alpaca.markets"
 print("✓ APCA schema with .env file works")
 '''


### PR DESCRIPTION
## Summary
- load `.env` via `ai_trading.env.ensure_dotenv_loaded` at startup
- route environment lookups through `ai_trading.config.management.get_env`
- drop obsolete `dotenv` test stubs

## Testing
- `ruff check ai_trading/main.py scripts/download_backtest_data.py scripts/verify_config.py tests/test_features.py tests/test_data_fetcher.py tests/test_fetch_contract.py tests/test_advanced_features.py tests/test_integration_robust.py tests/test_env_order_and_lazy_import.py tests/test_systemd_startup.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 75 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68acb2dd18288330b4aebf4a6285e722