### PR TITLE
refactor: remove pathlib shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - **Package Structure**: Root modules previously moved into `ai_trading/` package
   - **Migration Required**: Use `from ai_trading.signals import ...` instead of `from signals import ...`
   - **Breaking**: Root imports are no longer supported as of this version
+- **Utils**: remove legacy `pathlib_shim` re-export; use `ai_trading.utils.paths` instead
 
 ### Fixed
 - Normalize broker-unavailable contract; remove false PDT warnings; add regression tests.

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -40,7 +40,7 @@ __all__ = tuple(sorted({
     "retry",
     "timing",
     "device",
-    "pathlib_shim",
+    "paths",
     "datetime",
     "capital_scaling",
 }))
@@ -50,7 +50,7 @@ _LAZY_MAP = {
     "retry": ("ai_trading.utils.retry", None),
     "timing": ("ai_trading.utils.timing", None),
     "device": ("ai_trading.utils.device", None),
-    "pathlib_shim": ("ai_trading.utils.pathlib_shim", None),
+    "paths": ("ai_trading.utils.paths", None),
     "datetime": ("ai_trading.utils.datetime", None),
     "capital_scaling": ("ai_trading.utils.capital_scaling", None),
 
@@ -75,7 +75,7 @@ if TYPE_CHECKING:  # pragma: no cover - for static analyzers only
     from . import retry as retry  # type: ignore
     from . import timing as timing  # type: ignore
     from . import device as device  # type: ignore
-    from . import pathlib_shim as pathlib_shim  # type: ignore
+    from . import paths as paths  # type: ignore
     from . import datetime as datetime  # type: ignore
     from .base import (  # type: ignore
         EASTERN_TZ,


### PR DESCRIPTION
## Summary
- drop stale pathlib shim from utils exports
- expose `ai_trading.utils.paths` via lazy map and `__all__`
- document removal in changelog

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError: cannot import name 'utcnow' from 'ai_trading.utils.time', among others)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1eb6021083308f6a77c5d7344138