### PR TITLE
refactor: centralize Alpaca APIError

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -53,6 +53,7 @@ from ai_trading.alpaca_api import (
     ALPACA_AVAILABLE,
     get_bars_df,  # AI-AGENT-REF: canonical bar fetcher (auto start/end)
 )
+from ai_trading.broker.alpaca import ensure_api_error
 from ai_trading.config.management import derive_cap_from_settings
 from ai_trading.data.bars import (_ensure_df, safe_get_stock_bars, _create_empty_bars_dataframe, StockBarsRequest, TimeFrame, TimeFrameUnit, _resample_minutes_to_daily)
 
@@ -1416,13 +1417,9 @@ class _AlpacaStub:  # AI-AGENT-REF: placeholder when Alpaca unavailable
         return _noop
 
 
-class APIErrorStub(Exception):
-    pass
-
-
 # Assign lightweight stubs for Alpaca SDK types; keep TimeFrame separate for constants.
 Quote = StockBarsRequest = StockLatestQuoteRequest = OrderSide = OrderStatus = TimeInForce = Order = MarketOrderRequest = _AlpacaStub  # type: ignore
-APIError = APIErrorStub
+APIError = ensure_api_error()
 
 # Minimal enum-like placeholder so code can reference TimeFrame.Day etc.
 class _TimeFrame:  # AI-AGENT-REF: safe constants when Alpaca SDK not installed

--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -5,7 +5,6 @@ Provides order lifecycle management, execution algorithms,
 and real-time execution monitoring with institutional controls.
 """
 from __future__ import annotations
-import importlib
 import logging
 import math
 import threading
@@ -16,21 +15,11 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
-_log = logging.getLogger(__name__)
+from ai_trading.broker.alpaca import ensure_api_error
 from ai_trading.logging.emit_once import emit_once
 
-def _optional_import(name: str):
-    try:
-        return importlib.import_module(name)
-    except ImportError:
-        return None
-_alpaca_rest = _optional_import('alpaca_trade_api.rest')
-if _alpaca_rest is not None:
-    APIError = _alpaca_rest.APIError
-else:
-
-    class APIError(Exception):
-        pass
+_log = logging.getLogger(__name__)
+APIError = ensure_api_error()
 ORDER_STALE_AFTER_S = 8 * 60
 
 @dataclass(slots=True)

--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -8,18 +8,16 @@ import logging
 import time
 from datetime import UTC, datetime
 from typing import Any
-from ai_trading.logging import logger
-_log = logging.getLogger(__name__)
+from ai_trading.broker.alpaca import AlpacaBroker, ensure_api_error
 from ai_trading.config import AlpacaConfig, get_alpaca_config
-try:
-    from alpaca_trade_api.rest import APIError  # type: ignore
+from ai_trading.logging import logger
+
+_log = logging.getLogger(__name__)
+APIError = ensure_api_error()
+try:  # pragma: no cover - optional dependency
     from alpaca_trade_api import REST as AlpacaREST  # type: ignore
 except (ValueError, TypeError, ModuleNotFoundError, ImportError):
     AlpacaREST = None
-
-    class APIError(Exception):
-        pass
-from ai_trading.broker.alpaca import AlpacaBroker
 
 def _req_str(name: str, v: str | None) -> str:
     if not v:

--- a/ai_trading/execution/production_engine.py
+++ b/ai_trading/execution/production_engine.py
@@ -8,17 +8,15 @@ import asyncio
 import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from ai_trading.broker.alpaca import ensure_api_error
 from ai_trading.logging import logger
-try:
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except (ValueError, TypeError, ModuleNotFoundError, ImportError):
-    class APIError(Exception):
-        pass
 from ..core.constants import EXECUTION_PARAMETERS
 from ..core.enums import OrderSide, OrderType, RiskLevel
 from ..monitoring import AlertManager, AlertSeverity
 from ..risk import DynamicPositionSizer, RiskManager, TradingHaltManager
 from .engine import ExecutionAlgorithm, Order, OrderStatus
+
+APIError = ensure_api_error()
 
 class ExecutionResult:
     """

--- a/ai_trading/rebalancer.py
+++ b/ai_trading/rebalancer.py
@@ -6,15 +6,13 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 import numpy as np
-_log = logging.getLogger(__name__)
-try:
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except ImportError:
-    class APIError(Exception):
-        pass
+from ai_trading.broker.alpaca import ensure_api_error
 from ai_trading.config import get_settings
 from ai_trading.portfolio import compute_portfolio_weights
 from ai_trading.settings import get_rebalance_interval_min
