### PR TITLE
Ensure deterministic test seeding

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -55,7 +55,7 @@ Unit Tests (70%)
 
 ## Deterministic Testing
 
-To keep results reproducible, all tests run with a fixed random seed. A session-scoped pytest fixture sets `PYTHONHASHSEED=0`, seeds Python's `random` module and NumPy, and calls `torch.manual_seed(0)` when PyTorch is available. Tests should avoid introducing additional sources of nondeterminism.
+To keep results reproducible, all tests start with a fixed random seed. An autouse fixture in `tests/conftest.py` sets `PYTHONHASHSEED=0` (if not already configured), seeds Python's `random` module and NumPy, and calls `torch.manual_seed(0)` when PyTorch is available. Tests should avoid introducing additional sources of nondeterminism.
 
 ## Test Structure
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,11 +42,13 @@ if not hasattr(_alpaca_rest, "APIError"):
     _alpaca_rest.APIError = Exception
 
 import asyncio
+import random
 import socket
 import sys
 from datetime import datetime, timezone
 import pathlib
 
+import numpy as np
 import pytest
 try:
     # Optional dev dependency. Provide a benign fallback for smoke/collect.
@@ -84,6 +86,19 @@ def _env_defaults(monkeypatch):
     monkeypatch.setenv("ALPACA_SECRET_KEY", "dummy")
     monkeypatch.setenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
     monkeypatch.setenv("TZ", "UTC")
+
+
+@pytest.fixture(autouse=True)
+def _seed_prng() -> None:
+    os.environ.setdefault("PYTHONHASHSEED", "0")
+    random.seed(0)
+    np.random.seed(0)
+    try:
+        import torch  # type: ignore
+    except Exception:
+        pass
+    else:
+        torch.manual_seed(0)
 
 
 def pytest_configure(config: pytest.Config) -> None:


### PR DESCRIPTION
## Summary
- Seed Python's `random`, NumPy, and optional PyTorch at the start of every test
- Guard `PYTHONHASHSEED` to guarantee deterministic hash ordering
- Document deterministic seeding in testing framework guide

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib', import errors across suite)*

------
https://chatgpt.com/codex/tasks/task_e_68acf40b498c8330b26680da9781f565