### PR TITLE
Cache env validation result for healthz

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -34,7 +34,9 @@ present before the service starts:
 | `WEBHOOK_SECRET` | Protects inbound webhooks |
 
 If any are missing or empty the process exits with a `RuntimeError` listing the
-missing keys; values are masked in logs and exceptions.
+missing keys; values are masked in logs and exceptions. During health server
+startup the validation result is cached and `/healthz` reuses it, returning
+`{"ok": false, "error": "..."}` while still responding with HTTP 200.
 
 ### Health endpoints & env
 


### PR DESCRIPTION
## Summary
- cache `validate_required_env` once at startup and reuse result in `/healthz`
- document cached validation and failure response in `DEPLOYING.md`

## Testing
- `python -m pip install -U pip`
- `pip install -e .` *(terminated: installing dependencies was taking too long)*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: multiple ImportError and assertion errors)*
- `pre-commit run --files ai_trading/app.py DEPLOYING.md` *(failed: CalledProcessError during hook env setup)*
- `python - <<'PY' ...` to verify `/healthz` returns `200` with cached env check

## Rollback
- Revert commit `cache env validation for healthz`


------
https://chatgpt.com/codex/tasks/task_e_68ad1b1efa808330a8039557d4ed8e5c