### PR TITLE
Improve empty DataFrame logging context

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -4773,7 +4773,10 @@ def _parse_local_positions() -> dict[str, int]:
             dtype=str,
         )
         if df.empty:
-            logger.info("Loaded DataFrame is empty after parsing/fallback")
+            logger.debug(
+                "Loaded DataFrame from %s is empty after parsing/fallback",
+                TRADE_LOG_FILE,
+            )
     except pd.errors.ParserError as e:
         get_logger(__name__).warning(
             "Failed to parse TRADE_LOG_FILE (malformed row): %s; returning empty set",
@@ -5187,7 +5190,10 @@ class SignalManager:
                 usecols=["signal_name", "weight"],
             )
             if df.empty:
-                logger.info("Loaded DataFrame is empty after parsing/fallback")
+                logger.warning(
+                    "Loaded DataFrame from %s is empty after parsing/fallback",
+                    SIGNAL_WEIGHTS_FILE,
+                )
                 return {}
             return {row["signal_name"]: row["weight"] for _, row in df.iterrows()}
         except ValueError as e:
@@ -6804,9 +6810,15 @@ def count_day_trades() -> int:
     )
     if df.empty:
         if _is_market_open_now():
-            logger.info("Loaded DataFrame is empty after parsing/fallback")
+            logger.debug(
+                "Loaded DataFrame from %s is empty after parsing/fallback",
+                TRADE_LOG_FILE,
+            )
         else:
-            logger.info("Loaded DataFrame is empty (market closed)")
+            logger.debug(
+                "Loaded DataFrame from %s is empty (market closed)",
+                TRADE_LOG_FILE,
+            )
     df["entry_time"] = pd.to_datetime(df["entry_time"], errors="coerce")
     df["exit_time"] = pd.to_datetime(df["exit_time"], errors="coerce")
     df = df.dropna(subset=["entry_time", "exit_time"])
@@ -7004,9 +7016,15 @@ def too_correlated(ctx: BotContext, sym: str) -> bool:
     )
     if df.empty:
         if _is_market_open_now():
-            logger.info("Loaded DataFrame is empty after parsing/fallback")
+            logger.debug(
+                "Loaded DataFrame from %s is empty after parsing/fallback",
+                TRADE_LOG_FILE,
+            )
         else:
-            logger.info("Loaded DataFrame is empty (market closed)")
+            logger.debug(
+                "Loaded DataFrame from %s is empty (market closed)",
+                TRADE_LOG_FILE,
+            )
     if "exit_time" not in df.columns or "symbol" not in df.columns:
         return False
     open_syms = df.loc[df.exit_time == "", "symbol"].unique().tolist() + [sym]
@@ -9951,7 +9969,10 @@ def update_signal_weights() -> None:
             ],
         ).dropna(subset=["entry_price", "exit_price", "signal_tags"])
         if df.empty:
-            logger.info("Loaded DataFrame is empty after parsing/fallback")
+            logger.debug(
+                "Loaded DataFrame from %s is empty after parsing/fallback",
+                TRADE_LOG_FILE,
+            )
         direction = np.where(df["side"] == "buy", 1, -1)
         df["pnl"] = (df["exit_price"] - df["entry_price"]) * direction
         df["confidence"] = df.get("confidence", 0.5)
@@ -9991,7 +10012,10 @@ def update_signal_weights() -> None:
                     usecols=["signal_name", "weight"],
                 )
                 if old_df.empty:
-                    logger.info("Loaded DataFrame is empty after parsing/fallback")
+                    logger.debug(
+                        "Loaded DataFrame from %s is empty after parsing/fallback",
+                        SIGNAL_WEIGHTS_FILE,
+                    )
                     old = {}
                 else:
                     old = old_df.set_index("signal_name")["weight"].to_dict()
@@ -10080,7 +10104,10 @@ def run_meta_learning_weight_optimizer(
             usecols=["entry_price", "exit_price", "signal_tags", "side", "confidence"],
         ).dropna(subset=["entry_price", "exit_price", "signal_tags"])
         if df.empty:
-            logger.info("Loaded DataFrame is empty after parsing/fallback")
+            logger.warning(
+                "Loaded DataFrame from %s is empty after parsing/fallback",
+                trade_log_path,
+            )
             logger.warning("METALEARN_NO_VALID_ROWS")
             return
 
@@ -10149,7 +10176,10 @@ def run_bayesian_meta_learning_optimizer(
             usecols=["entry_price", "exit_price", "signal_tags", "side"],
         ).dropna(subset=["entry_price", "exit_price", "signal_tags"])
         if df.empty:
