### PR TITLE
fix: update Alpaca import paths

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1429,8 +1429,8 @@ YFINANCE_AVAILABLE = has_yfinance()  # AI-AGENT-REF: cached provider availabilit
 # fallbacks that mask missing dependencies.
 try:  # pragma: no cover - import resolution
     from alpaca_trade_api.entity import Quote, Order
-    from alpaca_trade_api.common.enums import OrderSide, OrderStatus, TimeInForce
-    from alpaca_trade_api.common.types import MarketOrderRequest
+    from alpaca_trade_api.enums import OrderSide, OrderStatus, TimeInForce
+    from alpaca_trade_api.types import MarketOrderRequest
     try:  # pragma: no cover - StockLatestQuoteRequest may not exist
         from alpaca_trade_api.rest import StockLatestQuoteRequest  # type: ignore
     except Exception:


### PR DESCRIPTION
## Summary
- update bot engine to new `alpaca-trade-api` import locations for order enums and request type

## Testing
- `ruff check ai_trading/core/bot_engine.py`
- `python -m ai_trading --dry-run`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68ad21f72f7c8330b25c0f40f35d6d38