### PR TITLE
Remove unused logging imports and enforce get_logger usage

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -876,7 +876,7 @@ def handle_exception(exc_type, exc_value, exc_traceback):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
         return
     "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
-    logging.critical(
+    logger.critical(
         "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
     )
     # AI-AGENT-REF: flush and close log handlers to preserve logs on crash

--- a/ai_trading/core/hyperparams_schema.py
+++ b/ai_trading/core/hyperparams_schema.py
@@ -5,7 +5,6 @@ Provides pydantic model for hyperparams.json validation and ensures
 schema compatibility across different versions of the trading system.
 """
 import json
-import logging
 from ai_trading.logging import get_logger
 import os
 from datetime import UTC, datetime
@@ -176,11 +175,11 @@ def validate_hyperparams_file(file_path: str='hyperparams.json') -> dict[str, An
         report['warnings'].append(f'File not found: {file_path}')
     return report
 if __name__ == '__main__':
-    logging.info('Testing Hyperparameters Schema')
+    logger.info('Testing Hyperparameters Schema')
     default_params = get_default_hyperparams()
-    logging.info(f'Default schema version: {default_params.schema_version}')
+    logger.info(f'Default schema version: {default_params.schema_version}')
     loaded_params = load_hyperparams()
-    logging.info(f'Loaded params - buy_threshold: {loaded_params.buy_threshold}')
+    logger.info(f'Loaded params - buy_threshold: {loaded_params.buy_threshold}')
     validation_report = validate_hyperparams_file()
-    logging.info(f'Validation report: {validation_report}')
-    logging.info('Hyperparams schema tests completed!')
+    logger.info(f'Validation report: {validation_report}')
+    logger.info('Hyperparams schema tests completed!')

--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -5,7 +5,6 @@ Provides order lifecycle management, execution algorithms,
 and real-time execution monitoring with institutional controls.
 """
 from __future__ import annotations
-import logging
 from ai_trading.logging import get_logger
 import math
 import threading

--- a/ai_trading/monitoring/performance_dashboard.py
+++ b/ai_trading/monitoring/performance_dashboard.py
@@ -4,7 +4,6 @@ Real-time performance monitoring dashboard for production trading.
 Provides comprehensive performance tracking, real-time P&L monitoring,
 risk metrics calculation, and anomaly detection for institutional trading.
 """
-import logging
 import statistics
 import threading
 from collections import deque

--- a/ai_trading/portfolio/sizing.py
+++ b/ai_trading/portfolio/sizing.py
@@ -6,7 +6,6 @@ and other institutional-grade position sizing methodologies.
 """
 from __future__ import annotations
 
-import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 import numpy as np

--- a/ai_trading/risk/circuit_breakers.py
+++ b/ai_trading/risk/circuit_breakers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 'Circuit breakers and safety mechanisms for production trading.'
 import functools
-import logging
 import threading
 from collections.abc import Callable
 from datetime import UTC, datetime

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-import logging
 from ai_trading.logging import get_logger
 import random
 import threading
@@ -773,23 +772,23 @@ def calculate_position_size(*args, **kwargs) -> int:
     if len(args) == 2 and (not kwargs):
         cash, price = args
         if not isinstance(cash, int | float) or cash <= 0:
-            logging.warning(f'Invalid cash amount: {cash}')
+            logger.warning(f'Invalid cash amount: {cash}')
             return 0
         if not isinstance(price, int | float) or price <= 0:
-            logging.warning(f'Invalid price: {price}')
+            logger.warning(f'Invalid price: {price}')
             return 0
         dummy = TradeSignal(symbol='DUMMY', side='buy', confidence=1.0, strategy='default')
         return engine.position_size(dummy, cash, price)
     if len(args) >= 3:
         signal, cash, price = args[:3]
         if not isinstance(cash, int | float) or cash <= 0:
-            logging.warning(f'Invalid cash amount: {cash}')
+            logger.warning(f'Invalid cash amount: {cash}')
             return 0
         if not isinstance(price, int | float) or price <= 0:
-            logging.warning(f'Invalid price: {price}')
+            logger.warning(f'Invalid price: {price}')
             return 0
         if not hasattr(signal, 'confidence') or not hasattr(signal, 'symbol'):
-            logging.error(f'Invalid signal object: {type(signal)}')
+            logger.error(f'Invalid signal object: {type(signal)}')
             return 0
         api = args[3] if len(args) > 3 else kwargs.get('api')
         return engine.position_size(signal, cash, price, api)
@@ -825,15 +824,15 @@ def check_max_drawdown(state: dict[str, float]) -> bool:
     - Used for automated risk management decisions
     """
     if not isinstance(state, dict):
-        logging.warning(f'Invalid state type: {type(state)}')
+        logger.warning(f'Invalid state type: {type(state)}')
         return False
     current_dd = state.get('current_drawdown', 0)
     max_dd = state.get('max_drawdown', 0)
     if not isinstance(current_dd, int | float) or current_dd < 0:
-        logging.warning(f'Invalid current_drawdown: {current_dd}')
+        logger.warning(f'Invalid current_drawdown: {current_dd}')
         return False
     if not isinstance(max_dd, int | float) or max_dd <= 0:
-        logging.warning(f'Invalid max_drawdown: {max_dd}')
+        logger.warning(f'Invalid max_drawdown: {max_dd}')
         return False
     return current_dd > max_dd
 

--- a/ai_trading/strategies/backtest.py
+++ b/ai_trading/strategies/backtest.py
@@ -4,7 +4,6 @@ Backtesting engine and performance analysis for strategies.
 Provides comprehensive backtesting capabilities and
 performance analysis for institutional trading strategies.
 """
-import logging
 import math
 import random
 import statistics
@@ -291,19 +290,19 @@ def run_smoke_test():
     This validates that the cost model properly reduces net P&L
     compared to gross P&L when all costs are included.
     """
-    logging.info('=== Backtest Smoke Test ===')
-    logging.info('Testing that net < gross due to all costs')
+    logger.info('=== Backtest Smoke Test ===')
+    logger.info('Testing that net < gross due to all costs')
     try:
         import sys
         from pathlib import Path
         sys.path.insert(0, str(Path(__file__).parent.parent / 'math'))
         from money import Money
-        logging.info('Simulating backtest with costs')
+        logger.info('Simulating backtest with costs')
         entry_price = Money('100.00')
         exit_price = Money('102.00')
         quantity = 100
         gross_pnl = (exit_price - entry_price) * quantity
-        logging.info(f'Gross P&L: ${gross_pnl}')
+        logger.info(f'Gross P&L: ${gross_pnl}')
         position_value = entry_price * quantity
         execution_cost_bps = 5.0
         execution_cost = position_value * (execution_cost_bps / 10000)
@@ -312,23 +311,23 @@ def run_smoke_test():
         commission = Money('2.00')
         total_costs = execution_cost + overnight_cost + commission
         net_pnl = gross_pnl - total_costs
-        logging.info(f'Execution cost (5 bps): ${execution_cost}')
-        logging.info(f'Overnight cost (2 bps): ${overnight_cost}')
-        logging.info(f'Commission: ${commission}')
-        logging.info(f'Total costs: ${total_costs}')
-        logging.info(f'Net P&L: ${net_pnl}')
+        logger.info(f'Execution cost (5 bps): ${execution_cost}')
+        logger.info(f'Overnight cost (2 bps): ${overnight_cost}')
+        logger.info(f'Commission: ${commission}')
+        logger.info(f'Total costs: ${total_costs}')
+        logger.info(f'Net P&L: ${net_pnl}')
         if net_pnl >= gross_pnl:
             raise AssertionError(f'Net P&L ({net_pnl}) should be less than gross P&L ({gross_pnl})')
         cost_drag_bps = total_costs / position_value * 10000
-        logging.info(f'Total cost drag: {cost_drag_bps:.1f} bps')
+        logger.info(f'Total cost drag: {cost_drag_bps:.1f} bps')
         if cost_drag_bps < 5.0:
             raise AssertionError(f'Cost drag ({cost_drag_bps:.1f} bps) seems too low')
-        logging.info('✓ Net P&L is correctly less than gross P&L due to costs')
-        logging.info(f'✓ Cost drag of {cost_drag_bps:.1f} bps is realistic')
-        logging.info('✓ Backtest smoke test passed!')
+        logger.info('✓ Net P&L is correctly less than gross P&L due to costs')
+        logger.info(f'✓ Cost drag of {cost_drag_bps:.1f} bps is realistic')
+        logger.info('✓ Backtest smoke test passed!')
         return True
     except (ValueError, TypeError) as e:
-        logging.error(f'✗ Backtest smoke test failed: {e}')
+        logger.error(f'✗ Backtest smoke test failed: {e}')
         return False
 if __name__ == '__main__':
     import argparse
@@ -340,4 +339,4 @@ if __name__ == '__main__':
         success = run_smoke_test()
         sys.exit(0 if success else 1)
     else:
-        logging.info('Backtest module. Use --smoke to run smoke test.')
+        logger.info('Backtest module. Use --smoke to run smoke test.')

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -822,7 +822,7 @@ def check_symbol(symbol: str, api: Any) -> bool:
         path = os.path.join("data", f"{symbol}.csv")
         df = pd.read_csv(path)
     except COMMON_EXC as exc:
-        logging.warning("Health check fetch failed for %s: %s", symbol, exc)
+        logger.warning("Health check fetch failed for %s: %s", symbol, exc)
         return False
     return health_check(df, "daily")
 
@@ -845,7 +845,7 @@ def pre_trade_health_check(symbols: list[str], api: Any) -> dict[str, bool]:
         ok = check_symbol(sym, api)
         symbol_health[sym] = ok
         if not ok:
-            logging.warning(f"Health check skipped for {sym}: insufficient data")
+            logger.warning(f"Health check skipped for {sym}: insufficient data")
     return symbol_health
 
 


### PR DESCRIPTION
## Summary
- drop stray `import logging` statements in modules using project logger
- route runtime logging through `get_logger`/`logger` for sanitization filters

## Testing
- `ruff check ai_trading`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy'; 61 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1469cbfc8330b04dde0bba37265b