### PR TITLE
Fix logging deadlock during configuration

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -1,6 +1,6 @@
 ## Logging Configuration
 
- The AI trading bot supports several logging configuration flags to control output verbosity and format. Logger initialization is idempotent—calling the setup multiple times will not create duplicate handlers. The setup routine now inspects existing handler *types* and ensures only one of each type is active, preventing accidental handler growth across repeated calls.
+ The AI trading bot supports several logging configuration flags to control output verbosity and format. Logger initialization is idempotent—calling the setup multiple times will not create duplicate handlers. The setup routine now inspects existing handler *types* and ensures only one of each type is active, preventing accidental handler growth across repeated calls. A re-entrant lock guards the setup sequence so imports that indirectly invoke logging cannot deadlock during application startup.
 
 ### Environment Variables
 

--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -270,7 +270,11 @@ _loggers: dict[str, SanitizingLoggerAdapter] = {}
 _log_queue: queue.Queue | None = None
 _listener: QueueListener | None = None
 _LOGGING_LISTENER: QueueListener | None = None
-_LOGGING_LOCK = threading.Lock()
+# Use a re-entrant lock so setup_logging can be safely invoked if it is
+# indirectly re-entered during module import (e.g. config -> logging).
+# A standard Lock would deadlock when setup_logging imports modules that in
+# turn call get_logger(), which also attempts to acquire this lock.
+_LOGGING_LOCK = threading.RLock()
 _LOGGING_CONFIGURED = False
 
 def ensure_logging_configured(level: int | None=None) -> None:


### PR DESCRIPTION
## Summary
- prevent logging setup deadlocks by switching to a re-entrant lock
- document re-entrant logging lock to clarify startup behaviour

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68ad124a4b1883309d4c2c550f2303a1