### PR TITLE
feat: lazily load heavy modules

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -334,8 +334,11 @@ def _log_finbert_disabled() -> None:
         _finbert_logged = True
 
 # AI-AGENT-REF: normalize arbitrary inputs into DataFrames
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
 import logging
+
+# Lazy pandas proxy
+pd = load_pandas()
 logger = logging.getLogger(__name__)
 
 def _alpaca_diag_info() -> dict[str, object]:

--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
-import pandas as pd
+from dataclasses import dataclass
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.config import get_settings
 from ai_trading.data.market_calendar import previous_trading_session, rth_session_utc
 from ai_trading.data_fetcher import get_bars, get_minute_df
@@ -15,7 +16,10 @@ from ai_trading.logging.normalize import canon_feed as _canon_feed
 from ai_trading.logging.normalize import canon_timeframe as _canon_tf
 from ai_trading.utils.time import now_utc
 from .timeutils import ensure_utc_datetime, expected_regular_minutes
-from dataclasses import dataclass
+
+# Lazy pandas proxy; only imported on first use
+pd = load_pandas()
+
 _log = get_logger(__name__)
 'AI-AGENT-REF: canonicalizers moved to ai_trading.logging.normalize'
 

--- a/ai_trading/data/market_calendar.py
+++ b/ai_trading/data/market_calendar.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from zoneinfo import ZoneInfo
+from ai_trading.utils.lazy_imports import load_pandas, load_pandas_market_calendars
+
 _ET = ZoneInfo('America/New_York')
-_HAVE_PMC = False
-try:
-    import pandas as pd
-    import pandas_market_calendars as mcal
-    _CAL = mcal.get_calendar('XNYS')
-    _HAVE_PMC = True
-except ImportError:
-    pd = None
-    _CAL = None
+_CAL = None
+
+def _get_calendar():
+    """Load and cache the trading calendar on demand."""
+    global _CAL
+    if _CAL is None:
+        mcal = load_pandas_market_calendars()
+        if mcal is None:
+            return None
+        _CAL = mcal.get_calendar('XNYS')
+    return _CAL
 
 @dataclass(frozen=True)
 class Session:
@@ -20,24 +24,30 @@ class Session:
 
 def is_trading_day(d: date) -> bool:
     """Return True if *d* is a trading day."""
-    if _HAVE_PMC:
-        days = _CAL.valid_days(start_date=d, end_date=d)
+    cal = _get_calendar()
+    if cal is not None:
+        days = cal.valid_days(start_date=d, end_date=d)
         return len(days) == 1
     return d.weekday() < 5
 
 def _pmc_session_utc(d: date) -> Session:
     """Fetch accurate session times via pandas-market-calendars."""
-    sched = _CAL.schedule(start_date=d, end_date=d, tz=_ET)
+    cal = _get_calendar()
+    if cal is None:
+        raise RuntimeError("pandas_market_calendars not available")
+    pd = load_pandas()
+    sched = cal.schedule(start_date=d, end_date=d, tz=_ET)
     if sched.empty:
         prev = previous_trading_session(d)
-        sched = _CAL.schedule(start_date=prev, end_date=prev, tz=_ET)
+        sched = cal.schedule(start_date=prev, end_date=prev, tz=_ET)
     open_et = sched.iloc[0]['market_open'].to_pydatetime().astimezone(_ET)
     close_et = sched.iloc[0]['market_close'].to_pydatetime().astimezone(_ET)
     return Session(open_et.astimezone(UTC), close_et.astimezone(UTC))
 
 def rth_session_utc(d: date) -> tuple[datetime, datetime]:
     """Return the Regular Trading Hours window in UTC."""
-    if _HAVE_PMC:
+    cal = _get_calendar()
+    if cal is not None:
         s = _pmc_session_utc(d)
         return (s.start_utc, s.end_utc)
     start_et = datetime(d.year, d.month, d.day, 9, 30, tzinfo=_ET)
@@ -46,12 +56,13 @@ def rth_session_utc(d: date) -> tuple[datetime, datetime]:
 
 def previous_trading_session(d: date) -> date:
     """Return the previous trading day for *d*."""
-    if _HAVE_PMC:
-        days = _CAL.valid_days(start_date=d.replace(day=1), end_date=d)
+    cal = _get_calendar()
+    if cal is not None:
+        days = cal.valid_days(start_date=d.replace(day=1), end_date=d)
         if len(days) == 0:
             from datetime import timedelta
             back = d.replace(day=1) - timedelta(days=1)
-            days = _CAL.valid_days(start_date=back.replace(day=1), end_date=back)
+            days = cal.valid_days(start_date=back.replace(day=1), end_date=back)
         return days[-1].date()
     from datetime import timedelta
     dd = d

--- a/ai_trading/data/universe.py
+++ b/ai_trading/data/universe.py
@@ -1,7 +1,10 @@
 import os
 from importlib.resources import files as pkg_files
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.logging import logger
+
+# Lazy pandas proxy
+pd = load_pandas()
 
 def locate_tickers_csv() -> str | None:
     env = os.getenv('AI_TRADER_TICKERS_CSV')

