### PR TITLE
docs: mention dry run verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,15 @@ A sophisticated **AI-powered algorithmic trading system** that combines machine 
 ```bash
 python -m pip install -U pip
 pip install -e .
+python -m ai_trading --dry-run
 ruff check .
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
 RUN_HEALTHCHECK=1 python -m ai_trading.app &
 curl -s http://127.0.0.1:9001/healthz
 curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9001/metrics
 ```
+
+The dry run exits with status **0** and prints `INDICATOR_IMPORT_OK`, confirming optional indicator modules are available.
 
 Set `RUN_HEALTHCHECK=1` to launch the lightweight Flask app that serves:
 


### PR DESCRIPTION
## Summary
- document quick dry-run command to verify install

## Testing
- `python -m ai_trading --dry-run`
- `make smoke`
- `python tools/run_pytest.py -k "runner_smoke or utils_timing or trading_config_aliases"`
- `ruff check .`
- `curl -sf http://127.0.0.1:9001/healthz`
- `journalctl -u ai-trading.service -n 200`


------
https://chatgpt.com/codex/tasks/task_e_68ad3e6a1b008330b9d107faabbd8b89