### PR TITLE
test: standardize optional dependency skips

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -98,6 +98,22 @@ markers =
     flaky: Tests that may be unreliable (should be fixed)
 ```
 
+### Optional Test Groups
+
+Some tests depend on optional third-party libraries. These tests use
+`from tests.optdeps import require` to call `pytest.importorskip` with a
+helpful installation hint. When the dependency is missing the test is
+skipped.
+
+| Group | Dependencies | Example tests |
+|-------|--------------|---------------|
+| Indicators | `pandas`, `ta`, `talib` | `tests/test_indicators.py` |
+| Meta learning | `numpy`, `torch`, `sklearn` | `tests/test_meta_learning.py`, `tests/slow/test_meta_learning_heavy.py` |
+| Reinforcement learning | `stable_baselines3`, `gymnasium`, `torch` | `tests/test_rl_import_performance.py` |
+| Alpaca SDK | `alpaca_trade_api`, `alpaca_api` | `tests/test_broker_alpaca_adapter.py`, `tests/unit/test_alpaca_api.py` |
+| Retry utilities | `tenacity` | `tests/test_tenacity_import.py` |
+| Calendars | `pandas_market_calendars` | `tests/test_market_calendar_wrapper.py` |
+
 ## Unit Testing
 
 ### Core Trading Logic Tests

--- a/tests/institutional/test_live_trading.py
+++ b/tests/institutional/test_live_trading.py
@@ -10,13 +10,15 @@ import datetime as dt
 import os
 
 import pytest
+from tests.optdeps import require
 from zoneinfo import ZoneInfo  # AI-AGENT-REF: drop pytz for stdlib zoneinfo
 
 pytestmark = pytest.mark.alpaca
 
 # Set test environment
 os.environ['PYTEST_RUNNING'] = '1'
-pytest.importorskip('alpaca_trade_api', reason='alpaca not installed')
+require("requests")
+require("alpaca_trade_api")
 
 from ai_trading.execution.live_trading import AlpacaExecutionEngine
 

--- a/tests/optdeps.py
+++ b/tests/optdeps.py
@@ -7,6 +7,14 @@ HINT = {
     "torch":        'pip install "ai-trading-bot[ml]"',
     "ta":           'pip install "ai-trading-bot[ta]"',
     "talib":        'pip install "ai-trading-bot[ta]"',
+    "stable_baselines3": 'pip install "stable-baselines3 gymnasium torch"',
+    "gymnasium":    'pip install "stable-baselines3 gymnasium torch"',
+    "alpaca_trade_api": 'pip install "alpaca-trade-api"',
+    "alpaca_api":   'pip install "ai-trading-bot"',
+    "tenacity":     'pip install "tenacity"',
+    "pandas_market_calendars": 'pip install "pandas-market-calendars"',
+    "pydantic":     'pip install "pydantic"',
+    "requests":     'pip install "requests"',
 }
 
 def require(pkg: str):

--- a/tests/runtime/test_alpaca_wrapped.py
+++ b/tests/runtime/test_alpaca_wrapped.py
@@ -1,8 +1,10 @@
 import pytest
+from tests.optdeps import require
 
 pytestmark = pytest.mark.alpaca
 
-pytest.importorskip("alpaca_trade_api")
+require("requests")
+require("alpaca_trade_api")
 
 from ai_trading.broker.alpaca import AlpacaBroker, APIError
 

--- a/tests/test_broker_alpaca_adapter.py
+++ b/tests/test_broker_alpaca_adapter.py
@@ -1,4 +1,9 @@
 import pytest
+from tests.optdeps import require
+
+require("requests")
+require("alpaca_trade_api")
+
 from ai_trading.broker.alpaca import AlpacaBroker
 
 pytestmark = pytest.mark.alpaca
@@ -56,7 +61,6 @@ class FakeOld:
 
 
 def test_adapter_orders_new(monkeypatch):
-    pytest.importorskip("alpaca_trade_api")
     fake = FakeNew()
     broker = AlpacaBroker(fake)
     broker._is_new = True

--- a/tests/test_clients_memoized.py
+++ b/tests/test_clients_memoized.py
@@ -1,6 +1,9 @@
 import pytest
 
-pytest.importorskip("alpaca_trade_api", reason="vendor SDK not installed")
+from tests.optdeps import require
+
+require("requests")
+require("alpaca_trade_api")
 
 
 def test_clients_built_once(monkeypatch):

--- a/tests/test_market_calendar_wrapper.py
+++ b/tests/test_market_calendar_wrapper.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 from datetime import date
 
 import pytest
+from tests.optdeps import require
 from ai_trading.data.market_calendar import is_trading_day, rth_session_utc
 
-pmc = pytest.importorskip("pandas_market_calendars")
+pmc = require("pandas_market_calendars")
 
 
 def test_rth_dst_summer_standard_times() -> None:

--- a/tests/test_meta_learning_module.py
+++ b/tests/test_meta_learning_module.py
@@ -1,5 +1,7 @@
 from tests.optdeps import require
+
 require("numpy")
+
 import json
 import sys
 from pathlib import Path

--- a/tests/test_retry_idempotency_integration.py
+++ b/tests/test_retry_idempotency_integration.py
@@ -4,12 +4,13 @@
 import sys
 import time
 import pytest
-import sys
 
 sys.path.insert(0, '/tmp')
 
+from tests.optdeps import require
+
 # Skip when tenacity isn't installed (CI smoke with SKIP_INSTALL=1)
-pytest.importorskip("tenacity")
+require("tenacity")
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 pytestmark = pytest.mark.integration

--- a/tests/test_rl_import_performance.py
+++ b/tests/test_rl_import_performance.py
@@ -3,10 +3,11 @@ import sys
 import time
 
 import pytest
+from tests.optdeps import require
 
-pytest.importorskip("stable_baselines3", reason="RL extras not installed")
-pytest.importorskip("gymnasium", reason="RL extras not installed")
-pytest.importorskip("torch", reason="RL extras not installed")
+require("stable_baselines3")
+require("gymnasium")
+require("torch")
 
 MODULES = [
     "ai_trading.rl_trading",

--- a/tests/test_tenacity_import.py
+++ b/tests/test_tenacity_import.py
@@ -1,8 +1,9 @@
 """Test to ensure real tenacity package is imported from PyPI."""
 import pytest
+from tests.optdeps import require
 
 # Skip when tenacity isn't installed (CI smoke with SKIP_INSTALL=1)
-pytest.importorskip("tenacity")
+require("tenacity")
 
 import inspect
 

--- a/tests/test_trading_config_aliases.py
+++ b/tests/test_trading_config_aliases.py
@@ -6,8 +6,9 @@ script-only knobs get dropped from the model surface.
 from __future__ import annotations
 
 import pytest
+from tests.optdeps import require
 
-pydantic = pytest.importorskip("pydantic")
+pydantic = require("pydantic")
 from ai_trading.config.management import TradingConfig
 
 

--- a/tests/unit/test_alpaca_api.py
+++ b/tests/unit/test_alpaca_api.py
@@ -1,6 +1,7 @@
 import pytest
+from tests.optdeps import require
 
-alpaca_api = pytest.importorskip("alpaca_api", reason="alpaca_api module not found")
+alpaca_api = require("alpaca_api")
 
 @pytest.mark.unit
 def test_pending_orders_lock_exists_and_is_lock():

--- a/tests/unit/test_logging_dedupe.py
+++ b/tests/unit/test_logging_dedupe.py
@@ -1,6 +1,7 @@
 import pytest
+from tests.optdeps import require
 
-log_mod = pytest.importorskip("ai_trading.logging", reason="logging module not importable")
+log_mod = require("ai_trading.logging")
 
 @pytest.mark.unit
 def test_phase_logger_no_propagation():


### PR DESCRIPTION
## Summary
- use `tests.optdeps.require` to guard optional imports across tests
- add install hints for optional libraries
- document optional test groups in testing guide

## Testing
- `ruff check tests/test_meta_learning_module.py tests/test_rl_import_performance.py tests/test_broker_alpaca_adapter.py tests/institutional/test_live_trading.py tests/test_tenacity_import.py tests/unit/test_alpaca_api.py tests/runtime/test_alpaca_wrapped.py tests/test_clients_memoized.py tests/test_market_calendar_wrapper.py tests/test_retry_idempotency_integration.py tests/test_trading_config_aliases.py tests/unit/test_logging_dedupe.py tests/optdeps.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_meta_learning_module.py tests/test_rl_import_performance.py tests/test_broker_alpaca_adapter.py tests/institutional/test_live_trading.py tests/test_tenacity_import.py tests/unit/test_alpaca_api.py tests/runtime/test_alpaca_wrapped.py tests/test_clients_memoized.py tests/test_market_calendar_wrapper.py tests/test_retry_idempotency_integration.py tests/test_trading_config_aliases.py tests/unit/test_logging_dedupe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd104a6608330bf69b07c9c06be23