### PR TITLE
Use central get_logger and mask secret log extras

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 import logging
+from ai_trading.logging import get_logger
 import os
 from flask import Flask, jsonify
 
 def create_app():
     app = Flask(__name__)
-    logging.getLogger('werkzeug').setLevel(logging.ERROR)
+    get_logger('werkzeug').setLevel(logging.ERROR)
 
     @app.route('/health')
     def health():

--- a/ai_trading/audit.py
+++ b/ai_trading/audit.py
@@ -1,7 +1,7 @@
 import csv
-import logging
+from ai_trading.logging import get_logger
 from pathlib import Path
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 TRADE_LOG_FILE = 'trades.csv'
 
 def fix_file_permissions(path: str) -> bool:

--- a/ai_trading/backtesting/grid_runner.py
+++ b/ai_trading/backtesting/grid_runner.py
@@ -5,9 +5,9 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from itertools import product
 from typing import Any
-import logging
+from ai_trading.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 try:  # optional joblib import
     from joblib import Parallel, delayed
 except ImportError:  # pragma: no cover - optional dependency

--- a/ai_trading/config/__init__.py
+++ b/ai_trading/config/__init__.py
@@ -1,4 +1,4 @@
-import logging
+from ai_trading.logging import get_logger
 import os
 import threading
 from typing import Any
@@ -11,7 +11,7 @@ from .management import (
     derive_cap_from_settings,
 )
 from .settings import Settings, broker_keys, get_settings
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 _LOCK_TIMEOUT = 30
 _ENV_LOCK = LockWithTimeout(_LOCK_TIMEOUT)
 _lock_state = threading.local()

--- a/ai_trading/core/hyperparams_schema.py
+++ b/ai_trading/core/hyperparams_schema.py
@@ -6,12 +6,13 @@ schema compatibility across different versions of the trading system.
 """
 import json
 import logging
+from ai_trading.logging import get_logger
 import os
 from datetime import UTC, datetime
 from typing import Any
 from pydantic import BaseModel, Field, validator
 PYDANTIC_AVAILABLE = True
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 HYPERPARAMS_SCHEMA_VERSION = '1.0.0'
 _last_missing_warning = 0
 _warning_interval = 3600

--- a/ai_trading/data/corp_actions.py
+++ b/ai_trading/data/corp_actions.py
@@ -7,7 +7,7 @@ features, labels, and execution sizing to ensure consistency.
 from __future__ import annotations
 
 import json
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import asdict, dataclass
 from datetime import date
 from pathlib import Path
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - import only for typing
     import pandas as pd
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class CorporateAction:
@@ -75,7 +75,7 @@ class CorporateActionRegistry:
         """
         self.data_path = Path(data_path)
         self.data_path.mkdir(parents=True, exist_ok=True)
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self._actions: dict[str, list[CorporateAction]] = {}
         self._load_actions()
 

--- a/ai_trading/data/sanitize.py
+++ b/ai_trading/data/sanitize.py
@@ -5,11 +5,12 @@ Provides data cleaning pipeline with winsorization, volume filtering,
 and stale data detection to guard against poor quality market data.
 """
 import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from typing import Any
 import numpy as np
 import pandas as pd
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class SanitizationConfig:
@@ -45,7 +46,7 @@ class DataSanitizer:
             config: Sanitization configuration
         """
         self.config = config or SanitizationConfig()
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self._rejection_stats = {'outliers': 0, 'low_volume': 0, 'stale_gaps': 0, 'stale_prices': 0, 'invalid_prices': 0, 'excessive_moves': 0, 'total_processed': 0}
 
     def sanitize_bars(self, bars: pd.DataFrame, symbol: str='UNKNOWN') -> tuple[pd.DataFrame, dict[str, Any]]:

--- a/ai_trading/execution/costs.py
+++ b/ai_trading/execution/costs.py
@@ -5,13 +5,13 @@ Maintains per-symbol cost parameters (half_spread_bps, slip_k) and applies
 them in both backtesting and live position sizing.
 """
 import json
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import asdict, dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
 import numpy as np
 import pandas as pd
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class SymbolCosts:
@@ -117,7 +117,7 @@ class SymbolCostModel:
         """
         self.data_path = Path(data_path)
         self.data_path.mkdir(parents=True, exist_ok=True)
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self._costs: dict[str, SymbolCosts] = {}
         self._default_costs = SymbolCosts(symbol='DEFAULT', half_spread_bps=2.0, slip_k=1.5, commission_bps=0.5, min_commission=1.0, borrow_fee_bps=10.0, overnight_bps=0.5, locate_required=False)
         self._load_cost_data()

