### PR TITLE
Sanitize bar request timestamps

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -95,9 +95,9 @@ def _client_fetch_stock_bars(client: Any, request: StockBarsRequest):
         raise AttributeError("Alpaca client missing get_stock_bars/get_bars")
     params = {}
     if getattr(request, "start", None) is not None:
-        params["start"] = request.start
+        params["start"] = ensure_utc_datetime(request.start).isoformat()
     if getattr(request, "end", None) is not None:
-        params["end"] = request.end
+        params["end"] = ensure_utc_datetime(request.end).isoformat()
     if getattr(request, "limit", None) is not None:
         params["limit"] = request.limit
     if getattr(request, "feed", None) is not None:
@@ -114,6 +114,8 @@ def safe_get_stock_bars(client: Any, request: StockBarsRequest, symbol: str, con
     prev_open, _ = rth_session_utc(previous_trading_session(now.date()))
     end_dt = ensure_utc_datetime(getattr(request, 'end', None) or now, default=now, clamp_to='eod', allow_callables=False)
     start_dt = ensure_utc_datetime(getattr(request, 'start', None) or prev_open, default=prev_open, clamp_to='bod', allow_callables=False)
+    request.start = start_dt.isoformat()
+    request.end = end_dt.isoformat()
     try:
         try:
             response = _client_fetch_stock_bars(client, request)


### PR DESCRIPTION
## Summary
- sanitize `StockBarsRequest` `start`/`end` to RFC3339 timestamps in `safe_get_stock_bars`
- ensure `_client_fetch_stock_bars` converts request timestamps to RFC3339 when building Alpaca params
- cover timestamp sanitization in bar requests with unit tests

## Testing
- `ruff check ai_trading/data/bars.py tests/test_daily_bars_datetime_sanitization.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_daily_bars_datetime_sanitization.py tests/test_minute_fallback_none_safe.py tests/test_bars_timeframe_feed_canonicalization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae0b9f1ff083309a679f0cb714a647