### PR TITLE
refactor: load dotenv lazily in entry points

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -7,8 +7,6 @@ from threading import Thread
 import signal
 from datetime import datetime, UTC
 from ai_trading.env import ensure_dotenv_loaded
-
-ensure_dotenv_loaded()
 from ai_trading.logging import get_logger
 
 logger = get_logger(__name__)
@@ -177,6 +175,7 @@ def run_bot(*_a, **_k) -> int:
 
     Sets up logging, validates configuration, and starts the bot.
     """
+    ensure_dotenv_loaded()
     global config
     from ai_trading.logging import setup_logging, validate_logging_setup
 
@@ -225,6 +224,7 @@ def run_flask_app(port: int = 5000, ready_signal: threading.Event = None) -> Non
 
 def start_api(ready_signal: threading.Event = None) -> None:
     """Spin up the Flask API server."""
+    ensure_dotenv_loaded()
     settings = get_settings()
     port = int(settings.api_port or 9001)
     run_flask_app(port, ready_signal)
@@ -250,6 +250,7 @@ def parse_cli(argv: list[str] | None = None):
 
 def main(argv: list[str] | None = None) -> None:
     """Start the API thread and repeatedly run trading cycles."""
+    ensure_dotenv_loaded()
     args = parse_cli(argv)
     global config
     config = get_settings()


### PR DESCRIPTION
## Summary
- remove module-level `ensure_dotenv_loaded` call in `main`
- call `ensure_dotenv_loaded()` inside `run_bot`, `start_api`, and `main`
- add regression test ensuring importing `ai_trading.main` has no dotenv side effects

## Testing
- `ruff check tests/test_env_order_and_lazy_import.py ai_trading/main.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_env_order_and_lazy_import.py::TestEnvironmentOrderAndLazyImport::test_main_loads_dotenv_before_runner_import tests/test_env_order_and_lazy_import.py::TestEnvironmentOrderAndLazyImport::test_import_main_has_no_env_side_effect -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError: cannot import name 'fetch_minute_df_safe' from 'ai_trading.core.bot_engine')*

------
https://chatgpt.com/codex/tasks/task_e_68aceff0f8588330a0322e07d6d1b10e