### PR TITLE
docs: use timezone-aware datetime examples

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -744,7 +744,7 @@ class TestPerformanceBenchmarks:
 from unittest.mock import Mock, MagicMock
 import pandas as pd
 import numpy as np
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 
 class MockDataFactory:
@@ -782,14 +782,14 @@ class MockDataFactory:
     def create_alpaca_order_mock(symbol='AAPL', qty=100, side='buy', status='filled'):
         """Create mock Alpaca order object."""
         order = Mock()
-        order.id = f'order-{symbol}-{int(datetime.now().timestamp())}'
+        order.id = f'order-{symbol}-{int(datetime.now(UTC).timestamp())}'
         order.symbol = symbol
         order.qty = str(qty)
         order.side = side
         order.status = status
         order.filled_qty = str(qty) if status == 'filled' else '0'
         order.filled_avg_price = '150.25' if status == 'filled' else None
-        order.created_at = datetime.now().isoformat()
+        order.created_at = datetime.now(UTC).isoformat()
         return order
     
     @staticmethod

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -196,11 +196,11 @@ nslookup api.alpaca.markets 8.8.8.8
 # test_data_providers.py
 from ai_trading import data_fetcher
 import pandas as pd
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 def test_data_provider(symbol='SPY', timeframe='1h'):
     """Test all data providers for a symbol."""
-    end_date = datetime.now()
+    end_date = datetime.now(UTC)
     start_date = end_date - timedelta(days=5)
     
     providers = ['alpaca', 'finnhub', 'yahoo']
@@ -235,12 +235,12 @@ if __name__ == "__main__":
 ```python
 # check_market_hours.py
 import pandas_market_calendars as mcal
-from datetime import datetime
+from datetime import UTC, datetime
 
 def check_market_status():
     """Check if market is currently open."""
     nyse = mcal.get_calendar('NYSE')
-    now = datetime.now()
+    now = datetime.now(UTC)
     
     # Check if today is a trading day
     schedule = nyse.schedule(start_date=now.date(), end_date=now.date())

--- a/docs/ALPHA_UPGRADE.md
+++ b/docs/ALPHA_UPGRADE.md
@@ -164,6 +164,7 @@ signal = aggregator.aggregate_signals(signals, method="weighted_average")
 
 # NEW - With meta-learning
 from ai_trading.strategies.signals import SignalAggregator
+from datetime import UTC, datetime
 
 aggregator = SignalAggregator(
     enable_stacking=True,
@@ -173,10 +174,10 @@ aggregator = SignalAggregator(
 )
 
 signal = aggregator.aggregate_signals(
-    signals, 
+    signals,
     method="stacking",  # Meta-learning approach
     market_data=current_market_data,
-    timestamp=datetime.now()
+    timestamp=datetime.now(UTC)
 )
 
 # Update performance for meta-learning


### PR DESCRIPTION
## Summary
- ensure troubleshooting and testing docs use timezone-aware `datetime.now(UTC)`
- document UTC usage in alpha upgrade guide

## Testing
- `python -m ai_trading --dry-run`
- `make smoke`
- `python tools/run_pytest.py -k "runner_smoke or utils_timing or trading_config_aliases"`
- `ruff check .`
- `curl -sf http://127.0.0.1:${HEALTHCHECK_PORT:-9001}/healthz`
- `journalctl -u ai-trading.service -n 200`

------
https://chatgpt.com/codex/tasks/task_e_68addb1ef6ac83308dd2574bd9a84919