### PR TITLE
feat: lazy psutil import for system health snapshot

### DIFF
--- a/ai_trading/monitoring/system_health.py
+++ b/ai_trading/monitoring/system_health.py
@@ -1,21 +1,27 @@
 from __future__ import annotations
-try:
-    import psutil
-    _HAS_PSUTIL = True
-except (KeyError, ValueError, TypeError):
-    psutil = None
-    _HAS_PSUTIL = False
+
+_HAS_PSUTIL = False
 
 
 def snapshot_basic() -> dict[str, float | bool]:
     """Return a minimal health snapshot that works even without psutil."""
+    global _HAS_PSUTIL
+    try:  # Import psutil only when this function is called
+        import psutil
+        _HAS_PSUTIL = True
+    except ImportError:
+        _HAS_PSUTIL = False
+        psutil = None  # noqa: F841
+
     data: dict[str, float | bool] = {"has_psutil": _HAS_PSUTIL}
     if _HAS_PSUTIL:
         try:
-            data.update({
-                "cpu_percent": psutil.cpu_percent(interval=None),
-                "mem_percent": psutil.virtual_memory().percent,
-            })
+            data.update(
+                {
+                    "cpu_percent": psutil.cpu_percent(interval=None),
+                    "mem_percent": psutil.virtual_memory().percent,
+                }
+            )
         except (KeyError, ValueError, TypeError):
             pass
     return data

--- a/tests/test_system_health_import_no_psutil.py
+++ b/tests/test_system_health_import_no_psutil.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+
+def test_import_system_health_without_psutil(monkeypatch):
+    """Import system_health when psutil is missing should not raise ImportError."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("psutil not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "psutil", raising=False)
+    monkeypatch.delitem(sys.modules, "ai_trading.monitoring.system_health", raising=False)
+
+    module = importlib.import_module("ai_trading.monitoring.system_health")
+    assert module.snapshot_basic()["has_psutil"] is False


### PR DESCRIPTION
## Summary
- avoid importing psutil on module import by importing it lazily in `snapshot_basic`
- add regression test covering import when psutil is unavailable

## Testing
- `ruff check ai_trading/monitoring/system_health.py tests/test_system_health_import_no_psutil.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_production_fixes.py::TestSystemHealthSnapshot::test_snapshot_basic tests/test_system_health_import_no_psutil.py::test_import_system_health_without_psutil -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0ae13f8c8330a2b203cf1da6bb41