### PR TITLE
Raise error when Alpaca SDK missing

### DIFF
--- a/ai_trading/broker/alpaca_credentials.py
+++ b/ai_trading/broker/alpaca_credentials.py
@@ -30,7 +30,7 @@ def resolve_alpaca_credentials(env: Mapping[str, str] | None = None) -> AlpacaCr
 
 
 def check_alpaca_available() -> bool:
-    """Return ``True`` if the Alpaca SDK is importable."""
+    """Return ``True`` if the ``alpaca_trade_api`` SDK is importable."""
 
     try:  # pragma: no cover - purely a presence check
         import alpaca_trade_api  # type: ignore  # noqa: F401
@@ -40,15 +40,20 @@ def check_alpaca_available() -> bool:
 
 
 def initialize(env: Mapping[str, str] | None = None, *, shadow: bool = False):
-    """Return an ``alpaca_trade_api.REST`` instance or a benign placeholder."""
+    """Return an ``alpaca_trade_api.REST`` instance.
+
+    If *shadow* is ``True``, a simple ``object`` placeholder is returned even
+    when the SDK is missing. Otherwise, a :class:`RuntimeError` is raised when
+    the ``alpaca_trade_api`` package cannot be imported.
+    """
 
     creds = resolve_alpaca_credentials(env)
     if shadow:
         return object()
     try:  # pragma: no cover - optional dependency
         from alpaca_trade_api import REST  # type: ignore
-    except ModuleNotFoundError:
-        return object()
+    except ModuleNotFoundError as exc:  # pragma: no cover - tested via unit test
+        raise RuntimeError("alpaca_trade_api package is required") from exc
     return REST(key_id=creds.api_key, secret_key=creds.secret_key, base_url=creds.base_url)
 
 

--- a/tests/unit/test_alpaca_api.py
+++ b/tests/unit/test_alpaca_api.py
@@ -1,10 +1,14 @@
+import builtins
+import importlib
+
 import pytest
 from tests.optdeps import require
 
-alpaca_api = require("alpaca_api")
+from ai_trading.broker import alpaca_credentials
 
 @pytest.mark.unit
 def test_pending_orders_lock_exists_and_is_lock():
+    alpaca_api = require("alpaca_api")
     assert hasattr(alpaca_api, "_pending_orders_lock")
     lock = alpaca_api._pending_orders_lock
     # Check that it has threading lock behavior
@@ -14,7 +18,12 @@ def test_pending_orders_lock_exists_and_is_lock():
     assert isinstance(alpaca_api._pending_orders, dict)
 
 @pytest.mark.unit
+@pytest.mark.skipif(
+    importlib.util.find_spec("alpaca_api") is None,
+    reason="alpaca_api not installed",
+)
 def test_submit_order_uses_client_and_returns(dummy_alpaca_client, monkeypatch):
+    alpaca_api = require("alpaca_api")
     submit = getattr(alpaca_api, "submit_order", None)
     if submit is None:
         pytest.skip("submit_order not available")
@@ -41,3 +50,23 @@ def test_submit_order_uses_client_and_returns(dummy_alpaca_client, monkeypatch):
     assert res is not None
     assert getattr(res, "id", None) is not None
     assert dummy_alpaca_client.calls, "Client submit_order should be called"
+
+
+@pytest.mark.unit
+def test_initialize_raises_when_sdk_missing(monkeypatch):
+    """initialize should raise if the Alpaca SDK is absent."""
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "alpaca_trade_api":
+            raise ModuleNotFoundError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(RuntimeError):
+        alpaca_credentials.initialize(shadow=False)
+
+    placeholder = alpaca_credentials.initialize(shadow=True)
+    assert placeholder.__class__ is object


### PR DESCRIPTION
## Summary
- raise `RuntimeError` from `initialize` when `alpaca_trade_api` is missing and not in shadow mode
- clarify `initialize` docstring and keep os import at module top
- add unit test covering missing Alpaca SDK

## Testing
- `ruff check ai_trading/broker/alpaca_credentials.py tests/unit/test_alpaca_api.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_alpaca_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68acfb55d5e4833086a8123e13982cb3