--- a/ai_trading/execution/order_policy.py
+++ b/ai_trading/execution/order_policy.py
@@ -4,12 +4,12 @@ Enhanced order policy with marketable limit orders and smart routing.
 Provides intelligent order placement with symbol-specific parameters,
 IOC for fades, and market fallback logic.
 """
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
 from ai_trading.execution.costs import get_symbol_costs
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class OrderType(Enum):
     """Order type enumeration."""
@@ -70,7 +70,7 @@ class SmartOrderRouter:
 
     def __init__(self):
         """Initialize smart order router."""
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self._symbol_params: dict[str, OrderParameters] = {}
         self._active_orders: dict[str, dict] = {}
 

--- a/ai_trading/execution/reconcile.py
+++ b/ai_trading/execution/reconcile.py
@@ -6,11 +6,11 @@ Reconciles local trading state with broker truth by:
 2. Comparing with local state
 3. Fixing drifts (cancel stale locals, resync quantities)
 """
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from ai_trading.core.interfaces import Order, OrderStatus, Position
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class PositionDrift:
@@ -68,7 +68,7 @@ class PositionReconciler:
         """
         self.tolerance_pct = tolerance_pct
         self.min_drift_qty = min_drift_qty
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
 
     def reconcile_positions(self, local_positions: dict[str, Position], broker_positions: dict[str, Position]) -> list[PositionDrift]:
         """

--- a/ai_trading/features/indicators.py
+++ b/ai_trading/features/indicators.py
@@ -7,10 +7,10 @@ technical indicators used in trading strategies.
 Moved from root features.py for package-safe imports.
 """
 from __future__ import annotations
-import logging
+from ai_trading.logging import get_logger
 from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.indicators import atr, ema
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Lazy pandas proxy
 pd = load_pandas()

--- a/ai_trading/governance/promotion.py
+++ b/ai_trading/governance/promotion.py
@@ -5,13 +5,13 @@ Manages the promotion process from shadow testing to production deployment
 with performance validation and safety checks.
 """
 import json
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from ..model_registry import ModelRegistry
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class PromotionCriteria:
@@ -58,7 +58,7 @@ class ModelPromotion:
         self.criteria = criteria or PromotionCriteria()
         self.base_path = Path(base_path)
         self.base_path.mkdir(parents=True, exist_ok=True)
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self.active_dir = self.base_path / 'active'
         self.active_dir.mkdir(exist_ok=True)
 

--- a/ai_trading/health_monitor.py
+++ b/ai_trading/health_monitor.py
@@ -9,7 +9,7 @@ AI-AGENT-REF: Production health monitoring for institutional trading
 from __future__ import annotations
 import asyncio
 import contextlib
-import logging
+from ai_trading.logging import get_logger
 import os
 import threading
 import time
@@ -24,7 +24,7 @@ if _HAS_PSUTIL:
     import psutil
 else:
     psutil = None
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class HealthStatus(Enum):
@@ -160,7 +160,7 @@ class HealthMonitor:
     """Comprehensive health monitoring system."""
 
     def __init__(self, check_interval: float = 60.0, labels: dict[str, str] | None = None):
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
         self.check_interval = check_interval
         self.labels = {} if labels is None else dict(labels)
         self.checkers: dict[str, HealthChecker] = dict()

--- a/ai_trading/indicators.py
+++ b/ai_trading/indicators.py
@@ -1,12 +1,12 @@
 """Technical indicator helpers used across the bot."""
 from __future__ import annotations
-import logging
+from ai_trading.logging import get_logger
 from collections.abc import Iterable
 from functools import lru_cache
 from typing import Any
 import numpy as np
 from ai_trading.utils.lazy_imports import load_pandas
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Lazy pandas proxy
 pd = load_pandas()

--- a/ai_trading/integrations/rate_limit.py
+++ b/ai_trading/integrations/rate_limit.py
@@ -6,7 +6,7 @@ and async-safe interfaces to prevent 429 errors and API throttling.
 """
 
 import asyncio
-import logging
+from ai_trading.logging import get_logger
 import random
 import threading
 import time
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from ai_trading.utils.timing import sleep as psleep
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -107,7 +107,7 @@ class RateLimiter:
             global_capacity: Global burst capacity across all routes (override)
             global_rate: Global refill rate (tokens per second) (override)
         """
-        self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+        self.logger = get_logger(f"{__name__}.{self.__class__.__name__}")
         if config is not None:
             capacity = getattr(config, "capacity", global_capacity)
             rate = getattr(config, "refill_rate", global_rate)

--- a/ai_trading/market/cache.py
+++ b/ai_trading/market/cache.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
-import logging
+from ai_trading.logging import get_logger
 import threading
 import time
 from pathlib import Path
 from typing import Any
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 try:
     import pandas as pd
 except (pd.errors.EmptyDataError, KeyError, ValueError, TypeError):

--- a/ai_trading/market/calendars.py
+++ b/ai_trading/market/calendars.py
@@ -4,11 +4,11 @@ Per-symbol trading calendar registry for session validation.
 Provides calendar-aware trading session validation to prevent trades
 outside market hours and handle ETF half-days, futures sessions, etc.
 """
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time, timedelta
 from enum import Enum
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class AssetClass(Enum):
     """Asset class for calendar determination."""
@@ -51,7 +51,7 @@ class CalendarRegistry:
 
     def __init__(self):
         """Initialize calendar registry."""
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self._symbol_calendars: dict[str, TradingSession] = {}
         self._asset_calendars: dict[AssetClass, TradingSession] = {}
         self._holidays: set[date] = set()

--- a/ai_trading/market/symbol_specs.py
+++ b/ai_trading/market/symbol_specs.py
@@ -4,10 +4,10 @@ Symbol specifications for tick sizes and lot sizes.
 Provides centralized mapping of symbol trading specifications for
 precise order sizing and execution.
 """