-            logger.info("Loaded DataFrame is empty after parsing/fallback")
+            logger.warning(
+                "Loaded DataFrame from %s is empty after parsing/fallback",
+                trade_log_path,
+            )
             logger.warning("METALEARN_NO_VALID_ROWS")
             return
 
@@ -11399,9 +11429,15 @@ def daily_summary() -> None:
         ).dropna(subset=["entry_price", "exit_price"])
         if df.empty:
             if _is_market_open_now():
-                logger.info("Loaded DataFrame is empty after parsing/fallback")
+                logger.debug(
+                    "Loaded DataFrame from %s is empty after parsing/fallback",
+                    TRADE_LOG_FILE,
+                )
             else:
-                logger.info("Loaded DataFrame is empty (market closed)")
+                logger.debug(
+                    "Loaded DataFrame from %s is empty (market closed)",
+                    TRADE_LOG_FILE,
+                )
         direction = np.where(df["side"] == "buy", 1, -1)
         df["pnl"] = (df.exit_price - df.entry_price) * direction
         total_trades = len(df)
@@ -11519,9 +11555,15 @@ def _average_reward(n: int = 20) -> float:
     ).tail(n)
     if df.empty:
         if _is_market_open_now():
-            logger.info("Loaded DataFrame is empty after parsing/fallback")
+            logger.debug(
+                "Loaded DataFrame from %s is empty after parsing/fallback",
+                REWARD_LOG_FILE,
+            )
         else:
-            logger.info("Loaded DataFrame is empty (market closed)")
+            logger.debug(
+                "Loaded DataFrame from %s is empty (market closed)",
+                REWARD_LOG_FILE,
+            )
     if df.empty or "reward" not in df.columns:
         return 0.0
     return float(df["reward"].mean())

--- a/tests/test_empty_dataframe_logging.py
+++ b/tests/test_empty_dataframe_logging.py
@@ -1,0 +1,89 @@
+"""Tests for contextual empty DataFrame logging."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ai_trading.core import bot_engine
+
+
+def _write_empty_csv(path: Path, header: list[str]) -> None:
+    path.write_text(",".join(header) + "\n")
+
+
+def test_parse_local_positions_debug(caplog, tmp_path, monkeypatch):
+    """_parse_local_positions should log debug with file context."""
+
+    trade_log = tmp_path / "trades.csv"
+    _write_empty_csv(trade_log, ["symbol", "qty", "side", "exit_time"])
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(trade_log))
+
+    with caplog.at_level(logging.DEBUG):
+        bot_engine._parse_local_positions()
+
+    assert any(
+        r.levelno == logging.DEBUG
+        and str(trade_log) in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_load_signal_weights_warning(caplog, tmp_path, monkeypatch):
+    """load_signal_weights should warn when the CSV is empty."""
+
+    weights_file = tmp_path / "weights.csv"
+    _write_empty_csv(weights_file, ["signal_name", "weight"])
+    monkeypatch.setattr(bot_engine, "SIGNAL_WEIGHTS_FILE", str(weights_file))
+
+    manager = bot_engine.SignalManager()
+
+    with caplog.at_level(logging.WARNING):
+        manager.load_signal_weights()
+
+    assert any(
+        r.levelno == logging.WARNING
+        and str(weights_file) in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_meta_learning_weight_optimizer_warning(caplog, tmp_path):
+    """Meta-learning optimizer should warn on empty trade log."""
+
+    trade_log = tmp_path / "trades.csv"
+    _write_empty_csv(
+        trade_log,
+        ["entry_price", "exit_price", "signal_tags", "side", "confidence"],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        bot_engine.run_meta_learning_weight_optimizer(
+            trade_log_path=str(trade_log),
+            output_path=str(tmp_path / "out.csv"),
+        )
+
+    assert any(
+        r.levelno == logging.WARNING
+        and str(trade_log) in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_average_reward_debug(caplog, tmp_path, monkeypatch):
+    """_average_reward should log debug with file context when empty."""
+
+    reward_file = tmp_path / "rewards.csv"
+    _write_empty_csv(reward_file, ["reward"])
+    monkeypatch.setattr(bot_engine, "REWARD_LOG_FILE", str(reward_file))
+    monkeypatch.setattr(bot_engine, "_is_market_open_now", lambda: True)
+
+    with caplog.at_level(logging.DEBUG):
+        bot_engine._average_reward()
+
+    assert any(
+        r.levelno == logging.DEBUG
+        and str(reward_file) in r.getMessage()
+        for r in caplog.records
+    )
+


### PR DESCRIPTION
## Summary
- add file path context to empty DataFrame logs and adjust levels based on expectations
- test logging context and levels for empty trade, reward and weights files

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_empty_dataframe_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e5551288330bad95c904aa5b7d0