### PR TITLE
Limit pytest collection with keyword-only runs

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -57,6 +57,8 @@ Unit Tests (70%)
 
 To keep results reproducible, all tests start with a fixed random seed. The `tools/run_pytest.py` helper sets `PYTHONHASHSEED=0` before invoking pytest to ensure consistent hash randomization. An autouse fixture in `tests/conftest.py` then seeds Python's `random` module and NumPy and calls `torch.manual_seed(0)` when PyTorch is available. Tests should avoid introducing additional sources of nondeterminism.
 
+When a `-k` expression is provided without explicit targets, `tools/run_pytest.py` automatically limits collection to test files whose names contain the specified keywords. This prevents unrelated tests from being imported and keeps smoke runs deterministic even in environments missing optional dependencies.
+
 ## Test Structure
 
 ### Directory Organization


### PR DESCRIPTION
## Summary
- avoid repo-wide test collection when `tools/run_pytest.py` is invoked with only `-k`, keeping smoke tests deterministic without optional deps
- document the keyword-target behavior in `TESTING_FRAMEWORK.md`

## Testing
- `python -m ai_trading --dry-run`
- `make smoke`
- `python tools/run_pytest.py -k "runner_smoke or utils_timing or trading_config_aliases"`
- `ruff check .`
- `curl -s http://127.0.0.1:9001/healthz`
- `journalctl -u ai-trading.service -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68ad36fbd4f48330b7338ba2a429d1ad