### PR TITLE
Lazy risk engine initialization in backtester

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,9 @@ python -m ai_trading --live --interval 10
 
 ### 📈 Backtesting & Optimization
 
+> The backtester now initializes the risk engine lazily at runtime,
+> removing side effects from module import.
+
 #### Basic Backtesting
 
 ```bash


### PR DESCRIPTION
## Summary
- remove module-level risk engine instantiation in backtester
- lazily load and cache the risk engine when running backtests
- document delayed risk engine initialization

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing dependencies)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_cli_smoke.py tests/test_backtest_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1eb835c083309af34755df3c92d0