### PR TITLE
Enforce risk env validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,11 @@ python verify_config.py
    MAX_POSITION_PCT=0.05               # Maximum 5% per position
    MAX_PORTFOLIO_HEAT=0.15             # Maximum 15% total risk
    ENABLE_STOP_LOSS=true               # Enable stop-loss orders
+
+   # Required risk parameters
+   CAPITAL_CAP=0.04                    # Fraction of equity usable per cycle
+   DOLLAR_RISK_LIMIT=0.05              # Max fraction of equity at risk per position
+   MAX_POSITION_SIZE=1000              # Absolute USD cap per position
    ```
 
 4. **Quick Self-Check**

--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -47,12 +47,24 @@ def create_app():
     def healthz():
         """Minimal liveness probe."""
         from datetime import UTC, datetime
+        from ai_trading.config.management import validate_required_env
 
-        return jsonify(
-            ok=True,
-            ts=datetime.now(UTC).isoformat(),
-            service="ai-trading",
-        )
+        try:
+            validate_required_env()
+            ok = True
+            err = None
+        except Exception as e:  # noqa: BLE001
+            ok = False
+            err = str(e)
+
+        payload = {
+            "ok": ok,
+            "ts": datetime.now(UTC).isoformat(),
+            "service": "ai-trading",
+        }
+        if err:
+            payload["error"] = err
+        return jsonify(payload)
 
     @app.route('/metrics')
     def metrics():

--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -61,6 +61,9 @@ _MANDATORY_ENV_VARS: tuple[str, ...] = (
     "ALPACA_SECRET_KEY",
     "ALPACA_BASE_URL",
     "WEBHOOK_SECRET",
+    "CAPITAL_CAP",
+    "DOLLAR_RISK_LIMIT",
+    "MAX_POSITION_SIZE",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,9 @@ def _env_defaults(monkeypatch):
     monkeypatch.setenv("ALPACA_SECRET_KEY", "dummy")
     monkeypatch.setenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
     monkeypatch.setenv("TZ", "UTC")
+    monkeypatch.setenv("CAPITAL_CAP", "0.04")
+    monkeypatch.setenv("DOLLAR_RISK_LIMIT", "0.05")
+    monkeypatch.setenv("MAX_POSITION_SIZE", "1000")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_config_deadlock_fix.py
+++ b/tests/test_config_deadlock_fix.py
@@ -44,7 +44,10 @@ def test_nested_validation_calls_no_deadlock():
         'ALPACA_SECRET_KEY': 'test_secret_1234567890',
         'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets',
         'WEBHOOK_SECRET': 'test_webhook_secret',
-        'SCHEDULER_SLEEP_SECONDS': '30'
+        'SCHEDULER_SLEEP_SECONDS': '30',
+        'CAPITAL_CAP': '0.04',
+        'DOLLAR_RISK_LIMIT': '0.05',
+        'MAX_POSITION_SIZE': '1000',
     }
 
     with patch.dict(os.environ, env_vars):
@@ -114,7 +117,10 @@ def test_validation_with_proper_env_vars():
         'ALPACA_SECRET_KEY': 'test_secret_1234567890',
         'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets',
         'WEBHOOK_SECRET': 'test_webhook_secret',
-        'SCHEDULER_SLEEP_SECONDS': '30'
+        'SCHEDULER_SLEEP_SECONDS': '30',
+        'CAPITAL_CAP': '0.04',
+        'DOLLAR_RISK_LIMIT': '0.05',
+        'MAX_POSITION_SIZE': '1000',
     }
 
     with patch.dict(os.environ, env_vars):


### PR DESCRIPTION
## Summary
- require risk limits like `CAPITAL_CAP`, `DOLLAR_RISK_LIMIT`, and `MAX_POSITION_SIZE` in environment validation
- validate mandatory environment variables during `/healthz`
- document required risk parameters and adjust tests to provide them

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'sklearn', ...)*


------
https://chatgpt.com/codex/tasks/task_e_68ad146b035c8330ad7154be55140932