### PR TITLE
Expose health and metrics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,15 @@ python -m pip install -U pip
 pip install -e .
 ruff check .
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
-curl -s http://127.0.0.1:9001/health
+RUN_HEALTHCHECK=1 python -m ai_trading.app &
+curl -s http://127.0.0.1:9001/healthz
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9001/metrics
 ```
+
+Set `RUN_HEALTHCHECK=1` to launch the lightweight Flask app that serves:
+
+* `GET /healthz` &mdash; minimal JSON liveness probe
+* `GET /metrics` &mdash; Prometheus metrics (returns **501** if metrics are disabled)
 
 Use **one** Alpaca SDK in production (recommended: `alpaca-trade-api`). If choosing `alpaca-py`, update broker modules accordingly.
 
@@ -977,7 +984,8 @@ docker logs -f ai-trading-prod
 
 ```bash
 # Built-in health endpoint
-curl http://localhost:5000/health
+curl http://localhost:9001/healthz
+curl -s -o /dev/null -w "%{http_code}" http://localhost:9001/metrics
 
 # System resource monitoring
 python monitoring_dashboard.py &

--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -22,11 +22,32 @@ def create_app():
             trading_client, key, secret, base_url, paper = (None, None, None, '', False)
         shadow = bool(getattr(__import__('ai_trading', fromlist=['config']).config, 'SHADOW_MODE', False) or os.getenv('SHADOW_MODE', '').lower() in ('true', '1', 'yes'))
         return jsonify(alpaca=dict(sdk_ok=bool(sdk_ok), initialized=bool(trading_client), client_attached=bool(trading_client), has_key=bool(key), has_secret=bool(secret), base_url=base_url, paper=paper, shadow_mode=shadow))
+
+    @app.route('/healthz')
+    def healthz():
+        """Minimal liveness probe."""
+        return jsonify(ok=True)
+
+    @app.route('/metrics')
+    def metrics():
+        """Expose Prometheus metrics if available."""
+        try:
+            from ai_trading.metrics import PROMETHEUS_AVAILABLE, REGISTRY
+        except Exception:
+            PROMETHEUS_AVAILABLE, REGISTRY = False, None
+        if not PROMETHEUS_AVAILABLE:
+            return ('metrics unavailable', 501)
+        from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+        return generate_latest(REGISTRY), 200, {'Content-Type': CONTENT_TYPE_LATEST}
+
     return app
+
+
 if __name__ == '__main__':
-    from ai_trading.config.settings import get_settings
-    s = get_settings()
-    port = int(s.api_port or 9001)
-    app = create_app()
-    app.logger.info('Starting Flask', extra={'port': port})
-    app.run(host='0.0.0.0', port=port)
+    if os.getenv('RUN_HEALTHCHECK') == '1':
+        from ai_trading.config.settings import get_settings
+        s = get_settings()
+        port = int(s.api_port or 9001)
+        app = create_app()
+        app.logger.info('Starting Flask', extra={'port': port})
+        app.run(host='0.0.0.0', port=port)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -10,8 +10,11 @@ sudo systemctl stop ai-trading.service
 sudo systemctl restart ai-trading.service
 sudo systemctl status ai-trading.service
 journalctl -u ai-trading.service -n 200 --no-pager
-curl -s http://127.0.0.1:9001/health  # JSON, never 500
+curl -s http://127.0.0.1:9001/healthz  # JSON, never 500
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9001/metrics  # 200 if enabled, else 501
 ```
+
+Set `RUN_HEALTHCHECK=1` in the environment to enable the Flask endpoints.
 
 ### Paths & default files
 - Trade log file defaults to `<repo>/logs/trades.jsonl` when `TRADE_LOG_PATH` is not set. The directory is auto-created.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,8 +56,11 @@ sudo systemctl enable --now ai-trading.service
 sudo systemctl restart ai-trading.service
 sudo systemctl status ai-trading.service
 journalctl -u ai-trading.service -n 200 --no-pager
-curl -s http://127.0.0.1:9001/health
+curl -s http://127.0.0.1:9001/healthz
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9001/metrics
 ```
+
+Ensure `RUN_HEALTHCHECK=1` is set in the environment to expose these endpoints.
 
 The service writes to `logs/scheduler.log` (or `$BOT_LOG_FILE`). View logs with
 `tail -F logs/scheduler.log` or via the systemd journal.


### PR DESCRIPTION
## Summary
- start Flask health server only when `RUN_HEALTHCHECK=1`
- add `/healthz` endpoint for basic liveness
- add `/metrics` endpoint returning Prometheus metrics when available
- document new endpoints and env control

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'numpy', 'pydantic', 'psutil')*
- `RUN_HEALTHCHECK=1 python -m ai_trading.app &`
- `curl -s http://127.0.0.1:9001/healthz`
- `curl -s -o /tmp/metrics.out -w "%{http_code}" http://127.0.0.1:9001/metrics`

------
https://chatgpt.com/codex/tasks/task_e_68acf00daa7883309fdb8cdcc1db8ef9