### PR TITLE
Remove explicit pytz dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
   "numpy==1.26.4",
   "pandas==2.2.2",
   "pydantic==2.8.2",
-  "pytz==2024.1",
   "requests>=2.31,<3",
   "Flask>=2.3,<3",
   "python-dateutil>=2.8.2,<3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ pydantic-settings>=2.2,<3
 
 # Deterministic calendars & time zones
 tzdata>=2024.1  # AI-AGENT-REF: ensure timezone data
-pytz==2024.1
 pandas-market-calendars>=4.4,<6  # AI-AGENT-REF: exchange calendars
 schedule==1.2.2
 prometheus-client==0.20.0


### PR DESCRIPTION
## Summary
- drop explicit `pytz` dependency from project metadata

## Testing
- `python3.12 -m pip install --break-system-packages -e .`
- `python3.12 -m pip check`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing optional packages and multiple import errors)*
- `curl http://127.0.0.1:9001/health` *(connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68acb2d15e3083309e8992a73856e02b