### PR TITLE
Ensure data fetcher initializes at startup

### DIFF
--- a/tests/test_data_fetcher_missing.py
+++ b/tests/test_data_fetcher_missing.py
@@ -1,0 +1,33 @@
+import types
+import pytest
+
+from ai_trading.core import bot_engine as eng
+
+
+def test_ensure_data_fetcher_rebuilds(monkeypatch):
+    runtime = types.SimpleNamespace(data_fetcher=None, params={'a': 1})
+    sentinel = object()
+
+    def fake_build(params):
+        assert params == runtime.params
+        return sentinel
+
+    eng.data_fetcher = None
+    monkeypatch.setattr(eng.data_fetcher_module, 'build_fetcher', fake_build)
+    assert eng.ensure_data_fetcher(runtime) is sentinel
+    assert runtime.data_fetcher is sentinel
+    assert eng.data_fetcher is sentinel
+
+
+def test_ensure_data_fetcher_raises(monkeypatch):
+    runtime = types.SimpleNamespace(data_fetcher=None, params={})
+
+    def fake_build(params):
+        raise eng.DataFetchError('boom')
+
+    eng.data_fetcher = None
+    monkeypatch.setattr(eng.data_fetcher_module, 'build_fetcher', fake_build)
+    with pytest.raises(eng.DataFetchError):
+        eng.ensure_data_fetcher(runtime)
+    assert runtime.data_fetcher is None
+    assert eng.data_fetcher is None


### PR DESCRIPTION
## Summary
- add `ensure_data_fetcher` helper to rebuild missing market data fetcher and raise `DataFetchError` when reconstruction fails
- use the helper during runtime preparation to fail fast if market data dependencies are unavailable
- cover data fetcher reinitialization and failure paths with unit tests

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/test_data_fetcher_missing.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

## Rollback Plan
- Revert the commits if startup sequence fails or data fetcher regression occurs.

------
https://chatgpt.com/codex/tasks/task_e_68ae03a012708330898783c72a251af5