### PR TITLE
refactor: inline pandas imports with explicit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ This trading bot requires both **Python packages** and **system libraries** for 
 All Python packages are specified in `requirements.txt`, including:
 - **ta==0.11.0**: Professional technical analysis library with 150+ indicators
 - **pandas**, **numpy**: Data processing and numerical computations
+- **pandas-market-calendars**: Exchange session calendars
 - **scikit-learn**: Machine learning algorithms
 - **alpaca-trade-api**: Broker integration
 
@@ -165,6 +166,9 @@ Some functionality depends on optional libraries. Install only what you need:
 ```bash
 # Data wrangling & CSV/Parquet I/O
 pip install "ai-trading-bot[pandas]"
+
+# Trading calendar utilities
+pip install "ai-trading-bot[pandas-market-calendars]"
 
 # Plotting
 pip install "ai-trading-bot[plot]"
@@ -182,6 +186,7 @@ pip install "ai-trading-bot[all]"
 | Feature / Area       | Extra    | Packages (summary)           |
 |----------------------|----------|------------------------------|
 | DataFrames & I/O     | `pandas` | `pandas`                     |
+| Trading Calendars    | `pandas-market-calendars` | `pandas-market-calendars` |
 | Plotting             | `plot`   | `matplotlib`                 |
 | Machine Learning     | `ml`     | `scikit-learn`, `torch`      |
 | Technical Indicators | `ta`     | `ta`, `TA-Lib`               |
@@ -193,6 +198,8 @@ pip install "ai-trading-bot[all]"
 When a feature is used without its optional dependency, the code raises a helpful error like:
 
 > Missing optional dependency 'pandas'. Install with: `pip install "ai-trading-bot[pandas]"`
+> 
+> Missing optional dependency 'pandas-market-calendars'. Install with: `pip install "ai-trading-bot[pandas-market-calendars]"`
 
 ### Manual Installation
 

--- a/ai_trading/rl_trading/train.py
+++ b/ai_trading/rl_trading/train.py
@@ -11,8 +11,8 @@ from ai_trading.logging import logger
 from . import _load_rl_stack
 
 
-class _SB3Shim:
-    """Minimal shim used when RL stack is unavailable."""
+class _SB3Stub:
+    """Minimal placeholder used when RL stack is unavailable."""
 
     def __init__(self, *a, **k):
         pass
@@ -28,7 +28,7 @@ class _SB3Shim:
         return cls()
 
 
-PPO = A2C = DQN = _SB3Shim
+PPO = A2C = DQN = _SB3Stub
 
 
 class BaseCallback:
@@ -56,9 +56,9 @@ def evaluate_policy(*a, **k):
 
 
 def _ensure_rl() -> bool:
-    """Import the RL stack on demand, updating global shims."""
+    """Import the RL stack on demand, replacing global placeholders."""
     global PPO, A2C, DQN, BaseCallback, EvalCallback, make_vec_env, evaluate_policy, DummyVecEnv
-    if PPO is not _SB3Shim:
+    if PPO is not _SB3Stub:
         return True
     stack = _load_rl_stack()
     if stack is None:


### PR DESCRIPTION
## Summary
- replace optional pandas and market-calendar shims with direct imports
- raise clear ImportErrors for missing `pandas` or `pandas-market-calendars`
- remove shim terminology from RL training placeholder

## Testing
- `python -m pip install pandas pandas-market-calendars`
- `python -m pip install psutil pydantic joblib scikit-learn requests alpaca-trade-api`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing modules and 87 errors during collection)*
- `curl -s http://127.0.0.1:9001/health`


------
https://chatgpt.com/codex/tasks/task_e_68acc5dc57508330932940369d09b66a