+
+_log = logging.getLogger(__name__)
+APIError = ensure_api_error()
 
 def apply_no_trade_bands(current: dict[str, float], target: dict[str, float], band_bps: float=25.0) -> dict[str, float]:
     """

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -8,27 +8,28 @@ from dataclasses import dataclass
 from datetime import UTC
 from typing import Any
 import numpy as np
-if not hasattr(np, 'NaN'):
-    np.NaN = np.nan
 import importlib
 import pandas as pd
+from ai_trading.broker.alpaca import ensure_api_error
+from ai_trading.config.management import SEED, TradingConfig
+from ai_trading.config.settings import get_settings
+
+if not hasattr(np, 'NaN'):
+    np.NaN = np.nan
 
 def _optional_import(name: str):
     try:
         return importlib.import_module(name)
     except ImportError:
         return None
+
 ta = _optional_import('pandas_ta')
-from ai_trading.config.management import SEED, TradingConfig
-try:
+try:  # pragma: no cover - optional dependency
     from alpaca_trade_api import REST as AlpacaREST
-    from alpaca_trade_api.rest import APIError
 except ImportError:
     AlpacaREST = None
 
-    class APIError(Exception):
-        pass
-from ai_trading.config.settings import get_settings
+APIError = ensure_api_error()
 
 def _safe_call(fn, *a, **k):
     try:

--- a/ai_trading/shutdown_handler.py
+++ b/ai_trading/shutdown_handler.py
@@ -16,14 +16,12 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from ai_trading.broker.alpaca import ensure_api_error
+from ai_trading.logging import logger
+
 Hook = Callable[[], None]
 PositionsHandler = Callable[[], list[dict[str, Any]]]
-try:
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except (ValueError, TypeError, ModuleNotFoundError):
-    class APIError(Exception):
-        pass
-from ai_trading.logging import logger
+APIError = ensure_api_error()
 
 class ShutdownReason(Enum):
     """Reasons for system shutdown."""

--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -7,12 +7,10 @@ import statistics
 from collections.abc import Iterable
 from functools import lru_cache
 from typing import Any
+from ai_trading.broker.alpaca import ensure_api_error
 from ai_trading.utils import clamp_timeout as _clamp_timeout
-try:
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except ImportError:
-    class APIError(Exception):
-        pass
+
+APIError = ensure_api_error()
 _log = logging.getLogger(__name__)
 logger = _log
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,9 @@
 
 -r requirements.txt
 
+# Ensure Alpaca SDK available for tests
+alpaca-trade-api==3.2.0
+
 # Lint & format
 ruff==0.5.6
 black==24.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ charset-normalizer>=3.2,<4
 idna>=3.4,<4
 psutil>=5.9,<6
 portalocker==2.7.0
-alpaca-trade-api>=3.0,<4  # AI-AGENT-REF: include Alpaca SDK
+alpaca-trade-api==3.2.0  # AI-AGENT-REF: include Alpaca SDK
 joblib>=1.3,<2
 Flask>=3,<4
 beautifulsoup4>=4.12,<5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,6 +2,7 @@
 numpy>=1.26
 pandas>=2.2
 pandas-market-calendars>=4.4
+alpaca-trade-api==3.2.0
 pytest>=7.4
 pytest-xdist>=3.6
 psutil>=5.9

--- a/tests/runtime/test_alpaca_wrapped.py
+++ b/tests/runtime/test_alpaca_wrapped.py
@@ -2,7 +2,7 @@ import pytest
 
 pytestmark = pytest.mark.alpaca
 
-pytest.importorskip("alpaca")
+pytest.importorskip("alpaca_trade_api")
 
 from ai_trading.broker.alpaca import AlpacaBroker, APIError
 

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from ai_trading.broker.alpaca import APIError
 from tests.helpers.asserts import assert_df_like
 
 os.environ.setdefault("ALPACA_API_KEY", "dummy")
@@ -102,7 +103,7 @@ def test_subscription_error_logged(monkeypatch, caplog):
         def get_stock_bars(self, req):
             if getattr(req, "feed", None) == "iex":
                 return FakeBars(df)
-            raise data_fetcher.APIError("subscription does not permit querying recent SIP data")
+            raise APIError("subscription does not permit querying recent SIP data")
 
     monkeypatch.setattr(data_fetcher, "client", DummyClient())
     monkeypatch.setattr(data_fetcher, "TimeFrame", types.SimpleNamespace(Minute="1Min"))


### PR DESCRIPTION
## Summary
- pin `alpaca-trade-api` to 3.2.0 in prod and dev requirements
- add `ensure_api_error` helper and replace scattered fallbacks
- adjust tests to import helper and skip when SDK missing

## Testing
- `ruff check ai_trading/broker/alpaca.py ai_trading/shutdown_handler.py ai_trading/execution/engine.py ai_trading/execution/live_trading.py ai_trading/execution/production_engine.py ai_trading/rebalancer.py ai_trading/risk/engine.py ai_trading/signals.py ai_trading/core/bot_engine.py tests/test_data_fetcher.py tests/runtime/test_alpaca_wrapped.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_data_fetcher.py tests/test_broker_alpaca.py tests/runtime/test_alpaca_wrapped.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68acceab8ec08330ba10f40902418c7d