### PR TITLE
refactor: lazily import heavy modules in meta learning

### DIFF
--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -1,5 +1,6 @@
 from tests.optdeps import require
 require("pandas")
+require("numpy")
 import builtins
 import importlib
 import runpy
@@ -177,7 +178,7 @@ def test_meta_update_weights_error(monkeypatch, tmp_path):
     hist = tmp_path / "h.json"
     monkeypatch.setattr(meta_learning.Path, "exists", lambda self: False)
     monkeypatch.setattr(
-        meta_learning.np,
+        np,
         "savetxt",
         lambda *a, **k: (_ for _ in ()).throw(OSError("fail")),
     )

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -133,7 +133,7 @@ def test_load_weights_default_zero(tmp_path):
 def test_update_weights_failure(monkeypatch, tmp_path):
     p = tmp_path / "w.csv"
     monkeypatch.setattr(
-        meta_learning.np,
+        np,
         "savetxt",
         lambda *a, **k: (_ for _ in ()).throw(OSError("bad")),
     )

--- a/tests/test_meta_learning_additional.py
+++ b/tests/test_meta_learning_additional.py
@@ -1,10 +1,12 @@
 from tests.optdeps import require
 require("numpy")
+require("pandas")
 require("sklearn")
 import types
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 import sklearn.linear_model
 from ai_trading import meta_learning
@@ -16,7 +18,7 @@ def test_load_weights_save_fail(monkeypatch, tmp_path, caplog):
     monkeypatch.setattr(meta_learning.Path, "exists", lambda self: False)
     def fail(*a, **k):
         raise OSError("fail")
-    monkeypatch.setattr(meta_learning.np, "savetxt", fail)
+    monkeypatch.setattr(np, "savetxt", fail)
     caplog.set_level("ERROR")
     arr = meta_learning.load_weights(str(p), default=np.array([1.0]))
     assert arr.tolist() == [1.0]
@@ -42,7 +44,7 @@ def test_save_and_load_checkpoint(tmp_path):
 def test_retrain_meta_learner(monkeypatch, tmp_path):
     """Meta learner retrains with small dataset."""
     data = Path(tmp_path / "trades.csv")
-    df = meta_learning.pd.DataFrame({
+    df = pd.DataFrame({
         "entry_price": [1, 2],
         "exit_price": [2, 3],
         "signal_tags": ["a", "b"],


### PR DESCRIPTION
## Summary
- lazily import numpy, pandas, torch and scikit-learn only when needed
- raise clear ImportError when required optional dependencies are missing
- update meta-learning tests to skip gracefully when optional deps are absent

## Testing
- `ruff check ai_trading/meta_learning.py tests/test_meta_learning.py tests/test_meta_learning_additional.py tests/test_additional_coverage.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68aceff5bd7c8330b80105f250e2747a