### PR TITLE
Gate pandas imports in runtime modules

### DIFF
--- a/ai_trading/strategies/mean_reversion.py
+++ b/ai_trading/strategies/mean_reversion.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
-import pandas as pd
+from typing import TYPE_CHECKING
 from ai_trading.logging import logger as log
 from .base import StrategySignal
+
+if TYPE_CHECKING:  # pragma: no cover - heavy import only for typing
+    import pandas as pd
 
 class MeanReversionStrategy:
 
@@ -11,7 +14,8 @@ class MeanReversionStrategy:
         self.lookback = lookback
         self.z_entry = z_entry
 
-    def _latest_stats(self, series: pd.Series, window: int):
+    def _latest_stats(self, series: 'pd.Series', window: int):
+        import pandas as pd  # heavy import; keep local
         if len(series) < max(3, window):
             log.warning('mean_reversion: insufficient data')
             return (None, None)

--- a/ai_trading/strategies/momentum.py
+++ b/ai_trading/strategies/momentum.py
@@ -5,12 +5,15 @@ This module provides a simple long-only momentum strategy used in tests and
 example workflows.
 """
 from __future__ import annotations
+from typing import TYPE_CHECKING
 import numpy as np
-import pandas as pd
 from ai_trading.logging import logger
 from ..core.enums import RiskLevel
 from ..core.interfaces import OrderSide
 from .base import BaseStrategy, StrategySignal
+
+if TYPE_CHECKING:  # pragma: no cover
+    import pandas as pd
 
 class MomentumStrategy(BaseStrategy):
     """Momentum-based trading strategy."""
@@ -21,6 +24,7 @@ class MomentumStrategy(BaseStrategy):
         self.threshold = threshold
 
     def generate_signals(self, market_data: dict) -> list[StrategySignal]:
+        import pandas as pd  # heavy import; keep local
         """
         Generate momentum-based long-only signals using price changes over a
         lookback period. Accepts market_data with keys:

--- a/ai_trading/strategies/moving_average_crossover.py
+++ b/ai_trading/strategies/moving_average_crossover.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
+from typing import TYPE_CHECKING
 from ai_trading.logging import get_logger
 from dataclasses import dataclass
-import pandas as pd
 from .base import StrategySignal
+
+if TYPE_CHECKING:  # pragma: no cover - heavy import for typing only
+    import pandas as pd
 logger = get_logger(__name__)
 
 @dataclass
@@ -17,7 +20,8 @@ class MovingAverageCrossoverStrategy:
     long_window: int = 50
     min_history: int = 55
 
-    def _latest_cross(self, short: pd.Series, long: pd.Series) -> str | None:
+    def _latest_cross(self, short: 'pd.Series', long: 'pd.Series') -> str | None:
+        import pandas as pd  # heavy import; keep local
         if len(short) < 2 or len(long) < 2:
             return None
         s_prev, s_now = (short.iloc[-2], short.iloc[-1])

--- a/ai_trading/strategies/multi_timeframe.py
+++ b/ai_trading/strategies/multi_timeframe.py
@@ -7,11 +7,13 @@ institutional-grade trading strategies.
 """
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
-import pandas as pd
+from typing import Any, TYPE_CHECKING
 from ai_trading.exc import COMMON_EXC
 from ai_trading.logging import logger
 from ..core.enums import TimeFrame
+
+if TYPE_CHECKING:  # pragma: no cover
+    import pandas as pd
 
 class SignalStrength(Enum):
     """Signal strength enumeration."""
@@ -119,7 +121,7 @@ class MultiTimeframeAnalyzer:
         self.confidence_threshold = 0.6
         logger.info(f'MultiTimeframeAnalyzer initialized with timeframes: {[tf.value for tf in self.primary_timeframes]}')
 
-    def analyze_symbol(self, symbol: str, market_data: dict[TimeFrame, pd.DataFrame]) -> dict[str, Any]:
+    def analyze_symbol(self, symbol: str, market_data: dict[TimeFrame, 'pd.DataFrame']) -> dict[str, Any]:
         """
         Perform comprehensive multi-timeframe analysis for a symbol.
 
@@ -148,7 +150,7 @@ class MultiTimeframeAnalyzer:
             logger.error(f'Error analyzing symbol {symbol}: {e}')
             return {'error': str(e), 'symbol': symbol}
 
-    def _analyze_timeframe(self, symbol: str, timeframe: TimeFrame, data: pd.DataFrame) -> list[MultiTimeframeSignal]:
+    def _analyze_timeframe(self, symbol: str, timeframe: TimeFrame, data: 'pd.DataFrame') -> list[MultiTimeframeSignal]:
         """Analyze a single timeframe and generate signals."""
         try:
             signals = []
