### PR TITLE
Ensure consistent dollar risk limit config

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -238,7 +238,7 @@ class TradingConfig:
         return cls(
             capital_cap=_get("CAPITAL_CAP", float),
             dollar_risk_limit=_get(
-                "DAILY_LOSS_LIMIT", float, aliases=("DOLLAR_RISK_LIMIT",)
+                "DOLLAR_RISK_LIMIT", float, aliases=("DAILY_LOSS_LIMIT",)
             ),
             max_position_size=_get("MAX_POSITION_SIZE", float),
             sector_exposure_cap=_get("SECTOR_EXPOSURE_CAP", float),

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -3101,8 +3101,22 @@ def _env_float(default: float, *keys: str) -> float:
 
 CAPITAL_CAP = _env_float(0.04, "AI_TRADING_CAPITAL_CAP", "get_capital_cap()")
 _cfg = TradingConfig.from_env()
-DOLLAR_RISK_LIMIT = (
-    _cfg.dollar_risk_limit if _cfg.dollar_risk_limit is not None else 0.05
+_settings_drl = get_dollar_risk_limit()
+DOLLAR_RISK_LIMIT = _settings_drl
+if _cfg.dollar_risk_limit is not None and _cfg.dollar_risk_limit != _settings_drl:
+    logger.debug(
+        "DOLLAR_RISK_LIMIT_OVERRIDE",
+        extra={
+            "settings": _settings_drl,
+            "trading_config": _cfg.dollar_risk_limit,
+        },
+    )
+    DOLLAR_RISK_LIMIT = _cfg.dollar_risk_limit
+_emit_once(
+    logger,
+    "dollar_risk_limit_resolved",
+    logging.DEBUG,
+    f"DOLLAR_RISK_LIMIT resolved to {DOLLAR_RISK_LIMIT:.3f}",
 )
 BUY_THRESHOLD = params.get(
     "get_buy_threshold()",

--- a/ai_trading/runner.py
+++ b/ai_trading/runner.py
@@ -166,12 +166,19 @@ def run_cycle() -> None:
         runtime = build_runtime(cfg)
 
         # Use TradingConfig as single source of truth for risk limit
-        risk_limit = (
-            cfg.dollar_risk_limit
-            if cfg.dollar_risk_limit is not None
-            else runtime.params.get("DOLLAR_RISK_LIMIT")
-        )
+        existing = runtime.params.get("DOLLAR_RISK_LIMIT")
+        if (
+            existing is not None
+            and cfg.dollar_risk_limit is not None
+            and existing != cfg.dollar_risk_limit
+        ):
+            log.debug(
+                "DOLLAR_RISK_LIMIT_OVERRIDE",
+                extra={"runtime": existing, "env": cfg.dollar_risk_limit},
+            )
+        risk_limit = cfg.dollar_risk_limit if cfg.dollar_risk_limit is not None else existing
         runtime.params["DOLLAR_RISK_LIMIT"] = risk_limit
+        log.debug("DOLLAR_RISK_LIMIT_RESOLVED", extra={"value": risk_limit})
 
         # One-time validation & log as specified in problem statement
         missing = [k for k in REQUIRED_PARAM_DEFAULTS if k not in runtime.params]


### PR DESCRIPTION
## Summary
- Prioritize `DOLLAR_RISK_LIMIT` env var in `TradingConfig.from_env`
- Align `bot_engine` and `runner` on a single risk limit value with debug logs for overrides

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae03a1fa808330b07076dd8764ec16