### PR TITLE
Gate config load log to fire only on init

### DIFF
--- a/tests/test_config_logging.py
+++ b/tests/test_config_logging.py
@@ -1,0 +1,23 @@
+import importlib
+import logging
+
+import ai_trading.core.bot_engine as bot_engine
+
+
+def test_config_loaded_logs_once_and_on_reload(caplog):
+    """Config load log fires once and repeats after reload."""
+    with caplog.at_level(logging.INFO):
+        importlib.reload(bot_engine)
+    assert caplog.text.count("Config settings loaded, validation deferred to runtime") == 1
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        bot_engine.BotMode()
+        bot_engine.BotMode()
+    assert "Config settings loaded, validation deferred to runtime" not in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        bot_engine._reload_env()
+        bot_engine.BotMode()
+    assert caplog.text.count("Config settings loaded, validation deferred to runtime") == 1


### PR DESCRIPTION
## Summary
- Gate configuration load log with a flag so it fires only once per initialization and resets after environment reload.
- Replace BotMode init log with guarded call and expose `_reload_env` helper to reset the guard.
- Add regression test ensuring config load log appears once and again after reload.

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails to install package for Python 3.12; limited tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68adf111ea608330a11ed56440fcdbe4