### PR TITLE
test: gate optional heavy dependencies

### DIFF
--- a/tests/data_fetcher/test_datetime_narrow_exceptions.py
+++ b/tests/data_fetcher/test_datetime_narrow_exceptions.py
@@ -1,7 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 import sys
 import types
 

--- a/tests/execution/test_fetch_minute_df_safe_empty.py
+++ b/tests/execution/test_fetch_minute_df_safe_empty.py
@@ -1,7 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.core.bot_engine import DataFetchError, fetch_minute_df_safe
 
 

--- a/tests/helpers/asserts.py
+++ b/tests/helpers/asserts.py
@@ -1,8 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 def assert_df_like(df: pd.DataFrame) -> None:
     """Check DataFrame shape without enforcing row count."""  # AI-AGENT-REF
     assert isinstance(df, pd.DataFrame)

--- a/tests/slow/test_meta_learning_heavy.py
+++ b/tests/slow/test_meta_learning_heavy.py
@@ -1,15 +1,12 @@
-from tests.optdeps import require
-require("pandas")
-require("sklearn")
-require("torch")
 import io
 import types
 
-import pandas as pd
 import pytest
-import sklearn.linear_model
-import torch
 
+pd = pytest.importorskip("pandas")
+sklearn = pytest.importorskip("sklearn")
+import sklearn.linear_model
+torch = pytest.importorskip("torch")
 try:
     import pydantic_settings  # noqa: F401
     from ai_trading import meta_learning

--- a/tests/support/assert_df_like.py
+++ b/tests/support/assert_df_like.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-from pandas import DataFrame
+import pytest
+DataFrame = pytest.importorskip("pandas").DataFrame
 
 
 def assert_df_like(df: DataFrame, *, columns: list[str] | None = None) -> None:

--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -1,5 +1,4 @@
 from tests.optdeps import require
-require("pandas")
 require("numpy")
 import builtins
 import importlib
@@ -9,9 +8,9 @@ import types
 from datetime import datetime
 
 import numpy as np
-import pandas as pd
-import pydantic
 import pytest
+pd = pytest.importorskip("pandas")
+import pydantic
 
 try:
     import pydantic_settings  # noqa: F401

--- a/tests/test_alpaca_time_params.py
+++ b/tests/test_alpaca_time_params.py
@@ -1,9 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import datetime as dt
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.alpaca_api import get_bars_df
 
 from tests.helpers.asserts import assert_df_like

--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -1,10 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 import types
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.alpaca_api import get_bars_df
 
 from tests.helpers.asserts import assert_df_like

