### PR TITLE
Seed tests for deterministic runs

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -12,6 +12,7 @@ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
 ## Table of Contents
 
 - [Testing Philosophy](#testing-philosophy)
+- [Deterministic Testing](#deterministic-testing)
 - [Test Structure](#test-structure)
 - [Unit Testing](#unit-testing)
 - [Integration Testing](#integration-testing)
@@ -51,6 +52,10 @@ Unit Tests (70%)
 3. **Maintainable**: Clear test structure and naming
 4. **Comprehensive**: High test coverage (>80%)
 5. **Realistic**: Use realistic test data and scenarios
+
+## Deterministic Testing
+
+To keep results reproducible, all tests run with a fixed random seed. A session-scoped pytest fixture sets `PYTHONHASHSEED=0`, seeds Python's `random` module and NumPy, and calls `torch.manual_seed(0)` when PyTorch is available. Tests should avoid introducing additional sources of nondeterminism.
 
 ## Test Structure
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,26 @@
 import importlib.util
+import os
+import random
 from pathlib import Path
+
+import numpy as np
+import pytest
 
 
 def _missing(mod: str) -> bool:
     return importlib.util.find_spec(mod) is None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _seed_tests() -> None:
+    """Ensure deterministic test execution."""
+    os.environ["PYTHONHASHSEED"] = "0"
+    random.seed(0)
+    np.random.seed(0)
+    if not _missing("torch"):
+        import torch
+
+        torch.manual_seed(0)
 
 
 def pytest_ignore_collect(path, config):


### PR DESCRIPTION
## Summary
- Add session-scoped fixture that seeds `random`, `numpy`, `PYTHONHASHSEED`, and PyTorch when available for reproducible tests
- Document deterministic testing policy in the testing framework guide

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'pydantic', 'psutil', and other dependency issues)*

## Rollback
- Revert the commit

------
https://chatgpt.com/codex/tasks/task_e_68acf011f9908330847fe0e6f8d5f58b