### PR TITLE
Remove optional_import shims for optional deps

### DIFF
--- a/ai_trading/backtesting/grid_runner.py
+++ b/ai_trading/backtesting/grid_runner.py
@@ -5,17 +5,14 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from itertools import product
 from typing import Any
-from ai_trading.utils.optdeps import optional_import, module_ok  # AI-AGENT-REF: unify optional deps
+import logging
 
-_joblib = optional_import(
-    "joblib", purpose="parallel grid search", extra="backtest"
-)  # AI-AGENT-REF: extras hint uses key
-if module_ok(_joblib):  # joblib available
-    Parallel = _joblib.Parallel
-    delayed = _joblib.delayed
-else:
+logger = logging.getLogger(__name__)
+try:  # optional joblib import
+    from joblib import Parallel, delayed
+except ImportError:  # pragma: no cover - optional dependency
+    logger.info('JOBLIB_MISSING', extra={'hint': 'pip install joblib'})
     Parallel = None
-
     def delayed(f):
         return f
 

--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -21,10 +21,13 @@ from ai_trading.logging.empty_policy import should_emit as _empty_should_emit
 from ai_trading.logging.normalize import canon_feed as _canon_feed
 from ai_trading.logging.normalize import canon_timeframe as _canon_tf
 from ai_trading.logging.normalize import normalize_extra as _norm_extra
-from ai_trading.utils.optdeps import optional_import
 from ai_trading.logging import logger
 from ai_trading.monitoring import metrics
-yf = optional_import('yfinance')
+try:  # optional yfinance import
+    import yfinance as yf  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    yf = None
+    logger.info('YFINANCE_MISSING', extra={'hint': 'pip install yfinance'})
 YF_AVAILABLE = yf is not None
 
 def _to_timeframe_str(tf: object) -> str:

--- a/ai_trading/indicators.py
+++ b/ai_trading/indicators.py
@@ -6,13 +6,14 @@ from functools import lru_cache
 from typing import Any
 import numpy as np
 import pandas as pd
-from ai_trading.utils.optdeps import optional_import, module_ok  # AI-AGENT-REF: unify optional deps
 logger = logging.getLogger(__name__)
 
-_numba = optional_import(
-    "numba", purpose="speeding up indicators", extra="fast"
-)  # AI-AGENT-REF: extras hint uses key
-_numba_jit = getattr(_numba, "jit", None) if module_ok(_numba) else None
+try:  # optional numba import
+    import numba as _numba  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    _numba = None
+    logger.info('NUMBA_MISSING', extra={'hint': 'pip install numba'})
+_numba_jit = getattr(_numba, "jit", None) if _numba is not None else None
 
 def jit(*args, **kwargs):
     """Lazily apply numba JIT based on configuration."""

--- a/ai_trading/plotting/renderer.py
+++ b/ai_trading/plotting/renderer.py
@@ -1,37 +1,21 @@
 """Basic plotting helpers."""
 from __future__ import annotations
-import importlib.util
-from pathlib import Path
-import sys
+import logging
+from ai_trading.utils.optdeps import OptionalDependencyError
 
-# AI-AGENT-REF: load optdeps without heavy package import
-_spec = importlib.util.spec_from_file_location(
-    "_optdeps", Path(__file__).resolve().parent.parent / "utils" / "optdeps.py"
-)
-_optdeps = importlib.util.module_from_spec(_spec)
-sys.modules["_optdeps"] = _optdeps
-assert _spec.loader is not None
-_spec.loader.exec_module(_optdeps)
-optional_import = _optdeps.optional_import
-module_ok = _optdeps.module_ok
-OptionalDependencyError = _optdeps.OptionalDependencyError
-
-# AI-AGENT-REF: optional matplotlib import
-plt = optional_import(
-    "matplotlib.pyplot",
-    purpose="plotting results",
-    extra="plot",
-)  # AI-AGENT-REF: extras hint uses key
-
+logger = logging.getLogger(__name__)
 
 def render_equity_curve(series, *, title: str = "Equity") -> None:
     """Render a simple equity curve using matplotlib if available."""
-    if not module_ok(plt):
+    try:
+        import matplotlib.pyplot as plt  # type: ignore
+    except ImportError:  # pragma: no cover - optional dependency
+        logger.info(
+            'MATPLOTLIB_MISSING', extra={'hint': 'pip install "ai-trading-bot[plot]"'}
+        )
         raise OptionalDependencyError(
-            "matplotlib",
-            feature="plotting",
-            extra="plot",
-        )  # AI-AGENT-REF: extras hint uses key
+            "matplotlib", feature="plotting", extra="plot"
+        )
     plt.figure()
     plt.plot(series)
     plt.title(title)

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -17,13 +17,13 @@ from ai_trading.config.settings import get_settings
 if not hasattr(np, 'NaN'):
     np.NaN = np.nan
 
