### PR TITLE
Use ellipsis in AllocatorProtocol allocate and add subclass test

### DIFF
--- a/ai_trading/core/protocols.py
+++ b/ai_trading/core/protocols.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 from collections.abc import Mapping, Sequence
-from typing import Any, Protocol, TYPE_CHECKING  # AI-AGENT-REF: add TYPE_CHECKING to break cycle
+from typing import Any, Protocol, TYPE_CHECKING, runtime_checkable  # AI-AGENT-REF: add TYPE_CHECKING to break cycle
 
 if TYPE_CHECKING:  # AI-AGENT-REF: avoid runtime import cycle
     from .runtime import BotRuntime
 
 
+@runtime_checkable
 class AllocatorProtocol(Protocol):
-    def allocate(self, signals: Sequence[Mapping[str, Any]], runtime: 'BotRuntime') -> Mapping[str, Any]:  # AI-AGENT-REF: forward ref to runtime
-        """Allocate positions based on signals."""
-        raise NotImplementedError  # AI-AGENT-REF: remove placeholder ellipsis
+    def allocate(
+        self,
+        signals: Sequence[Mapping[str, Any]],
+        runtime: 'BotRuntime',
+    ) -> Mapping[str, Any]:  # AI-AGENT-REF: forward ref to runtime
+        """Return target allocations derived from *signals* and runtime state.
+
+        Implementations should examine each signal and may consult the runtime
+        for context to produce a mapping of symbols to allocation metadata.
+        """
+        ...
 

--- a/tests/test_allocator_protocol_subclass.py
+++ b/tests/test_allocator_protocol_subclass.py
@@ -1,0 +1,10 @@
+from ai_trading.core.protocols import AllocatorProtocol
+
+
+class DummyAllocator(AllocatorProtocol):
+    def allocate(self, signals, runtime):
+        return {}
+
+
+def test_subclass_isinstance():
+    assert isinstance(DummyAllocator(), AllocatorProtocol)


### PR DESCRIPTION
## Summary
- replace NotImplementedError in `AllocatorProtocol.allocate` with an ellipsis and document expected behavior
- mark `AllocatorProtocol` as runtime-checkable
- add a regression test ensuring subclasses register with `AllocatorProtocol`

## Testing
- `ruff check ai_trading/core/protocols.py tests/test_allocator_protocol_subclass.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'pydantic', 'psutil', etc.)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_allocator_protocol_subclass.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad038058c083308851a2c885bd43e9