### PR TITLE
feat: lazy load pandas

### DIFF
--- a/ai_trading/portfolio/sizing.py
+++ b/ai_trading/portfolio/sizing.py
@@ -4,11 +4,14 @@ Advanced position sizing and portfolio allocation strategies.
 Provides volatility targeting, risk parity, correlation-based sizing,
 and other institutional-grade position sizing methodologies.
 """
+from __future__ import annotations
+
 import logging
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 import numpy as np
-import pandas as pd
 from json import JSONDecodeError
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.logging import logger
 try:
     import requests
@@ -18,6 +21,9 @@ except ImportError:
     class RequestException(Exception):
         pass
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import pandas as pd
 
 def _import_clustering():
     from ai_trading.config import get_settings
@@ -115,6 +121,7 @@ class VolatilityTargetingSizer:
 
     def _estimate_correlations(self, symbols: list[str]) -> np.ndarray:
         """Estimate correlation matrix from price history."""
+        pd = load_pandas()
         try:
             if len(symbols) < 2:
                 return np.array([[1.0]])
@@ -267,6 +274,7 @@ class RiskParitySizer:
 
     def _calculate_covariance_matrix(self, symbols: list[str], price_history: dict[str, pd.Series]) -> np.ndarray | None:
         """Calculate covariance matrix from price history."""
+        pd = load_pandas()
         try:
             return_series = {}
             for symbol in symbols:
@@ -362,6 +370,7 @@ class CorrelationClusterSizer:
 
     def _calculate_correlation_matrix(self, symbols: list[str], price_history: dict[str, pd.Series]) -> np.ndarray | None:
         """Calculate correlation matrix."""
+        pd = load_pandas()
         try:
             return_series = {}
             for symbol in symbols:

--- a/tests/test_lazy_pandas_import.py
+++ b/tests/test_lazy_pandas_import.py
@@ -1,0 +1,35 @@
+import importlib
+import builtins
+import sys
+import types
+import pytest
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "ai_trading.features.pipeline",
+        "ai_trading.portfolio.sizing",
+        "ai_trading.monitoring.metrics",
+    ],
+)
+def test_module_import_without_pandas(monkeypatch, module):
+    """Modules should import even if pandas is unavailable."""
+    pytest.importorskip("pandas")
+    if module == "ai_trading.features.pipeline":
+        pytest.importorskip("sklearn")
+    for key in ["ALPACA_API_KEY", "ALPACA_SECRET_KEY", "ALPACA_BASE_URL", "WEBHOOK_SECRET"]:
+        monkeypatch.setenv(key, "test")
+    monkeypatch.delitem(sys.modules, "pandas", raising=False)
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("pandas"):
+            raise ModuleNotFoundError("No module named 'pandas'")
+        try:
+            return real_import(name, *args, **kwargs)
+        except ModuleNotFoundError:
+            return types.ModuleType(name)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, module, raising=False)
+    importlib.import_module(module)


### PR DESCRIPTION
## Summary
- lazily import pandas within feature pipeline, portfolio sizer, and metrics utilities
- update code paths to request pandas only inside functions
- add test ensuring key modules import when pandas is missing

## Testing
- `ruff check ai_trading/features/pipeline.py ai_trading/portfolio/sizing.py ai_trading/monitoring/metrics.py tests/test_lazy_pandas_import.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_lazy_pandas_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0ae0ccf88330846a50368bd0d404