### PR TITLE
Refactor yfinance import for data fetcher

### DIFF
--- a/tests/test_data_fetcher_init.py
+++ b/tests/test_data_fetcher_init.py
@@ -46,7 +46,7 @@ def test_build_fetcher_fallback_requests(monkeypatch):
 
     dummy_core = types.SimpleNamespace(DataFetcher=DummyFetcher, DataFetchError=Exception)
     monkeypatch.setitem(sys.modules, "ai_trading.core.bot_engine", dummy_core)
-    monkeypatch.setattr(df_module, "yf", None, raising=False)
+    monkeypatch.setitem(sys.modules, "yfinance", None)
     monkeypatch.setattr(df_module, "requests", object(), raising=False)
     fetcher = df_module.build_fetcher(object())
     assert fetcher is not None
@@ -64,7 +64,7 @@ def test_build_fetcher_offline_returns_empty_df(monkeypatch):
 
     dummy_core = types.SimpleNamespace(DataFetcher=DummyFetcher, DataFetchError=Exception)
     monkeypatch.setitem(sys.modules, "ai_trading.core.bot_engine", dummy_core)
-    monkeypatch.setattr(df_module, "yf", None, raising=False)
+    monkeypatch.setitem(sys.modules, "yfinance", None)
     monkeypatch.setattr(df_module, "requests", None, raising=False)
     fetcher = df_module.build_fetcher(object())
     df = fetcher.get_daily_df(object(), "SPY")


### PR DESCRIPTION
## Summary
- import yfinance inside `build_fetcher` and `_yahoo_get_bars` instead of at module import time
- set provider `source` on returned fetcher
- update tests to patch `sys.modules` for `yfinance` and stub heavy modules

## Testing
- `ruff check ai_trading/data_fetcher.py tests/data_fetcher/test_build_fetcher.py tests/test_data_fetcher_init.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', etc.)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_data_fetcher_init.py tests/data_fetcher/test_build_fetcher.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ace911dc6c8330b179158cbfae9150