### PR TITLE
chore: order config imports

### DIFF
--- a/ai_trading/config/__init__.py
+++ b/ai_trading/config/__init__.py
@@ -2,14 +2,15 @@ import logging
 import os
 import threading
 from typing import Any
+
 from .alpaca import AlpacaConfig, get_alpaca_config
 from .locks import LockWithTimeout
-from .settings import Settings, broker_keys, get_settings
 # AI-AGENT-REF: re-export config management helpers
 from .management import (
     TradingConfig,
     derive_cap_from_settings,
 )
+from .settings import Settings, broker_keys, get_settings
 logger = logging.getLogger(__name__)
 _LOCK_TIMEOUT = 30
 _ENV_LOCK = LockWithTimeout(_LOCK_TIMEOUT)


### PR DESCRIPTION
## Summary
- reorder `ai_trading.config` imports and ensure `logging` is imported

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68acefe901bc8330b494d396489ee287