### PR TITLE
feat: derive max position size when env var missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,11 +665,11 @@ python verify_config.py
    MAX_PORTFOLIO_HEAT=0.15             # Maximum 15% total risk
    ENABLE_STOP_LOSS=true               # Enable stop-loss orders
 
-   # Required risk parameters
-   CAPITAL_CAP=0.04                    # Fraction of equity usable per cycle
-   DOLLAR_RISK_LIMIT=0.05              # Max fraction of equity at risk per position
-   MAX_POSITION_SIZE=1000              # Absolute USD cap per position
-   ```
+  # Risk parameters
+  CAPITAL_CAP=0.04                    # Fraction of equity usable per cycle
+  DOLLAR_RISK_LIMIT=0.05              # Max fraction of equity at risk per position
+  # Optional: MAX_POSITION_SIZE=1000   # Absolute USD cap per position (derived if unset)
+  ```
 
 4. **Quick Self-Check**
    ```bash

--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -55,7 +55,9 @@ def is_shadow_mode() -> bool:
 # Canonical runtime seed used by risk/engine and anywhere else needing determinism.
 SEED: int = int(os.environ.get("SEED", "42"))  # AI-AGENT-REF: expose runtime seed
 
-# Required environment variables for a functional deployment
+# Required environment variables for a functional deployment. "MAX_POSITION_SIZE"
+# is intentionally excluded; when unset the runtime derives an appropriate value
+# based on capital constraints.
 _MANDATORY_ENV_VARS: tuple[str, ...] = (
     "ALPACA_API_KEY",
     "ALPACA_SECRET_KEY",
@@ -63,7 +65,6 @@ _MANDATORY_ENV_VARS: tuple[str, ...] = (
     "WEBHOOK_SECRET",
     "CAPITAL_CAP",
     "DOLLAR_RISK_LIMIT",
-    "MAX_POSITION_SIZE",
 )
 
 

--- a/tests/test_missing_max_position_size.py
+++ b/tests/test_missing_max_position_size.py
@@ -1,0 +1,44 @@
+import logging
+
+from ai_trading.config.management import validate_required_env
+import ai_trading.main as m
+
+
+def test_startup_without_max_position_size(monkeypatch, caplog):
+    env = {
+        "ALPACA_API_KEY": "dummy",
+        "ALPACA_SECRET_KEY": "dummy",
+        "ALPACA_BASE_URL": "https://paper-api.alpaca.markets",
+        "WEBHOOK_SECRET": "secret",
+        "CAPITAL_CAP": "0.04",
+        "DOLLAR_RISK_LIMIT": "0.05",
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.delenv("MAX_POSITION_SIZE", raising=False)
+    monkeypatch.delenv("AI_TRADING_MAX_POSITION_SIZE", raising=False)
+
+    snapshot = validate_required_env()
+    assert "MAX_POSITION_SIZE" not in snapshot
+    assert snapshot["ALPACA_API_KEY"] == "***"
+    assert snapshot["ALPACA_SECRET_KEY"] == "***"
+
+    class DummyCfg:
+        alpaca_base_url = "paper"
+        paper = True
+
+    class DummySettings:
+        trading_mode = "balanced"
+        capital_cap = 0.04
+        dollar_risk_limit = 0.05
+        max_position_size = None
+
+    with caplog.at_level(logging.INFO):
+        m._validate_runtime_config(cfg=DummyCfg(), tcfg=DummySettings())
+
+    records = [
+        r for r in caplog.records
+        if r.name == "ai_trading.position_sizing" and r.msg == "CONFIG_AUTOFIX"
+    ]
+    assert records, "CONFIG_AUTOFIX log not emitted"
+    assert getattr(records[0], "fallback", 0) > 0


### PR DESCRIPTION
## Summary
- derive MAX_POSITION_SIZE instead of requiring it during env validation
- document MAX_POSITION_SIZE as optional in README
- add regression test ensuring startup without MAX_POSITION_SIZE logs fallback and masks other env values

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'pandas', 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68ad1b1dcbc48330b6dcefc3ab35659b