### PR TITLE
feat: add runtime loop flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ python -m ai_trading
 
 # Or use the convenience script
 ./start.sh
+
+# Run a single paper-trading cycle
+python -m ai_trading --once --paper
+
+# Continuous live trading with a 10s loop interval
+python -m ai_trading --live --interval 10
 ```
 
 ### 📈 Backtesting & Optimization

--- a/ai_trading/__main__.py
+++ b/ai_trading/__main__.py
@@ -1,95 +1,142 @@
 from __future__ import annotations
+
 import argparse
 import sys
+from collections.abc import Callable
+
 from ai_trading.logging import get_logger
+
 logger = get_logger(__name__)
+
+
+def _build_parser(description: str, *, symbols: bool = False) -> argparse.ArgumentParser:
+    """Return a base parser with common runtime options."""
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--dry-run", action="store_true", help="Exit before heavy imports")
+    parser.add_argument("--once", action="store_true", help="Run a single iteration and exit")
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="Delay between iterations in seconds",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--paper", dest="paper", action="store_true", help="Use paper trading (default)")
+    mode.add_argument("--live", dest="paper", action="store_false", help="Use live trading")
+    parser.set_defaults(paper=True)
+    if symbols:
+        parser.add_argument("--symbols", type=str)
+    return parser
+
+
+def _run_loop(fn: Callable[[], None], args: argparse.Namespace, label: str) -> None:
+    """Execute ``fn`` respecting --once/--interval and uniform error handling."""
+
+    import time
+
+    try:
+        while True:
+            fn()
+            if args.once:
+                break
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        logger.info("%s interrupted", label)
+        sys.exit(0)
+    except (KeyError, ValueError, TypeError) as e:
+        logger.error("%s failed: %s", label, e, exc_info=True)
+        sys.exit(1)
+
 
 def run_trade() -> None:
     """Entrypoint for live trading loop."""
-    p = argparse.ArgumentParser(description='AI Trading Bot')
-    p.add_argument('--dry-run', action='store_true')
-    p.add_argument('--symbols', type=str)
-    args = p.parse_args()
+
+    parser = _build_parser("AI Trading Bot", symbols=True)
+    args = parser.parse_args()
     if args.dry_run:
-        logger.info('AI Trade: Dry run - exiting')
+        logger.info("AI Trade: Dry run - exiting")
         return
+
+    import os
+
+    os.environ["TRADING_MODE"] = "paper" if args.paper else "live"
     from ai_trading.settings import ensure_dotenv_loaded
+
     ensure_dotenv_loaded()
     from ai_trading import runner
-    try:
-        runner.run_cycle()
-    except KeyboardInterrupt:
-        logger.info('Trade interrupted')
-        sys.exit(0)
-    except (KeyError, ValueError, TypeError) as e:
-        logger.error('Trade failed: %s', e, exc_info=True)
-        sys.exit(1)
+
+    _run_loop(runner.run_cycle, args, "Trade")
+
 
 def run_backtest() -> None:
-    p = argparse.ArgumentParser(description='AI Trading Bot Backtesting')
-    p.add_argument('--dry-run', action='store_true')
-    p.add_argument('--symbols', type=str)
-    args = p.parse_args()
+    """Entrypoint for backtesting loop."""
+
+    parser = _build_parser("AI Trading Bot Backtesting", symbols=True)
+    args = parser.parse_args()
     if args.dry_run:
-        logger.info('AI Backtest: Dry run - exiting')
+        logger.info("AI Backtest: Dry run - exiting")
         return
+
+    import os
+
+    os.environ["TRADING_MODE"] = "paper" if args.paper else "live"
     from ai_trading.settings import ensure_dotenv_loaded
+
     ensure_dotenv_loaded()
     from ai_trading import runner
-    try:
-        runner.run_cycle()
-    except KeyboardInterrupt:
-        logger.info('Backtest interrupted')
-        sys.exit(0)
-    except (KeyError, ValueError, TypeError) as e:
-        logger.error('Backtest failed: %s', e, exc_info=True)
-        sys.exit(1)
+
+    _run_loop(runner.run_cycle, args, "Backtest")
+
 
 def run_healthcheck() -> None:
-    p = argparse.ArgumentParser(description='AI Trading Bot Health Check')
-    p.add_argument('--dry-run', action='store_true')
-    args = p.parse_args()
+    """Entrypoint for health check loop."""
+
+    parser = _build_parser("AI Trading Bot Health Check")
+    args = parser.parse_args()
     if args.dry_run:
-        logger.info('AI Health: Dry run - exiting')
+        logger.info("AI Health: Dry run - exiting")
         return
+
+    import os
+
+    os.environ["TRADING_MODE"] = "paper" if args.paper else "live"
     from ai_trading.settings import ensure_dotenv_loaded
+
     ensure_dotenv_loaded()
     from ai_trading.health_monitor import run_health_check
-    try:
-        run_health_check()
-    except KeyboardInterrupt:
-        logger.info('Health check interrupted')
-        sys.exit(0)
-    except (KeyError, ValueError, TypeError) as e:
-        logger.error('Health check failed: %s', e, exc_info=True)
-        sys.exit(1)
+
+    _run_loop(run_health_check, args, "Health check")
+
 
 def main() -> None:
-    p = argparse.ArgumentParser(description='AI Trading Bot')
-    p.add_argument('--dry-run', action='store_true')
-    p.add_argument('--symbols', type=str)
-    args = p.parse_args()
+    """Default CLI entrypoint mirroring ``run_trade``."""
+
+    parser = _build_parser("AI Trading Bot", symbols=True)
+    args = parser.parse_args()
     if args.dry_run:
-        logger.info('AI Main: Dry run - exiting')
+        logger.info("AI Main: Dry run - exiting")
         return
+
+    import os
+
+    os.environ["TRADING_MODE"] = "paper" if args.paper else "live"
     from ai_trading.settings import ensure_dotenv_loaded
+
     ensure_dotenv_loaded()
     from ai_trading import runner
-    try:
-        runner.run_cycle()
-    except KeyboardInterrupt:
-        logger.info('Main interrupted')
-        sys.exit(0)
-    except (KeyError, ValueError, TypeError) as e:
-        logger.error('Main failed: %s', e, exc_info=True)
-        sys.exit(1)
-if __name__ == '__main__':
+
+    _run_loop(runner.run_cycle, args, "Main")
+
+
+if __name__ == "__main__":
     try:
         main()
     except SystemExit:
         raise
     except Exception as e:
-        if '--dry-run' in sys.argv:
-            logger.warning('dry-run: ignoring startup exception: %s', e)
+        if "--dry-run" in sys.argv:
+            logger.warning("dry-run: ignoring startup exception: %s", e)
             sys.exit(0)
         raise
+


### PR DESCRIPTION
## Summary
- add shared CLI parser with `--once`, `--interval`, and `--paper/--live` options
- loop runner helpers respect new flags while preserving early `--dry-run` exit
- document trading loop examples in README

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 63 errors during collection)*
- `curl -sS http://127.0.0.1:9001/health` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68acf017d9188330a93db6d6bf8c64df