-import logging
+from ai_trading.logging import get_logger
 from decimal import Decimal
 from typing import NamedTuple
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class SymbolSpec(NamedTuple):
     """Trading specifications for a symbol."""

--- a/ai_trading/math/money.py
+++ b/ai_trading/math/money.py
@@ -4,13 +4,13 @@ Exact money math using Decimal for profit-critical P&L calculations.
 Provides Money class for precise financial calculations, avoiding float
 arithmetic errors that can cause silent P&L drag.
 """
-import logging
+from ai_trading.logging import get_logger
 from decimal import ROUND_HALF_EVEN, Decimal, getcontext
 from typing import TYPE_CHECKING, Union
 if TYPE_CHECKING:
     pass
 getcontext().prec = 28
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 Number = Union[int, float, str, Decimal, 'Money']
 
 class Money:

--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -6,7 +6,7 @@ SKLEARN_AVAILABLE = bool(find_spec("sklearn"))
 "Utility helpers for meta-learning weight management."
 import csv
 import json
-import logging
+from ai_trading.logging import get_logger
 import os
 import pickle
 import random
@@ -37,7 +37,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing helpers
     import pandas as _pd  # noqa: F401
 
 open = open
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _import_numpy(optional: bool = False):
@@ -154,7 +154,7 @@ class MetaLearning:
 
     def __init__(self):
         """Initialize the MetaLearning instance."""
-        self.logger = logging.getLogger(__name__ + '.MetaLearning')
+        self.logger = get_logger(__name__ + '.MetaLearning')
         self.logger.debug('MetaLearning instance initialized')
 
 def validate_trade_data_quality(trade_log_path: str) -> dict:
@@ -792,7 +792,7 @@ def _generate_realistic_price(base_price: float) -> float:
     return round(price, 2)
 
 def _append_bootstrap_trades_to_log(trade_log_path: str, bootstrap_trades: list) -> None:
-    """Append bootstrap trades to the trade log."""
+    """Append bootstrap trades to the trade logger."""
     try:
         if not os.path.exists(trade_log_path):
             _create_emergency_trade_log(trade_log_path)

--- a/ai_trading/model_loader.py
+++ b/ai_trading/model_loader.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import logging
+from ai_trading.logging import get_logger
 import pickle
 from datetime import UTC
 from pathlib import Path
 from pickle import UnpicklingError
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 BASE_DIR = Path(__file__).resolve().parents[1]
 ML_MODELS: dict[str, object | None] = {}
 

--- a/ai_trading/model_registry.py
+++ b/ai_trading/model_registry.py
@@ -1,3 +1,4 @@
+from ai_trading.logging import get_logger
 """
 Clean model registry for storage, versioning, and retrieval with metadata.
 """
@@ -13,7 +14,7 @@ try:
     from ai_trading.logging import logger
 except (ValueError, TypeError):
     import logging
-    logger = logging.getLogger(__name__)
+    logger = get_logger(__name__)
 
 class ModelRegistry:
     """Centralized registry for trained models."""

--- a/ai_trading/monitoring/drift.py
+++ b/ai_trading/monitoring/drift.py
@@ -6,14 +6,14 @@ tracks per-signal attribution, and provides shadow mode for
 experimental model validation.
 """
 import json
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 import numpy as np
 import pandas as pd
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class DriftMetrics:
@@ -82,7 +82,7 @@ class DriftMonitor:
         self.baseline_path = Path(baseline_data_path)
         self.baseline_path.mkdir(parents=True, exist_ok=True)
         self.alert_thresholds = alert_thresholds or AlertThreshold()
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self._baseline_stats: dict[str, dict[str, float]] = {}
         self._load_baseline_stats()
         self._signal_history: dict[str, list[SignalAttribution]] = {}
@@ -284,7 +284,7 @@ class ShadowMode:
         """
         self.log_path = Path(log_path)
         self.log_path.mkdir(parents=True, exist_ok=True)
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
 
     def evaluate_shadow_model(self, model_name: str, shadow_predictions: dict[str, float], production_predictions: dict[str, float], market_data: dict[str, Any] | None=None) -> dict[str, Any]:
         """

