### PR TITLE
feat: add timestamped health check

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 - Python 3.12 app running on a DigitalOcean droplet, supervised by `systemd`.
 - Entry: `ai_trading/runner.py`; core loop in `ai_trading/core/bot_engine.py`.
 - Health & metrics via `ai_trading/app.py` when `RUN_HEALTHCHECK=1`.
-  - `/healthz` JSON and `/metrics` Prometheus on `$HEALTHCHECK_PORT` (default **9001**).
+  - `/healthz` JSON and `/metrics` Prometheus served on the port specified by the `HEALTHCHECK_PORT` environment variable (default **9001**).
 
 ## Object Model
 - **TradingConfig**: static config (API keys, paths, thresholds).

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -38,7 +38,7 @@ missing keys; values are masked in logs and exceptions.
 
 ### Health endpoints & env
 
-Set `RUN_HEALTHCHECK=1` to expose `/healthz` and `/metrics` on `$HEALTHCHECK_PORT` (default **9001**).
+Set `RUN_HEALTHCHECK=1` to expose `/healthz` and `/metrics` on the port defined by the `HEALTHCHECK_PORT` environment variable (default **9001**).
 
 | Key | Purpose |
 | --- | --- |

--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -48,7 +48,13 @@ def create_app():
     @app.route('/healthz')
     def healthz():
         """Minimal liveness probe."""
-        return jsonify(ok=True)
+        from datetime import UTC, datetime
+
+        return jsonify(
+            ok=True,
+            ts=datetime.now(UTC).isoformat(),
+            service="ai-trading",
+        )
 
     @app.route('/metrics')
     def metrics():
@@ -72,7 +78,7 @@ if __name__ == '__main__':
 
         validate_required_env()
         s = get_settings()
-        port = int(s.api_port or 9001)
+        port = int(s.healthcheck_port or 9001)
         app = create_app()
         app.logger.info('Starting Flask', extra={'port': port})
         app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- include service name and UTC timestamp in `/healthz` response
- read `HEALTHCHECK_PORT` setting when starting health server
- document `HEALTHCHECK_PORT` usage in deployment and architecture guides

## Testing
- `python - <<'PY'
from ai_trading.app import create_app
app = create_app()
client = app.test_client()
resp = client.get('/healthz')
print(resp.status_code)
print(resp.json)
PY`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'psutil', 'pydantic', etc.)*

## Rollback Plan
- Revert this PR.

------
https://chatgpt.com/codex/tasks/task_e_68ad037c78b88330bc49fe782fe681e3