@@ -171,8 +173,9 @@ class MultiTimeframeAnalyzer:
             logger.error(f'Error analyzing timeframe {timeframe.value}: {e}')
             return []
 
-    def _generate_ma_signals(self, timeframe: TimeFrame, data: pd.DataFrame) -> list[MultiTimeframeSignal]:
+    def _generate_ma_signals(self, timeframe: TimeFrame, data: 'pd.DataFrame') -> list[MultiTimeframeSignal]:
         """Generate moving average signals."""
+        import pandas as pd  # heavy import; keep local
         try:
             signals = []
             data['SMA_20'] = data['close'].rolling(20).mean()
@@ -209,8 +212,9 @@ class MultiTimeframeAnalyzer:
             logger.error(f'Error generating MA signals: {e}')
             return []
 
-    def _generate_rsi_signals(self, timeframe: TimeFrame, data: pd.DataFrame) -> list[MultiTimeframeSignal]:
+    def _generate_rsi_signals(self, timeframe: TimeFrame, data: 'pd.DataFrame') -> list[MultiTimeframeSignal]:
         """Generate RSI-based signals."""
+        import pandas as pd  # heavy import; keep local
         try:
             signals = []
             delta = data['close'].diff()
@@ -239,8 +243,9 @@ class MultiTimeframeAnalyzer:
             logger.error(f'Error generating RSI signals: {e}')
             return []
 
-    def _generate_macd_signals(self, timeframe: TimeFrame, data: pd.DataFrame) -> list[MultiTimeframeSignal]:
+    def _generate_macd_signals(self, timeframe: TimeFrame, data: 'pd.DataFrame') -> list[MultiTimeframeSignal]:
         """Generate MACD signals."""
+        import pandas as pd  # heavy import; keep local
         try:
             signals = []
             ema_12 = data['close'].ewm(span=12).mean()
@@ -268,8 +273,9 @@ class MultiTimeframeAnalyzer:
             logger.error(f'Error generating MACD signals: {e}')
             return []
 
-    def _generate_bollinger_signals(self, timeframe: TimeFrame, data: pd.DataFrame) -> list[MultiTimeframeSignal]:
+    def _generate_bollinger_signals(self, timeframe: TimeFrame, data: 'pd.DataFrame') -> list[MultiTimeframeSignal]:
         """Generate Bollinger Band signals."""
+        import pandas as pd  # heavy import; keep local
         try:
             signals = []
             data['BB_Middle'] = data['close'].rolling(20).mean()
@@ -301,8 +307,9 @@ class MultiTimeframeAnalyzer:
             logger.error(f'Error generating Bollinger signals: {e}')
             return []
 
-    def _generate_volume_signals(self, timeframe: TimeFrame, data: pd.DataFrame) -> list[MultiTimeframeSignal]:
+    def _generate_volume_signals(self, timeframe: TimeFrame, data: 'pd.DataFrame') -> list[MultiTimeframeSignal]:
         """Generate volume-based signals."""
+        import pandas as pd  # heavy import; keep local
         try:
             signals = []
             if 'volume' not in data.columns:

--- a/ai_trading/strategies/performance_allocator.py
+++ b/ai_trading/strategies/performance_allocator.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 import numpy as np
-import pandas as pd
 from ai_trading.config.management import TradingConfig
 from ai_trading.config.settings import get_settings
 from ai_trading.logging import logger

--- a/ai_trading/strategies/regime_detection.py
+++ b/ai_trading/strategies/regime_detection.py
@@ -6,11 +6,13 @@ using multiple indicators and statistical models for adaptive trading strategies
 """
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import numpy as np
-import pandas as pd
 from ai_trading.exc import COMMON_EXC
 from ai_trading.logging import logger
+
+if TYPE_CHECKING:  # pragma: no cover
+    import pandas as pd
 
 class MarketRegime(Enum):
     """Market regime classifications."""
@@ -57,7 +59,7 @@ class RegimeDetector:
         self.regime_confidence = 0.0
         logger.info(f'RegimeDetector initialized with {lookback_periods} day lookback')
 
-    def detect_regime(self, market_data: pd.DataFrame, supplementary_data: dict=None) -> dict[str, Any]:
+    def detect_regime(self, market_data: 'pd.DataFrame', supplementary_data: dict=None) -> dict[str, Any]:
         """
         Detect current market regime using comprehensive analysis.
 
@@ -89,8 +91,9 @@ class RegimeDetector:
             logger.error(f'Error detecting market regime: {e}')
             return {'error': str(e)}
 
-    def _analyze_trend(self, data: pd.DataFrame) -> dict[str, Any]:
+    def _analyze_trend(self, data: 'pd.DataFrame') -> dict[str, Any]:
         """Analyze trend characteristics."""
