### PR TITLE
feat(logging): sanitize log extras

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -31,6 +31,11 @@ The periodic `MARKET_FETCH` heartbeat logs can be controlled:
 #### Risk Engine Quieting
 Risk exposure update failures are demoted to DEBUG level when the trading context is not ready, reducing startup noise.
 
+#### Automatic Secret Redaction
+Any `extra` fields such as API keys, secrets, or URLs are sanitized before
+being emitted to handlers, ensuring sensitive values are replaced with
+`***REDACTED***`.
+
 ### Example Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- add `sanitize_extra` to mask api keys, secrets, and URLs in logging extras
- ensure all handlers sanitize extras via new filter
- document automatic secret redaction in logging guide

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `curl -s http://127.0.0.1:9001/health`

------
https://chatgpt.com/codex/tasks/task_e_68acf40892248330a7d20fee377b1b18