### PR TITLE
feat: tighten optional imports and config ergonomics

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -59,6 +59,12 @@ To keep results reproducible, all tests start with a fixed random seed. The `too
 
 When a `-k` expression is provided without explicit targets, `tools/run_pytest.py` automatically limits collection to test files whose names contain the specified keywords. This prevents unrelated tests from being imported and keeps smoke runs deterministic even in environments missing optional dependencies.
 
+Explicit test paths can be supplied either positionally or via `--files`:
+
+```bash
+python tools/run_pytest.py --files tests/test_utils_timing.py tests/test_trading_config_aliases.py
+```
+
 ## Test Structure
 
 ### Directory Organization

--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -182,6 +182,41 @@ class TradingConfig:
     data_feed: Optional[str] = None
     data_provider: Optional[str] = None
 
+    # --- Ergonomics: safe update & dict view ---
+    def update(self, **kwargs) -> None:
+        """Update known fields only; raise on unknown key."""
+        for k, v in kwargs.items():
+            if not hasattr(self, k):
+                raise AttributeError(f"TradingConfig has no field '{k}'")
+            object.__setattr__(self, k, v)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a dict of current tunables (no secrets)."""
+        keys = [
+            "seed",
+            "enable_finbert",
+            "capital_cap",
+            "dollar_risk_limit",
+            "max_position_size",
+            "sector_exposure_cap",
+            "max_drawdown_threshold",
+            "trailing_factor",
+            "take_profit_factor",
+            "max_position_size_pct",
+            "max_var_95",
+            "min_profit_factor",
+            "min_sharpe_ratio",
+            "min_win_rate",
+            "kelly_fraction_max",
+            "min_sample_size",
+            "confidence_level",
+            "max_position_mode",
+            "paper",
+            "data_feed",
+            "data_provider",
+        ]
+        return {k: getattr(self, k) for k in keys}
+
     @classmethod
     def from_env(
         cls, env: Mapping[str, str] | None = None

--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -23,6 +23,7 @@ except Exception:  # pragma: no cover - fallback when SDK missing
         pass
 from ai_trading.logging import get_logger
 from ai_trading.utils import clamp_timeout as _clamp_timeout
+from ai_trading.utils.lazy_imports import optional_import
 logger = get_logger(__name__)
 _log = logger
 
@@ -57,11 +58,7 @@ def _get_numpy():
 
 
 def _get_pandas():
-    try:  # pragma: no cover - import is tested indirectly
-        import pandas as pd  # type: ignore
-        return pd
-    except Exception:
-        return None
+    return optional_import("pandas")
 
 
 def _get_requests():

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -423,7 +423,8 @@ BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 
 def ensure_utc(value: dt.datetime | date) -> dt.datetime:
     """Return a timezone-aware UTC datetime for ``dt``."""
-    assert isinstance(value, dt.datetime | date), "dt must be date or datetime"
+    if not isinstance(value, (dt.datetime, date)):
+        raise TypeError("dt must be date or datetime")
     if isinstance(value, dt.datetime):
         if value.tzinfo is None:
             return value.replace(tzinfo=dt.UTC)

--- a/ai_trading/utils/lazy_imports.py
+++ b/ai_trading/utils/lazy_imports.py
@@ -48,3 +48,13 @@ def load_pandas_ta() -> ModuleType | None:
             "PANDAS_TA_MISSING", extra={"hint": "pip install pandas-ta"}
         )
         return None
+
+
+@lru_cache(maxsize=None)
+def optional_import(name: str) -> ModuleType | None:
+    """Return the imported module or ``None`` if not installed."""
+    try:
+        return importlib.import_module(name)
+    except Exception:  # pragma: no cover - optional dependency
+        get_logger(__name__).debug("optional_import failed", extra={"module": name})
+        return None

--- a/tests/test_runner_smoke.py
+++ b/tests/test_runner_smoke.py
@@ -23,6 +23,7 @@ def test_runner_echo_exact_command(tmp_path):  # AI-AGENT-REF: check exact runne
         "tools/run_pytest.py",
         "--disable-warnings",
         "-q",
+        "--files",
         "tests/test_utils_timing.py",
         "tests/test_trading_config_aliases.py",
     ]

--- a/tests/unit/test_trading_config_fields.py
+++ b/tests/unit/test_trading_config_fields.py
@@ -1,6 +1,7 @@
 # AI-AGENT-REF: validate new TradingConfig fields and env overrides
 from __future__ import annotations
 
+import pytest
 from ai_trading.config.management import TradingConfig
 
 
@@ -19,3 +20,20 @@ def test_env_overrides_and_defaults(monkeypatch):
     assert cfg.kelly_fraction_max == 0.20
     assert cfg.min_sample_size == 12
     assert cfg.confidence_level == 0.85
+
+
+def test_update_and_to_dict():
+    cfg = TradingConfig()
+    cfg.update(kelly_fraction_max=0.5, min_sample_size=20)
+    assert cfg.kelly_fraction_max == 0.5
+    assert cfg.min_sample_size == 20
+    snap = cfg.to_dict()
+    assert snap["kelly_fraction_max"] == 0.5
+    assert snap["min_sample_size"] == 20
+    assert snap["seed"] == cfg.seed
+
+
+def test_update_unknown_key():
+    cfg = TradingConfig()
+    with pytest.raises(AttributeError):
+        cfg.update(nonexistent=1)  # type: ignore[arg-type]

--- a/tests/unit/test_utils_lazy_import.py
+++ b/tests/unit/test_utils_lazy_import.py
@@ -1,4 +1,5 @@
 import types
+from ai_trading.utils.lazy_imports import optional_import
 
 
 def test_utils_http_lazy_import_no_recursion():
@@ -8,4 +9,9 @@ def test_utils_http_lazy_import_no_recursion():
     assert isinstance(mod, types.ModuleType)
     # cached on second access
     assert utils.http is mod
+
+
+def test_optional_import():
+    assert optional_import("math") is not None
+    assert optional_import("module_does_not_exist") is None
 

--- a/tools/run_pytest.py
+++ b/tools/run_pytest.py
@@ -38,6 +38,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Quiet mode (pytest -q)",
     )
+    p.add_argument(
+        "--files",
+        nargs="+",
+        default=None,
+        help="Explicit test file/dir/node-id targets (alias)",
+    )
     # AI-AGENT-REF: allow explicit test targets to avoid global collection
     p.add_argument(
         "targets",
@@ -64,9 +70,14 @@ def build_pytest_cmd(args: argparse.Namespace) -> list[str]:
     if args.collect_only:
         cmd += ["--collect-only"]
 
+    targets: list[str] = []
+    if args.files:
+        targets.extend(args.files)
     if args.targets:
+        targets.extend(args.targets)
+    if targets:
         # AI-AGENT-REF: append explicit targets last so pytest limits collection
-        cmd.extend(args.targets)
+        cmd.extend(targets)
         if args.keyword:
             cmd += ["-k", args.keyword]
         return cmd


### PR DESCRIPTION
## Summary
- add `update()` and `to_dict()` helpers on `TradingConfig`
- replace assert with `TypeError` in `ensure_utc`
- provide `optional_import` utility and reuse it for pandas in `signals`
- support `--files` flag in `tools/run_pytest.py` and document usage

## Testing
- `python -m compileall -q ai_trading`
- `ruff check ai_trading/config/management.py ai_trading/utils/base.py ai_trading/utils/lazy_imports.py ai_trading/signals.py tests/unit/test_trading_config_fields.py tests/unit/test_utils_lazy_import.py tools/run_pytest.py tests/test_runner_smoke.py`
- `pytest -q tests/unit/test_trading_config_fields.py::test_defaults_present tests/unit/test_trading_config_fields.py::test_update_and_to_dict tests/unit/test_trading_config_fields.py::test_update_unknown_key tests/unit/test_utils_lazy_import.py::test_optional_import tests/test_runner_smoke.py::test_runner_echo_exact_command`
- `python tools/run_pytest.py --files tests/test_runner_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad49e0381483308b90ebc7c3463fd9