### PR TITLE
fix: harden warm-up and lock

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -13216,8 +13216,9 @@ def main() -> None:
 
         pm = ProcessManager()
         if not pm.ensure_single_instance():
-            logger.error("Another trading bot instance is already running. Exiting.")
-            sys.exit(1)
+            msg = "Another trading bot instance is already running (single-instance lock busy)"
+            logger.error(msg)
+            raise RuntimeError(msg)
         logger.info("Single instance lock acquired successfully")
     except (
         FileNotFoundError,
@@ -13229,8 +13230,8 @@ def main() -> None:
         TypeError,
         OSError,
     ) as e:  # AI-AGENT-REF: narrow exception
-        logger.error("Failed to acquire single instance lock: %s", e)
-        sys.exit(1)
+        logger.error("Failed to acquire single instance lock", exc_info=e)
+        raise RuntimeError("Single-instance lock acquisition failed") from e
 
     # AI-AGENT-REF: Add comprehensive health check on startup
     try:

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -307,7 +307,27 @@ def main(argv: list[str] | None = None) -> None:
     logger.info("STARTUP_BANNER", extra=_redact(banner))
     _install_signal_handlers()
     rc = _get_run_cycle()
-    rc()
+    warmup_code = 0
+    try:
+        warmup_code = rc()
+    except SystemExit as e:
+        warmup_code = int(getattr(e, "code", 1) or 1)
+        logger.error(
+            "Warm-up run_cycle triggered SystemExit; continuing into main loop",
+            exc_info=e,
+        )
+    except Exception as e:  # noqa: BLE001
+        warmup_code = 1
+        logger.exception(
+            "Warm-up run_cycle failed; continuing into main loop",
+            exc_info=e,
+        )
+    else:
+        if warmup_code:
+            logger.warning(
+                "Warm-up returned non-zero code=%s; continuing into main loop",
+                warmup_code,
+            )
     api_ready = threading.Event()
     api_error = threading.Event()
     t = Thread(target=start_api_with_signal, args=(api_ready, api_error), daemon=True)

--- a/ai_trading/process_manager.py
+++ b/ai_trading/process_manager.py
@@ -52,7 +52,8 @@ class ProcessManager:
 
     def __enter__(self) -> ProcessManager:
         if not self.ensure_single_instance():
-            raise SystemExit('Another ai-trading instance is already running.')
+            msg = 'Another ai-trading instance is already running.'
+            raise RuntimeError(msg)
         return self
 
     def __exit__(self, *exc) -> bool:


### PR DESCRIPTION
## Summary
- guard warm-up cycle in `main` so failures log but do not exit
- raise `RuntimeError` instead of `sys.exit` for single-instance lock

## Testing
- `python -m ai_trading --once --dry-run`
- `python -m ai_trading.runner -n 1 -i 0`
- `make smoke`
- `ruff check ai_trading/main.py ai_trading/core/bot_engine.py ai_trading/process_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68add02290e8833085b1489a8a291029