### PR TITLE
Implement moving-average entry/exit signals with tests

### DIFF
--- a/docs/ENTRY_EXIT_SIGNALS.md
+++ b/docs/ENTRY_EXIT_SIGNALS.md
@@ -1,0 +1,33 @@
+# Entry and Exit Signal Methodology
+
+This project uses a simple moving-average crossover to derive trading signals.
+
+## Entry (Buy)
+
+A **buy** signal is generated when a short-term simple moving average (SMA)
+crosses above a longer-term SMA. The default window lengths are:
+
+- `entry_short_window`: 5 periods
+- `entry_long_window`: 20 periods
+
+Both values can be overridden on the runtime context (`ctx`). The functions
+operate on a price history DataFrame `df` that must include a `close` column.
+
+## Exit (Sell)
+
+A **sell** signal is produced when the short-term SMA crosses below the
+long-term SMA. The default windows mirror the entry settings:
+
+- `exit_short_window`: 5 periods
+- `exit_long_window`: 20 periods
+
+The functions return dictionaries with a boolean action flag and the latest
+price:
+
+```python
+{"buy": True, "price": 123.45}
+{"sell": True, "price": 123.45}
+```
+
+If no crossover is detected or insufficient data is provided, the functions
+return `None`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,9 @@
 This repository contains a simple trading bot together with a backtesting
 harness for optimizing its tunable hyperparameters.
 
+For details on how entry and exit signals are generated, see
+[Entry and Exit Signal Methodology](ENTRY_EXIT_SIGNALS.md).
+
 ## Running the Backtester
 
 ```

--- a/tests/test_entry_exit_signals.py
+++ b/tests/test_entry_exit_signals.py
@@ -1,0 +1,44 @@
+from tests.optdeps import require
+require("pandas")
+import pandas as pd
+from types import SimpleNamespace
+import sys
+import types
+
+# Stub heavy dependencies before importing trade_logic
+logger_mod = types.ModuleType("ai_trading.logging")
+logger_mod.get_logger = lambda name: types.SimpleNamespace(
+    info=lambda *a, **k: None,
+    debug=lambda *a, **k: None,
+    warning=lambda *a, **k: None,
+)
+sys.modules.setdefault("ai_trading.logging", logger_mod)
+
+cap_mod = types.ModuleType("ai_trading.capital_scaling")
+cap_mod.drawdown_adjusted_kelly = lambda *a, **k: 1.0
+cap_mod.drawdown_adjusted_kelly_alt = cap_mod.drawdown_adjusted_kelly
+sys.modules.setdefault("ai_trading.capital_scaling", cap_mod)
+
+settings_mod = types.ModuleType("ai_trading.config.settings")
+settings_mod.get_settings = lambda: SimpleNamespace(intraday_lookback_minutes=120)
+sys.modules.setdefault("ai_trading.config.settings", settings_mod)
+
+core_mod = types.ModuleType("ai_trading.core.bot_engine")
+core_mod._fetch_intraday_bars_chunked = lambda *a, **k: {}
+sys.modules.setdefault("ai_trading.core.bot_engine", core_mod)
+
+from ai_trading.trade_logic import _compute_entry_signal, _compute_exit_signal
+
+
+def test_entry_signal_buy_on_cross():
+    df = pd.DataFrame({"close": [3, 2, 2, 3]})
+    ctx = SimpleNamespace(entry_short_window=2, entry_long_window=3)
+    sig = _compute_entry_signal(ctx, "SYM", df)
+    assert sig == {"buy": True, "price": 3.0}
+
+
+def test_exit_signal_sell_on_cross():
+    df = pd.DataFrame({"close": [2, 3, 3, 2]})
+    ctx = SimpleNamespace(exit_short_window=2, exit_long_window=3)
+    sig = _compute_exit_signal(ctx, "SYM", df)
+    assert sig == {"sell": True, "price": 2.0}


### PR DESCRIPTION
## Summary
- implement simple moving-average crossover logic for `_compute_entry_signal` and `_compute_exit_signal`
- document moving-average signal methodology and link from docs index
- add unit tests verifying buy/sell signals on known price patterns

## Testing
- `ruff check ai_trading/trade_logic.py tests/test_entry_exit_signals.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_entry_exit_signals.py -q`
- `curl http://127.0.0.1:9001/health` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68acead873cc83309efb1131c6371bff