### PR TITLE
chore: loosen tenacity dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "ratelimit==2.2.1",
   "python-dotenv==1.1.1",
   "python-dateutil>=2.8.2,<3",
-  "tenacity==8.5.0",
+  "tenacity>=8",
   "scikit-learn==1.5.1",
   "scipy==1.13.1",
   "threadpoolctl==3.5.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ ratelimit==2.2.1
 # Explicit because main.py uses dotenv.load_dotenv directly
 python-dotenv==1.1.1
 python-dateutil>=2.8.2,<3
-tenacity==8.5.0
+tenacity>=8
 # ML stack used by non-RL code paths
 scikit-learn==1.5.1
 scipy==1.13.1


### PR DESCRIPTION
## Summary
- relax tenacity requirement to allow any version >=8

## Testing
- `python -m pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ee784ec8330bc851e83d38b284b