### PR TITLE
Cache ML model load for bot engine

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -560,8 +560,15 @@ def _sha256_file(path: str) -> str:
     return h.hexdigest()[:12]
 
 
+_MODEL_CACHE: Any | None = None
+
+
 def _load_required_model() -> Any:
     """Load ML model from path or module; fail fast if missing."""  # AI-AGENT-REF: strict model loader
+    global _MODEL_CACHE
+    if _MODEL_CACHE is not None:
+        return _MODEL_CACHE
+
     path = os.getenv("AI_TRADER_MODEL_PATH")
     modname = os.getenv("AI_TRADER_MODEL_MODULE")
 
@@ -572,6 +579,7 @@ def _load_required_model() -> Any:
         except OSError:  # hashing is best-effort; missing/perm issues shouldn't crash
             digest = "unknown"
         logger.info("MODEL_LOADED", extra={"source": "file", "path": path, "sha": digest})
+        _MODEL_CACHE = mdl
         return mdl
 
     if modname:
@@ -594,6 +602,7 @@ def _load_required_model() -> Any:
                 "model_module": modname,
             },  # AI-AGENT-REF: avoid reserved key
         )
+        _MODEL_CACHE = mdl
         return mdl
 
     msg = (
@@ -5611,7 +5620,10 @@ class LazyBotContext:
         data_fetcher = fetcher
         # One-time, mandatory model load
         if getattr(self._context, "model", None) is None:
-            self._context.model = _load_required_model()
+            if _MODEL_CACHE is None:
+                self._context.model = _load_required_model()
+            else:
+                self._context.model = _MODEL_CACHE
 
         # Propagate the capital_scaler to the risk engine so that position_size
         self._context.risk_engine.capital_scaler = self._context.capital_scaler

--- a/tests/test_context_singleton.py
+++ b/tests/test_context_singleton.py
@@ -52,3 +52,56 @@ def test_lazy_context_model_loaded_once(monkeypatch):
 
     assert build_calls['count'] == 1
     assert load_calls['count'] == 1
+
+
+def test_model_loaded_once_across_wrappers(monkeypatch):
+    be = importlib.reload(__import__('ai_trading.core.bot_engine', fromlist=['dummy']))
+    calls = {'count': 0}
+    orig_load = be._load_required_model
+
+    def spy_load():
+        calls['count'] += 1
+        return orig_load()
+
+    monkeypatch.setattr(be, '_load_required_model', spy_load)
+
+    mod = types.ModuleType('fake_mod')
+    mod.get_model = lambda: object()
+    import sys
+    sys.modules['fake_mod'] = mod
+    monkeypatch.setenv('AI_TRADER_MODEL_MODULE', 'fake_mod')
+    monkeypatch.delenv('AI_TRADER_MODEL_PATH', raising=False)
+
+    for name in ['_init_metrics', '_initialize_alpaca_clients']:
+        monkeypatch.setattr(be, name, lambda: None)
+    monkeypatch.setattr(be.data_fetcher_module, 'build_fetcher', lambda params: object())
+    monkeypatch.setattr(be, 'ensure_alpaca_attached', lambda ctx: None)
+    monkeypatch.setattr(be, 'ExecutionEngine', lambda ctx: object())
+    monkeypatch.setattr(be, 'CapitalScalingEngine', lambda params: object())
+    monkeypatch.setattr(be, 'get_risk_engine', lambda: types.SimpleNamespace(capital_scaler=None))
+    monkeypatch.setattr(be, 'get_allocator', lambda: None)
+    monkeypatch.setattr(be, 'get_strategies', lambda: [])
+    monkeypatch.setattr(be, 'get_volume_threshold', lambda: 0)
+    monkeypatch.setattr(be, 'ENTRY_START_OFFSET', 0)
+    monkeypatch.setattr(be, 'ENTRY_END_OFFSET', 0)
+    monkeypatch.setattr(be, 'MARKET_OPEN', 0)
+    monkeypatch.setattr(be, 'MARKET_CLOSE', 0)
+    monkeypatch.setattr(be, 'REGIME_LOOKBACK', 0)
+    monkeypatch.setattr(be, 'REGIME_ATR_THRESHOLD', 0.0)
+    monkeypatch.setattr(be, 'get_daily_loss_limit', lambda: 0.0)
+    monkeypatch.setattr(be, 'DrawdownCircuitBreaker', None)
+    monkeypatch.setattr(be, 'CFG', types.SimpleNamespace(max_drawdown_threshold=0))
+    monkeypatch.setattr(be, 'get_trade_logger', lambda: None)
+    monkeypatch.setattr(be, 'Semaphore', lambda n: object())
+    monkeypatch.setattr(be, 'BotContext', types.SimpleNamespace)
+    monkeypatch.setattr(be, 'params', {})
+    monkeypatch.setattr(be, 'trading_client', object())
+    monkeypatch.setattr(be, 'data_client', object())
+    monkeypatch.setattr(be, 'signal_manager', object())
+    monkeypatch.setattr(be, 'stream', None)
+    monkeypatch.setenv('PYTEST_RUNNING', '1')
+
+    be.LazyBotContext()._ensure_initialized()
+    be.LazyBotContext()._ensure_initialized()
+
+    assert calls['count'] == 1

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -1,36 +1,59 @@
+import importlib
+import sys
 import types
 
 import joblib
-from ai_trading.core.bot_engine import _load_required_model
+import pytest
+
+
+def reload_bot_engine():
+    return importlib.reload(__import__('ai_trading.core.bot_engine', fromlist=['dummy']))
 
 
 def test_load_model_from_path(monkeypatch, tmp_path):
+    be = reload_bot_engine()
     mpath = tmp_path / "m.pkl"
     joblib.dump({"ok": True}, mpath)
     monkeypatch.setenv("AI_TRADER_MODEL_PATH", str(mpath))
     monkeypatch.delenv("AI_TRADER_MODEL_MODULE", raising=False)
-    mdl = _load_required_model()
+    mdl = be._load_required_model()
     assert isinstance(mdl, dict) and mdl["ok"] is True
 
 
 def test_load_model_from_module(monkeypatch, tmp_path):
+    be = reload_bot_engine()
     mod = types.ModuleType("fake_model_mod")
-    class Dummy: pass
+    class Dummy:
+        pass
     mod.get_model = lambda: Dummy()
-    import sys
     sys.modules["fake_model_mod"] = mod
     monkeypatch.delenv("AI_TRADER_MODEL_PATH", raising=False)
     monkeypatch.setenv("AI_TRADER_MODEL_MODULE", "fake_model_mod")
-    mdl = _load_required_model()
+    mdl = be._load_required_model()
     assert isinstance(mdl, Dummy)
 
 
 def test_model_missing_raises(monkeypatch):
+    be = reload_bot_engine()
     monkeypatch.delenv("AI_TRADER_MODEL_PATH", raising=False)
     monkeypatch.delenv("AI_TRADER_MODEL_MODULE", raising=False)
-    try:
-        _ = _load_required_model()
-    except RuntimeError as e:
-        assert "Model required but not configured" in str(e)
-    else:
-        assert False, "Expected RuntimeError"
+    with pytest.raises(RuntimeError, match="Model required but not configured"):
+        be._load_required_model()
+
+
+def test_model_loaded_once(monkeypatch):
+    be = reload_bot_engine()
+    calls = {"count": 0}
+    def factory():
+        calls["count"] += 1
+        return object()
+    mod = types.ModuleType("fake_model_once")
+    mod.get_model = factory
+    sys.modules["fake_model_once"] = mod
+    monkeypatch.delenv("AI_TRADER_MODEL_PATH", raising=False)
+    monkeypatch.setenv("AI_TRADER_MODEL_MODULE", "fake_model_once")
+    mdl1 = be._load_required_model()
+    mdl2 = be._load_required_model()
+    assert mdl1 is mdl2
+    assert calls["count"] == 1
+


### PR DESCRIPTION
## Summary
- Cache ML model in `bot_engine` to avoid repeated imports
- Initialize engine context from cached model
- Add tests ensuring one-time model load and caching

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf110fcc88330b14763d851ca5ce5