### PR TITLE
feat: add disable_daily_retrain flag

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -162,6 +162,7 @@ class TradingConfig:
     """
     seed: int = SEED  # AI-AGENT-REF: propagate runtime seed
     enable_finbert: bool = False
+    disable_daily_retrain: bool = False
     capital_cap: Optional[float] = None
     dollar_risk_limit: Optional[float] = None
     max_position_size: Optional[float] = None
@@ -196,6 +197,7 @@ class TradingConfig:
         keys = [
             "seed",
             "enable_finbert",
+            "disable_daily_retrain",
             "capital_cap",
             "dollar_risk_limit",
             "max_position_size",
@@ -279,6 +281,9 @@ class TradingConfig:
             ),
             max_position_mode=_get("MAX_POSITION_MODE", str, default="STATIC"),
             paper=_get("PAPER", _to_bool, default=True),
+            disable_daily_retrain=_get(
+                "DISABLE_DAILY_RETRAIN", _to_bool, default=False
+            ),
             data_feed=_get("DATA_FEED", str),
             data_provider=_get("DATA_PROVIDER", str),
         )

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -74,6 +74,7 @@ class Settings(BaseSettings):
     webhook_secret: str | None = Field(default=None, alias='WEBHOOK_SECRET')
     testing: bool = Field(False, alias='TESTING')
     shadow_mode: bool = Field(False, alias='SHADOW_MODE')
+    disable_daily_retrain: bool = Field(False, alias='DISABLE_DAILY_RETRAIN')
     log_market_fetch: bool = Field(True, alias='LOG_MARKET_FETCH')
     healthcheck_port: int = Field(9001, alias='HEALTHCHECK_PORT')
     min_health_rows: int = Field(120, alias='MIN_HEALTH_ROWS')


### PR DESCRIPTION
## Summary
- expose `disable_daily_retrain` in `TradingConfig` and `Settings`
- parse `DISABLE_DAILY_RETRAIN` env var with safe default

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_env_flags.py tests/test_config_env.py tests/unit/test_trading_config_fields.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1eecfd788330aebd8e66005f9ac2