### PR TITLE
docs: document health endpoints and CLI flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS: Operating Contract & Playbook
 
-**Last updated:** 2025-08-25  
+**Last updated:** 2025-08-25
 **Runtime targets:** Ubuntu 24.04 • Python 3.12 • zoneinfo-only • Flask on :9001
 
 This document defines what automated agents (including LLM coding agents) may do in this repository and how they must do it.
@@ -9,7 +9,7 @@ This document defines what automated agents (including LLM coding agents) may do
 - **Python:** 3.12 (`requires-python=">=3.12"`). Tooling targets **py312**.
 - **Timezones:** Use stdlib **zoneinfo**; never depend on `pytz`.
 - **Service:** `ai-trading.service` runs a Flask API on **0.0.0.0:9001**.
-- **Health:** `GET /health` must always return JSON and never 500.
+- **Health:** `GET /healthz` must always return JSON and never 500.
 - **Config access:** via `ai_trading.config.management`:
   - `get_env(key, default=None, cast=None, required=False)`
   - `reload_env(path=None, override=True)` (use sparingly, not in hot paths)
@@ -36,7 +36,7 @@ python -m pip install -U pip
 pip install -e .
 ruff check .
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
-curl -s http://127.0.0.1:9001/health
+curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz
 ```
 
 ## 5) Timezone examples (docs reference)
@@ -60,11 +60,13 @@ seed = config.SEED  # defaults to 42
 config.reload_env()
 ```
 
-## 7) Health endpoint (docs reference)
+## 7) Health & metrics endpoints (docs reference)
 
-* Route: `GET /health`
-* Response: `{"ok": true, "ts": "...", "service": "ai-trading"}`
-* Requirement: Never raise exceptions. Log, return `ok: false` if degraded.
+* Routes: `GET /healthz`, `GET /metrics`
+* `/healthz` JSON: `{"ok": true, "ts": "...", "service": "ai-trading"}`
+* `/metrics` exposes Prometheus format
+* Set `RUN_HEALTHCHECK=1` to serve these on `$HEALTHCHECK_PORT` (default **9001**)
+* Requirement: Endpoints must not raise exceptions; log and return `ok: false` if degraded.
 
 ## 8) Alpaca SDK stance
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,11 +3,12 @@
 ## System
 - Python 3.12 app running on a DigitalOcean droplet, supervised by `systemd`.
 - Entry: `ai_trading/runner.py`; core loop in `ai_trading/core/bot_engine.py`.
-- HTTP status via `ai_trading/app.py` (Flask).
+- Health & metrics via `ai_trading/app.py` when `RUN_HEALTHCHECK=1`.
+  - `/healthz` JSON and `/metrics` Prometheus on `$HEALTHCHECK_PORT` (default **9001**).
 
 ## Object Model
 - **TradingConfig**: static config (API keys, paths, thresholds).
-- **BotRuntime**: process runtime (cfg, params, tickers, model, broker clients, etc.).  
+- **BotRuntime**: process runtime (cfg, params, tickers, model, broker clients, etc.).
   - Required fields: `cfg`, `params: dict`, `tickers: list[str]`, `model: Any (optional)`.
 
 ## Control Flow (happy path)
@@ -46,3 +47,10 @@
   sudo systemctl restart ai-trading.service
   journalctl -u ai-trading.service -f | sed -n '1,200p'
   ```
+
+## CLI
+- `ai-trade`, `ai-backtest`, `ai-health`
+  - `--dry-run`
+  - `--once`
+  - `--interval SECONDS`
+  - `--paper` / `--live`

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -16,7 +16,7 @@ Check logs and health:
 
 ```bash
 journalctl -u ai-trading.service -n 200 --no-pager
-curl -s http://127.0.0.1:9001/health
+curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz
 ```
 
 Configure environment in `/home/aiuser/ai-trading-bot/.env` (loaded with `override=True` at startup) and ensure PATH in the unit points to your venv.
@@ -36,3 +36,29 @@ present before the service starts:
 If any are missing or empty the process exits with a `RuntimeError` listing the
 missing keys; values are masked in logs and exceptions.
 
+### Health endpoints & env
+
+Set `RUN_HEALTHCHECK=1` to expose `/healthz` and `/metrics` on `$HEALTHCHECK_PORT` (default **9001**).
+
+| Key | Purpose |
+| --- | --- |
+| `RUN_HEALTHCHECK` | Enable lightweight Flask health server |
+| `HEALTHCHECK_PORT` | Port for `/healthz` and `/metrics` |
+
+### CLI
+
+`ai-trade`, `ai-backtest`, and `ai-health` share flags:
+
+| Flag | Description |
+| ---- | ----------- |
+| `--dry-run` | Exit after importing modules |
+| `--once` | Run a single iteration then exit |
+| `--interval SECONDS` | Sleep between iterations |
+| `--paper` / `--live` | Select paper (default) or live trading |
+
+### Operational checklist
+
+1. `sudo systemctl restart ai-trading.service`
+2. `journalctl -u ai-trading.service -n 200 --no-pager`
+3. `curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz`
+4. Roll back to previous release and restart if the health check fails


### PR DESCRIPTION
## Summary
- document `/healthz` and `/metrics` along with `RUN_HEALTHCHECK` and `HEALTHCHECK_PORT`
- add health test snippet and systemd ops checklist
- list common CLI flags `--dry-run`, `--once`, `--interval`, and `--paper`/`--live`

## Testing
- `python -m pre_commit run --files AGENTS.md API_DOCUMENTATION.md ARCHITECTURE.md DEPLOYING.md` *(fails: repo-guard mutable default, missing check_no_legacy_symbols.py)*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 60 errors during collection)*
- `HEALTHCHECK_PORT=9001 curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz` *(fails: curl failed)*


------
https://chatgpt.com/codex/tasks/task_e_68acfb5a543c83308078a50a06ed2383