### PR TITLE
Harden Alpaca client initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,10 @@ python verify_config.py
   the bot derives a value from `CAPITAL_CAP` and available equity. Optionally
   set `MAX_POSITION_SIZE_PCT` to cap positions as a percentage of the portfolio.
 
+If any `ALPACA_*` credentials are missing or `alpaca-trade-api` is not installed,
+the bot now aborts startup with a clear error instead of running without broker
+connectivity.
+
 4. **Quick Self-Check**
   ```bash
   make self-check

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -159,12 +159,16 @@ def ensure_alpaca_attached(ctx) -> None:
             e,
             key="alpaca_client_init_failed",
         )
+        if not is_shadow_mode():
+            raise RuntimeError("Alpaca client initialization failed") from e
         return
     global trading_client
     if trading_client is None:
         logger_once.error(
             "ALPACA_CLIENT_MISSING after initialization", key="alpaca_client_missing"
         )
+        if not is_shadow_mode():
+            raise RuntimeError("Alpaca client missing after initialization")
         return
     if hasattr(ctx, "_ensure_initialized"):
         try:
@@ -184,6 +188,8 @@ def ensure_alpaca_attached(ctx) -> None:
         logger_once.error(
             "FAILED_TO_ATTACH_ALPACA_CLIENT", key="alpaca_attach_failed"
         )
+        if not is_shadow_mode():
+            raise RuntimeError("Failed to attach Alpaca client to context")
 
 # Sentiment knobs used by tests
 SENTIMENT_FAILURE_THRESHOLD: int = 25

--- a/tests/test_alpaca_init_contract.py
+++ b/tests/test_alpaca_init_contract.py
@@ -87,6 +87,23 @@ def test_ctx_api_attached_after_initialization(monkeypatch):
     assert getattr(ctx, "api", None) is not None
 
 
+def test_ensure_alpaca_attached_raises_without_creds(monkeypatch):
+    """ensure_alpaca_attached raises when clients cannot be initialized."""
+    monkeypatch.delenv("SHADOW_MODE", raising=False)
+    monkeypatch.setenv("PYTEST_RUNNING", "true")
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("APCA_API_KEY_ID", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+    monkeypatch.delenv("APCA_API_SECRET_KEY", raising=False)
+
+    import ai_trading.core.bot_engine as eng
+    eng.trading_client = None
+
+    ctx = types.SimpleNamespace()
+    with pytest.raises(RuntimeError):
+        eng.ensure_alpaca_attached(ctx)
+
+
 def test_safe_get_account_attaches_client(monkeypatch):
     """safe_alpaca_get_account attaches a client and returns an account."""
     pytest.importorskip("alpaca_trade_api")


### PR DESCRIPTION
## Summary
- raise explicit RuntimeErrors when Alpaca client init or attachment fails
- document startup abort on missing Alpaca credentials or SDK
- test ensure_alpaca_attached raises without credentials

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: pydantic)*


------
https://chatgpt.com/codex/tasks/task_e_68adfbf1c778833091ea34c2fcd1030d