--- a/tests/test_alpha_quality.py
+++ b/tests/test_alpha_quality.py
@@ -4,16 +4,13 @@ Basic tests for the new alpha quality features.
 Tests cover data leakage prevention, walk-forward analysis,
 slippage calculations, and RL reward penalties.
 """
-from tests.optdeps import require
-require("pandas")
 
 from datetime import timedelta
 from unittest.mock import Mock
 
 import numpy as np
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 # Test data labeling and splits
 def test_fixed_horizon_return():
     """Test fixed horizon return calculation."""

--- a/tests/test_backtest_smoke.py
+++ b/tests/test_backtest_smoke.py
@@ -1,9 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 from pathlib import Path
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 
 def force_coverage(mod):

--- a/tests/test_bars_fallback.py
+++ b/tests/test_bars_fallback.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.data.bars import _resample_minutes_to_daily
 
 

--- a/tests/test_bars_timeframe_feed_canonicalization.py
+++ b/tests/test_bars_timeframe_feed_canonicalization.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from tests.optdeps import require
-require("pandas")
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.data import bars as bars_mod
 
 # AI-AGENT-REF: test central helpers

--- a/tests/test_batch_paths.py
+++ b/tests/test_batch_paths.py
@@ -1,12 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import types
 
 import ai_trading.core.bot_engine as be
 import ai_trading.trade_logic as tl
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 def _mk_df():
     return pd.DataFrame(
         {

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,10 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 import inspect
 
 import numpy as np
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading import indicators, signals
 
 df = pd.DataFrame({

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,11 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 import types
 from pathlib import Path
 
-import pandas as pd
+import pytest
 
+pd = pytest.importorskip("pandas")
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 dummy = types.ModuleType("dummy")

--- a/tests/test_bot_engine.py
+++ b/tests/test_bot_engine.py
@@ -1,8 +1,6 @@
-from tests.optdeps import require
-require("pandas")
 import numpy as np
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 
 pytest.importorskip("alpaca_trade_api")
 

--- a/tests/test_bot_engine_edge_cases.py
+++ b/tests/test_bot_engine_edge_cases.py
@@ -1,8 +1,6 @@
-from tests.optdeps import require
-require("pandas")
 import numpy as np
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 
 pytest.importorskip("alpaca_trade_api")
 

--- a/tests/test_bot_engine_unit.py
+++ b/tests/test_bot_engine_unit.py
@@ -1,10 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 import types
 
 import joblib
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 
 pytest.importorskip("alpaca_trade_api")
 

--- a/tests/test_bot_extended.py
+++ b/tests/test_bot_extended.py
@@ -1,11 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 import types
 from pathlib import Path
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 # Ensure repository root on path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_critical_fixes.py
+++ b/tests/test_critical_fixes.py
@@ -7,15 +7,13 @@ Tests for the fixes addressing the critical issues:
 3. Process management enhancements
 4. Data validation functionality
 """
-from tests.optdeps import require
-require("pandas")
 
 from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
-import pandas as pd
+import pytest
 
-
+pd = pytest.importorskip("pandas")
 def test_risk_engine_missing_methods():
     """Test that RiskEngine has the missing critical methods."""
     from ai_trading.risk.engine import RiskEngine  # AI-AGENT-REF: normalized import

--- a/tests/test_critical_fixes_focused.py
+++ b/tests/test_critical_fixes_focused.py
@@ -2,8 +2,6 @@
 """
 Focused test suite for the critical trading bot fixes per problem statement.
 """
-from tests.optdeps import require
-require("pandas")
 
 import csv
 import os
@@ -157,7 +155,8 @@ def test_meta_learning_price_conversion():
         }
 
         # Simulate the fixed price conversion logic
-        import pandas as pd
+        import pytest
+        pd = pytest.importorskip("pandas")
         df = pd.DataFrame(mock_df_data)
 
         # Test the fixed conversion logic

--- a/tests/test_critical_fixes_implementation.py
+++ b/tests/test_critical_fixes_implementation.py
@@ -3,16 +3,15 @@
 Tests the thread safety, memory leak prevention, division by zero protection,
 and other critical fixes for production readiness.
 """
-from tests.optdeps import require
-require("pandas")
 
 import os
 import sys
 import threading
 from unittest.mock import Mock, patch
 
-import pandas as pd
+import pytest
 
+pd = pytest.importorskip("pandas")
 # Set up test environment variables first
 os.environ.update({
     'ALPACA_API_KEY': 'test_key_123456789012345',

--- a/tests/test_critical_fixes_validation.py
+++ b/tests/test_critical_fixes_validation.py
@@ -3,8 +3,6 @@
 Critical fixes validation test for the AI trading bot.
 Tests the 5 major issues identified in the problem statement.
 """
-from tests.optdeps import require
-require("pandas")
 
 import os
 import sys
@@ -80,8 +78,8 @@ class TestCriticalFixes(unittest.TestCase):
         """Test 2: MetaLearning Data Validation - Price validation logic."""
         # Mock pandas for testing
         try:
