### PR TITLE
refactor: lazily load pandas and numpy

### DIFF
--- a/tests/test_peak_performance.py
+++ b/tests/test_peak_performance.py
@@ -7,7 +7,6 @@ from datetime import UTC, datetime
 
 import numpy as np
 import pytest
-pd = pytest.importorskip("pandas")
 
 
 # Test idempotency
@@ -162,6 +161,7 @@ def test_symbol_costs():
 def test_adaptive_risk_controls():
     """Test adaptive risk control system."""
     from ai_trading.portfolio.risk_controls import AdaptiveRiskController
+    pd = pytest.importorskip("pandas")
 
     # Create test data
     np.random.seed(42)
@@ -203,6 +203,7 @@ def test_adaptive_risk_controls():
 def test_determinism():
     """Test deterministic training setup."""
     from ai_trading.utils.determinism import hash_data, set_random_seeds
+    pd = pytest.importorskip("pandas")
 
     # Test seed setting
     set_random_seeds(42)
@@ -234,6 +235,7 @@ def test_determinism():
 def test_drift_monitoring():
     """Test drift monitoring functionality."""
     from ai_trading.monitoring.drift import DriftMonitor
+    pd = pytest.importorskip("pandas")
 
     monitor = DriftMonitor()
 
@@ -270,6 +272,7 @@ def test_performance_optimizations():
         VectorizedOperations,
         benchmark_operation,
     )
+    pd = pytest.importorskip("pandas")
 
     # Test caching
     cache = PerformanceCache(max_size=10, ttl_seconds=60)


### PR DESCRIPTION
## Summary
- lazily import pandas and numpy in drift monitoring, RL features, performance utilities and metrics
- gate pandas-dependent tests with pytest.importorskip

## Testing
- `ruff check ai_trading/monitoring/drift.py ai_trading/utils/performance.py ai_trading/rl_trading/features.py ai_trading/monitoring/metrics.py tests/test_peak_performance.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_peak_performance.py::test_drift_monitoring tests/test_peak_performance.py::test_performance_optimizations tests/test_rl_features.py::test_compute_features_shape_and_finite -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad21f7a0588330b5f4effdce2c2768