--- a/ai_trading/monitoring/order_health_monitor.py
+++ b/ai_trading/monitoring/order_health_monitor.py
@@ -8,7 +8,7 @@ Addresses the critical issues:
 """
 from __future__ import annotations
 import json
-import logging
+from ai_trading.logging import get_logger
 import threading
 import time
 from collections import deque
@@ -34,7 +34,7 @@ class OrderInfo:
         return self.qty
 _active_orders: dict[str, OrderInfo] = {}
 _order_tracking_lock = threading.Lock()
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class OrderHealthMetrics:
@@ -77,7 +77,7 @@ class OrderHealthMonitor:
     def __init__(self, execution_engine=None):
         """Initialize the order health monitor."""
         self.execution_engine = execution_engine
-        self.logger = logging.getLogger(__name__ + '.OrderHealthMonitor')
+        self.logger = get_logger(__name__ + '.OrderHealthMonitor')
         self._partial_fills: dict[str, PartialFillInfo] = {}
         self._fill_times: deque = deque(maxlen=1000)
         self._order_metrics: deque = deque(maxlen=100)

--- a/ai_trading/monitoring/slo.py
+++ b/ai_trading/monitoring/slo.py
@@ -6,6 +6,7 @@ breaking when performance degrades beyond acceptable thresholds.
 """
 import json
 import logging
+from ai_trading.logging import get_logger
 import threading
 from collections import defaultdict, deque
 from collections.abc import Callable
@@ -13,7 +14,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class SLOStatus(Enum):
     """SLO status levels."""
@@ -62,7 +63,7 @@ class SLOMonitor:
         Args:
             config_path: Optional path to SLO configuration file
         """
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self._metrics: dict[str, deque] = defaultdict(lambda: deque(maxlen=1000))
         self._slo_thresholds: dict[str, SLOThreshold] = {}
         self._slo_status: dict[str, SLOStatus] = {}

--- a/ai_trading/paths.py
+++ b/ai_trading/paths.py
@@ -4,10 +4,10 @@ Runtime paths for AI Trading Bot.
 Defines writable data, log, and cache directories with environment overrides.
 Creates directories at import time.
 """
-import logging
+from ai_trading.logging import get_logger
 import os
 from pathlib import Path
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 BASE_DIR = Path(__file__).resolve().parents[1]
 APP_NAME = 'ai-trading-bot'
 

--- a/ai_trading/pipeline.py
+++ b/ai_trading/pipeline.py
@@ -1,6 +1,6 @@
-import logging
+from ai_trading.logging import get_logger
 import numpy as np
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.linear_model import SGDRegressor
 from sklearn.pipeline import Pipeline

--- a/ai_trading/plotting/renderer.py
+++ b/ai_trading/plotting/renderer.py
@@ -1,9 +1,9 @@
 """Basic plotting helpers."""
 from __future__ import annotations
-import logging
+from ai_trading.logging import get_logger
 from ai_trading.utils.optdeps import OptionalDependencyError
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 def render_equity_curve(series, *, title: str = "Equity") -> None:
     """Render a simple equity curve using matplotlib if available."""

--- a/ai_trading/portfolio/core.py
+++ b/ai_trading/portfolio/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+from ai_trading.logging import get_logger
 import threading
 from typing import TYPE_CHECKING
 
