### PR TITLE
refactor: centralize env access for risk and sentiment

### DIFF
--- a/ai_trading/analysis/sentiment.py
+++ b/ai_trading/analysis/sentiment.py
@@ -4,7 +4,6 @@ Sentiment analysis module for AI trading bot.
 This module provides sentiment analysis functionality using FinBERT and NewsAPI,
 extracted from bot_engine.py to enable standalone imports and testing.
 """
-import os
 import time
 import time as pytime
 from datetime import datetime
@@ -15,8 +14,14 @@ from ai_trading.logging import logger
 from ai_trading.settings import get_news_api_key
 from ai_trading.config import get_settings
 from ai_trading.utils.timing import HTTP_TIMEOUT
-SENTIMENT_API_KEY = os.getenv('SENTIMENT_API_KEY', '')
+from ai_trading.config.management import get_env, validate_required_env
 from ai_trading.utils.device import get_device, tensors_to_device  # AI-AGENT-REF: guard torch import
+
+if not get_env("PYTEST_RUNNING", "0", cast=bool):
+    _ENV_SNAPSHOT = validate_required_env()
+    logger.debug("ENV_VARS_MASKED", extra=_ENV_SNAPSHOT)
+
+SENTIMENT_API_KEY = get_env("SENTIMENT_API_KEY", "")
 DEVICE = get_device()
 _BS4 = None
 _TRANSFORMERS = None
@@ -225,10 +230,10 @@ def _handle_rate_limit_with_enhanced_strategies(ticker: str) -> float:
 
 def _try_alternative_sentiment_sources(ticker: str) -> float | None:
     """Try alternative sentiment data sources when primary is rate limited."""
-    alt_api_key = os.getenv('ALTERNATIVE_SENTIMENT_API_KEY')
-    alt_api_url = os.getenv('ALTERNATIVE_SENTIMENT_API_URL')
-    primary_url = os.getenv('SENTIMENT_API_URL', 'https://newsapi.org/v2/everything')
-    primary_key = os.getenv('SENTIMENT_API_KEY')
+    alt_api_key = get_env("ALTERNATIVE_SENTIMENT_API_KEY")
+    alt_api_url = get_env("ALTERNATIVE_SENTIMENT_API_URL")
+    primary_url = get_env("SENTIMENT_API_URL", "https://newsapi.org/v2/everything")
+    primary_key = get_env("SENTIMENT_API_KEY")
     try:
         primary_url_full = f'{primary_url}?symbol={ticker}&apikey={primary_key}'
         timeout_v = HTTP_TIMEOUT

--- a/ai_trading/scripts/self_check.py
+++ b/ai_trading/scripts/self_check.py
@@ -1,16 +1,32 @@
-import os
 from ai_trading.alpaca_api import _bars_time_window, get_bars_df
 from ai_trading.utils.optdeps import optional_import
+from ai_trading.config.management import get_env, validate_required_env
+from ai_trading.logging import logger
+
 TimeFrame = optional_import('alpaca_trade_api.rest', attr='TimeFrame')
 
+
 def main() -> None:
-    feed = os.getenv('ALPACA_DATA_FEED', 'iex')
+    feed = get_env('ALPACA_DATA_FEED', 'iex')
     try:
         df_day = get_bars_df('SPY', TimeFrame.Day)
         df_min = get_bars_df('SPY', TimeFrame.Minute)
         start, end = _bars_time_window(TimeFrame.Day)
-        {'msg': 'SELF_CHECK', 'feed': feed, 'spy_day_rows': len(df_day), 'spy_min_rows': len(df_min), 'start': start, 'end': end}
+        {
+            'msg': 'SELF_CHECK',
+            'feed': feed,
+            'spy_day_rows': len(df_day),
+            'spy_min_rows': len(df_min),
+            'start': start,
+            'end': end,
+        }
     except (KeyError, ValueError, TypeError):
         raise SystemExit(1)
+
+
 if __name__ == '__main__':
+    if not get_env('PYTEST_RUNNING', '0', cast=bool):
+        snapshot = validate_required_env()
+        logger.debug('ENV_VARS_MASKED', extra=snapshot)
     main()
+

--- a/scripts/risk_engine_cli.py
+++ b/scripts/risk_engine_cli.py
@@ -1,16 +1,24 @@
 import logging
-import os
 import random
 from collections.abc import Sequence
 from datetime import UTC
 from typing import Any
 import numpy as np
 import pandas as pd
-from ai_trading.config.management import SEED, TradingConfig
+from ai_trading.config.management import (
+    SEED,
+    TradingConfig,
+    get_env,
+    validate_required_env,
+)
 from ai_trading.strategies.base import StrategySignal as TradeSignal
 from ai_trading.logging import _get_metrics_logger
 from ai_trading.utils.base import get_phase_logger
 logger = get_phase_logger(__name__, 'RISK_CHECK')
+if not get_env('PYTEST_RUNNING', '0', cast=bool):
+    _ENV_SNAPSHOT = validate_required_env()
+    logger.debug('ENV_VARS_MASKED', extra=_ENV_SNAPSHOT)
+
 random.seed(SEED)
 np.random.seed(SEED)
 if not hasattr(np, 'NaN'):
@@ -57,21 +65,21 @@ class RiskEngine:
         self._update_event = Event()
         self._last_update = 0.0
         try:
-            max_drawdown = float(os.getenv('MAX_DRAWDOWN_THRESHOLD', '0.15'))
+            max_drawdown = get_env('MAX_DRAWDOWN_THRESHOLD', '0.15', cast=float)
             if not 0 < max_drawdown <= 1.0:
                 logger.warning('Invalid MAX_DRAWDOWN_THRESHOLD %s, using default 0.15', max_drawdown)
                 max_drawdown = 0.15
-            self.max_drawdown_threshold = max_drawdown
-        except (ValueError, TypeError) as e:
+            self.max_drawdown_threshold = float(max_drawdown)
+        except (RuntimeError, ValueError, TypeError) as e:
             logger.error('Error parsing MAX_DRAWDOWN_THRESHOLD: %s, using default 0.15', e)
             self.max_drawdown_threshold = 0.15
         try:
-            cooldown = float(os.getenv('HARD_STOP_COOLDOWN_MIN', '10'))
+            cooldown = get_env('HARD_STOP_COOLDOWN_MIN', '10', cast=float)
             if cooldown < 0:
                 logger.warning('Invalid HARD_STOP_COOLDOWN_MIN %s, using default 10', cooldown)
                 cooldown = 10.0
-            self.hard_stop_cooldown = cooldown
-        except (ValueError, TypeError) as e:
+            self.hard_stop_cooldown = float(cooldown)
+        except (RuntimeError, ValueError, TypeError) as e:
             logger.error('Error parsing HARD_STOP_COOLDOWN_MIN: %s, using default 10', e)
             self.hard_stop_cooldown = 10.0
         self._hard_stop_until: float | None = None
@@ -198,13 +206,13 @@ class RiskEngine:
             signal_weight = 0.0
         if asset_exp + signal_weight > asset_cap:
             logger.warning('Exposure cap breach: symbol=%s qty=%s alloc=%.3f exposure=%.2f vs cap=%.2f', signal.symbol, getattr(signal, 'qty', 'n/a'), signal_weight, asset_exp + signal_weight, asset_cap)
-            if os.getenv('FORCE_CONTINUE_ON_EXPOSURE', 'false').lower() != 'true':
+            if not get_env('FORCE_CONTINUE_ON_EXPOSURE', 'false', cast=bool):
                 return False
             logger.warning('FORCE_CONTINUE_ON_EXPOSURE enabled; overriding cap')
         strat_cap = self.strategy_limits.get(signal.strategy, self.global_limit)
         if signal_weight > strat_cap:
             logger.warning('Strategy %s weight %.2f exceeds cap %.2f', signal.strategy, signal_weight, strat_cap)
-            if os.getenv('FORCE_CONTINUE_ON_EXPOSURE', 'false').lower() != 'true':
+            if not get_env('FORCE_CONTINUE_ON_EXPOSURE', 'false', cast=bool):
                 return False
             logger.warning('FORCE_CONTINUE_ON_EXPOSURE enabled; overriding cap')
         return True


### PR DESCRIPTION
## Summary
- replace `os.getenv` with `config.management.get_env` in sentiment and risk modules
- validate required env vars at startup with masked logging
- update helper scripts to use centralized env management

## Testing
- `PYTEST_RUNNING=1 ruff check .`
- `PYTEST_RUNNING=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68ad037ec5688330b205b1882d4239b5