### PR TITLE
Add runtime smoke tests and self-test script

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -13269,10 +13269,7 @@ def main() -> None:
         )  # AI-AGENT-REF: normalized import
 
         pm = ProcessManager()
-        if not pm.ensure_single_instance():
-            msg = "Another trading bot instance is already running (single-instance lock busy)"
-            logger.error(msg)
-            raise RuntimeError(msg)
+        pm.ensure_single_instance()
         logger.info("Single instance lock acquired successfully")
     except (
         FileNotFoundError,
@@ -13283,6 +13280,7 @@ def main() -> None:
         KeyError,
         TypeError,
         OSError,
+        RuntimeError,
     ) as e:  # AI-AGENT-REF: narrow exception
         logger.error("Failed to acquire single instance lock", exc_info=e)
         raise RuntimeError("Single-instance lock acquisition failed") from e

--- a/ai_trading/process_manager.py
+++ b/ai_trading/process_manager.py
@@ -21,14 +21,14 @@ class ProcessManager:
         return str(self._lockfile)
 
     def ensure_single_instance(self) -> bool:
-        """Acquire lock or return False if another instance is running."""
+        """Acquire lock or raise if another instance is running."""
         self._fd = os.open(self._lockfile, os.O_CREAT | os.O_RDWR, 420)
         try:
             fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            os.write(self._fd, str(os.getpid()).encode('utf-8'))
+            os.write(self._fd, str(os.getpid()).encode("utf-8"))
             os.fsync(self._fd)
-        except OSError:
-            return False
+        except OSError as e:
+            raise RuntimeError("Another ai-trading instance is already running.") from e
         atexit.register(self._cleanup)
         signal.signal(signal.SIGTERM, self._sigexit)
         signal.signal(signal.SIGINT, self._sigexit)

--- a/tests/test_cli_dry_run.py
+++ b/tests/test_cli_dry_run.py
@@ -1,0 +1,14 @@
+import subprocess, sys, os
+
+
+def test_cli_dry_run_exits_zero_and_marks_indicator():
+    env = dict(os.environ)
+    # Ensure clean behavior regardless of absent .env
+    env.setdefault("PYTHONFAULTHANDLER", "1")
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    # Do not require network or heavy stacks in dry-run
+    r = subprocess.run([sys.executable, "-m", "ai_trading", "--dry-run"],
+                       env=env, capture_output=True, text=True)
+    assert r.returncode == 0, f"non-zero exit: {r.returncode}\nSTDERR:\n{r.stderr}"
+    combined = (r.stdout or "") + (r.stderr or "")
+    assert "INDICATOR_IMPORT_OK" in combined, "missing INDICATOR_IMPORT_OK banner"

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -1,0 +1,13 @@
+import subprocess, sys, os
+
+
+def test_empty_interval_is_handled_gracefully():
+    # Simulate the bad case: env var defined but empty
+    env = dict(os.environ)
+    env["AI_TRADING_INTERVAL"] = ""
+    env.setdefault("PYTHONFAULTHANDLER", "1")
+    r = subprocess.run([sys.executable, "-m", "ai_trading", "--dry-run"],
+                       env=env, capture_output=True, text=True)
+    # We allow either a clean exit or a handled error, but not an unhandled traceback
+    combined = (r.stdout or "") + (r.stderr or "")
+    assert "Traceback" not in combined, f"Unhandled exception:\n{combined}"

--- a/tests/test_import_side_effects.py
+++ b/tests/test_import_side_effects.py
@@ -1,0 +1,11 @@
+import runpy, sys
+
+
+def test_module_imports_without_heavy_stacks(monkeypatch):
+    heavy_roots = {"torch","gymnasium","pandas","pyarrow","sklearn","matplotlib"}
+    before = set(sys.modules)
+    # Running the module main should not pull heavy deps implicitly
+    runpy.run_module("ai_trading", run_name="__main__")
+    after = set(sys.modules)
+    loaded = {m.split('.')[0] for m in (after - before)}
+    assert heavy_roots.isdisjoint(loaded), f"Heavy modules imported at startup: {heavy_roots & loaded}"