@@ -15,7 +15,7 @@ from ai_trading.data.bars import (
 
 if TYPE_CHECKING:  # pragma: no cover - import only for typing
     import pandas as pd
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 _portfolio_lock = threading.RLock()
 
 def _last_close_from(df: pd.DataFrame) -> float | None:

--- a/ai_trading/portfolio/risk_controls.py
+++ b/ai_trading/portfolio/risk_controls.py
@@ -4,7 +4,7 @@ Adaptive risk controls and exposure management.
 Provides vol-targeting, adaptive Kelly sizing, correlation clustering,
 cluster exposure caps, and turnover budget enforcement.
 """
-import logging
+from ai_trading.logging import get_logger
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -17,7 +17,7 @@ def _import_clustering():
     S = get_settings()
     if not S.ENABLE_PORTFOLIO_FEATURES:
         return (None, None, None, False)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class RiskBudget:
@@ -93,7 +93,7 @@ class AdaptiveRiskController:
             risk_budget: Risk budget parameters
         """
         self.risk_budget = risk_budget or RiskBudget()
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self.drawdown_multiplier = 1.0
         self.green_days_count = 0
         self.turnover_budget = TurnoverBudget(total_budget=self.risk_budget.max_turnover_daily)

--- a/ai_trading/position/correlation_analyzer.py
+++ b/ai_trading/position/correlation_analyzer.py
@@ -9,7 +9,7 @@ Monitors position correlations and portfolio concentrations:
 
 AI-AGENT-REF: Portfolio correlation analysis for risk-aware position management
 """
-import logging
+from ai_trading.logging import get_logger
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -18,7 +18,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 from ai_trading.exc import COMMON_EXC
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class ConcentrationLevel(Enum):
     """Portfolio concentration risk levels."""
@@ -85,7 +85,7 @@ class PortfolioCorrelationAnalyzer:
 
     def __init__(self, ctx=None):
         self.ctx = ctx
-        self.logger = logging.getLogger(__name__ + '.PortfolioCorrelationAnalyzer')
+        self.logger = get_logger(__name__ + '.PortfolioCorrelationAnalyzer')
         self.correlation_lookback_days = 30
         self.min_data_points = 20
         self.position_concentration_thresholds = {ConcentrationLevel.LOW: 20.0, ConcentrationLevel.MODERATE: 35.0, ConcentrationLevel.HIGH: 50.0}

--- a/ai_trading/position/intelligent_manager.py
+++ b/ai_trading/position/intelligent_manager.py
@@ -10,7 +10,7 @@ Coordinates all position management strategies:
 
 AI-AGENT-REF: Main intelligent position management orchestrator
 """
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
@@ -21,7 +21,7 @@ from .market_regime import MarketRegime, MarketRegimeDetector, RegimeMetrics
 from .profit_taking import ProfitTakingEngine
 from .technical_analyzer import DivergenceType, SignalStrength, TechnicalSignalAnalyzer
 from .trailing_stops import TrailingStopManager
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class PositionAction(Enum):
     """Recommended position actions."""
@@ -65,7 +65,7 @@ class IntelligentPositionManager:
 
     def __init__(self, ctx=None):
         self.ctx = ctx
-        self.logger = logging.getLogger(__name__ + '.IntelligentPositionManager')
+        self.logger = get_logger(__name__ + '.IntelligentPositionManager')
         self.regime_detector = MarketRegimeDetector(ctx)
         self.technical_analyzer = TechnicalSignalAnalyzer(ctx)
         self.trailing_stop_manager = TrailingStopManager(ctx)

--- a/ai_trading/position/profit_taking.py
+++ b/ai_trading/position/profit_taking.py
@@ -9,14 +9,14 @@ Implements sophisticated profit taking strategies:
 
 AI-AGENT-REF: Advanced profit taking with multi-tiered scale-out strategies
 """
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 import pandas as pd
 from ai_trading.exc import COMMON_EXC
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class ProfitTakingStrategy(Enum):
     """Profit taking strategy types."""
@@ -65,7 +65,7 @@ class ProfitTakingEngine:
 
     def __init__(self, ctx=None):
         self.ctx = ctx
-        self.logger = logging.getLogger(__name__ + '.ProfitTakingEngine')
+        self.logger = get_logger(__name__ + '.ProfitTakingEngine')
         self.default_targets = [{'level': 2.0, 'quantity_pct': 25.0, 'strategy': ProfitTakingStrategy.RISK_MULTIPLE}, {'level': 3.0, 'quantity_pct': 25.0, 'strategy': ProfitTakingStrategy.RISK_MULTIPLE}, {'level': 5.0, 'quantity_pct': 25.0, 'strategy': ProfitTakingStrategy.RISK_MULTIPLE}]
         self.resistance_buffer = 0.5
         self.overbought_threshold = 75

--- a/ai_trading/position/technical_analyzer.py
+++ b/ai_trading/position/technical_analyzer.py
@@ -9,13 +9,13 @@ Analyzes technical indicators to inform position holding decisions:
 
 AI-AGENT-REF: Technical signal analysis for intelligent position exits
 """
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 import pandas as pd
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class SignalStrength(Enum):
     """Technical signal strength levels."""
@@ -63,7 +63,7 @@ class TechnicalSignalAnalyzer:
 
     def __init__(self, ctx=None):
         self.ctx = ctx
-        self.logger = logging.getLogger(__name__ + '.TechnicalSignalAnalyzer')
+        self.logger = get_logger(__name__ + '.TechnicalSignalAnalyzer')
         self.momentum_period = 14
         self.volume_period = 20
         self.divergence_lookback = 10

--- a/ai_trading/position/trailing_stops.py
+++ b/ai_trading/position/trailing_stops.py
@@ -9,13 +9,13 @@ Implements sophisticated trailing stop strategies:
 
 AI-AGENT-REF: Advanced trailing stop management with multiple algorithms
 """
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 import pandas as pd
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class TrailingStopType(Enum):
     """Types of trailing stop algorithms."""
@@ -56,7 +56,7 @@ class TrailingStopManager:
 
     def __init__(self, ctx=None):
         self.ctx = ctx
-        self.logger = logging.getLogger(__name__ + '.TrailingStopManager')
+        self.logger = get_logger(__name__ + '.TrailingStopManager')
         self.base_trail_percent = 3.0
         self.atr_multiplier = 2.0
         self.atr_period = 14

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import logging
+from ai_trading.logging import get_logger
 import random
 import threading
 from collections.abc import Sequence
@@ -34,7 +35,7 @@ try:  # optional pandas_ta import for ta accessor registration
     import pandas_ta as ta  # type: ignore  # noqa: F401
 except ImportError:  # pragma: no cover - optional dependency
     ta = None
-    logging.getLogger(__name__).info(
+    get_logger(__name__).info(
         'PANDAS_TA_MISSING', extra={'hint': 'pip install pandas-ta'}
     )
 try:  # pragma: no cover - optional dependency
@@ -58,7 +59,7 @@ class TradeSignal:
     weight: float
     asset_class: str
     strength: float = 1.0
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 if not get_env("PYTEST_RUNNING", "0", cast=bool):
     _ENV_SNAPSHOT = validate_required_env()
     logger.debug("ENV_VARS_MASKED", extra=_ENV_SNAPSHOT)

--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 from functools import lru_cache
 import importlib
-import logging
+from ai_trading.logging import get_logger
 from pathlib import Path
 from typing import Any
 
 from typing import TYPE_CHECKING
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Exposed for tests to monkeypatch
 PPO: Any | None = None

--- a/ai_trading/rl_trading/env.py
+++ b/ai_trading/rl_trading/env.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass
-import logging
+from ai_trading.logging import get_logger
 from typing import TYPE_CHECKING
 
 try:  # optional dependency
@@ -13,7 +13,7 @@ except Exception:  # noqa: BLE001 - numpy is optional until env used
 
 from . import _load_rl_stack
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover - hints only
     import gymnasium as gym

--- a/ai_trading/rl_trading/inference.py
+++ b/ai_trading/rl_trading/inference.py
@@ -1,6 +1,6 @@
 """Load a trained RL policy and produce trade signals with unified action space."""
 from __future__ import annotations
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -9,7 +9,7 @@ from ai_trading.strategies.base import StrategySignal
 from . import RLAgent
 from .env import ActionSpaceConfig, RewardConfig
 TradeSignal = StrategySignal
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class InferenceConfig:
@@ -37,7 +37,7 @@ class UnifiedRLInference:
             config: Inference configuration
         """
         self.config = config
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self.agent = RLAgent(config.model_path)
         self.agent.load()
         self._validate_action_space()

--- a/ai_trading/rl_trading/tests/smoke_parity.py
+++ b/ai_trading/rl_trading/tests/smoke_parity.py
@@ -6,6 +6,7 @@ in both training environment and inference wrapper.
 """
 
 import logging
+from ai_trading.logging import get_logger
 import os
 import tempfile
 
@@ -13,7 +14,7 @@ import numpy as np
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def test_action_space_parity():

--- a/ai_trading/scheduler/aligned_clock.py
+++ b/ai_trading/scheduler/aligned_clock.py
@@ -4,7 +4,7 @@ Exchange-aligned clock and scheduling module.
 Provides timing synchronization with exchange schedules and validates
 bar finality before signal generation.
 """
-import logging
+from ai_trading.logging import get_logger
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -13,7 +13,7 @@ try:
 except (ValueError, TypeError):
     mcal = None
 MARKET_CALENDAR_AVAILABLE = mcal is not None
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 def _get_calendar(cal_name: str):
     if mcal is None:
@@ -53,7 +53,7 @@ class AlignedClock:
         """
         self.max_skew_ms = max_skew_ms
         self.exchange = exchange
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self.calendar = _get_calendar(exchange)
         self._bar_close_cache: dict[str, datetime] = {}
 

--- a/ai_trading/security.py
+++ b/ai_trading/security.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+from ai_trading.logging import get_logger
 import os
 import secrets
 from dataclasses import dataclass
@@ -36,7 +37,7 @@ except (ValueError, TypeError):
         def decrypt(self, token: bytes) -> bytes:
             return token
     hashes = PBKDF2HMAC = None
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class SecurityLevel(Enum):
     """Security event severity levels."""
@@ -75,7 +76,7 @@ class SecureConfig:
     """Secure configuration management with encryption."""
 
     def __init__(self, master_key: str | None=None):
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
         self._master_key = master_key or self._generate_master_key()
         self._fernet = self._init_encryption() if _CRYPTOGRAPHY_AVAILABLE else None
         self._config_cache: dict[str, Any] = {}
@@ -109,7 +110,7 @@ class SecureConfig:
 
     def _setup_audit_logging(self) -> logging.Logger:
         """Setup dedicated audit logging."""
-        audit_logger = logging.getLogger('ai_trading.audit')
+        audit_logger = get_logger('ai_trading.audit')
         audit_logger.setLevel(logging.INFO)
         if not audit_logger.handlers:
             log_dir = Path('logs')
@@ -249,7 +250,7 @@ class SecurityManager:
     """Central security management for the trading platform."""
 
     def __init__(self):
-        self.logger = logging.getLogger(__name__)
+        self.logger = get_logger(__name__)
         self.secure_config = SecureConfig()
         self.safe_logger = SafeLogger(self.logger, self.secure_config)
         self._security_events: list[AuditEvent] = []
@@ -325,7 +326,7 @@ def get_security_manager() -> SecurityManager:
 
 def get_safe_logger(name: str) -> SafeLogger:
     """Get a safe logger that masks sensitive data."""
-    base_logger = logging.getLogger(name)
+    base_logger = get_logger(name)
     security_manager = get_security_manager()
     return SafeLogger(base_logger, security_manager.secure_config)
 

--- a/ai_trading/strategies/imports.py
+++ b/ai_trading/strategies/imports.py
@@ -3,13 +3,13 @@
 All dependencies are imported directly. Optional features are controlled
 via Settings flags rather than import guards.
 """
-import logging
+from ai_trading.logging import get_logger
 import numpy as np
 import pandas as pd
 from sklearn import metrics
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 NUMPY_AVAILABLE = True
 PANDAS_AVAILABLE = True
 SKLEARN_AVAILABLE = True

--- a/ai_trading/strategies/moving_average_crossover.py
+++ b/ai_trading/strategies/moving_average_crossover.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-import logging
+from ai_trading.logging import get_logger
 from dataclasses import dataclass
 import pandas as pd
 from .base import StrategySignal
-log = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class MovingAverageCrossoverStrategy:

--- a/ai_trading/telemetry/metrics_logger.py
+++ b/ai_trading/telemetry/metrics_logger.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 import csv
-import logging
+from ai_trading.logging import get_logger
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 def compute_max_drawdown(curve: Sequence[float]) -> float:
     """Return max peak-to-trough drawdown as a fraction."""

--- a/ai_trading/trade_logic.py
+++ b/ai_trading/trade_logic.py
@@ -9,21 +9,21 @@ except (ValueError, TypeError):
     from ai_trading.capital_scaling import drawdown_adjusted_kelly
 from ai_trading.config.settings import get_settings
 from ai_trading.core.bot_engine import _fetch_intraday_bars_chunked
-log = get_logger(__name__)
+logger = get_logger(__name__)
 
 def should_enter_trade(price_data, signals, risk_params):
     """Determine whether a trade entry conditions are met."""
     if not isinstance(signals, dict) or not isinstance(risk_params, dict):
-        log.warning('Invalid input types for trade entry evaluation')
+        logger.warning('Invalid input types for trade entry evaluation')
         return False
     try:
         if price_data is None or len(price_data) < 2:
-            log.debug('Insufficient price data for trade entry')
+            logger.debug('Insufficient price data for trade entry')
             return False
         last_price, prev_price = (float(price_data[-1]), float(price_data[-2]))
         recent_gain = (last_price - prev_price) / max(prev_price, 1e-09)
     except (ValueError, TypeError):
-        log.warning('Failed to calculate recent gain from price data')
+        logger.warning('Failed to calculate recent gain from price data')
         return False
     signal_strength = signals.get('signal_strength', 0)
     max_risk = risk_params.get('max_risk', 0.02)
@@ -31,16 +31,16 @@ def should_enter_trade(price_data, signals, risk_params):
         signal_strength = float(signal_strength)
         max_risk = float(max_risk)
     except (ValueError, TypeError):
-        log.warning('Invalid signal_strength or max_risk values')
+        logger.warning('Invalid signal_strength or max_risk values')
         return False
     result = signal_strength > 0.7 and recent_gain > 0.001 and (max_risk < 0.05)
-    log.debug('Trade entry evaluation: signal=%.3f, gain=%.4f, risk=%.3f, result=%s', signal_strength, recent_gain, max_risk, result)
+    logger.debug('Trade entry evaluation: signal=%.3f, gain=%.4f, risk=%.3f, result=%s', signal_strength, recent_gain, max_risk, result)
     return result
 
 def extract_price(data: Any) -> float:
     """Return the last price from various data structures."""
     import logging
-    logger = logging.getLogger(__name__)
+    logger = get_logger(__name__)
     try:
         if data is None:
             logger.warning('extract_price called with None; returning fallback value')
@@ -97,11 +97,11 @@ def execute_trade(signal: int, position_size: float, price: float, equity_peak: 
     adj_kelly = drawdown_adjusted_kelly(account_value, equity_peak, raw_kelly)
     final_size = position_size * adj_kelly
     if signal == 1:
-        log.info('BUY %s at %s', final_size, price)
+        logger.info('BUY %s at %s', final_size, price)
     elif signal == -1:
-        log.info('SELL %s at %s', final_size, price)
+        logger.info('SELL %s at %s', final_size, price)
     else:
-        log.info('HOLD')
+        logger.info('HOLD')
 
 def evaluate_entries(ctx, candidates):
     """

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import logging
+from ai_trading.logging import get_logger
 import os
 import random
 import subprocess
@@ -63,7 +64,7 @@ def ensure_utc_index(df: DataFrame) -> DataFrame:
     return df
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 _LAST_MARKET_HOURS_LOG = 0.0
 _LAST_MARKET_STATE = ""
 _LAST_HEALTH_ROW_LOG = 0.0
@@ -86,7 +87,7 @@ class PhaseLoggerAdapter(logging.LoggerAdapter):
 
 def get_phase_logger(name: str, phase: str) -> logging.Logger:
     """Return logger with ``bot_phase`` context."""
-    base = logging.getLogger(name)
+    base = get_logger(name)
     return PhaseLoggerAdapter(base, {"bot_phase": phase})
 
 
@@ -475,7 +476,7 @@ def get_pid_on_port(port: int) -> int | None:
                 if int(local.split(":")[1], 16) == port:
                     return _pid_from_inode(inode)
     except COMMON_EXC as e:
-        logging.getLogger(__name__).error("get_pid_on_port failed", exc_info=e)
+        get_logger(__name__).error("get_pid_on_port failed", exc_info=e)
         return None
     return None
 

--- a/ai_trading/utils/determinism.py
+++ b/ai_trading/utils/determinism.py
@@ -6,14 +6,14 @@ model hashes, and data specifications.
 """
 import hashlib
 import json
-import logging
+from ai_trading.logging import get_logger
 import os
 import random
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 try:
     import numpy as np  # type: ignore
@@ -138,7 +138,7 @@ class ModelSpecification:
             spec_file: Path to specification file
         """
         self.spec_file = Path(spec_file)
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
         self._spec: dict[str, Any] = {}
         self._is_locked = False
         self._load_spec()

--- a/ai_trading/utils/device.py
+++ b/ai_trading/utils/device.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+from ai_trading.logging import get_logger
 
 # torch is optional and heavy; import lazily inside functions
 # Cache references for repeated calls
@@ -8,7 +8,7 @@ torch = None  # type: ignore[assignment]
 _torch_tensor = None
 _device = None
 
-_log = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def get_device() -> str:
@@ -31,7 +31,7 @@ def get_device() -> str:
         except Exception:  # defensive: do not let CUDA probing blow up
             _device = "cpu"
 
-    _log.info("ML_DEVICE_DETECTED", extra={"device": _device})  # AI-AGENT-REF: default CPU / optional CUDA
+    logger.info("ML_DEVICE_DETECTED", extra={"device": _device})  # AI-AGENT-REF: default CPU / optional CUDA
     return _device
 
 

--- a/ai_trading/utils/imports.py
+++ b/ai_trading/utils/imports.py
@@ -1,7 +1,7 @@
 import importlib
 import importlib.util
-import logging
-_log = logging.getLogger(__name__)
+from ai_trading.logging import get_logger
+logger = get_logger(__name__)
 
 def _try_import(module_name: str, cls_name: str):
     """find_spec + import_module; returns class or None; logs exceptions."""
@@ -12,7 +12,7 @@ def _try_import(module_name: str, cls_name: str):
         mod = importlib.import_module(module_name)
         return getattr(mod, cls_name, None)
     except (KeyError, ValueError, TypeError) as e:
-        _log.error('Failed to import %s (%s): %s', module_name, cls_name, e)
+        logger.error('Failed to import %s (%s): %s', module_name, cls_name, e)
         return None
 
 def resolve_risk_engine_cls():

--- a/ai_trading/utils/performance.py
+++ b/ai_trading/utils/performance.py
@@ -5,7 +5,7 @@ Provides parallel processing, caching, and vectorized operations
 for improved performance.
 """
 import functools
-import logging
+from ai_trading.logging import get_logger
 import multiprocessing as mp
 import time
 from collections.abc import Callable
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 from typing import Any
 import numpy as np
 import pandas as pd
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 @dataclass
 class BenchmarkResult:
@@ -45,7 +45,7 @@ class PerformanceCache:
         self.max_size = max_size
         self.ttl_seconds = ttl_seconds
         self._cache: dict[str, dict[str, Any]] = {}
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
 
     def _is_expired(self, entry: dict[str, Any]) -> bool:
         """Check if cache entry is expired."""
@@ -133,7 +133,7 @@ class ParallelProcessor:
         if max_workers is None:
             max_workers = min(mp.cpu_count(), 8)
         self.max_workers = max_workers
-        self.logger = logging.getLogger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
 
     def parallel_apply(self, func: Callable, data_chunks: list[Any], *args, **kwargs) -> list[Any]:
         """

--- a/tests/test_secret_filter_extra.py
+++ b/tests/test_secret_filter_extra.py
@@ -1,0 +1,27 @@
+import logging
+from ai_trading.logging import get_logger
+from ai_trading.logging_filters import SecretFilter
+
+
+class _CaptureHandler(logging.Handler):
+    """Capture a single log record for assertions."""
+
+    def __init__(self):
+        super().__init__()
+        self.last = None
+
+    def emit(self, record):
+        self.last = record
+
+
+def test_secret_filter_masks_extra():
+    log = get_logger("test.secret_filter")
+    handler = _CaptureHandler()
+    handler.addFilter(SecretFilter())
+    log.logger.addHandler(handler)
+    try:
+        log.info("msg", extra={"api_key": "supersecret", "value": 1})
+    finally:
+        log.logger.removeHandler(handler)
+    assert handler.last.api_key == "***REDACTED***"
+    assert handler.last.value == 1


### PR DESCRIPTION
## Summary
- switch modules to use `get_logger` instead of `logging.getLogger`
- ensure root logging utilities avoid recursion and sanitize extras
- add test verifying `SecretFilter` masks sensitive keys in logging `extra`

## Testing
- `python -m pip install -U pip`
- `pip install -e .` (fails: Package requires Python >=3.12)
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` (fails: 85 errors during collection)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_secret_filter_extra.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0ae97de08330b0ce8ce52fef0dbb