### PR TITLE
Skip Finnhub fetch when disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,8 @@ FALLBACK_DATA_PROVIDER=yahoo
 
 # Finnhub API (optional, for enhanced data)
 FINNHUB_API_KEY=your_finnhub_api_key
+# Disable Finnhub integration if credentials missing
+ENABLE_FINNHUB=false
 
 # Data quality settings
 ENABLE_DATA_VALIDATION=true

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -112,6 +112,7 @@ def test_subscription_error_logged(monkeypatch, caplog):
         )
 
     monkeypatch.setattr(data_fetcher.fh_fetcher, "fetch", lambda *a, **k: fake_yf("AAPL"))
+    monkeypatch.setattr(data_fetcher.fh_fetcher, "is_stub", False)
 
     start = pd.Timestamp("2023-01-01", tz="UTC")
     end = pd.Timestamp("2023-01-02", tz="UTC")
@@ -170,6 +171,7 @@ def test_finnhub_403_yfinance(monkeypatch):
 
     monkeypatch.setattr(data_fetcher, "_fetch_bars", raise_fetch)
     monkeypatch.setattr(data_fetcher.fh_fetcher, "fetch", raise_finnhub)
+    monkeypatch.setattr(data_fetcher.fh_fetcher, "is_stub", False)
     monkeypatch.setattr(data_fetcher.yf, "download", fake_yf)
     monkeypatch.setattr(data_fetcher, "is_market_open", lambda: True)
 
@@ -190,6 +192,7 @@ def test_empty_bars_handled(monkeypatch):
         index=[start],
     )
     monkeypatch.setattr(data_fetcher.fh_fetcher, "fetch", lambda *a, **k: fallback)
+    monkeypatch.setattr(data_fetcher.fh_fetcher, "is_stub", False)
     monkeypatch.setattr(data_fetcher, "is_market_open", lambda: True)
 
     df = data_fetcher.get_minute_df("AAPL", start, end)

--- a/tests/test_data_fetcher_extended.py
+++ b/tests/test_data_fetcher_extended.py
@@ -68,6 +68,7 @@ def test_get_minute_df_missing_columns(monkeypatch):
     monkeypatch.setattr(data_fetcher, "is_market_open", lambda: True)
     monkeypatch.setattr(data_fetcher, "_fetch_bars", lambda *a, **k: df_bad)
     monkeypatch.setattr(data_fetcher.fh_fetcher, "fetch", lambda *a, **k: df_good)
+    monkeypatch.setattr(data_fetcher.fh_fetcher, "is_stub", False)
     data_fetcher._MINUTE_CACHE.clear()
     result = data_fetcher.get_minute_df(
         "AAPL", datetime.date(2024, 1, 1), datetime.date(2024, 1, 1)

--- a/tests/test_finnhub_disabled.py
+++ b/tests/test_finnhub_disabled.py
@@ -1,0 +1,21 @@
+import datetime as dt
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading import data_fetcher
+
+
+def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch):
+    monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
+    monkeypatch.setenv("ENABLE_FINNHUB", "0")
+
+    def fail_fetch(*args, **kwargs):  # pragma: no cover - should never be called
+        raise AssertionError("Finnhub fetch should be skipped")
+
+    monkeypatch.setattr(data_fetcher.fh_fetcher, "fetch", fail_fetch)
+    monkeypatch.setattr(data_fetcher, "_fetch_bars", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", lambda *a, **k: pd.DataFrame())
+
+    df = data_fetcher.get_minute_df("AAPL", dt.datetime(2023, 1, 1), dt.datetime(2023, 1, 2))
+    assert df.empty


### PR DESCRIPTION
## Summary
- allow disabling Finnhub via `ENABLE_FINNHUB` env var and skip stub fetcher
- document new flag
- add test ensuring `get_minute_df` returns an empty DataFrame when Finnhub is disabled

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_finnhub_disabled.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae07b7e6a08330b0b9fb58c7a6867c