### PR TITLE
refactor: remove legacy capital scaling wrappers

### DIFF
--- a/ai_trading/capital_scaling.py
+++ b/ai_trading/capital_scaling.py
@@ -240,11 +240,18 @@ def cvar_scaling(returns: np.ndarray, alpha: float=0.05) -> float:
     cvar = np.mean(sorted_returns[sorted_returns <= var])
     return abs(cvar) if cvar < 0 else 1.0
 
-def drawdown_adjusted_kelly_alt(account_value: float, equity_peak: float, raw_kelly: float) -> float:
-    """Legacy wrapper for drawdown_adjusted_kelly."""
-    return drawdown_adjusted_kelly(account_value, equity_peak, raw_kelly)
-
-def volatility_parity_position_alt(base_risk: float, atr_value: float) -> float:
-    """Legacy wrapper for volatility_parity_position."""
-    return volatility_parity_position(base_risk, atr_value)
-__all__ = ['update_if_present', 'capital_scaler_update', 'capital_scale', 'CapitalScalingEngine', 'volatility_parity_position', 'dynamic_fractional_kelly', 'drawdown_adjusted_kelly', 'pyramiding_add', 'decay_position', 'fractional_kelly', 'kelly_fraction', 'volatility_parity', 'cvar_scaling', 'drawdown_adjusted_kelly_alt', 'volatility_parity_position_alt']
+__all__ = [
+    'update_if_present',
+    'capital_scaler_update',
+    'capital_scale',
+    'CapitalScalingEngine',
+    'volatility_parity_position',
+    'dynamic_fractional_kelly',
+    'drawdown_adjusted_kelly',
+    'pyramiding_add',
+    'decay_position',
+    'fractional_kelly',
+    'kelly_fraction',
+    'volatility_parity',
+    'cvar_scaling',
+]

--- a/ai_trading/trade_logic.py
+++ b/ai_trading/trade_logic.py
@@ -3,10 +3,7 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from ai_trading.logging import get_logger
-try:
-    from ai_trading.capital_scaling import drawdown_adjusted_kelly_alt as drawdown_adjusted_kelly
-except (ValueError, TypeError):
-    from ai_trading.capital_scaling import drawdown_adjusted_kelly
+from ai_trading.capital_scaling import drawdown_adjusted_kelly
 from ai_trading.config.settings import get_settings
 from ai_trading.core.bot_engine import _fetch_intraday_bars_chunked
 logger = get_logger(__name__)

--- a/tests/test_entry_exit_signals.py
+++ b/tests/test_entry_exit_signals.py
@@ -15,7 +15,6 @@ sys.modules.setdefault("ai_trading.logging", logger_mod)
 
 cap_mod = types.ModuleType("ai_trading.capital_scaling")
 cap_mod.drawdown_adjusted_kelly = lambda *a, **k: 1.0
-cap_mod.drawdown_adjusted_kelly_alt = cap_mod.drawdown_adjusted_kelly
 sys.modules.setdefault("ai_trading.capital_scaling", cap_mod)
 
 settings_mod = types.ModuleType("ai_trading.config.settings")


### PR DESCRIPTION
## Summary
- remove deprecated `drawdown_adjusted_kelly_alt` and `volatility_parity_position_alt`
- import `drawdown_adjusted_kelly` directly in trade logic
- update entry/exit signal test stubs for new import

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

## Rollback
- Revert commit `refactor: remove legacy capital scaling wrappers`

------
https://chatgpt.com/codex/tasks/task_e_68ae294efa208330b0161eff0ac1c987