### PR TITLE
Lazy-load health snapshot in utils and update logging

### DIFF
--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -17,8 +17,8 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 from ai_trading.config import get_settings
 from ai_trading.exc import COMMON_EXC
-from ai_trading.monitoring.system_health import snapshot_basic
 from ai_trading.settings import get_verbose_logging
+from ai_trading.logging import get_logger
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd  # pylint: disable=unused-import
@@ -63,7 +63,7 @@ def ensure_utc_index(df: DataFrame) -> DataFrame:
     return df
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 _LAST_MARKET_HOURS_LOG = 0.0
 _LAST_MARKET_STATE = ""
 _LAST_HEALTH_ROW_LOG = 0.0
@@ -86,12 +86,16 @@ class PhaseLoggerAdapter(logging.LoggerAdapter):
 
 def get_phase_logger(name: str, phase: str) -> logging.Logger:
     """Return logger with ``bot_phase`` context."""
-    base = logging.getLogger(name)
+    base = get_logger(name)
     return PhaseLoggerAdapter(base, {"bot_phase": phase})
 
 
 def log_cpu_usage(lg: logging.Logger, note: str | None = None) -> None:
     """Log current CPU usage using optional psutil snapshot."""
+    try:
+        from ai_trading.monitoring.system_health import snapshot_basic
+    except ImportError:  # pragma: no cover - psutil missing or monitoring unavailable
+        return
     pct = snapshot_basic().get("cpu_percent")
     if pct is None:
         return
@@ -475,7 +479,7 @@ def get_pid_on_port(port: int) -> int | None:
                 if int(local.split(":")[1], 16) == port:
                     return _pid_from_inode(inode)
     except COMMON_EXC as e:
-        logging.getLogger(__name__).error("get_pid_on_port failed", exc_info=e)
+        logger.error("get_pid_on_port failed", exc_info=e)
         return None
     return None
 

--- a/tests/utils/test_log_cpu_usage.py
+++ b/tests/utils/test_log_cpu_usage.py
@@ -1,0 +1,41 @@
+import builtins
+import importlib
+import sys
+
+import logging
+
+from ai_trading.logging import get_logger
+
+
+def test_import_base_without_system_health(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "psutil":
+            raise ImportError("psutil missing")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("ai_trading.monitoring.system_health", None)
+    sys.modules.pop("ai_trading.utils.base", None)
+    base = importlib.import_module("ai_trading.utils.base")
+    assert "ai_trading.monitoring.system_health" not in sys.modules
+    assert base.logger
+
+
+def test_log_cpu_usage_without_psutil(monkeypatch, caplog):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "psutil":
+            raise ImportError("psutil missing")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("ai_trading.monitoring.system_health", None)
+    from ai_trading.utils import base
+
+    lg = get_logger("test")
+    with caplog.at_level(logging.DEBUG):
+        base.log_cpu_usage(lg)
+    assert not any("CPU_USAGE" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- use `ai_trading.logging.get_logger` instead of `logging.getLogger`
- defer `snapshot_basic` import until `log_cpu_usage` is called and handle missing psutil
- add tests ensuring `log_cpu_usage` works without psutil and module import avoids health dependencies

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/utils/test_log_cpu_usage.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0ae49d548330a834c36871c8ce36