### PR TITLE
Narrow optional import exception handling

### DIFF
--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -11,7 +11,7 @@ import importlib
 from ai_trading.utils.lazy_imports import load_pandas, load_pandas_ta
 try:  # pragma: no cover - optional dependency
     from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
+except ImportError:  # pragma: no cover - fallback when SDK missing
     class APIError(Exception):
         """Fallback APIError when alpaca-trade-api is unavailable."""
 

--- a/ai_trading/rl_trading/train.py
+++ b/ai_trading/rl_trading/train.py
@@ -8,7 +8,7 @@ from typing import Any
 
 try:  # optional dependency
     import numpy as np
-except Exception:  # noqa: BLE001 - numpy not required unless training
+except ImportError:
     np = None
 
 from ai_trading.exc import COMMON_EXC


### PR DESCRIPTION
## Summary
- limit exception handling to ImportError for optional Alpaca API import
- narrow numpy import exception in RL training and drop lint override

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ee988708330b177620abd2b34ed