+        import pandas as pd  # heavy import; keep local
         try:
             returns_1m = data['close'].iloc[-1] / data['close'].iloc[-21] - 1 if len(data) >= 21 else 0
             returns_3m = data['close'].iloc[-1] / data['close'].iloc[-63] - 1 if len(data) >= 63 else 0
@@ -116,7 +119,7 @@ class RegimeDetector:
             logger.error(f'Error analyzing trend: {e}')
             return {'direction': 'unknown', 'strength': TrendStrength.WEAK}
 
-    def _analyze_volatility(self, data: pd.DataFrame) -> dict[str, Any]:
+    def _analyze_volatility(self, data: 'pd.DataFrame') -> dict[str, Any]:
         """Analyze volatility characteristics."""
         try:
             data['returns'] = data['close'].pct_change()
@@ -150,8 +153,9 @@ class RegimeDetector:
             logger.error(f'Error analyzing volatility: {e}')
             return {'regime': VolatilityRegime.NORMAL_VOL, 'current_vol': 0.2}
 
-    def _analyze_momentum(self, data: pd.DataFrame) -> dict[str, Any]:
+    def _analyze_momentum(self, data: 'pd.DataFrame') -> dict[str, Any]:
         """Analyze momentum characteristics."""
+        import pandas as pd  # heavy import; keep local
         try:
             delta = data['close'].diff()
             gain = delta.where(delta > 0, 0).rolling(window=14).mean()
@@ -184,8 +188,9 @@ class RegimeDetector:
             logger.error(f'Error analyzing momentum: {e}')
             return {'state': 'neutral', 'rsi': 50, 'momentum_strength': 'weak'}
 
-    def _analyze_volume(self, data: pd.DataFrame) -> dict[str, Any]:
+    def _analyze_volume(self, data: 'pd.DataFrame') -> dict[str, Any]:
         """Analyze volume characteristics."""
+        import pandas as pd  # heavy import; keep local
         try:
             if 'volume' not in data.columns:
                 return {'trend': 'unknown', 'strength': 'weak'}
@@ -282,7 +287,7 @@ class RegimeDetector:
             logger.error(f'Error determining primary regime: {e}')
             return MarketRegime.SIDEWAYS
 
-    def _detect_secondary_characteristics(self, data: pd.DataFrame, volume_analysis: dict, sentiment_analysis: dict) -> list[str]:
+    def _detect_secondary_characteristics(self, data: 'pd.DataFrame', volume_analysis: dict, sentiment_analysis: dict) -> list[str]:
         """Detect secondary market characteristics."""
         try:
             characteristics = []
@@ -346,7 +351,7 @@ class RegimeDetector:
             logger.error(f'Error calculating regime confidence: {e}')
             return 0.5
 
-    def _analyze_regime_transitions(self, data: pd.DataFrame) -> dict[str, Any]:
+    def _analyze_regime_transitions(self, data: 'pd.DataFrame') -> dict[str, Any]:
         """Analyze probability of regime transitions."""
         try:
             if len(self.regime_history) < 10:

--- a/ai_trading/utils/ohlcv.py
+++ b/ai_trading/utils/ohlcv.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
-import pandas as pd
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    import pandas as pd
 CANON = {'open': {'open', 'o', 'Open', 'OPEN'}, 'high': {'high', 'h', 'High', 'HIGH'}, 'low': {'low', 'l', 'Low', 'LOW'}, 'close': {'close', 'c', 'Close', 'CLOSE', 'adj_close', 'Adj Close'}, 'volume': {'volume', 'v', 'Volume', 'VOL', 'Vol'}}
 
-def standardize_ohlcv(df: pd.DataFrame) -> pd.DataFrame:
+def standardize_ohlcv(df: 'pd.DataFrame') -> 'pd.DataFrame':
     """
     Return a copy with canonical lowercase ['open','high','low','close','volume'] where possible.
     Unknown columns are preserved. Missing OHLCV fields are left absent (caller must handle).


### PR DESCRIPTION
## Summary
- Defer heavy pandas import in portfolio risk controls to reduce startup cost
- Lazily import pandas in mean reversion, momentum, moving average crossover, multi-timeframe, regime detection, and backtesting strategies
- Remove unused pandas import from performance allocator and gate DataFrame typing in OHLCV utilities

## Testing
- `ruff check ai_trading/portfolio/risk_controls.py ai_trading/strategies/backtester.py ai_trading/strategies/mean_reversion.py ai_trading/strategies/momentum.py ai_trading/strategies/moving_average_crossover.py ai_trading/strategies/multi_timeframe.py ai_trading/strategies/performance_allocator.py ai_trading/strategies/regime_detection.py ai_trading/utils/ohlcv.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68ad145f0ea88330899d5fd674c2f28a