### PR TITLE
Add coverage for data fetcher, bot engine, and config settings

### DIFF
--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import pytest
+
+from ai_trading.core import bot_engine
+
+
+def _sample_df():
+    return pd.DataFrame({"close": [1.0]}, index=[pd.Timestamp("2024-01-01", tz="UTC")])
+
+
+def test_fetch_minute_df_safe_returns_dataframe(monkeypatch):
+    monkeypatch.setattr(bot_engine, "get_minute_df", lambda s, start, end: _sample_df())
+    monkeypatch.setattr(bot_engine, "_ensure_data_fresh", lambda symbols, max_age_seconds: None)
+    result = bot_engine.fetch_minute_df_safe("AAPL")
+    assert isinstance(result, pd.DataFrame)
+    assert not result.empty
+
+
+def test_fetch_minute_df_safe_raises_on_empty(monkeypatch):
+    monkeypatch.setattr(bot_engine, "get_minute_df", lambda s, start, end: pd.DataFrame())
+    monkeypatch.setattr(bot_engine, "_ensure_data_fresh", lambda symbols, max_age_seconds: None)
+    with pytest.raises(bot_engine.DataFetchError):
+        bot_engine.fetch_minute_df_safe("AAPL")

--- a/tests/bot_engine/test_strategy_selection.py
+++ b/tests/bot_engine/test_strategy_selection.py
@@ -1,0 +1,38 @@
+from ai_trading.core import bot_engine
+
+
+def test_get_strategies_from_env(monkeypatch):
+    class Dummy:
+        name = "dummy"
+
+        def __init__(self):
+            pass
+
+    class Alt:
+        name = "alt"
+
+        def __init__(self):
+            pass
+
+    import ai_trading.strategies as strategies
+
+    monkeypatch.setattr(strategies, "REGISTRY", {"dummy": Dummy, "alt": Alt}, raising=False)
+    monkeypatch.setenv("STRATEGIES", "dummy,alt")
+    strategies_list = bot_engine.get_strategies()
+    assert {type(s) for s in strategies_list} == {Dummy, Alt}
+
+
+def test_get_strategies_defaults_to_momentum(monkeypatch):
+    class Momentum:
+        name = "momentum"
+
+        def __init__(self):
+            pass
+
+    import ai_trading.strategies as strategies
+
+    monkeypatch.setattr(strategies, "REGISTRY", {"momentum": Momentum}, raising=False)
+    monkeypatch.delenv("STRATEGIES", raising=False)
+    strategies_list = bot_engine.get_strategies()
+    assert len(strategies_list) == 1
+    assert isinstance(strategies_list[0], Momentum)

--- a/tests/config/test_settings_validation.py
+++ b/tests/config/test_settings_validation.py
@@ -1,0 +1,27 @@
+from datetime import timedelta
+
+import pytest
+
+from ai_trading.settings import Settings
+
+
+def test_risk_parameters_validated():
+    """Risk ratios must be within (0, 1]."""
+    with pytest.raises(ValueError):
+        Settings(capital_cap=1.5)
+    with pytest.raises(ValueError):
+        Settings(dollar_risk_limit=0)
+
+
+def test_max_position_size_positive():
+    with pytest.raises(ValueError):
+        Settings(MAX_POSITION_SIZE=-10)
+    s = Settings(MAX_POSITION_SIZE=1000)
+    assert s.max_position_size == 1000
+
+
+def test_computed_fields(monkeypatch):
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "")
+    s = Settings(ALPACA_SECRET_KEY="secret", TRADE_COOLDOWN_MIN=30)
+    assert s.alpaca_secret_key_plain == "secret"
+    assert s.trade_cooldown == timedelta(minutes=30)

--- a/tests/data_fetcher/test_api_exports.py
+++ b/tests/data_fetcher/test_api_exports.py
@@ -1,0 +1,33 @@
+import datetime as dt
+from zoneinfo import ZoneInfo
+import pytest
+
+from ai_trading import data_fetcher
+
+
+class TestDataFetcherAPI:
+    def test_data_fetch_error_alias(self):
+        """DataFetchError is exposed and matches the legacy alias."""
+        assert data_fetcher.DataFetchException is data_fetcher.DataFetchError
+
+    def test_ensure_datetime_handles_callable(self):
+        """ensure_datetime accepts callables returning datetimes."""
+        expected = dt.datetime(2024, 1, 1, 12, tzinfo=ZoneInfo("UTC"))
+
+        def factory():
+            return expected
+
+        result = data_fetcher.ensure_datetime(factory)
+        assert result == expected
+
+    def test_ensure_datetime_coerces_naive(self):
+        """Naive datetimes are treated as America/New_York before UTC conversion."""
+        naive = dt.datetime(2024, 1, 1, 9, 30)
+        result = data_fetcher.ensure_datetime(naive)
+        expected = naive.replace(tzinfo=ZoneInfo("America/New_York")).astimezone(ZoneInfo("UTC"))
+        assert result == expected
+
+    def test_ensure_datetime_invalid_input(self):
+        """Non-datetime values raise TypeError."""
+        with pytest.raises(TypeError):
+            data_fetcher.ensure_datetime("not-a-date")


### PR DESCRIPTION
## Summary
- test data fetcher exports like DataFetchError and ensure_datetime
- verify bot engine helpers fetch_minute_df_safe and strategy selection
- validate settings fields and computed properties

## Testing
- `ruff check tests/config/test_settings_validation.py tests/bot_engine/test_strategy_selection.py tests/bot_engine/test_fetch_minute_df_safe.py tests/data_fetcher/test_api_exports.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/data_fetcher/test_api_exports.py tests/bot_engine/test_fetch_minute_df_safe.py tests/bot_engine/test_strategy_selection.py tests/config/test_settings_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2347a71c8330b0cfec6bd1f2f8ce