### PR TITLE
Defer heavy imports in ML model module

### DIFF
--- a/tests/unit/test_ml_model_optional_imports.py
+++ b/tests/unit/test_ml_model_optional_imports.py
@@ -1,0 +1,20 @@
+import builtins
+import importlib
+import sys
+
+
+def test_ml_model_import_without_heavy_deps(monkeypatch):
+    missing = {"joblib", "numpy", "pandas"}
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in missing:
+            raise ModuleNotFoundError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    for mod in ["ai_trading.ml_model", *missing]:
+        monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    module = importlib.import_module("ai_trading.ml_model")
+    assert hasattr(module, "MLModel")


### PR DESCRIPTION
## Summary
- Lazily import joblib, pandas, and numpy within `ai_trading.ml_model` methods and raise clear ImportErrors when missing
- Provide a unit test ensuring `ai_trading.ml_model` imports successfully even if heavy deps are unavailable

## Testing
- `ruff check ai_trading/ml_model.py tests/unit/test_ml_model_optional_imports.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_ml_model_optional_imports.py -q`

## Rollback
- Revert the commits to restore eager imports and remove the new test.


------
https://chatgpt.com/codex/tasks/task_e_68acfb577e60833088b4541e57676e42