### PR TITLE
chore: remove pytz pins from constraints

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -69,8 +69,6 @@ python-dateutil==2.9.0.post0
     #   pandas-market-calendars
 python-dotenv==1.1.1
     # via pydantic-settings
-pytz==2025.2
-    # via pandas
 ruff==0.12.10
     # via -r requirements/dev.txt
 six==1.17.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -119,10 +119,6 @@ python-dotenv==1.1.1
     # via
     #   -r requirements.txt
     #   pydantic-settings
-pytz==2025.2
-    # via pandas
-pytz-deprecation-shim==0.1.0.post0
-    # via tzlocal
 pyyaml==6.0.1
     # via alpaca-trade-api
 ratelimit==2.2.1
@@ -166,7 +162,6 @@ tzdata==2025.2
     #   exchange-calendars
     #   pandas
     #   pandas-market-calendars
-    #   pytz-deprecation-shim
 tzlocal==4.3
     # via -r requirements.txt
 urllib3==1.26.20


### PR DESCRIPTION
## Summary
- drop pytz and pytz-deprecation-shim entries from constraints

## Testing
- `pip-compile --output-file=/tmp/constraints-new.txt requirements.txt`
- `pip install -r constraints.txt`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca_trade_api.__spec__ is None and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ace6a1cf408330956cd2c7bc9439fc