### PR TITLE
refactor: gate pandas and skip tests

### DIFF
--- a/CODING_AGENTS_GUIDE.md
+++ b/CODING_AGENTS_GUIDE.md
@@ -9,6 +9,8 @@ Make precise, minimal edits with first-pass correctness. Do not change strategy 
 - **No `except Exception:`** catch-alls; use specific exceptions.
 - **No global `ctx`**; use `runtime` everywhere (may alias `ctx = runtime` locally inside a single function if needed).
 - Preserve **structured JSON logging**.
+- Gate heavy libraries (e.g. `pandas`) inside functions; tests importing them must call
+  `pytest.importorskip("pandas")`.
 
 ## Edit Playbook
 1. **Search first**: locate function by name, not line numbers.

--- a/ai_trading/data/corp_actions.py
+++ b/ai_trading/data/corp_actions.py
@@ -4,12 +4,17 @@ Corporate actions adjustment pipeline for unified price/volume adjustments.
 Provides single source of truth for corporate action adjustments used by
 features, labels, and execution sizing to ensure consistency.
 """
+from __future__ import annotations
+
 import json
 import logging
 from dataclasses import asdict, dataclass
 from datetime import date
 from pathlib import Path
-import pandas as pd
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import only for typing
+    import pandas as pd
 logger = logging.getLogger(__name__)
 
 @dataclass
@@ -194,7 +199,9 @@ def get_corp_action_registry() -> CorporateActionRegistry:
         _global_registry = CorporateActionRegistry()
     return _global_registry
 
-def adjust_bars(bars: pd.DataFrame, symbol: str, reference_date: date | None=None) -> pd.DataFrame:
+def adjust_bars(
+    bars: pd.DataFrame, symbol: str, reference_date: date | None = None
+) -> pd.DataFrame:
     """
     Adjust OHLCV bars for corporate actions.
     
@@ -206,6 +213,8 @@ def adjust_bars(bars: pd.DataFrame, symbol: str, reference_date: date | None=Non
     Returns:
         DataFrame with adjusted OHLCV data
     """
+    import pandas as pd
+
     if bars.empty:
         return bars
     registry = get_corp_action_registry()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,16 +154,9 @@ except Exception:
     def elapsed_ms(start: float) -> float:  # AI-AGENT-REF: fallback timer
         return (_t.perf_counter() - start) * 1000.0
 
-try:
-    import pandas as pd
-except Exception:  # pragma: no cover - optional for smoke
-    pd = None  # AI-AGENT-REF: allow pandas absence for smoke
-
-
 @pytest.fixture
 def dummy_data_fetcher():
-    if pd is None:
-        pytest.skip("pandas required")  # AI-AGENT-REF: optional dep
+    pd = pytest.importorskip("pandas")
 
     class DF:
         def get_minute_bars(self, symbol, start=None, end=None, limit=None):
@@ -178,8 +171,11 @@ def dummy_data_fetcher():
 
 @pytest.fixture
 def dummy_data_fetcher_empty():
+    pd = pytest.importorskip("pandas")
+
     class DF:
         def get_minute_bars(self, symbol, start=None, end=None, limit=None):
             return pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+
     return DF()
 


### PR DESCRIPTION
## Summary
- Gate heavy pandas import in corporate actions and portfolio core modules
- Skip pandas-dependent fixtures with `pytest.importorskip`
- Document pattern of gating heavy imports in coding guide

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 84 errors during collection)*

## Rollback Plan
- Revert the commit with `git revert <commit>`

------
https://chatgpt.com/codex/tasks/task_e_68ad037d8a888330b3e02fbc0ece342c