### PR TITLE
Guard trading loops when Alpaca client missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file.
 - Fix IndentationError in `bot_engine.py` (pybreaker stub); add static compile guard.
 - **Runtime safety**: improved Alpaca availability checks, stable logging shutdown,
   lazy client init, config parity, and added utility/environment helpers.
+- **Alpaca client**: log initialization failures, skip account logic when client
+  unavailable, and abort trading loop if API remains unset.
 - **ExecutionEngine**: Removed unsupported slippage metrics kwargs from initialization to prevent runtime `TypeError`.
 - **Import Blocker**: Replaced corrupted `ai_trading/model_registry.py` with clean, minimal, typed model registry implementation
 - Removed hard `data_client` dependency in risk engine with optional Alpaca client.

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -149,29 +149,37 @@ data_client = None
 # -- New helper: ensure context has an attached Alpaca client -----------------
 def ensure_alpaca_attached(ctx) -> None:
     """Attach global trading client to the context if it's missing."""
+    if getattr(ctx, "api", None) is not None:
+        return
     try:
-        if getattr(ctx, "api", None) is not None:
-            return
         _initialize_alpaca_clients()
-        global trading_client
-        if trading_client is None:
-            return
-        if hasattr(ctx, "_ensure_initialized"):
+    except COMMON_EXC as e:  # AI-AGENT-REF: surface init failure
+        logger_once.error(
+            "ALPACA_CLIENT_INIT_FAILED - %s",
+            e,
+            key="alpaca_client_init_failed",
+        )
+        return
+    global trading_client
+    if trading_client is None:
+        logger_once.error(
+            "ALPACA_CLIENT_MISSING after initialization", key="alpaca_client_missing"
+        )
+        return
+    if hasattr(ctx, "_ensure_initialized"):
+        try:
+            ctx._ensure_initialized()  # type: ignore[attr-defined]
+        except COMMON_EXC:
+            pass
+    try:
+        setattr(ctx, "api", trading_client)
+    except COMMON_EXC:
+        inner = getattr(ctx, "_context", None)
+        if inner is not None and getattr(inner, "api", None) is None:
             try:
-                ctx._ensure_initialized()  # type: ignore[attr-defined]
+                setattr(inner, "api", trading_client)
             except COMMON_EXC:
                 pass
-        try:
-            setattr(ctx, "api", trading_client)
-        except COMMON_EXC:
-            inner = getattr(ctx, "_context", None)
-            if inner is not None and getattr(inner, "api", None) is None:
-                try:
-                    setattr(inner, "api", trading_client)
-                except COMMON_EXC:
-                    pass
-    except COMMON_EXC:
-        pass
 
 # Sentiment knobs used by tests
 SENTIMENT_FAILURE_THRESHOLD: int = 25
@@ -3422,7 +3430,7 @@ def safe_alpaca_get_account(ctx: BotContext) -> object | None:
     ensure_alpaca_attached(ctx)
     if ctx.api is None:
         # Log once per process to avoid per-cycle noise when creds are missing
-        logger_once.info(
+        logger_once.error(
             "ctx.api is None - Alpaca trading client unavailable",
             key="alpaca_unavailable",
         )  # AI-AGENT-REF: unify key to dedupe across call sites
@@ -5472,25 +5480,16 @@ def _initialize_alpaca_clients():
         from alpaca_trade_api import REST as AlpacaREST
 
         logger.debug("Successfully imported Alpaca SDK class")
-    except (
-        FileNotFoundError,
-        PermissionError,
-        IsADirectoryError,
-        JSONDecodeError,
-        ValueError,
-        KeyError,
-        TypeError,
-        OSError,
-    ) as e:
+    except COMMON_EXC as e:
         logger.error(
-            "alpaca_trade_api import failed; cannot initialize clients", exc_info=e
+            "ALPACA_CLIENT_IMPORT_FAILED", extra={"error": str(e)}
         )
-        if os.getenv("PYTEST_RUNNING") or os.getenv("TESTING"):
-            logger.info(
-                "Test environment detected, skipping Alpaca client initialization",
-            )
-            return
-        raise
+        logger_once.error(
+            "ALPACA_CLIENT_INIT_FAILED - import", key="alpaca_client_init_failed"
+        )
+        trading_client = None
+        data_client = None
+        return
     trading_client = AlpacaREST(
         key_id=key,
         secret_key=secret,
@@ -12597,6 +12596,13 @@ def run_all_trades_worker(state: BotState, runtime) -> None:
         if not is_market_open():
             logger.info("MARKET_CLOSED_NO_FETCH")
             return  # FIXED: skip work when market closed
+        ensure_alpaca_attached(runtime)
+        if getattr(runtime, "api", None) is None:
+            logger_once.error(
+                "ALPACA_CLIENT_MISSING - entering paper mode", key="alpaca_client_missing"
+            )
+            _send_heartbeat()
+            return
         state.pdt_blocked = check_pdt_rule(runtime)
         if state.pdt_blocked:
             return

--- a/tests/test_broker_unavailable_paths.py
+++ b/tests/test_broker_unavailable_paths.py
@@ -1,7 +1,9 @@
 import logging
 from types import SimpleNamespace
 
+from ai_trading.core import bot_engine
 from ai_trading.core.bot_engine import check_pdt_rule, safe_alpaca_get_account
+from ai_trading.logging import logger_once
 
 
 def test_safe_account_none():
@@ -18,3 +20,25 @@ def test_pdt_rule_skips_without_false_fail(caplog):
     msgs = [r.getMessage() for r in caplog.records]
     assert any("PDT" in m and "PPED" in m for m in msgs)
     assert not any("PDT_CHECK_FAILED" in m for m in msgs)
+
+
+def test_run_all_trades_aborts_without_api(monkeypatch, caplog):
+    """run_all_trades_worker should abort early when Alpaca client missing."""
+    logger_once._emitted_keys.clear()
+    state = bot_engine.BotState()
+    runtime = bot_engine.get_ctx()
+    runtime.api = None
+    monkeypatch.setenv("SHADOW_MODE", "true")
+    monkeypatch.setattr(bot_engine, "is_market_open", lambda: True)
+    monkeypatch.setattr(bot_engine, "_ensure_alpaca_classes", lambda: None)
+    monkeypatch.setattr(bot_engine, "_ALPACA_IMPORT_ERROR", None)
+    heartbeat = {}
+    monkeypatch.setattr(bot_engine, "_send_heartbeat", lambda: heartbeat.setdefault("called", True))
+    def fail(*a, **k):
+        raise AssertionError("PDT should not be called")
+    monkeypatch.setattr(bot_engine, "check_pdt_rule", fail)
+    with caplog.at_level("ERROR"):
+        bot_engine.run_all_trades_worker(state, runtime)
+    assert heartbeat.get("called")
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("ALPACA_CLIENT_MISSING" in m for m in msgs)


### PR DESCRIPTION
## Summary
- surface errors when Alpaca client cannot be built and avoid account-dependent logic
- abort trading loop with heartbeat when Alpaca API stays unset
- test early abort path and document improved Alpaca client handling

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/test_broker_unavailable_paths.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_broker_unavailable_paths.py tests/test_alpaca_init_contract.py -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*


------
https://chatgpt.com/codex/tasks/task_e_68adee44023c83309250dbaae45326ea