### PR TITLE
refactor: drop legacy data fetch helpers

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -43,7 +43,6 @@ from ai_trading.data_fetcher import (
     get_bars,
     get_bars_batch,
     get_minute_df,
-    warmup_cache,
 )
 from ai_trading.utils.time import last_market_session
 from ai_trading.capital_scaling import capital_scale, update_if_present
@@ -2536,8 +2535,17 @@ def _maybe_warm_cache(ctx: BotContext) -> None:
     if not getattr(settings, "data_cache_enable", False):
         return
     try:
-        # Daily warm-up
-        warmup_cache(ctx.symbols, lookback_days=settings.data_warmup_lookback_days)
+        # Daily warm-up via batched fetch
+        end_dt = datetime.now(UTC)
+        start_dt = end_dt - timedelta(days=int(settings.data_warmup_lookback_days))
+        if ctx.symbols:
+            get_bars_batch(
+                ctx.symbols,
+                "1D",
+                start_dt,
+                end_dt,
+                feed=getattr(ctx, "data_feed", None),
+            )
         # Optional intraday warm-up
         if getattr(settings, "intraday_batch_enable", True):
             end_dt = datetime.now(UTC)

--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -490,19 +490,6 @@ def get_bars_batch(symbols: list[str], timeframe: str, start: Any, end: Any, *, 
     """Fetch bars for multiple symbols via get_bars."""
     return {sym: get_bars(sym, timeframe, start, end, feed=feed, adjustment=adjustment) for sym in symbols}
 
-def get_bars_df(symbol: str, timeframe: Any, start: Any | None=None, end: Any | None=None, *, feed: str | None=None, adjustment: str | None=None) -> pd.DataFrame:
-    """Legacy alias expected by bot_engine (accepts optional start/end)."""
-    if start is None or end is None:
-        start, end = _default_window_for(timeframe)
-    try:
-        df = get_bars(symbol, str(timeframe), start, end, feed=feed, adjustment=adjustment)
-    except (ValueError, RuntimeError) as e:
-        logger.warning('ALPACA_DAILY_FETCH_FAILED', extra={'symbol': symbol, 'err': str(e)})
-        df = None
-    if df is None or getattr(df, 'empty', True):
-        return _post_process(_yahoo_get_bars(symbol, start, end, interval='1d'))
-    return _post_process(df)
-
 def fetch_minute_yfinance(symbol: str, start_dt: _dt.datetime, end_dt: _dt.datetime) -> pd.DataFrame:
     """Explicit helper for tests and optional direct Yahoo minute fetch."""
     df = _yahoo_get_bars(symbol, start_dt, end_dt, interval='1m')
@@ -512,38 +499,5 @@ def is_market_open() -> bool:
     """Simplistic market-hours check used in tests."""
     return True
 
-__all__ = ['_DEFAULT_FEED', '_VALID_FEEDS', 'ensure_datetime', '_yahoo_get_bars', '_fetch_bars', 'get_bars', 'get_bars_batch', 'get_bars_df', 'fetch_minute_yfinance', 'is_market_open', 'get_last_available_bar', 'fh_fetcher', 'get_minute_df', 'build_fetcher', 'DataFetchError']
-
-# ------------------------------------------------------------
-# Back-compat test-facing exports (no behavior change)
-# ------------------------------------------------------------
-# AI-AGENT-REF: restore legacy fetcher exports for tests
-# Several tests import these symbols directly. Keep them extremely
-# lightweight and side-effect free. If an internal cache stats object
-# already exists, these helpers simply expose it; otherwise create a
-# minimal counter dict.
-
-try:  # if a counter already exists in this module, reuse it
-    _CACHE_STATS  # type: ignore[name-defined]
-except NameError:  # pragma: no cover - created only if missing
-    from collections import defaultdict
-    _CACHE_STATS = defaultdict(int)  # type: ignore[var-annotated]
-
-
-def get_cache_stats() -> dict:
-    """Expose current cache counters as a plain dict for tests.
-    Intentionally returns a copy-like view to avoid accidental mutation.
-    """
-    try:
-        return dict(_CACHE_STATS)
-    except Exception:  # extremely defensive; never raise from import
-        return {}
-
-
-def warmup_cache(*_args, **_kwargs) -> None:
-    """Allow tests to invoke a warmup hook; no-op by design."""
-    try:
-        _CACHE_STATS["warmup_calls"] += 1
-    except Exception:
-        pass
+__all__ = ['_DEFAULT_FEED', '_VALID_FEEDS', 'ensure_datetime', '_yahoo_get_bars', '_fetch_bars', 'get_bars', 'get_bars_batch', 'fetch_minute_yfinance', 'is_market_open', 'get_last_available_bar', 'fh_fetcher', 'get_minute_df', 'build_fetcher', 'DataFetchError']
 

--- a/tests/test_batch_and_warmup.py
+++ b/tests/test_batch_and_warmup.py
@@ -1,9 +1,7 @@
-from datetime import UTC, datetime, timedelta
-
 import pytest
 
 try:
-    from ai_trading.data_fetcher import get_bars_batch, warmup_cache
+    from ai_trading.data_fetcher import get_bars_batch
 except (ValueError, TypeError):
     pytest.skip("data_fetcher deps missing", allow_module_level=True)
 
@@ -13,6 +11,4 @@ def test_get_bars_batch_handles_empty_list():
     assert out == {}
 
 
-def test_warmup_cache_no_symbols():
-    n = warmup_cache([], "1D", datetime.now(UTC)-timedelta(days=1), datetime.now(UTC))
-    assert n == 0
+

--- a/tests/test_data_fetcher_fallbacks.py
+++ b/tests/test_data_fetcher_fallbacks.py
@@ -50,5 +50,5 @@ def test_daily_fallback_on_empty(monkeypatch):
     monkeypatch.setattr(dfetch, "get_bars", lambda *a, **k: pd.DataFrame())
     monkeypatch.setattr(dfetch.yf, "download", _fake_yf)
     now = dt.datetime.now(dt.UTC)
-    df = dfetch.get_bars_df("SPY", now - dt.timedelta(days=30), now, timeframe="1D")
+    df = dfetch.get_bars("SPY", "1D", now - dt.timedelta(days=30), now)
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode

--- a/tests/test_performance_fixes.py
+++ b/tests/test_performance_fixes.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 """
-Test suite for meta-learning and cache performance fixes.
+Test suite for meta-learning and related performance fixes.
 
 This test validates the key fixes:
 1. Meta-learning system can handle mixed trade log formats
-2. Cache performance improvements work correctly
-3. Position size reporting is consistent
-4. Order execution latency tracking is more granular
+2. Position size reporting is consistent
+3. Order execution latency tracking is more granular
 """
 
 import os
@@ -43,24 +42,6 @@ def test_meta_learning_mixed_format():
     # Test that retrain_meta_learner works
     result = retrain_meta_learner("trades.csv", min_samples=10)
     assert result, "Meta-learning retraining should succeed"
-
-
-def test_cache_performance_metrics():
-    """Test that cache performance metrics are recorded."""
-
-    from ai_trading.data_fetcher import _CACHE_STATS, get_cache_stats
-
-    # Reset cache stats
-    _CACHE_STATS["hits"] = 0
-    _CACHE_STATS["misses"] = 0
-    _CACHE_STATS["invalidations"] = 0
-
-    # Get initial stats
-    stats = get_cache_stats()
-    assert "hits" in stats, "Should track cache hits"
-    assert "misses" in stats, "Should track cache misses"
-    assert "hit_ratio_pct" in stats, "Should calculate hit ratio"
-    assert "total_requests" in stats, "Should track total requests"
 
 
 def test_position_size_reporting():
@@ -121,8 +102,6 @@ def test_comprehensive_fixes():
     """Run comprehensive test of all performance fixes."""
 
     test_meta_learning_mixed_format()
-
-    test_cache_performance_metrics()
 
     test_position_size_reporting()
 

--- a/tests/test_strategies_module.py
+++ b/tests/test_strategies_module.py
@@ -22,7 +22,6 @@ sys.modules["tzlocal"] = tzlocal_mod
 # Stub internal modules pulled in by bot_engine imports we don't exercise
 df_stub = types.ModuleType("ai_trading.data_fetcher")
 df_stub.get_bars = df_stub.get_bars_batch = lambda *a, **k: []
-df_stub.warmup_cache = lambda *a, **k: None
 df_stub.get_minute_df = lambda *a, **k: None
 sys.modules["ai_trading.data_fetcher"] = df_stub
 


### PR DESCRIPTION
## Summary
- remove outdated DataFrame fetcher and cache helpers from data_fetcher
- warm cache via get_bars_batch in bot_engine
- update tests to use get_bars and drop warmup_cache dependency

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2952f8948330b78942746c71d081