### PR TITLE
Move RiskEngine env validation to runtime

### DIFF
--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -59,9 +59,6 @@ class TradeSignal:
     asset_class: str
     strength: float = 1.0
 logger = get_logger(__name__)
-if not get_env("PYTEST_RUNNING", "0", cast=bool):
-    _ENV_SNAPSHOT = validate_required_env()
-    logger.debug("ENV_VARS_MASKED", extra=_ENV_SNAPSHOT)
 
 random.seed(SEED)
 np.random.seed(SEED)
@@ -75,6 +72,7 @@ class RiskEngine:
 
     def __init__(self, cfg: TradingConfig | None=None) -> None:
         """Initialize the engine with an optional trading config."""
+        self._validate_env()
         self.config = cfg if cfg is not None else TradingConfig()
         self._lock = threading.Lock()
         self.hard_stop = False
@@ -129,6 +127,13 @@ class RiskEngine:
             logger.error('Error parsing HARD_STOP_COOLDOWN_MIN: %s, using default 10', e)
             self.hard_stop_cooldown = 10.0
         self._hard_stop_until: float | None = None
+
+    def _validate_env(self) -> None:
+        """Validate required environment variables unless running tests."""
+        if get_env("PYTEST_RUNNING", "0", cast=bool):
+            return
+        snapshot = validate_required_env()
+        logger.debug("ENV_VARS_MASKED", extra=snapshot)
 
     def _dynamic_cap(self, asset_class: str, volatility: float | None=None, cash_ratio: float | None=None) -> float:
         """Return exposure cap for ``asset_class`` using adaptive rules."""

--- a/tests/unit/test_risk_engine_import.py
+++ b/tests/unit/test_risk_engine_import.py
@@ -1,4 +1,5 @@
 # AI-AGENT-REF: ensure RiskEngine imports without crash
+import pytest
 
 
 def test_import_risk_engine():
@@ -6,4 +7,23 @@ def test_import_risk_engine():
     from ai_trading.risk.engine import RiskEngine  # noqa: F401
 
     assert True
+
+
+def test_risk_engine_validates_env_at_runtime(monkeypatch):
+    keys = (
+        "ALPACA_API_KEY",
+        "ALPACA_SECRET_KEY",
+        "ALPACA_BASE_URL",
+        "WEBHOOK_SECRET",
+        "CAPITAL_CAP",
+        "DOLLAR_RISK_LIMIT",
+        "MAX_POSITION_SIZE",
+    )
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("PYTEST_RUNNING", raising=False)
+    from ai_trading.risk.engine import RiskEngine
+
+    with pytest.raises(RuntimeError):
+        RiskEngine()
 


### PR DESCRIPTION
## Summary
- Validate required env vars during `RiskEngine` initialization instead of module import
- Add regression test covering runtime env validation

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'ai_trading.config.management'; 'ai_trading.config' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1b1d2bb8833095fe55da487198a4