### PR TITLE
refactor: dynamic shadow mode detection

### DIFF
--- a/STARTUP_FIXES_DEPLOYMENT_GUIDE.md
+++ b/STARTUP_FIXES_DEPLOYMENT_GUIDE.md
@@ -84,7 +84,7 @@ pytest -q -k "env_order or dual_schema or utc_timefmt"
 **Before:**
 ```python
 # ai_trading/core/bot_engine.py (BROKEN)
-if not (API_KEY and API_SECRET) and not config.SHADOW_MODE:
+if not (API_KEY and API_SECRET) and not config.is_shadow_mode():
     logger.critical("Alpaca credentials missing – aborting startup")
     sys.exit(1)  # ❌ Crashes during import
 ```
@@ -97,7 +97,7 @@ def _initialize_alpaca_clients():
     try:
         api_key, secret_key, base_url = _ensure_alpaca_env_or_raise()
     except RuntimeError as e:
-        if config.SHADOW_MODE:
+        if config.is_shadow_mode():
             logger.warning("Running in SHADOW_MODE with missing credentials: %s", e)
             return
         else:

--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -11,12 +11,12 @@ from typing import Any, Optional, TYPE_CHECKING
 import requests
 import importlib.util
 from ai_trading.logging import get_logger
+from ai_trading.config.management import is_shadow_mode
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd
 
 _log = get_logger(__name__)
-SHADOW_MODE = os.getenv('SHADOW_MODE', '').lower() in {'1', 'true', 'yes'}
 RETRY_HTTP_CODES = {429, 500, 502, 503, 504}
 RETRYABLE_HTTP_STATUSES = tuple(RETRY_HTTP_CODES)
 _UTC = timezone.utc  # AI-AGENT-REF: prefer stdlib UTC
@@ -194,8 +194,8 @@ class _AlpacaConfig:
         base = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets").rstrip("/")
         key = os.getenv("ALPACA_API_KEY_ID") or os.getenv("APCA_API_KEY_ID")
         sec = os.getenv("ALPACA_API_SECRET_KEY") or os.getenv("APCA_API_SECRET_KEY")
-        shadow_env = os.getenv("ALPACA_SHADOW") or os.getenv("SHADOW_MODE") or ""
-        shadow = SHADOW_MODE or str(shadow_env).strip().lower() in {"1", "true", "yes", "on"}
+        shadow_env = os.getenv("ALPACA_SHADOW", "")
+        shadow = is_shadow_mode() or str(shadow_env).strip().lower() in {"1", "true", "yes", "on"}
         return _AlpacaConfig(base, key, sec, shadow)
 
 
