### PR TITLE
feat(metrics): lazy-load monitoring metrics

### DIFF
--- a/ai_trading/metrics/__init__.py
+++ b/ai_trading/metrics/__init__.py
@@ -61,11 +61,48 @@ except (KeyError, ValueError, TypeError):
             pass
     Gauge = Counter = Histogram = Summary = _NoopMetric
     start_http_server = _noop_start_http_server
-from ai_trading.monitoring.metrics import calculate_atr, safe_divide
+
+
+_calculate_atr = None
+_safe_divide = None
+
+
+def calculate_atr(*args, **kwargs):
+    """Lazy import wrapper for ``monitoring.metrics.calculate_atr``."""
+    global _calculate_atr
+    if _calculate_atr is None:  # pragma: no cover - simple cache
+        from ai_trading.monitoring.metrics import (
+            calculate_atr as _calculate_atr_fn,
+        )
+        _calculate_atr = _calculate_atr_fn
+    return _calculate_atr(*args, **kwargs)
+
+
+def safe_divide(*args, **kwargs):
+    """Lazy import wrapper for ``monitoring.metrics.safe_divide``."""
+    global _safe_divide
+    if _safe_divide is None:  # pragma: no cover - simple cache
+        from ai_trading.monitoring.metrics import (
+            safe_divide as _safe_divide_fn,
+        )
+        _safe_divide = _safe_divide_fn
+    return _safe_divide(*args, **kwargs)
 
 def compute_basic_metrics(data):
     """Return minimal metrics dict."""
     if hasattr(data, 'empty') and data.empty:
         return {'sharpe': 0.0, 'max_drawdown': 0.0}
     return {'sharpe': 0.0, 'max_drawdown': 0.0}
-__all__ = ['PROMETHEUS_AVAILABLE', 'REGISTRY', 'CollectorRegistry', 'Gauge', 'Counter', 'Histogram', 'Summary', 'start_http_server', 'safe_divide', 'calculate_atr', 'compute_basic_metrics']
+__all__ = [
+    'PROMETHEUS_AVAILABLE',
+    'REGISTRY',
+    'CollectorRegistry',
+    'Gauge',
+    'Counter',
+    'Histogram',
+    'Summary',
+    'start_http_server',
+    'safe_divide',
+    'calculate_atr',
+    'compute_basic_metrics',
+]

--- a/tests/test_lazy_pandas_import.py
+++ b/tests/test_lazy_pandas_import.py
@@ -10,6 +10,7 @@ import pytest
         "ai_trading.features.pipeline",
         "ai_trading.portfolio.sizing",
         "ai_trading.monitoring.metrics",
+        "ai_trading.metrics",
     ],
 )
 def test_module_import_without_pandas(monkeypatch, module):


### PR DESCRIPTION
## Summary
- avoid importing heavy ai_trading.monitoring.metrics at ai_trading.metrics import time
- add cached accessors for calculate_atr and safe_divide
- ensure metrics can be imported without pandas by extending test

## Testing
- `ruff check ai_trading/metrics/__init__.py tests/test_lazy_pandas_import.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas' etc.)*
- `python -m ai_trading --dry-run`
- `python -X importtime -m ai_trading --dry-run 2>&1 | tee /tmp/import.log >/dev/null`
- `rg 'ai_trading.metrics|numpy|pandas' /tmp/import.log`


------
https://chatgpt.com/codex/tasks/task_e_68ad1461e1c08330bb94940a68173605