### PR TITLE
Add helper for plain Alpaca secret key

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -72,6 +72,7 @@ from ai_trading.config.management import (
     is_shadow_mode,
     TradingConfig,
 )
+from ai_trading.settings import get_alpaca_secret_key_plain
 
 
 def _alpaca_available() -> bool:
@@ -3738,9 +3739,8 @@ class DataFetcher:
                 return self._daily_cache[symbol]
 
         api_key = get_settings().alpaca_api_key
-        api_secret = (
-            get_settings().alpaca_secret_key_plain
-        )  # AI-AGENT-REF: use plain secret string
+        api_secret = get_alpaca_secret_key_plain()
+        # AI-AGENT-REF: use plain secret string
         if not api_key or not api_secret:
             logger.error(f"Missing Alpaca credentials for {symbol}")
             return None
@@ -4012,9 +4012,8 @@ class DataFetcher:
                 logger.exception("bot.py unexpected", exc_info=exc)
                 raise
         api_key = get_settings().alpaca_api_key
-        api_secret = (
-            get_settings().alpaca_secret_key_plain
-        )  # AI-AGENT-REF: use plain secret string
+        api_secret = get_alpaca_secret_key_plain()
+        # AI-AGENT-REF: use plain secret string
         if not api_key or not api_secret:
             raise RuntimeError(
                 "ALPACA_API_KEY and ALPACA_SECRET_KEY must be set for data fetching"
@@ -4262,9 +4261,8 @@ def prefetch_daily_data(
     symbols: list[str], start_date: date, end_date: date
 ) -> dict[str, pd.DataFrame]:
     alpaca_key = get_settings().alpaca_api_key
-    alpaca_secret = (
-        get_settings().alpaca_secret_key_plain
-    )  # AI-AGENT-REF: use plain secret string
+    alpaca_secret = get_alpaca_secret_key_plain()
+    # AI-AGENT-REF: use plain secret string
     if not alpaca_key or not alpaca_secret:
         raise RuntimeError(
             "ALPACA_API_KEY and ALPACA_SECRET_KEY must be set for data fetching"

--- a/ai_trading/position_sizing.py
+++ b/ai_trading/position_sizing.py
@@ -6,6 +6,7 @@ from typing import Any
 import os
 from ai_trading.logging import get_logger
 from ai_trading.net.http import get_global_session
+from ai_trading.settings import get_alpaca_secret_key_plain
 _log = get_logger(__name__)
 
 @dataclass
@@ -95,7 +96,7 @@ def _get_equity_from_alpaca(cfg) -> float:
         base = str(getattr(cfg, 'alpaca_base_url', '')).rstrip('/')
         url = f'{base}/v2/account'
         key = getattr(cfg, 'alpaca_api_key', None)
-        secret = getattr(cfg, 'alpaca_secret_key_plain', None)
+        secret = getattr(cfg, 'alpaca_secret_key_plain', None) or get_alpaca_secret_key_plain()
         if not key or not secret or (not base):
             return 0.0
         s = get_global_session()

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -23,6 +23,7 @@ from ai_trading.config.management import (
     validate_required_env,
 )
 from ai_trading.config.settings import get_settings
+from ai_trading.settings import get_alpaca_secret_key_plain
 
 if not hasattr(np, 'NaN'):
     np.NaN = np.nan
@@ -89,8 +90,9 @@ class RiskEngine:
         self.data_client = None
         try:
             s = get_settings()
-            if AlpacaREST and getattr(s, 'alpaca_api_key', None) and getattr(s, 'alpaca_secret_key_plain', None) and getattr(s, 'alpaca_base_url', None):
-                self.data_client = AlpacaREST(s.alpaca_api_key, s.alpaca_secret_key_plain, s.alpaca_base_url)
+            secret = get_alpaca_secret_key_plain()
+            if AlpacaREST and getattr(s, 'alpaca_api_key', None) and secret and getattr(s, 'alpaca_base_url', None):
+                self.data_client = AlpacaREST(s.alpaca_api_key, secret, s.alpaca_base_url)
         except (APIError, ValueError, TypeError, AttributeError, OSError) as e:
             logger.warning('Could not initialize AlpacaREST: %s', e)
         self._returns: list[float] = []

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -156,6 +156,12 @@ class Settings(BaseSettings):
 
     @computed_field
     @property
+    def alpaca_secret_key_plain(self) -> str | None:
+        """Return the Alpaca secret key as a plain string."""
+        return _secret_to_str(self.alpaca_secret_key)
+
+    @computed_field
+    @property
     def trade_cooldown(self) -> timedelta:
         return timedelta(minutes=_to_int(getattr(self, 'trade_cooldown_min', 15), 15))
     model_config = SettingsConfigDict(env_prefix='AI_TRADER_', extra='ignore', case_sensitive=False)


### PR DESCRIPTION
## Summary
- add computed field `alpaca_secret_key_plain` to settings
- refactor bot engine, risk engine, and position sizing to use `get_alpaca_secret_key_plain`
- avoid AttributeError when Alpaca credentials are accessed

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae05e0b2bc833099e7041be0c80449