### PR TITLE
fix: guard alpaca SDK availability

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -13,8 +13,8 @@
 #### Emit-Once Logging
 Startup banners and environment setup messages use emit-once logging to prevent duplicate messages during multiple initialization attempts:
 
-- "Alpaca SDK is available"
-- "FinBERT loaded successfully" 
+- "Alpaca SDK is available" (or a warning if the SDK is missing)
+- "FinBERT loaded successfully"
 - Configuration verification messages
 
 #### Compact JSON Format


### PR DESCRIPTION
## Summary
- detect Alpaca SDK presence before logging availability and warn when missing
- avoid repeated import attempts once Alpaca classes fail to load
- document conditional Alpaca startup message

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `RUN_HEALTHCHECK=1 python -m ai_trading.app` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68add63da79c8330b265825848a23ace