### PR TITLE
chore: drop pytz dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
   "pydantic==2.8.2",
   "pydantic-settings>=2.2,<3",
   "tzdata>=2024.1",  # AI-AGENT-REF: ensure timezone data
-  "pytz==2024.1",
   "pandas-market-calendars>=4.4,<6",  # AI-AGENT-REF: exchange calendars
   "schedule==1.2.2",
   "prometheus-client==0.20.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ pydantic-settings>=2.2,<3
 
 # Deterministic calendars & time zones
 tzdata>=2024.1  # AI-AGENT-REF: ensure timezone data
-pytz==2024.1
 pandas-market-calendars>=4.4,<6  # AI-AGENT-REF: exchange calendars
 schedule==1.2.2
 prometheus-client==0.20.0


### PR DESCRIPTION
## Summary
- remove pytz from project dependencies

## Testing
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')*
- `pip check`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', etc.)*
- `curl http://127.0.0.1:9001/health` *(fails: Failed to connect to 127.0.0.1 port 9001: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68acb64425988330bd6962b77c074b96