### PR TITLE
Guard health endpoint against import failures

### DIFF
--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,20 @@
+import builtins
+from ai_trading.app import create_app
+
+
+def test_health_endpoint_handles_import_error(monkeypatch):
+    original_import = builtins.__import__
+
+    def fail_alpaca(name, *args, **kwargs):
+        if name == "ai_trading.alpaca_api":
+            raise ImportError("boom")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_alpaca)
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get("ok") is False
+    assert "boom" in data.get("error", "")


### PR DESCRIPTION
## Summary
- protect `/health` from unexpected errors by catching all exceptions
- reference explicit `config.SHADOW_MODE` instead of dynamic import
- add regression test to ensure `/health` returns 200 when imports fail

## Testing
- `ruff check ai_trading/app.py tests/test_health_check.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_health_check.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acfb5852c48330ac462506de0aad64