### PR TITLE
refactor: drop legacy sentiment predictor

### DIFF
--- a/scripts/validate_critical_fixes.py
+++ b/scripts/validate_critical_fixes.py
@@ -15,13 +15,14 @@ def test_sentiment_module():
     try:
         from ai_trading.analysis import sentiment
         logging.info('  ✅ sentiment module imported successfully')
-        required_functions = ['fetch_sentiment', 'predict_text_sentiment', 'sentiment_lock']
+        required_functions = ['fetch_sentiment', 'analyze_text', 'sentiment_lock']
         for func_name in required_functions:
             assert hasattr(sentiment, func_name), f'Missing function: {func_name}'
         logging.info('  ✅ All required sentiment functions available')
-        result = sentiment.predict_text_sentiment('This is a test')
-        assert isinstance(result, int | float), 'predict_text_sentiment should return a number'
-        logging.info(f'  ✅ predict_text_sentiment works: {result}')
+        result = sentiment.analyze_text('This is a test')
+        assert isinstance(result, dict), 'analyze_text should return a dict'
+        assert {'available', 'pos', 'neg', 'neu'} <= set(result), 'analyze_text result keys missing'
+        logging.info(f"  ✅ analyze_text works: {result}")
         return True
     except (KeyError, ValueError, TypeError) as e:
         logging.info(f'  ❌ Sentiment module test failed: {e}')

--- a/tests/test_sentiment_interface.py
+++ b/tests/test_sentiment_interface.py
@@ -1,0 +1,16 @@
+import os
+import pytest
+
+os.environ.setdefault("PYTEST_RUNNING", "1")
+from ai_trading.analysis import sentiment
+
+
+def test_analyze_text_interface():
+    assert not hasattr(sentiment, "predict_text_sentiment")
+    try:
+        res = sentiment.analyze_text("markets look good")
+    except ModuleNotFoundError:
+        pytest.skip("transformers not installed")
+    assert isinstance(res, dict)
+    assert {'available', 'pos', 'neg', 'neu'} <= set(res)
+


### PR DESCRIPTION
## Summary
- remove obsolete `predict_text_sentiment` helper
- switch critical-fixes validator to `analyze_text`
- add test covering modern sentiment interface

## Testing
- `ruff check ai_trading/analysis/sentiment.py scripts/validate_critical_fixes.py tests/test_sentiment_interface.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_sentiment_interface.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae2950372c83308535fc34f692a718