### PR TITLE
chore: remove duplicate logger import

### DIFF
--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -19,7 +19,6 @@ from zoneinfo import ZoneInfo
 from ai_trading.config import get_settings
 from ai_trading.exc import COMMON_EXC
 from ai_trading.settings import get_verbose_logging
-from ai_trading.logging import get_logger
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd  # pylint: disable=unused-import


### PR DESCRIPTION
## Summary
- remove duplicate `get_logger` import in utils `base`

## Testing
- `ruff check --fix ai_trading/utils/base.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError: cannot import name 'utcnow' from 'ai_trading.utils.time', ModuleNotFoundError: No module named 'joblib', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1eba0310833089cd447e7ab9f47a