### PR TITLE
refactor: lazy-load pandas in last_market_session

### DIFF
--- a/ai_trading/utils/time.py
+++ b/ai_trading/utils/time.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from dataclasses import dataclass
-from ai_trading.utils.lazy_imports import load_pandas
-from ai_trading.market.calendars import get_calendar_registry
+from typing import TYPE_CHECKING
 
-# Lazy pandas proxy
-pd = load_pandas()
+from ai_trading.market.calendars import get_calendar_registry
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    import pandas as pd
 
 def utcnow() -> datetime:
     """Repository-standard UTC now (timezone-aware)."""
@@ -20,6 +22,9 @@ class SessionWindow:
 
 def last_market_session(now: pd.Timestamp) -> SessionWindow | None:
     """Return previous market session window for NYSE."""
+    pd = load_pandas()
+    if pd is None:
+        return None
     cal = get_calendar_registry()
     current = now.tz_convert('UTC').date()
     for _ in range(10):


### PR DESCRIPTION
## Summary
- call `load_pandas()` inside `last_market_session`
- return `None` when pandas isn't available
- clean up pandas references with `TYPE_CHECKING`

## Testing
- `ruff check ai_trading/utils/time.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/time/test_last_market_session_import.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_healthcheck_minute_fallback.py -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68acf4058f88833083602ace87cb19df