-def _optional_import(name: str):
-    try:
-        return importlib.import_module(name)
-    except ImportError:
-        return None
-
-ta = _optional_import('pandas_ta')
+try:  # optional pandas_ta import for ta accessor registration
+    import pandas_ta as ta  # type: ignore  # noqa: F401
+except ImportError:  # pragma: no cover - optional dependency
+    ta = None
+    logging.getLogger(__name__).info(
+        'PANDAS_TA_MISSING', extra={'hint': 'pip install pandas-ta'}
+    )
 try:  # pragma: no cover - optional dependency
     from alpaca_trade_api import REST as AlpacaREST
 except ImportError:

--- a/tests/data_fetcher/test_build_fetcher.py
+++ b/tests/data_fetcher/test_build_fetcher.py
@@ -10,12 +10,6 @@ sys.modules.setdefault("ai_trading.config", cfg_stub)
 
 utils_stub = types.ModuleType("ai_trading.utils")
 utils_stub.__path__ = []  # mark as package
-opt_stub = types.ModuleType("ai_trading.utils.optdeps")
-
-def _optional_import(name):
-    return None
-
-opt_stub.optional_import = _optional_import
 utils_stub.health_check = lambda *a, **k: True
 http_stub = types.ModuleType("ai_trading.utils.http")
 time_stub = types.ModuleType("ai_trading.utils.time")
@@ -24,7 +18,6 @@ time_stub.now_utc = lambda *a, **k: None
 dt_stub = types.ModuleType("ai_trading.utils.datetime")
 dt_stub.ensure_datetime = lambda *a, **k: None
 sys.modules.setdefault("ai_trading.utils", utils_stub)
-sys.modules.setdefault("ai_trading.utils.optdeps", opt_stub)
 sys.modules.setdefault("ai_trading.utils.http", http_stub)
 sys.modules.setdefault("ai_trading.utils.time", time_stub)
 sys.modules.setdefault("ai_trading.utils.datetime", dt_stub)

--- a/tests/data_fetcher/test_datetime_narrow_exceptions.py
+++ b/tests/data_fetcher/test_datetime_narrow_exceptions.py
@@ -10,12 +10,6 @@ cfg_stub.get_settings = lambda: None
 sys.modules.setdefault("ai_trading.config", cfg_stub)
 utils_stub = types.ModuleType("ai_trading.utils")
 utils_stub.__path__ = []
-opt_stub = types.ModuleType("ai_trading.utils.optdeps")
-
-def _optional_import(name):
-    return None
-
-opt_stub.optional_import = _optional_import
 utils_stub.health_check = lambda *a, **k: True
 http_stub = types.ModuleType("ai_trading.utils.http")
 time_stub = types.ModuleType("ai_trading.utils.time")
@@ -24,7 +18,6 @@ time_stub.now_utc = lambda *a, **k: None
 dt_stub = types.ModuleType("ai_trading.utils.datetime")
 dt_stub.ensure_datetime = lambda *a, **k: None
 sys.modules.setdefault("ai_trading.utils", utils_stub)
-sys.modules.setdefault("ai_trading.utils.optdeps", opt_stub)
 sys.modules.setdefault("ai_trading.utils.http", http_stub)
 sys.modules.setdefault("ai_trading.utils.time", time_stub)
 sys.modules.setdefault("ai_trading.utils.datetime", dt_stub)

--- a/tests/test_utils_optdeps.py
+++ b/tests/test_utils_optdeps.py
@@ -57,9 +57,18 @@ def test_auto_derives_extra(monkeypatch):
 
 def test_render_equity_curve_handles_missing_matplotlib(monkeypatch):
     sys.modules.pop("ai_trading.plotting.renderer", None)
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "matplotlib.pyplot":
+            raise ImportError("simulated missing")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
     from ai_trading.plotting import renderer
 
-    renderer.plt = None
     with pytest.raises(renderer.OptionalDependencyError):
         renderer.render_equity_curve([1, 2, 3])
 


### PR DESCRIPTION
## Summary
- refactor optional imports to explicit try/except blocks in data fetcher, risk engine, indicators, grid runner, and plotting renderer
- log missing optional deps with install hints
- adjust tests for new ImportError handling

## Testing
- `python3 -m pip install -U pip` *(fails: externally-managed-environment)*
- `pip install -e .` *(fails: externally-managed-environment)*
- `ruff check .` *(fails: command not found)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: command not found)*
- `curl -sS http://127.0.0.1:9001/health` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68acd53622dc8330898b87752e1dec4a