### PR TITLE
Log Alpaca client attachment failures and add tests

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -180,6 +180,10 @@ def ensure_alpaca_attached(ctx) -> None:
                 setattr(inner, "api", trading_client)
             except COMMON_EXC:
                 pass
+    if getattr(ctx, "api", None) is None:
+        logger_once.error(
+            "FAILED_TO_ATTACH_ALPACA_CLIENT", key="alpaca_attach_failed"
+        )
 
 # Sentiment knobs used by tests
 SENTIMENT_FAILURE_THRESHOLD: int = 25

--- a/tests/test_alpaca_init_contract.py
+++ b/tests/test_alpaca_init_contract.py
@@ -40,7 +40,9 @@ def test_initialize_skips_in_shadow_mode(monkeypatch):
     with mock.patch.object(eng, "logger") as mock_logger:
         eng._initialize_alpaca_clients()
         # Should have logged the skip message
-        mock_logger.info.assert_called_with("Shadow mode or missing credentials: skipping Alpaca client initialization")
+        mock_logger.info.assert_any_call(
+            "Shadow mode or missing credentials: skipping Alpaca client initialization"
+        )
         # Client should still be None
         assert eng.trading_client is None
 
@@ -82,4 +84,29 @@ def test_ctx_api_attached_after_initialization(monkeypatch):
 
     ctx = types.SimpleNamespace()
     eng.ensure_alpaca_attached(ctx)
+    assert getattr(ctx, "api", None) is not None
+
+
+def test_safe_get_account_attaches_client(monkeypatch):
+    """safe_alpaca_get_account attaches a client and returns an account."""
+    pytest.importorskip("alpaca_trade_api")
+    eng = pytest.importorskip("ai_trading.core.bot_engine")
+    monkeypatch.setenv("ALPACA_API_KEY", "key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
+    monkeypatch.setenv("ALPACA_BASE_URL", "https://example.com")
+    monkeypatch.setenv("PYTEST_RUNNING", "true")
+
+    class DummyREST:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_account(self):
+            return object()
+
+    monkeypatch.setattr("alpaca_trade_api.REST", DummyREST)
+    eng.trading_client = None
+
+    ctx = types.SimpleNamespace()
+    acct = eng.safe_alpaca_get_account(ctx)
+    assert acct is not None
     assert getattr(ctx, "api", None) is not None


### PR DESCRIPTION
## Summary
- log when `ensure_alpaca_attached` fails to set `ctx.api`
- test `safe_alpaca_get_account` attaches and returns client with valid credentials

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/test_alpaca_init_contract.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_init_contract.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68adf7b0b36883308656ec9d93495d1c