### PR TITLE
Refactor runtime modules to drop optional_import shims

### DIFF
--- a/ai_trading/broker/alpaca.py
+++ b/ai_trading/broker/alpaca.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 from typing import Any
 from ai_trading.alpaca_api import ALPACA_AVAILABLE
 from ai_trading.logging import get_logger
-from ai_trading.utils.optdeps import optional_import
 from ai_trading.utils.retry import retry_call
 from .alpaca_credentials import resolve_alpaca_credentials
 try:
@@ -13,9 +12,14 @@ except ImportError:
 
     class HTTPError(Exception):
         pass
-APIError = optional_import('alpaca.common.exceptions', attr='APIError') or Exception
-TradingClient = optional_import('alpaca.trading.client', attr='TradingClient')
-if TradingClient is None:
+try:
+    from alpaca.common.exceptions import APIError  # type: ignore
+except ModuleNotFoundError:
+    APIError = Exception  # type: ignore[misc,assignment]
+try:
+    from alpaca.trading.client import TradingClient  # type: ignore
+except ModuleNotFoundError:
+    TradingClient = None  # type: ignore[assignment]
     _tmp_logger = get_logger(__name__)
     _tmp_logger.warning('VENDOR_MISSING: alpaca SDK not installed; using REST fallback/offline path')
 from ai_trading.exc import TRANSIENT_HTTP_EXC

--- a/ai_trading/broker/alpaca_credentials.py
+++ b/ai_trading/broker/alpaca_credentials.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
-from ai_trading.utils.optdeps import optional_import
 
 @dataclass
 class Credentials:
@@ -16,14 +15,19 @@ def resolve_alpaca_credentials(env: Mapping[str, str] | None=None) -> Credential
     return Credentials(env.get('ALPACA_API_KEY'), env.get('ALPACA_SECRET_KEY'), env.get('ALPACA_BASE_URL') or 'https://paper-api.alpaca.markets')
 
 def check_alpaca_available() -> bool:
-    return optional_import('alpaca_trade_api') is not None
+    try:
+        import alpaca_trade_api  # type: ignore  # noqa: F401
+    except ModuleNotFoundError:
+        return False
+    return True
 
 def initialize(env: Mapping[str, str] | None=None, *, shadow: bool=False):
     creds = resolve_alpaca_credentials(env)
-    if shadow or not check_alpaca_available():
+    if shadow:
         return object()
-    TradeApiREST = optional_import('alpaca_trade_api', attr='REST')
-    if TradeApiREST is None:
+    try:
+        from alpaca_trade_api import REST  # type: ignore
+    except ModuleNotFoundError:
         return object()
-    return TradeApiREST(key_id=creds.API_KEY, secret_key=creds.SECRET_KEY, base_url=creds.BASE_URL)
+    return REST(key_id=creds.API_KEY, secret_key=creds.SECRET_KEY, base_url=creds.BASE_URL)
 __all__ = ['Credentials', 'resolve_alpaca_credentials', 'check_alpaca_available', 'initialize']

--- a/ai_trading/env.py
+++ b/ai_trading/env.py
@@ -1,23 +1,6 @@
 from __future__ import annotations
 import os
-import importlib.util
-from pathlib import Path
-import sys
 
-# AI-AGENT-REF: optional dotenv via optdeps without heavy package import
-_spec = importlib.util.spec_from_file_location(
-    "_optdeps", Path(__file__).resolve().parent / "utils" / "optdeps.py"
-)
-_optdeps = importlib.util.module_from_spec(_spec)
-sys.modules["_optdeps"] = _optdeps
-assert _spec.loader is not None
-_spec.loader.exec_module(_optdeps)
-optional_import = _optdeps.optional_import
-module_ok = _optdeps.module_ok
-
-load_dotenv = optional_import(
-    "dotenv", attr="load_dotenv", purpose=".env loading", extra="pip install python-dotenv"
-)
 _ENV_LOADED = False
 
 def ensure_dotenv_loaded() -> None:
@@ -29,7 +12,9 @@ def ensure_dotenv_loaded() -> None:
     here = os.path.abspath(os.path.dirname(__file__))
     repo_root = os.path.abspath(os.path.join(here, os.pardir, os.pardir))
     explicit = os.path.join(repo_root, '.env')
-    if not module_ok(load_dotenv):
+    try:
+        from dotenv import load_dotenv  # type: ignore
+    except ModuleNotFoundError:
         return
     if os.path.exists(explicit):
         load_dotenv(dotenv_path=explicit, override=True)


### PR DESCRIPTION
## Summary
- gate third-party dependencies with direct imports in runtime modules
- ensure dotenv loading and alpaca clients import directly

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: pandas, numpy, etc., 75 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acb2d904c883309c44f2bb988d3ada