### PR TITLE
Handle missing ML model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1366,6 +1366,16 @@ Set exactly one of:
 Service example:
 Environment="AI_TRADER_MODEL_PATH=/home/aiuser/ai-trading-bot/trained_model.pkl"
 
+`trained_model.pkl` is expected at the project root when using
+`AI_TRADER_MODEL_PATH`. Generate it via the training workflow, for example:
+
+```bash
+python -m ai_trading.training.train_ml
+```
+
+If the file is absent, the bot logs `ML_MODEL_MISSING` and falls back to the
+baseline model (`USE_ML=False`).
+
 ### Universe CSV
 - Optional: `AI_TRADER_TICKERS_CSV=/abs/path/to/tickers.csv`
 - Default: packaged `ai_trading/data/tickers.csv` (S&P-100)

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -2376,11 +2376,14 @@ def abspath(fname: str) -> str:
 
 # AI-AGENT-REF: safe ML model path resolution
 MODEL_PATH = abspath_safe(getattr(S, "model_path", None))
-if not MODEL_PATH:
+if not MODEL_PATH or not os.path.exists(MODEL_PATH):
     logger.warning(
-        "ML_MODEL_MISSING", extra={"path": os.path.join(BASE_DIR, "trained_model.pkl")}
+        "ML_MODEL_MISSING",
+        extra={"path": MODEL_PATH or os.path.join(BASE_DIR, "trained_model.pkl")},
     )
-USE_ML = bool(MODEL_PATH)
+    USE_ML = False
+else:
+    USE_ML = True
 
 info_kv(
     logger,

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -57,3 +57,13 @@ def test_model_loaded_once(monkeypatch):
     assert mdl1 is mdl2
     assert calls["count"] == 1
 
+
+def test_missing_model_file_fallback(monkeypatch, tmp_path, caplog):
+    missing = tmp_path / "no_model.pkl"
+    monkeypatch.setenv("AI_TRADER_MODEL_PATH", str(missing))
+    monkeypatch.delenv("AI_TRADER_MODEL_MODULE", raising=False)
+    caplog.set_level("WARNING")
+    be = reload_bot_engine()
+    assert be.USE_ML is False
+    assert "ML_MODEL_MISSING" in caplog.text
+


### PR DESCRIPTION
## Summary
- check for missing `trained_model.pkl` and disable ML fallback
- document model file expectations
- add test covering missing model scenario

## Testing
- `python -m pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf7b25ca88330a972c8dc8853ab24