### PR TITLE
refactor: streamline safe_submit_order

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -704,10 +704,6 @@ def _get_memory_optimization():
 ) = _get_memory_optimization()
 
 
-# AI-AGENT-REF: replace utcnow with timezone-aware now
-old_generate = datetime.now(UTC)  # replaced utcnow for tz-aware
-new_generate = datetime.now(UTC)
-
 # AI-AGENT-REF: suppress noisy external library warnings
 warnings.filterwarnings(
     "ignore", category=SyntaxWarning, message="invalid escape sequence"
@@ -7626,7 +7622,6 @@ def submit_order(ctx: BotContext, symbol: str, qty: int, side: str) -> Order | N
 
 
 def safe_submit_order(api: AlpacaBroker, req) -> Order | None:
-    config.reload_env()
     if not market_is_open():
         _log.warning(
             "MARKET_CLOSED_ORDER_SKIP", extra={"symbol": getattr(req, "symbol", "")}


### PR DESCRIPTION
## Summary
- drop unused timezone example variables in bot_engine
- avoid env reload during each order submission

## Testing
- `ruff check ai_trading/core/bot_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68acf00b01508330a60248678dac59d2