--- a/tests/test_process_manager_singleton.py
+++ b/tests/test_process_manager_singleton.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from ai_trading.process_manager import ProcessManager
 
 
@@ -10,6 +11,7 @@ def test_process_manager_single_instance(tmp_path, monkeypatch):
     pm1 = ProcessManager(lock_name="unit", dir_env="TEST_RUNTIME_DIR")
     assert pm1.ensure_single_instance() is True
     pm2 = ProcessManager(lock_name="unit", dir_env="TEST_RUNTIME_DIR")
-    assert pm2.ensure_single_instance() is False
+    with pytest.raises(RuntimeError):
+        pm2.ensure_single_instance()
     pm1._cleanup()
 

--- a/tests/test_single_instance_lock.py
+++ b/tests/test_single_instance_lock.py
@@ -1,0 +1,17 @@
+import os, tempfile, pytest
+
+
+@pytest.mark.parametrize("envvar", ["AI_TRADING_RUNTIME_DIR"])
+def test_single_instance_lock_no_sys_exit(monkeypatch, envvar):
+    # Use a temp runtime dir; no reliance on /tmp state
+    d = tempfile.mkdtemp(prefix="ai-trading-test-")
+    monkeypatch.setenv(envvar, d)
+    from ai_trading.process_manager import ProcessManager
+
+    pm1 = ProcessManager()
+    assert pm1.ensure_single_instance(), "first lock acquire failed"
+
+    pm2 = ProcessManager()
+    with pytest.raises(Exception):
+        # Second acquire should raise/log (not hard-exit) if code was patched accordingly
+        pm2.ensure_single_instance()

--- a/tools/selftest.sh
+++ b/tools/selftest.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export PYTHONFAULTHANDLER=1
+export PYTHONUNBUFFERED=1
+export PYTHONHASHSEED=0
+export PYTHONDONTWRITEBYTECODE=1
+
+echo "== Import smoke =="
+python -X dev -c "import ai_trading; print('IMPORT_OK')"
+
+echo "== CLI dry-run =="
+python -m ai_trading --dry-run || { echo 'dry-run failed'; exit 1; }
+
+echo "== Runner one-cycle =="
+python -m ai_trading.runner -n 1 -i 0 || { echo 'runner -n1 failed'; exit 1; }
+
+echo "== Heavy import check =="
+python - <<'PY'
+import importlib, sys
+heavy={"torch","gymnasium","pandas","pyarrow","sklearn","matplotlib"}
+before=set(sys.modules)
+importlib.import_module('ai_trading.core.bot_engine')
+after=set(sys.modules)
+loaded=sorted(m for m in (after-before) if m.split('.')[0] in heavy)
+print("HEAVY_LOADED_DURING_IMPORT:", loaded)
+assert not loaded, f"Heavy stacks imported at import-time: {loaded}"
+print("HEAVY_IMPORT_OK")
+PY
+
+echo "== Ruff (core) =="
+if command -v ruff >/dev/null 2>&1; then
+  ruff check ai_trading/main.py ai_trading/core/bot_engine.py ai_trading/runner.py ai_trading/process_manager.py || true
+else
+  echo "ruff not installed; skipping lint"
+fi
+
+echo "== Selftest OK =="


### PR DESCRIPTION
## Summary
- add lightweight runtime smoke tests for CLI, imports, lock, and env edge cases
- introduce tools/selftest.sh for local smoke including ruff lint and heavy import check
- wire new selftest and targeted pytest cases into `make smoke`
- raise on lock contention and simplify single-instance check in bot_engine

## Testing
- `ruff check ai_trading/main.py ai_trading/core/bot_engine.py ai_trading/runner.py ai_trading/process_manager.py`
- `pytest -q tests/test_cli_dry_run.py::test_cli_dry_run_exits_zero_and_marks_indicator tests/test_import_side_effects.py::test_module_imports_without_heavy_stacks tests/test_single_instance_lock.py::test_single_instance_lock_no_sys_exit tests/test_env_validation.py::test_empty_interval_is_handled_gracefully` *(fails: missing INDICATOR_IMPORT_OK banner)*
- `make smoke` *(fails: selftest heavy import check)*


------
https://chatgpt.com/codex/tasks/task_e_68adde9f8c2083308db2035a2c8122d6