### PR TITLE
docs: clarify dry run and health check usage

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -276,6 +276,13 @@ class RiskMetrics:
 | `--paper` / `--live` | Select paper (default) or live trading |
 
 
+Example dry run:
+
+```bash
+python -m ai_trading --dry-run
+```
+
+
 The Alpaca SDK is imported lazily; runtime preflight checks will terminate the process if `alpaca-trade-api` is unavailable.
 The trading engine honors `AI_TRADER_CONF_THRESHOLD` (default **0.75**) to require a minimum model confidence before executing a trade.
 
@@ -290,6 +297,13 @@ GET http://127.0.0.1:$HEALTHCHECK_PORT/healthz
 ```
 
 Available when `RUN_HEALTHCHECK=1` on `$HEALTHCHECK_PORT` (default **9001**); always returns JSON and must never 500.
+
+Example:
+
+```bash
+RUN_HEALTHCHECK=1 python -m ai_trading.app &
+curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz
+```
 
 **Response:**
 ```json

--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ For comprehensive development environment setup, see [**docs/DEVELOPMENT.md**](d
 ### Quick Start Trading
 
 ```bash
+# Verify environment and imports only
+python -m ai_trading --dry-run
+
 # Start the bot with default settings
 python -m ai_trading
 


### PR DESCRIPTION
## Summary
- document `python -m ai_trading --dry-run` for quick import checks
- show how to start the optional health server and query `/healthz`

## Testing
- `python -m ai_trading --dry-run`
- `make smoke`
- `python tools/run_pytest.py -k "runner_smoke or utils_timing or trading_config_aliases"`
- `ruff check .`
- `RUN_HEALTHCHECK=1 python -m ai_trading.app & curl -sf http://127.0.0.1:9001/healthz`
- `journalctl -u ai-trading.service -n 200`

------
https://chatgpt.com/codex/tasks/task_e_68ad3cb769a88330b571e088fa52ff5e