-            import pandas as pd
-
+            import pytest
+            pd = pytest.importorskip("pandas")
             # Test data with mixed price types
             test_data = {
                 "entry_price": ["100.50", "200", "invalid", "50.25"],

--- a/tests/test_critical_trading_fixes.py
+++ b/tests/test_critical_trading_fixes.py
@@ -9,8 +9,6 @@ Tests the five main areas of improvement:
 4. Partial Order Management
 5. Order Status Monitoring
 """
-from tests.optdeps import require
-require("pandas")
 
 import csv
 import os
@@ -21,8 +19,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 # Import modules under test
 try:

--- a/tests/test_critical_trading_issues.py
+++ b/tests/test_critical_trading_issues.py
@@ -3,8 +3,6 @@
 Critical trading bot issues test suite.
 Tests for order execution tracking, meta-learning log formats, liquidity management.
 """
-from tests.optdeps import require
-require("pandas")
 
 import csv
 import os
@@ -12,8 +10,9 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
-import pandas as pd
+import pytest
 
+pd = pytest.importorskip("pandas")
 # Set up minimal environment for imports
 os.environ.setdefault('ALPACA_API_KEY', 'test_key')
 os.environ.setdefault('ALPACA_SECRET_KEY', 'test_secret')

--- a/tests/test_daily_bars_datetime_sanitization.py
+++ b/tests/test_daily_bars_datetime_sanitization.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from tests.optdeps import require
-require("pandas")
 
 from datetime import UTC, datetime, timedelta
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.core import bot_engine as be
 
 

--- a/tests/test_daily_sanitization_retry.py
+++ b/tests/test_daily_sanitization_retry.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tests.optdeps import require
-require("pandas")
 
 import ai_trading.core.bot_engine as be_mod
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.core.bot_engine import DataFetcher
 
 

--- a/tests/test_daily_sanitize_debug.py
+++ b/tests/test_daily_sanitize_debug.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from tests.optdeps import require
-require("pandas")
 
 import types
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.core import bot_engine as be
 
 

--- a/tests/test_data_cache.py
+++ b/tests/test_data_cache.py
@@ -1,8 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 import time
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.market import cache as mcache
 
 

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -1,13 +1,12 @@
-from tests.optdeps import require
-require("pandas")
 import datetime
 import os
 import sys
 import types
 from pathlib import Path
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 from alpaca_trade_api.rest import APIError  # type: ignore
 from tests.helpers.asserts import assert_df_like
@@ -45,8 +44,7 @@ class _DummyHist:
         pass
 
     def get_stock_bars(self, *a, **k):
-        import pandas as pd
-
+        pd = pytest.importorskip("pandas")
         return types.SimpleNamespace(df=pd.DataFrame())
 
 

--- a/tests/test_data_fetcher_datetime.py
+++ b/tests/test_data_fetcher_datetime.py
@@ -1,11 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from ai_trading import data_fetcher

--- a/tests/test_data_fetcher_extended.py
+++ b/tests/test_data_fetcher_extended.py
@@ -1,10 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import datetime
 import types
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading import data_fetcher
 
 

--- a/tests/test_data_fetcher_fallbacks.py
+++ b/tests/test_data_fetcher_fallbacks.py
@@ -1,8 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 import datetime as dt
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading import data_fetcher as dfetch
 
 from tests.helpers.asserts import assert_df_like

--- a/tests/test_data_fetcher_init.py
+++ b/tests/test_data_fetcher_init.py
@@ -1,11 +1,10 @@
 """Tests for data_fetcher.build_fetcher initialization paths."""  # AI-AGENT-REF
 from __future__ import annotations
 
-from tests.optdeps import require
-require("pandas")
 
-import pandas as pd
+import pytest
 
+pd = pytest.importorskip("pandas")
 import sys
 import types
 

--- a/tests/test_data_fetcher_timezone.py
+++ b/tests/test_data_fetcher_timezone.py
@@ -1,11 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 import types
 from datetime import UTC, datetime
 
-import pandas as pd
+import pytest
 
+pd = pytest.importorskip("pandas")
 # AI-AGENT-REF: regression test for Yahoo timezone normalization
 
 

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.features import compute_macd, compute_macds, ensure_columns
 
 

--- a/tests/test_enhanced_signals.py
+++ b/tests/test_enhanced_signals.py
@@ -1,12 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import numpy as np
-import pandas as pd
-
+import pytest
+pd = pytest.importorskip("pandas")
 try:
     import ai_trading.risk.engine as risk_engine  # AI-AGENT-REF: normalized import
 except ImportError:  # pragma: no cover - optional dependency
-    import pytest
     pytest.skip("risk_engine not available", allow_module_level=True)
 from ai_trading import signals
 

--- a/tests/test_entry_exit_signals.py
+++ b/tests/test_entry_exit_signals.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from types import SimpleNamespace
 import sys
 import types

--- a/tests/test_equity_curve.py
+++ b/tests/test_equity_curve.py
@@ -1,8 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 def test_equity_curve_monotonic():
     df = pd.read_csv("data/last_equity.txt", names=["equity"])
     assert df["equity"].is_monotonic_increasing or df["equity"].is_monotonic_decreasing, \

--- a/tests/test_fallback_concurrency.py
+++ b/tests/test_fallback_concurrency.py
@@ -1,13 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import threading
 import time
 import types
 
 import ai_trading.core.bot_engine as be
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 def _mk_df():
     return pd.DataFrame(
         {

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,10 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 import types
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.features import build_features_pipeline
 
 ps_stub = types.ModuleType("pydantic_settings")
@@ -23,7 +22,6 @@ sys.modules.setdefault("validate_env", validate_stub)
 
 pytestmark = pytest.mark.usefixtures("default_env", "features_env")
 
-import pytest
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_fetch_and_screen.py
+++ b/tests/test_fetch_and_screen.py
@@ -1,10 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import datetime as dt
 import sys
 import types
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading import data_fetcher
 from ai_trading.utils.base import health_check
 

--- a/tests/test_fetch_contract.py
+++ b/tests/test_fetch_contract.py
@@ -1,11 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import os
 import sys
 import types
 
-import pandas as pd
+import pytest
 
+pd = pytest.importorskip("pandas")
 os.environ.setdefault("ALPACA_API_KEY", "dummy")
 os.environ.setdefault("ALPACA_SECRET_KEY", "dummy")
 

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -3,8 +3,6 @@
 Test script to validate the trading bot fixes.
 This script tests the expanded ticker portfolio and TA-Lib fallback handling.
 """
-from tests.optdeps import require
-require("pandas")
 
 import csv
 import os
@@ -73,7 +71,8 @@ def test_talib_imports():
         # Test basic functionality with small dataset
         test_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 3  # 30 data points
         try:
-            import pandas as pd
+            import pytest
+            pd = pytest.importorskip("pandas")
             test_series = pd.Series(test_data)
             sma_result = ta.trend.sma_indicator(test_series, window=10)
             if sma_result is not None and len(sma_result) == len(test_data):

--- a/tests/test_grid_sanity.py
+++ b/tests/test_grid_sanity.py
@@ -1,8 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 def test_grid_search_results():
     try:
         df = pd.read_csv("logs/grid_results.csv")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,11 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 import types
 from pathlib import Path
 
-import pandas as pd
+import pytest
 
+pd = pytest.importorskip("pandas")
 # Minimal stubs so importing bot_engine succeeds without optional deps
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 mods = [

--- a/tests/test_healthcheck_minute_fallback.py
+++ b/tests/test_healthcheck_minute_fallback.py
@@ -1,10 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import logging
 from types import SimpleNamespace
 
 import ai_trading.data.bars as data_bars
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading import data_fetcher
 from ai_trading.core import bot_engine
 

--- a/tests/test_healthcheck_minute_fallback_handles_none.py
+++ b/tests/test_healthcheck_minute_fallback_handles_none.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.core.bot_engine import _ensure_df
 
 from tests.helpers.asserts import assert_df_like

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,9 +1,7 @@
-from tests.optdeps import require
-require("pandas")
 
-import pandas as pd
+import pytest
 
-
+pd = pytest.importorskip("pandas")
 def test_ichimoku_indicator_returns_dataframe(monkeypatch):
     from ai_trading.core import bot_engine as bot
 

--- a/tests/test_initial_rebalance.py
+++ b/tests/test_initial_rebalance.py
@@ -1,9 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import datetime
 import types
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.core import bot_engine
 
 

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -1,12 +1,11 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 # Ensure project root is importable and stub heavy optional deps
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -168,8 +167,7 @@ class _Client:
         pass
 
     def get_stock_bars(self, *a, **k):
-        import pandas as pd
-
+        pd = pytest.importorskip("pandas")
         df = pd.DataFrame(
             {
                 "open": [1.0],

--- a/tests/test_mean_reversion_extra.py
+++ b/tests/test_mean_reversion_extra.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.strategies.mean_reversion import MeanReversionStrategy
 
 

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -1,11 +1,8 @@
-from tests.optdeps import require
-require("numpy")
-require("torch")
 import types
 
-import numpy as np
 import pytest
-import torch
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
 from torch import nn
 
 np.random.seed(0)

--- a/tests/test_meta_learning_additional.py
+++ b/tests/test_meta_learning_additional.py
@@ -1,13 +1,10 @@
-from tests.optdeps import require
-require("numpy")
-require("pandas")
-require("sklearn")
 import types
 from pathlib import Path
 
-import numpy as np
-import pandas as pd
 import pytest
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+sklearn = pytest.importorskip("sklearn")
 import sklearn.linear_model
 from ai_trading import meta_learning
 

--- a/tests/test_metalearning_strategy.py
+++ b/tests/test_metalearning_strategy.py
@@ -2,16 +2,14 @@
 """
 Test suite for MetaLearning strategy.
 """
-from tests.optdeps import require
-require("pandas")
 
 import os
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import numpy as np
-import pandas as pd
-
+import pytest
+pd = pytest.importorskip("pandas")
 # Set minimal environment variables to avoid config errors
 os.environ['ALPACA_API_KEY'] = 'test'
 os.environ['ALPACA_SECRET_KEY'] = 'test'

--- a/tests/test_minute_fallback_none_safe.py
+++ b/tests/test_minute_fallback_none_safe.py
@@ -1,9 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 import types
 
 import ai_trading.data.bars as data_bars
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.data.bars import safe_get_stock_bars
 
 

--- a/tests/test_ml_model_extra.py
+++ b/tests/test_ml_model_extra.py
@@ -1,11 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from ai_trading import ml_model  # AI-AGENT-REF: canonical import

--- a/tests/test_ml_model_loading.py
+++ b/tests/test_ml_model_loading.py
@@ -1,12 +1,10 @@
-from tests.optdeps import require
-require("numpy")
-require("sklearn")
 import pickle
 import sys
 import types
 
-import numpy as np
 import pytest
+np = pytest.importorskip("numpy")
+sklearn = pytest.importorskip("sklearn")
 
 # AI-AGENT-REF: Replaced unsafe _raise_dynamic_exec_disabled() with direct imports from core module
 from ai_trading.core.bot_engine import _load_ml_model

--- a/tests/test_ml_model_validation.py
+++ b/tests/test_ml_model_validation.py
@@ -1,11 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
-
+import pytest
+pd = pytest.importorskip("pandas")
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from ai_trading.ml_model import MLModel  # AI-AGENT-REF: canonical import
 

--- a/tests/test_model_registry_roundtrip.py
+++ b/tests/test_model_registry_roundtrip.py
@@ -1,12 +1,9 @@
 """Test model registry register → latest_for → load_model workflow."""
-from tests.optdeps import require
-require("numpy")
-require("sklearn")
-
 import tempfile
 
-import numpy as np
 import pytest
+np = pytest.importorskip("numpy")
+sklearn = pytest.importorskip("sklearn")
 from ai_trading.model_registry import ModelRegistry
 from sklearn.linear_model import LinearRegression
 

--- a/tests/test_momentum_extra.py
+++ b/tests/test_momentum_extra.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.strategies import momentum
 from ai_trading.strategies.momentum import MomentumStrategy
 

--- a/tests/test_moving_average_crossover_extra.py
+++ b/tests/test_moving_average_crossover_extra.py
@@ -1,8 +1,8 @@
 """Tests for moving average crossover strategy."""
-from tests.optdeps import require
-require("pandas")
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.strategies.moving_average_crossover import (
     MovingAverageCrossoverStrategy,
 )

--- a/tests/test_parallel_speed.py
+++ b/tests/test_parallel_speed.py
@@ -1,8 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 import time
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading import signals
 
 

--- a/tests/test_peak_performance.py
+++ b/tests/test_peak_performance.py
@@ -2,14 +2,12 @@
 """
 Tests for peak performance hardening modules.
 """
-from tests.optdeps import require
-require("pandas")
 
 from datetime import UTC, datetime
 
 import numpy as np
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 
 
 # Test idempotency

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -1,13 +1,11 @@
-from tests.optdeps import require
-require("pandas")
 import importlib
 import sys
 import types
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 
 
 def force_coverage(mod):

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,8 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 import types
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.core import bot_engine
 
 

--- a/tests/test_predict_smoke.py
+++ b/tests/test_predict_smoke.py
@@ -1,12 +1,11 @@
-from tests.optdeps import require
-require("pandas")
 import importlib
 import sys
 import types
 from pathlib import Path
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 
 def _import_predict(monkeypatch):

--- a/tests/test_price_snapshot_minute_fallback.py
+++ b/tests/test_price_snapshot_minute_fallback.py
@@ -1,8 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 from types import SimpleNamespace
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.portfolio import core as portfolio_core
 from ai_trading import utils as _utils  # type: ignore
 

--- a/tests/test_production_fixes.py
+++ b/tests/test_production_fixes.py
@@ -8,8 +8,6 @@ This test suite validates the four main fixes:
 3. Market-aware data staleness thresholds
 4. Enhanced environment debugging capabilities
 """
-from tests.optdeps import require
-require("pandas")
 
 import os
 import sys
@@ -83,7 +81,8 @@ class TestDataStalenessThresholds(unittest.TestCase):
     def setUp(self):
         """Set up data validation test."""
         try:
-            import pandas as pd
+            import pytest
+            pd = pytest.importorskip("pandas")
             from ai_trading.data_validation import (
                 check_data_freshness,
                 get_staleness_threshold,

--- a/tests/test_property_based.py
+++ b/tests/test_property_based.py
@@ -1,11 +1,9 @@
-from tests.optdeps import require
-require("pandas")
 import sys
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 

--- a/tests/test_regime_and_schema_guard.py
+++ b/tests/test_regime_and_schema_guard.py
@@ -1,7 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 
 
 def test_validate_ohlcv_detects_missing():

--- a/tests/test_regime_filters.py
+++ b/tests/test_regime_filters.py
@@ -1,7 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 
 
 def test_regime_changes():

--- a/tests/test_resample_daily.py
+++ b/tests/test_resample_daily.py
@@ -1,10 +1,10 @@
 """Test minute-to-daily resampling fallback."""
-from tests.optdeps import require
-require("pandas")
 
 from datetime import UTC, datetime
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.data import bars
 from tests.support.assert_df_like import assert_df_like
 

--- a/tests/test_retrain_smoke.py
+++ b/tests/test_retrain_smoke.py
@@ -1,12 +1,11 @@
-from tests.optdeps import require
-require("pandas")
 import importlib
 import sys
 import types
 from pathlib import Path
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 
 def _import_retrain(monkeypatch):

--- a/tests/test_risk_new.py
+++ b/tests/test_risk_new.py
@@ -1,9 +1,6 @@
-from tests.optdeps import require
-require("pandas")
 import ai_trading.risk.engine as risk_engine  # AI-AGENT-REF: normalized import
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 def test_stop_levels():
     stop, take = risk_engine.compute_stop_levels(100, 2)
     assert stop == 98 and take == 104

--- a/tests/test_rl_features.py
+++ b/tests/test_rl_features.py
@@ -1,7 +1,6 @@
-from tests.optdeps import require
-require("pandas")
 import numpy as np
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.rl_trading.features import FeatureConfig, compute_features
 
 

--- a/tests/test_rl_import_performance.py
+++ b/tests/test_rl_import_performance.py
@@ -3,11 +3,10 @@ import sys
 import time
 
 import pytest
-from tests.optdeps import require
 
-require("stable_baselines3")
-require("gymnasium")
-require("torch")
+pytest.importorskip("stable_baselines3")
+pytest.importorskip("gymnasium")
+pytest.importorskip("torch")
 
 MODULES = [
     "ai_trading.rl_trading",

--- a/tests/test_run_strategy_no_signals.py
+++ b/tests/test_run_strategy_no_signals.py
@@ -1,8 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 from types import SimpleNamespace
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.core import bot_engine
 
 

--- a/tests/test_safety_fallbacks.py
+++ b/tests/test_safety_fallbacks.py
@@ -1,9 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 import os
 
-import pandas as pd
+import pytest
 
+pd = pytest.importorskip("pandas")
 # Set test environment before importing heavy modules
 os.environ['PYTEST_RUNNING'] = 'true'
 

--- a/tests/test_short_selling_implementation.py
+++ b/tests/test_short_selling_implementation.py
@@ -3,8 +3,6 @@
 Focused test for short selling implementation.
 Tests the specific changes needed to enable short selling capability.
 """
-from tests.optdeps import require
-require("pandas")
 
 import os
 import sys
@@ -192,7 +190,8 @@ class TestShortSellingImplementation(unittest.TestCase):
         with patch('os.path.exists', return_value=True):
             with patch('pandas.read_csv') as mock_read_csv:
                 # Mock empty dataframe
-                import pandas as pd
+                import pytest
+                pd = pytest.importorskip("pandas")
                 mock_read_csv.return_value = pd.DataFrame()
 
                 result = load_global_signal_performance(min_trades=1)  # Lower threshold

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,12 +1,10 @@
-from tests.optdeps import require
-require("pandas")
 import importlib
 import sys
 import types
 
 import numpy as np
-import pandas as pd
 import pytest
+pd = pytest.importorskip("pandas")
 
 np.random.seed(0)
 

--- a/tests/test_signals_multi_horizon.py
+++ b/tests/test_signals_multi_horizon.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.indicators import (
     compute_atr,
     compute_bollinger,

--- a/tests/test_signals_scoring.py
+++ b/tests/test_signals_scoring.py
@@ -1,7 +1,6 @@
-from tests.optdeps import require
-require("pandas")
 import numpy as np
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading import signals
 
 

--- a/tests/test_skip_logic.py
+++ b/tests/test_skip_logic.py
@@ -1,8 +1,8 @@
-from tests.optdeps import require
-require("pandas")
 import types
 
-import pandas as pd
+import pytest
+
+pd = pytest.importorskip("pandas")
 from ai_trading.core import bot_engine
 
 

--- a/tests/test_slippage.py
+++ b/tests/test_slippage.py
@@ -1,8 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 def test_slippage_limits():
     df = pd.read_csv("logs/slippage.csv")
     if df.empty:

--- a/tests/test_staleness_guard.py
+++ b/tests/test_staleness_guard.py
@@ -1,13 +1,12 @@
 """
 Tests for data staleness guard functionality.
 """
-from tests.optdeps import require
-require("pandas")
 import datetime
 from unittest.mock import Mock
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 
 class TestStalenessGuard:

--- a/tests/test_strategy_components.py
+++ b/tests/test_strategy_components.py
@@ -4,16 +4,14 @@ Test for advanced strategy components - multi-timeframe analysis and regime dete
 Tests the functionality of the new strategy modules without requiring
 full market data or external dependencies.
 """
-from tests.optdeps import require
-require("pandas")
 
 import asyncio
 import os
 import sys
 
 import numpy as np
-import pandas as pd
-
+import pytest
+pd = pytest.importorskip("pandas")
 # Add the project root to the Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 

--- a/tests/test_stubs_and_prices.py
+++ b/tests/test_stubs_and_prices.py
@@ -1,8 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 def test_timeframe_has_basic_members():
     from ai_trading.core.bot_engine import TimeFrame
 

--- a/tests/test_time_utc_now.py
+++ b/tests/test_time_utc_now.py
@@ -1,8 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
-
-
+import pytest
+pd = pytest.importorskip("pandas")
 def test_now_is_aware_utc():
     # AI-AGENT-REF: ensure timezone-aware UTC now
     now_utc = pd.Timestamp.now(tz="UTC")

--- a/tests/test_trade_logic.py
+++ b/tests/test_trade_logic.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.trade_logic import (
     compute_order_price,
     extract_price,

--- a/tests/test_universe_csv.py
+++ b/tests/test_universe_csv.py
@@ -1,6 +1,5 @@
-from tests.optdeps import require
-require("pandas")
-import pandas as pd
+import pytest
+pd = pytest.importorskip("pandas")
 from ai_trading.data.universe import load_universe, locate_tickers_csv
 
 

--- a/tests/test_yf_auto_adjust_and_cache.py
+++ b/tests/test_yf_auto_adjust_and_cache.py
@@ -1,6 +1,4 @@
 """Ensure yfinance fallback sets auto_adjust and TzCache."""
-from tests.optdeps import require
-require("pandas")
 
 import sys
 import types
@@ -17,8 +15,8 @@ def test_yfinance_auto_adjust_and_cache(monkeypatch):
 
     def download(*args, auto_adjust=None, **kwargs):  # AI-AGENT-REF: capture auto_adjust
         calls["auto_adjust"] = auto_adjust
-        import pandas as pd
-
+        import pytest
+        pd = pytest.importorskip("pandas")
         return pd.DataFrame(
             {"Open": [1.0], "High": [1.0], "Low": [1.0], "Close": [1.0], "Volume": [100]},
             index=pd.date_range(datetime(2025, 8, 1, tzinfo=UTC), periods=1, name="Date"),

--- a/tests/unit/test_data_fetcher_http.py
+++ b/tests/unit/test_data_fetcher_http.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from tests.optdeps import require
-require("pandas")
 
 import json
 from datetime import UTC, datetime, timedelta
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 import ai_trading.data_fetcher as df
 

--- a/tests/unit/test_features_pipeline_narrowing.py
+++ b/tests/unit/test_features_pipeline_narrowing.py
@@ -1,11 +1,10 @@
 """Tests for narrowed exceptions in feature pipeline."""
 from __future__ import annotations
 
-from tests.optdeps import require
-require("pandas")
 
-import pandas as pd
 import pytest
+
+pd = pytest.importorskip("pandas")
 
 from ai_trading.features.pipeline import BuildFeatures
 

--- a/tests/unit/test_sanitize_edges.py
+++ b/tests/unit/test_sanitize_edges.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from tests.optdeps import require
-require("pandas")
 
-import pandas as pd
+import pytest
 
+pd = pytest.importorskip("pandas")
 from ai_trading.data.sanitize import DataSanitizer, SanitizationConfig
 
 


### PR DESCRIPTION
## Summary
- gate optional heavy test deps like pandas, sklearn, torch with `pytest.importorskip`
- ensure RL perf tests and stubs skip gracefully when heavy libs absent

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runner_smoke.py tests/test_utils_timing.py tests/test_trading_config_aliases.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1462f48c83308232a46d89b9fd3b