### PR TITLE
Forward LoggerAdapter attributes

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -118,6 +118,38 @@ class ExtraSanitizerFilter(logging.Filter):
 class SanitizingLoggerAdapter(logging.LoggerAdapter):
     """Adapter that sanitizes ``extra`` keys to avoid LogRecord collisions."""
 
+    def __getattribute__(self, name):
+        """Delegate missing attributes to the underlying logger."""
+        try:
+            return super().__getattribute__(name)
+        except AttributeError:
+            logger = super().__getattribute__("logger")
+            return getattr(logger, name)
+
+    @property
+    def handlers(self):
+        return self.logger.handlers
+
+    @handlers.setter
+    def handlers(self, value):
+        self.logger.handlers = value
+
+    @property
+    def filters(self):
+        return self.logger.filters
+
+    @filters.setter
+    def filters(self, value):
+        self.logger.filters = value
+
+    @property
+    def propagate(self):
+        return self.logger.propagate
+
+    @propagate.setter
+    def propagate(self, value):
+        self.logger.propagate = value
+
     def process(self, msg, kwargs):
         extra = kwargs.get('extra')
         if extra is not None:


### PR DESCRIPTION
## Summary
- delegate unknown `SanitizingLoggerAdapter` attributes to its underlying `Logger`
- expose handlers, filters, and propagation flags through adapter properties

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ee8bc5c833080253ca632f7b66c