--- a/ai_trading/data_validation.py
+++ b/ai_trading/data_validation.py
@@ -5,8 +5,11 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from pathlib import Path
 from typing import Any
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.data_fetcher import get_bars
+
+# Lazy pandas proxy for on-demand import
+pd = load_pandas()
 __all__ = ['check_data_freshness', 'get_stale_symbols', 'validate_trading_data', 'emergency_data_check', 'is_valid_ohlcv', 'validate_trade_log_integrity', 'monitor_real_time_data_quality', 'MarketDataValidator', 'ValidationSeverity']
 REQUIRED_PRICE_COLS = ('open', 'high', 'low', 'close', 'volume')
 

--- a/ai_trading/features/indicators.py
+++ b/ai_trading/features/indicators.py
@@ -6,10 +6,14 @@ technical indicators used in trading strategies.
 
 Moved from root features.py for package-safe imports.
 """
+from __future__ import annotations
 import logging
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.indicators import atr, ema
 logger = logging.getLogger(__name__)
+
+# Lazy pandas proxy
+pd = load_pandas()
 
 def compute_macd(df: pd.DataFrame) -> pd.DataFrame:
     """Compute MACD indicator."""

--- a/ai_trading/indicators.py
+++ b/ai_trading/indicators.py
@@ -5,8 +5,11 @@ from collections.abc import Iterable
 from functools import lru_cache
 from typing import Any
 import numpy as np
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
 logger = logging.getLogger(__name__)
+
+# Lazy pandas proxy
+pd = load_pandas()
 
 try:  # optional numba import
     import numba as _numba  # type: ignore

--- a/ai_trading/market/calendars.py
+++ b/ai_trading/market/calendars.py
@@ -8,7 +8,6 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from enum import Enum
-import pandas as pd
 logger = logging.getLogger(__name__)
 
 class AssetClass(Enum):

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -9,13 +9,16 @@ from datetime import UTC
 from typing import Any
 import numpy as np
 import importlib
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.broker.alpaca import ensure_api_error
 from ai_trading.config.management import SEED, TradingConfig
 from ai_trading.config.settings import get_settings
 
 if not hasattr(np, 'NaN'):
     np.NaN = np.nan
+
+# Lazy pandas proxy
+pd = load_pandas()
 
 try:  # optional pandas_ta import for ta accessor registration
     import pandas_ta as ta  # type: ignore  # noqa: F401

--- a/ai_trading/utils/lazy_imports.py
+++ b/ai_trading/utils/lazy_imports.py
@@ -1,0 +1,36 @@
+"""Helpers for lazily loading heavy third-party modules."""
+
+from __future__ import annotations
+
+import importlib
+from functools import lru_cache
+from importlib.util import find_spec
+from types import ModuleType
+
+class _LazyModule(ModuleType):
+    """Proxy module that loads the real module upon first attribute access."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self._name = name
+        self._module: ModuleType | None = None
+
+    def _load(self) -> ModuleType:
+        if self._module is None:
+            self._module = importlib.import_module(self._name)
+        return self._module
+
+    def __getattr__(self, item: str):  # pragma: no cover - passthrough
+        return getattr(self._load(), item)
+
+@lru_cache(maxsize=None)
+def load_pandas() -> ModuleType:
+    """Return a proxy for :mod:`pandas` loaded on first use."""
+    return _LazyModule("pandas")
+
+@lru_cache(maxsize=None)
+def load_pandas_market_calendars() -> ModuleType | None:
+    """Return a proxy for :mod:`pandas_market_calendars` if available."""
+    if find_spec("pandas_market_calendars") is None:
+        return None
+    return _LazyModule("pandas_market_calendars")

--- a/ai_trading/utils/time.py
+++ b/ai_trading/utils/time.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from dataclasses import dataclass
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.market.calendars import get_calendar_registry
+
+# Lazy pandas proxy
+pd = load_pandas()
 
 def utcnow() -> datetime:
     """Repository-standard UTC now (timezone-aware)."""
     return datetime.now(UTC)
+
 now_utc = utcnow
 
 @dataclass
@@ -24,4 +28,5 @@ def last_market_session(now: pd.Timestamp) -> SessionWindow | None:
             return SessionWindow(pd.Timestamp(start).tz_convert('UTC'), pd.Timestamp(end).tz_convert('UTC'))
         current -= timedelta(days=1)
     return None
+
 __all__ = ['utcnow', 'now_utc', 'SessionWindow', 'last_market_session']


### PR DESCRIPTION
## Summary
- add `utils.lazy_imports` with cached lazy loaders
- defer pandas and calendar imports across data fetch, bars, indicators, and risk modules
- ensure startup runs without pandas installed

## Testing
- `ruff check ai_trading/core/bot_engine.py ai_trading/data/bars.py ai_trading/data/market_calendar.py ai_trading/data_fetcher.py ai_trading/data_validation.py ai_trading/market/calendars.py ai_trading/utils/time.py ai_trading/utils/lazy_imports.py ai_trading/data/universe.py ai_trading/indicators.py ai_trading/features/indicators.py ai_trading/risk/engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 51 errors during collection)*
- `python -m ai_trading.main --iterations 0` *(fails: No module named 'yfinance')*

------
https://chatgpt.com/codex/tasks/task_e_68acd7ebaba883309fcaa80397b5fa2a