### PR TITLE
handle None config values in runtime

### DIFF
--- a/ai_trading/core/runtime.py
+++ b/ai_trading/core/runtime.py
@@ -19,9 +19,13 @@ def _cfg_coalesce(cfg, key, default):
     """
     lower = key.lower()
     if hasattr(cfg, lower):
-        return getattr(cfg, lower)
+        val = getattr(cfg, lower)
+        if val is not None:
+            return val
     if hasattr(cfg, key):
-        return getattr(cfg, key)
+        val = getattr(cfg, key)
+        if val is not None:
+            return val
     return default
 
 class NullAlphaModel:

--- a/tests/test_runtime_params_hydration.py
+++ b/tests/test_runtime_params_hydration.py
@@ -162,5 +162,23 @@ def test_parameter_values_are_floats():
         assert isinstance(value, float), f"Parameter {key} is not a float: {type(value)}"
 
 
+def test_build_runtime_ignores_none_values():
+    """build_runtime should fall back to defaults when config values are None."""
+    from ai_trading.config.management import TradingConfig
+    from ai_trading.core.runtime import REQUIRED_PARAM_DEFAULTS, build_runtime
+
+    cfg = TradingConfig(
+        capital_cap=None,
+        dollar_risk_limit=None,
+        max_position_size=None,
+        kelly_fraction_max=None,  # unrelated field to ensure None doesn't break
+    )
+
+    runtime = build_runtime(cfg)
+
+    for key, default in REQUIRED_PARAM_DEFAULTS.items():
+        assert runtime.params[key] == default
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary
- guard runtime parameter hydration from None config values
- test runtime defaults when config contains None values

## Testing
- `python -m pip install -U pip`
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `curl -sf http://127.0.0.1:9001/healthz` *(fails: healthz check failed)*

------
https://chatgpt.com/codex/tasks/task_e_68add3450d2883309c16758d1e2f01dd