### PR TITLE
feat: cache torch availability

### DIFF
--- a/ai_trading/utils/device.py
+++ b/ai_trading/utils/device.py
@@ -2,35 +2,52 @@ from __future__ import annotations
 
 import logging
 
-try:  # RL optional: never fail import if torch isn't installed
-    import torch  # type: ignore[assignment]
-except Exception:  # noqa: BLE001
-    torch = None  # type: ignore[assignment]
+# torch is optional and heavy; import lazily inside functions
+# Cache references for repeated calls
+torch = None  # type: ignore[assignment]
+_torch_tensor = None
+_device = None
 
 _log = logging.getLogger(__name__)
 
 
 def get_device() -> str:
     """Simple, import-safe detection of the ML device."""
-    if torch is not None:
+    global torch, _device
+    if _device is not None:
+        return _device
+
+    try:
+        import torch as _torch  # type: ignore[assignment]
+        torch = _torch
+    except Exception:  # noqa: BLE001
+        _device = "cpu"
+    else:
         try:
             if hasattr(torch, "cuda") and torch.cuda.is_available():
-                dev = "cuda"
-                _log.info("ML_DEVICE_DETECTED", extra={"device": dev})  # AI-AGENT-REF: optional CUDA
-                return dev
+                _device = "cuda"
+            else:
+                _device = "cpu"
         except Exception:  # defensive: do not let CUDA probing blow up
-            pass
-    dev = "cpu"
-    _log.info("ML_DEVICE_DETECTED", extra={"device": dev})  # AI-AGENT-REF: default CPU
-    return dev
+            _device = "cpu"
+
+    _log.info("ML_DEVICE_DETECTED", extra={"device": _device})  # AI-AGENT-REF: default CPU / optional CUDA
+    return _device
 
 
 def tensors_to_device(batch: dict, device: str):
     """Move a tokenizer batch (dict of tensors) to the target device."""
+    global torch, _torch_tensor
     if torch is None:
-        return batch
-    try:
-        from torch import Tensor
-    except Exception:  # noqa: BLE001
-        return batch
-    return {k: v.to(device) if isinstance(v, Tensor) else v for k, v in batch.items()}
+        try:
+            import torch as _torch  # type: ignore[assignment]
+            torch = _torch
+        except Exception:  # noqa: BLE001
+            return batch
+    if _torch_tensor is None:
+        try:
+            from torch import Tensor as _Tensor
+            _torch_tensor = _Tensor
+        except Exception:  # noqa: BLE001
+            return batch
+    return {k: v.to(device) if isinstance(v, _torch_tensor) else v for k, v in batch.items()}


### PR DESCRIPTION
## Summary
- avoid module-level torch import and cache a lazily imported copy
- locally import torch and Tensor, caching the ML device and tensor class for reuse

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68aceff2561c833091bb93f1fd4d9760