### PR TITLE
Improve Alpaca client init logging

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5462,7 +5462,18 @@ def _initialize_alpaca_clients():
     if trading_client is not None:
         return  # Already initialized
     # Validate at runtime, now that .env should be present
-    key, secret, base_url = _ensure_alpaca_env_or_raise()
+    try:
+        key, secret, base_url = _ensure_alpaca_env_or_raise()
+    except Exception as e:  # AI-AGENT-REF: surface env resolution failures
+        logger.error(
+            "ALPACA_ENV_RESOLUTION_FAILED", extra={"error": str(e)}
+        )
+        logger_once.error(
+            "ALPACA_CLIENT_INIT_FAILED - env", key="alpaca_client_init_failed"
+        )
+        trading_client = None
+        data_client = None
+        raise
     if not (key and secret):
         # In SHADOW_MODE we may not have creds; skip client init
         diag = _alpaca_diag_info()
@@ -5490,13 +5501,26 @@ def _initialize_alpaca_clients():
         trading_client = None
         data_client = None
         return
-    trading_client = AlpacaREST(
-        key_id=key,
-        secret_key=secret,
-        base_url=base_url,
-    )
+    try:
+        trading_client = AlpacaREST(
+            key_id=key,
+            secret_key=secret,
+            base_url=base_url,
+        )
+    except Exception as e:  # AI-AGENT-REF: expose network or auth issues
+        logger.error(
+            "ALPACA_CLIENT_INIT_FAILED", extra={"error": str(e)}
+        )
+        logger_once.error(
+            "ALPACA_CLIENT_INIT_FAILED - client", key="alpaca_client_init_failed"
+        )
+        trading_client = None
+        data_client = None
+        return
     data_client = trading_client
-    logger.info("ALPACA_DIAG", extra=_redact({"initialized": True, **_alpaca_diag_info()}))
+    logger.info(
+        "ALPACA_DIAG", extra=_redact({"initialized": True, **_alpaca_diag_info()})
+    )
     stream = None  # initialize stream lazily elsewhere if/when required
 
 


### PR DESCRIPTION
## Summary
- add detailed error logging and network failure handling when initializing Alpaca clients
- add regression test ensuring context gets Alpaca API client when credentials are present

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_init_contract.py::test_ctx_api_attached_after_initialization -q` *(skipped: could not import 'ai_trading.core.bot_engine': No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_68adf10ffe8c8330ac617951655dae03