### PR TITLE
docs: clarify health server usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,11 @@ config.reload_env()
 * `/healthz` JSON: `{"ok": true, "ts": "...", "service": "ai-trading"}`
 * `/metrics` exposes Prometheus format
 * Set `RUN_HEALTHCHECK=1` to serve these on `$HEALTHCHECK_PORT` (default **9001**)
+* Local check:
+  ```bash
+  RUN_HEALTHCHECK=1 python -m ai_trading.app &
+  curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz
+  ```
 * Requirement: Endpoints must not raise exceptions; log and return `ok: false` if degraded.
 
 ## 8) Alpaca SDK stance

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -308,17 +308,13 @@ curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz
 **Response:**
 ```json
 {
-    "status": "healthy",
-    "timestamp": "2024-01-15T10:30:00Z",
-    "components": {
-        "database": "healthy",
-        "api_connection": "healthy",
-        "model_status": "loaded"
-    },
-    "uptime": "2d 4h 32m",
-    "version": "0.1.0"
+  "ok": true,
+  "ts": "2025-01-01T00:00:00+00:00",
+  "service": "ai-trading"
 }
 ```
+
+If required environment variables are missing the response remains HTTP 200 with `"ok": false` and an `"error"` field.
 
 #### Metrics Endpoint
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 - Python 3.12 app running on a DigitalOcean droplet, supervised by `systemd`.
 - Entry: `ai_trading/runner.py`; core loop in `ai_trading/core/bot_engine.py`.
 - Alpaca SDK (`alpaca-trade-api`) is imported lazily; startup preflight aborts if the SDK is missing.
-- Health & metrics via `ai_trading/app.py` when `RUN_HEALTHCHECK=1`.
+- Health & metrics via `python -m ai_trading.app` when `RUN_HEALTHCHECK=1`.
   - `/healthz` JSON and `/metrics` Prometheus served on the port specified by the `HEALTHCHECK_PORT` environment variable (default **9001**).
 
 ## Object Model

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -19,6 +19,13 @@ journalctl -u ai-trading.service -n 200 --no-pager
 curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz
 ```
 
+For local verification without systemd:
+
+```bash
+RUN_HEALTHCHECK=1 python -m ai_trading.app &
+curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz
+```
+
 Configure environment in `/home/aiuser/ai-trading-bot/.env` (loaded with `override=True` at startup) and ensure PATH in the unit points to your venv.
 
 Startup runs an import preflight and will exit if the `alpaca-trade-api` package is missing.


### PR DESCRIPTION
## Summary
- document how to launch the Flask health server for local checks
- refresh architecture and API docs to reflect python -m ai_trading.app usage
- note manual health check workflow in deployment guide

## Testing
- `python -m ai_trading --dry-run`
- `make smoke`
- `python tools/run_pytest.py -k "runner_smoke or utils_timing or trading_config_aliases"`
- `ruff check .`
- `curl -sf http://127.0.0.1:9001/healthz`
- `journalctl -u ai-trading.service -n 200`

------
https://chatgpt.com/codex/tasks/task_e_68ad4325f7d083308b07a34bf555e6f2