### PR TITLE
Ensure dollar risk limit uses config as single source

### DIFF
--- a/ai_trading/runner.py
+++ b/ai_trading/runner.py
@@ -164,7 +164,17 @@ def run_cycle() -> None:
         # Build a proper runtime with guaranteed parameter hydration
         cfg = TradingConfig.from_env()  # Load config from environment
         runtime = build_runtime(cfg)
-        
+
+        # Ensure runtime params use TradingConfig as single source of truth
+        cfg_risk = getattr(cfg, "dollar_risk_limit", None)
+        rt_risk = runtime.params.get("DOLLAR_RISK_LIMIT")
+        if cfg_risk != rt_risk:
+            log.warning(
+                "DOLLAR_RISK_LIMIT_MISMATCH",
+                extra={"config_value": cfg_risk, "runtime_value": rt_risk},
+            )
+            runtime.params["DOLLAR_RISK_LIMIT"] = cfg_risk
+
         # One-time validation & log as specified in problem statement
         missing = [k for k in REQUIRED_PARAM_DEFAULTS if k not in runtime.params]
         if missing:

--- a/tests/test_runner_dollar_risk_limit.py
+++ b/tests/test_runner_dollar_risk_limit.py
@@ -1,0 +1,46 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_runner_prefers_config_for_dollar_risk_limit(monkeypatch):
+    """Environment override should propagate to runtime.params."""
+    monkeypatch.setenv("DOLLAR_RISK_LIMIT", "0.2")
+
+    from ai_trading.core import runtime as runtime_mod
+
+    orig_build = runtime_mod.build_runtime
+
+    def fake_build(cfg):
+        rt = orig_build(cfg)
+        rt.params["DOLLAR_RISK_LIMIT"] = 0.05
+        return rt
+
+    monkeypatch.setattr(runtime_mod, "build_runtime", fake_build)
+
+    from ai_trading import runner
+
+    captured = {}
+    def worker(state, runtime):
+        captured["runtime"] = runtime
+
+    class DummyState:
+        pass
+
+    monkeypatch.setattr(runner, "_load_engine", lambda: (worker, DummyState))
+    dummy_bot_engine = SimpleNamespace(
+        get_ctx=lambda: SimpleNamespace(),
+        _maybe_warm_cache=lambda ctx: None,
+    )
+    monkeypatch.setitem(sys.modules, "ai_trading.core.bot_engine", dummy_bot_engine)
+    monkeypatch.setitem(sys.modules, "ai_trading.data_fetcher", SimpleNamespace(DataFetchError=Exception))
+    monkeypatch.setattr("ai_trading.core.runtime.enhance_runtime_with_context", lambda rt, ctx: rt)
+
+    warnings = []
+    monkeypatch.setattr(runner.log, "warning", lambda msg, *a, **k: warnings.append(msg))
+
+    runner.run_cycle()
+
+    assert captured["runtime"].params["DOLLAR_RISK_LIMIT"] == pytest.approx(0.2)
+    assert "DOLLAR_RISK_LIMIT_MISMATCH" in warnings


### PR DESCRIPTION
## Summary
- warn and resolve mismatched `DOLLAR_RISK_LIMIT` between `TradingConfig` and runtime params
- test that environment overrides hydrate runtime params via `TradingConfig`

## Testing
- `ruff check ai_trading/runner.py tests/test_runner_dollar_risk_limit.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf7b184ec8330be4b58e3c7fb5d97