### PR TITLE
Seed PYTHONHASHSEED during pytest runs

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -55,7 +55,7 @@ Unit Tests (70%)
 
 ## Deterministic Testing
 
-To keep results reproducible, all tests start with a fixed random seed. An autouse fixture in `tests/conftest.py` sets `PYTHONHASHSEED=0` (if not already configured), seeds Python's `random` module and NumPy, and calls `torch.manual_seed(0)` when PyTorch is available. Tests should avoid introducing additional sources of nondeterminism.
+To keep results reproducible, all tests start with a fixed random seed. The `tools/run_pytest.py` helper sets `PYTHONHASHSEED=0` before invoking pytest to ensure consistent hash randomization. An autouse fixture in `tests/conftest.py` then seeds Python's `random` module and NumPy and calls `torch.manual_seed(0)` when PyTorch is available. Tests should avoid introducing additional sources of nondeterminism.
 
 ## Test Structure
 

--- a/tools/run_pytest.py
+++ b/tools/run_pytest.py
@@ -98,6 +98,7 @@ def main(argv: list[str] | None = None) -> int:
     os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
     parser = build_parser()
     args = parser.parse_args(argv)
+    os.environ.setdefault("PYTHONHASHSEED", "0")
     cmd = build_pytest_cmd(args)
     # AI-AGENT-REF: echo exact command for smoke test assertions
     logger.info("[run_pytest] %s", " ".join(cmd))


### PR DESCRIPTION
## Summary
- Set `PYTHONHASHSEED=0` in `tools/run_pytest.py` to enforce deterministic hashing
- Document deterministic `PYTHONHASHSEED` seeding in `TESTING_FRAMEWORK.md`

## Testing
- `ruff check tools/run_pytest.py`
- `python tools/run_pytest.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68ad1eb8d6108330857376d91ef31ccd