### PR TITLE
chore: lazily load pandas_ta

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1090,6 +1090,10 @@ class _LazyModule(types.ModuleType):
                 self._module = importlib.import_module(self.__name__)
             except COMMON_EXC:
                 self._failed = True
+                logger.info(
+                    f"{self.__name__.upper()}_MISSING",
+                    extra={"hint": f"pip install {self.__name__}"},
+                )
 
     def _create_fallback(self):
         """Create a fallback module object with common methods."""

--- a/ai_trading/utils/lazy_imports.py
+++ b/ai_trading/utils/lazy_imports.py
@@ -7,6 +7,8 @@ from functools import lru_cache
 from importlib.util import find_spec
 from types import ModuleType
 
+from ai_trading.logging import get_logger
+
 class _LazyModule(ModuleType):
     """Proxy module that loads the real module upon first attribute access."""
 
@@ -34,3 +36,15 @@ def load_pandas_market_calendars() -> ModuleType | None:
     if find_spec("pandas_market_calendars") is None:
         return None
     return _LazyModule("pandas_market_calendars")
+
+
+@lru_cache(maxsize=None)
+def load_pandas_ta() -> ModuleType | None:
+    """Return :mod:`pandas_ta` if available, logging once when missing."""
+    try:
+        return importlib.import_module("pandas_ta")
+    except Exception:  # pragma: no cover - optional dependency
+        get_logger(__name__).info(
+            "PANDAS_TA_MISSING", extra={"hint": "pip install pandas-ta"}
+        )
+        return None


### PR DESCRIPTION
## Summary
- Add `load_pandas_ta` utility for on-demand pandas_ta import with one-time warning
- Use lazy pandas_ta loading with fallback ATR computation in risk engine
- Log missing optional modules once via `_LazyModule` in bot engine

## Testing
- `python -m pip install -r requirements-test.txt`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib'; plus multiple import errors)*
- `ruff check ai_trading/utils/lazy_imports.py ai_trading/risk/engine.py ai_trading/core/bot_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad1b1e6dd08330adc5ee002452267e