### PR TITLE
Ensure single data fetcher and model load

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5611,7 +5611,8 @@ class LazyBotContext:
         self._context.execution_engine = _exec_engine
         data_fetcher = fetcher
         # One-time, mandatory model load
-        self._context.model = _load_required_model()
+        if getattr(self._context, "model", None) is None:
+            self._context.model = _load_required_model()
 
         # Propagate the capital_scaler to the risk engine so that position_size
         self._context.risk_engine.capital_scaler = self._context.capital_scaler

--- a/tests/data_fetcher/test_build_fetcher.py
+++ b/tests/data_fetcher/test_build_fetcher.py
@@ -63,6 +63,21 @@ def test_build_fetcher_fallback(monkeypatch):
     assert getattr(fetcher, "source") == "fallback"
 
 
+def test_build_fetcher_singleton(monkeypatch, caplog):
+    """Repeated calls should reuse a single DataFetcher instance."""
+    df._FETCHER_SINGLETON = None
+    alpaca_stub.ALPACA_AVAILABLE = False
+    monkeypatch.delenv("APCA_API_KEY_ID", raising=False)
+    monkeypatch.delenv("APCA_API_SECRET_KEY", raising=False)
+    monkeypatch.setitem(sys.modules, "yfinance", None)
+    caplog.set_level("INFO")
+    first = df.build_fetcher({})
+    second = df.build_fetcher({})
+    assert first is second
+    msgs = [r.getMessage() for r in caplog.records if r.getMessage().startswith("DATA_FETCHER_BUILD")]
+    assert len(msgs) == 1
+
+
 def test_build_fetcher_raises_and_engine_skips(monkeypatch, caplog):
     alpaca_stub.ALPACA_AVAILABLE = False
     monkeypatch.delenv("APCA_API_KEY_ID", raising=False)

--- a/tests/test_context_singleton.py
+++ b/tests/test_context_singleton.py
@@ -1,0 +1,54 @@
+import importlib
+import types
+
+import pytest
+
+
+def test_lazy_context_model_loaded_once(monkeypatch):
+    be = importlib.reload(__import__('ai_trading.core.bot_engine', fromlist=['dummy']))
+    load_calls = {'count': 0}
+    def fake_load():
+        load_calls['count'] += 1
+        return object()
+    monkeypatch.setattr(be, '_load_required_model', fake_load)
+
+    build_calls = {'count': 0}
+    def fake_build_fetcher(params):
+        build_calls['count'] += 1
+        return object()
+    monkeypatch.setattr(be.data_fetcher_module, 'build_fetcher', fake_build_fetcher)
+
+    monkeypatch.setattr(be, '_init_metrics', lambda: None)
+    monkeypatch.setattr(be, '_initialize_alpaca_clients', lambda: None)
+    monkeypatch.setattr(be, 'ensure_alpaca_attached', lambda ctx: None)
+    monkeypatch.setattr(be, 'ExecutionEngine', lambda ctx: object())
+    monkeypatch.setattr(be, 'CapitalScalingEngine', lambda params: object())
+    monkeypatch.setattr(be, 'get_risk_engine', lambda: types.SimpleNamespace(capital_scaler=None))
+    monkeypatch.setattr(be, 'get_allocator', lambda: None)
+    monkeypatch.setattr(be, 'get_strategies', lambda: [])
+    monkeypatch.setattr(be, 'get_volume_threshold', lambda: 0)
+    monkeypatch.setattr(be, 'ENTRY_START_OFFSET', 0)
+    monkeypatch.setattr(be, 'ENTRY_END_OFFSET', 0)
+    monkeypatch.setattr(be, 'MARKET_OPEN', 0)
+    monkeypatch.setattr(be, 'MARKET_CLOSE', 0)
+    monkeypatch.setattr(be, 'REGIME_LOOKBACK', 0)
+    monkeypatch.setattr(be, 'REGIME_ATR_THRESHOLD', 0.0)
+    monkeypatch.setattr(be, 'get_daily_loss_limit', lambda: 0.0)
+    monkeypatch.setattr(be, 'DrawdownCircuitBreaker', None)
+    monkeypatch.setattr(be, 'CFG', types.SimpleNamespace(max_drawdown_threshold=0))
+    monkeypatch.setattr(be, 'get_trade_logger', lambda: None)
+    monkeypatch.setattr(be, 'Semaphore', lambda n: object())
+    monkeypatch.setattr(be, 'BotContext', types.SimpleNamespace)
+    monkeypatch.setattr(be, 'params', {})
+    monkeypatch.setattr(be, 'trading_client', object())
+    monkeypatch.setattr(be, 'data_client', object())
+    monkeypatch.setattr(be, 'signal_manager', object())
+    monkeypatch.setattr(be, 'stream', None)
+    monkeypatch.setenv('PYTEST_RUNNING', '1')
+
+    wrapper = be.LazyBotContext()
+    wrapper._ensure_initialized()
+    wrapper._ensure_initialized()
+
+    assert build_calls['count'] == 1
+    assert load_calls['count'] == 1


### PR DESCRIPTION
## Summary
- add singleton cache to data fetcher so build executes once per process
- guard model loading in LazyBotContext to avoid redundant reloads
- test that data fetcher and model load run only once across cycles

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adee4534008330bc1c5559005684fc