### PR TITLE
feat: add data fetch logging and retry

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -36,6 +36,13 @@ Any `extra` fields such as API keys, secrets, or URLs are sanitized before
 being emitted to handlers, ensuring sensitive values are replaced with
 `***REDACTED***`.
 
+#### Data Fetch Diagnostics
+Daily price requests now log their parameters and outcome:
+
+- `DAILY_FETCH_REQUEST` records the symbol, timeframe, and date range
+- `DAILY_FETCH_RESULT` reports the number of rows returned and whether the
+  response came from cache
+
 ### Example Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- add retry with backoff and fallback defaults for SPY volatility stats
- instrument daily data fetches with request/response logging
- document new logging and update tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e5567ec83308189c0b02a369006