### PR TITLE
Narrow subprocess errors and add coverage

### DIFF
--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -48,7 +48,8 @@ def safe_subprocess_run(cmd: list[str] | tuple[str, ...], timeout: float | int |
         t = float(timeout) if timeout is not None else SUBPROCESS_TIMEOUT_DEFAULT
         res = subprocess.run(list(cmd), timeout=t, check=True, capture_output=True)
         return (res.stdout or b"").decode(errors="ignore").strip()
-    except Exception:
+    except (subprocess.SubprocessError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("safe_subprocess_run(%s) failed: %s", cmd, exc)
         return ""
 
 def get_ohlcv_columns(df) -> list[str]:

--- a/tests/utils/test_safe_subprocess_run.py
+++ b/tests/utils/test_safe_subprocess_run.py
@@ -1,0 +1,25 @@
+import sys
+import pytest
+
+from ai_trading.utils.base import safe_subprocess_run
+
+
+def test_safe_subprocess_run_success():
+    out = safe_subprocess_run([sys.executable, "-c", "print('ok')"])
+    assert out == "ok"
+
+
+def test_safe_subprocess_run_timeout(caplog):
+    cmd = [sys.executable, "-c", "import time; time.sleep(1)"]
+    with caplog.at_level("WARNING"):
+        out = safe_subprocess_run(cmd, timeout=0.1)
+    assert out == ""
+    assert any(str(cmd) in rec.message for rec in caplog.records)
+
+
+def test_safe_subprocess_run_nonzero_exit(caplog):
+    cmd = [sys.executable, "-c", "import sys; sys.exit(2)"]
+    with caplog.at_level("WARNING"):
+        out = safe_subprocess_run(cmd)
+    assert out == ""
+    assert any(str(cmd) in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- Handle only subprocess-related exceptions and log warnings in `safe_subprocess_run`
- Add unit tests for subprocess success, timeout, and non-zero exits

## Testing
- `ruff check ai_trading/utils/base.py tests/utils/test_safe_subprocess_run.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/utils/test_safe_subprocess_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc3820530833089902eee8c50abfa