### PR TITLE
Make requests optional for data fetcher

### DIFF
--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -59,7 +59,7 @@ except ImportError:
 requests = _requests
 try:
     from requests.exceptions import ConnectionError, HTTPError, RequestException, Timeout
-except (ValueError, TypeError):
+except ImportError:  # requests is optional
     RequestException = Timeout = ConnectionError = HTTPError = Exception
 
 def _format_fallback_payload_df(tf_str: str, feed_str: str, start_dt: _dt.datetime, end_dt: _dt.datetime) -> list[str]:


### PR DESCRIPTION
## Summary
- Handle missing `requests` imports in `data_fetcher`
- Provide default exception fallbacks when `requests` is absent

## Testing
- `ruff check ai_trading/data_fetcher.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ee70a308330be742d4e99a40820