@@ -424,7 +424,7 @@ def start_trade_updates_stream(*_a, **_k):
     return None
 __all__ = [
     'ALPACA_AVAILABLE',
-    'SHADOW_MODE',
+    'is_shadow_mode',
     'RETRY_HTTP_CODES',
     'RETRYABLE_HTTP_STATUSES',
     'submit_order',

--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -23,12 +23,9 @@ def create_app():
             except (KeyError, ValueError, TypeError):
                 trading_client, key, secret, base_url, paper = (None, None, None, '', False)
 
-            from ai_trading.config import management as config
+            from ai_trading.config.management import is_shadow_mode
 
-            shadow = bool(
-                getattr(config, 'SHADOW_MODE', False)
-                or os.getenv('SHADOW_MODE', '').lower() in ('true', '1', 'yes')
-            )
+            shadow = is_shadow_mode()
 
             return jsonify(
                 alpaca=dict(

--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -47,6 +47,11 @@ def get_env(
         ) from e
 
 
+def is_shadow_mode() -> bool:
+    """Return True when the ``SHADOW_MODE`` env var is truthy."""
+    return bool(get_env("SHADOW_MODE", "0", cast=bool))
+
+
 # Canonical runtime seed used by risk/engine and anywhere else needing determinism.
 SEED: int = int(os.environ.get("SEED", "42"))  # AI-AGENT-REF: expose runtime seed
 
@@ -104,6 +109,7 @@ __all__ = [
     "get_settings",
     "derive_cap_from_settings",
     "get_env",
+    "is_shadow_mode",
     "SEED",
     "validate_required_env",
 ]

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -60,7 +60,7 @@ except Exception:  # pragma: no cover - fallback when SDK missing
         """Fallback APIError when alpaca-trade-api is unavailable."""
 
         pass
-from ai_trading.config.management import derive_cap_from_settings
+from ai_trading.config.management import derive_cap_from_settings, is_shadow_mode
 from ai_trading.data.bars import (_ensure_df, safe_get_stock_bars, _create_empty_bars_dataframe, StockBarsRequest, TimeFrame, TimeFrameUnit, _resample_minutes_to_daily)
 
 if os.getenv("BOT_SHOW_DEPRECATIONS", "").lower() in {"1", "true", "yes"}:
@@ -352,11 +352,7 @@ def _alpaca_diag_info() -> dict[str, object]:
     # AI-AGENT-REF: structured diag for once-per-process logging
     try:
         key, secret, base_url = _resolve_alpaca_env()
-        shadow = getattr(config, "SHADOW_MODE", False) or os.getenv("SHADOW_MODE", "").lower() in (
-            "true",
-            "1",
-            "yes",
-        )
+        shadow = is_shadow_mode()
         paper = bool(base_url and ("paper" in base_url))
         return {
             "has_key": bool(key),
@@ -1558,13 +1554,8 @@ def _ensure_alpaca_env_or_raise():
     - Outside SHADOW_MODE, if missing key/secret, raise with a clear message.
     """
     k, s, b = _resolve_alpaca_env()
-    # Check both config and environment for SHADOW_MODE
-    shadow_mode = getattr(config, "SHADOW_MODE", False) or os.getenv(
-        "SHADOW_MODE", ""
-    ).lower() in (
-        "true",
-        "1",
-    )
+    # Check for shadow mode
+    shadow_mode = is_shadow_mode()
     if shadow_mode:
         return k, s, b
     if not (k and s):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ import pathlib
 
 import numpy as np
 import pytest
+import types
 try:
     # Optional dev dependency. Provide a benign fallback for smoke/collect.
     from freezegun import freeze_time  # type: ignore
@@ -117,6 +118,19 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         for item in items:
             if "integration" in item.keywords:
                 item.add_marker(skip_integration)
+
+
+@pytest.fixture
+def dummy_alpaca_client():
+    class Client:
+        def __init__(self):
+            self.calls = 0
+
+        def submit_order(self, **order_data):
+            self.calls += 1
+            return types.SimpleNamespace(id="123", **order_data)
+
+    return Client()
 
 
 def _install_vendor_stubs() -> None:

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -35,14 +35,9 @@ def test_submit_order_shadow(monkeypatch):
         def submit_order(self, order_data=None):
             raise AssertionError("should not call in shadow")
 
-    monkeypatch.setattr(alpaca_api, "SHADOW_MODE", True)
-    log = types.SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None)
-    resp = alpaca_api.submit_order(
-        DummyAPI(),
-        types.SimpleNamespace(symbol="AAPL", qty=1, side="buy", time_in_force="day"),
-        log,
-    )
-    assert resp["status"] == "shadow"
+    monkeypatch.setenv("SHADOW_MODE", "1")
+    resp = alpaca_api.submit_order("AAPL", 1, "buy", client=DummyAPI())
+    assert resp["status"] == "accepted"
 
 
 def test_monitor_slippage_alert(monkeypatch):

--- a/tests/test_shadow_mode_runtime.py
+++ b/tests/test_shadow_mode_runtime.py
@@ -1,0 +1,28 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+req_mod = types.ModuleType("requests")
+req_mod.post = lambda *a, **k: None
+req_mod.exceptions = types.SimpleNamespace(RequestException=Exception)
+sys.modules.setdefault("requests", req_mod)
+
+import ai_trading.alpaca_api as api
+
+
+def test_shadow_mode_env_change_affects_behavior(monkeypatch):
+    monkeypatch.delenv("SHADOW_MODE", raising=False)
+    importlib.reload(api)
+
+    class Dummy:
+        def submit_order(self, **kwargs):
+            raise AssertionError("called real submit")
+
+    with pytest.raises(AssertionError):
+        api.submit_order("AAPL", 1, "buy", client=Dummy())
+
+    monkeypatch.setenv("SHADOW_MODE", "1")
+    res = api.submit_order("AAPL", 1, "buy", client=Dummy())
+    assert res["id"].startswith("shadow-")

--- a/tests/unit/test_alpaca_api.py
+++ b/tests/unit/test_alpaca_api.py
@@ -30,7 +30,7 @@ def test_submit_order_uses_client_and_returns(dummy_alpaca_client, monkeypatch):
 
     # Mock the DRY_RUN setting to False so the actual client is used
     monkeypatch.setattr(alpaca_api, "DRY_RUN", False)
-    monkeypatch.setattr(alpaca_api, "SHADOW_MODE", False)
+    monkeypatch.setenv("SHADOW_MODE", "0")
 
     # Create a simple order request object
     class OrderReq:
@@ -46,9 +46,15 @@ def test_submit_order_uses_client_and_returns(dummy_alpaca_client, monkeypatch):
             return None
 
     order_req = OrderReq()
-    res = submit(dummy_alpaca_client, order_req)
+    res = submit(
+        order_req.symbol,
+        order_req.qty,
+        order_req.side,
+        time_in_force=order_req.time_in_force,
+        client=dummy_alpaca_client,
+    )
     assert res is not None
-    assert getattr(res, "id", None) is not None
+    assert res.get("id") is not None
     assert dummy_alpaca_client.calls, "Client submit_order should be called"
 
 


### PR DESCRIPTION
## Summary
- add `is_shadow_mode()` helper for runtime reads of the `SHADOW_MODE` env var
- switch Alpaca and diagnostics to consult `is_shadow_mode()` instead of static constants
- cover dynamic SHADOW_MODE toggling with regression test and update existing tests

## Testing
- `python -m pip install -U pip`
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 60 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0ae6ed50833088469fa9bd91d27b