### PR TITLE
feat: centralize required env validation

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -21,3 +21,18 @@ curl -s http://127.0.0.1:9001/health
 
 Configure environment in `/home/aiuser/ai-trading-bot/.env` (loaded with `override=True` at startup) and ensure PATH in the unit points to your venv.
 
+### Required environment variables
+
+`ai_trading.config.management.validate_required_env()` ensures these keys are
+present before the service starts:
+
+| Key | Purpose |
+| --- | --- |
+| `ALPACA_API_KEY` | Alpaca API authentication |
+| `ALPACA_SECRET_KEY` | Alpaca API authentication |
+| `ALPACA_BASE_URL` | Broker endpoint URL |
+| `WEBHOOK_SECRET` | Protects inbound webhooks |
+
+If any are missing or empty the process exits with a `RuntimeError` listing the
+missing keys; values are masked in logs and exceptions.
+

--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -45,7 +45,10 @@ def create_app():
 
 if __name__ == '__main__':
     if os.getenv('RUN_HEALTHCHECK') == '1':
+        from ai_trading.config.management import validate_required_env
         from ai_trading.config.settings import get_settings
+
+        validate_required_env()
         s = get_settings()
         port = int(s.api_port or 9001)
         app = create_app()

--- a/ai_trading/config/__init__.py
+++ b/ai_trading/config/__init__.py
@@ -70,13 +70,9 @@ def _require_env_vars(*names: str) -> None:
         raise RuntimeError(msg)
 
 def _perform_env_validation() -> None:
-    required = ['ALPACA_API_KEY', 'ALPACA_SECRET_KEY', 'ALPACA_BASE_URL', 'WEBHOOK_SECRET']
-    missing: list[str] = []
-    for env_key in required:
-        if not os.getenv(env_key, '').strip():
-            missing.append(env_key)
-    if missing:
-        raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")
+    from .management import validate_required_env
+
+    validate_required_env()
 
 def validate_environment() -> None:
     """Validate required environment variables with deadlock-safe locking."""
@@ -95,11 +91,9 @@ def validate_environment() -> None:
             _set_lock_held_by_current_thread(False)
 
 def validate_alpaca_credentials() -> None:
-    api = str(globals().get('ALPACA_API_KEY', os.getenv('ALPACA_API_KEY', ''))).strip()
-    sec = str(globals().get('ALPACA_SECRET_KEY', os.getenv('ALPACA_SECRET_KEY', ''))).strip()
-    url = str(globals().get('ALPACA_BASE_URL', os.getenv('ALPACA_BASE_URL', ''))).strip()
-    if not (api and sec and url):
-        raise RuntimeError('Alpaca credentials are missing or empty')
+    from .management import validate_required_env
+
+    validate_required_env(("ALPACA_API_KEY", "ALPACA_SECRET_KEY", "ALPACA_BASE_URL"))
 
 def validate_env_vars() -> None:
     return validate_environment()

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -152,11 +152,10 @@ def _interruptible_sleep(total_seconds: float) -> None:
 
 def validate_environment() -> None:
     """Ensure required environment variables are present and dependencies are available."""
-    cfg = get_settings()
-    if not cfg.webhook_secret:
-        raise RuntimeError("WEBHOOK_SECRET is required")
-    if not cfg.alpaca_api_key or not cfg.alpaca_secret_key_plain:
-        raise RuntimeError("ALPACA_API_KEY and ALPACA_SECRET_KEY are required")
+    from ai_trading.config.management import validate_required_env
+
+    validate_required_env()
+    _ = get_settings()
     import os
 
     data_dir = "data"


### PR DESCRIPTION
## Summary
- centralize mandatory environment validation with masking
- invoke validation from startup modules
- document required keys and failure behavior

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'pydantic', 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_68acf41283188330830671920f1e7d3c