### PR TITLE
refactor: consolidate ProcessManager import

### DIFF
--- a/CRITICAL_FIXES_IMPLEMENTATION_SUMMARY.md
+++ b/CRITICAL_FIXES_IMPLEMENTATION_SUMMARY.md
@@ -34,7 +34,7 @@ def alpaca_client(self):
 - `check_multiple_instances()` - Detection and remediation recommendations
 - Integrated into `runner.py` startup to prevent duplicate instances
 
-**Files**: `process_manager.py` (lines 355-428), `runner.py` (lines 109-138)
+**Files**: `ai_trading/process_manager.py` (lines 355-428), `runner.py` (lines 109-138)
 
 ### 4. ✅ Data Staleness Validation
 **Problem**: All symbols trading on stale data
@@ -131,7 +131,7 @@ def alpaca_client(self):
 
 1. **risk_engine.py**: Added missing critical methods (4 new methods, 35 lines)
 2. **bot_engine.py**: Added alpaca_client compatibility property (4 lines)
-3. **process_manager.py**: Enhanced with locking and instance detection (73 lines)
+3. **ai_trading/process_manager.py**: Enhanced with locking and instance detection (73 lines)
 4. **runner.py**: Integrated process management (29 lines)
 5. **audit.py**: Enhanced permission error handling (35 lines)
 6. **data_validation.py**: Complete new module for data validation (217 lines)

--- a/PERFORMANCE_OPTIMIZATION_README.md
+++ b/PERFORMANCE_OPTIMIZATION_README.md
@@ -77,7 +77,7 @@ from performance_monitor import start_performance_monitoring
 start_performance_monitoring()
 ```
 
-### 4. Process Manager (`process_manager.py`)
+### 4. Process Manager (`ai_trading/process_manager.py`)
 
 Process management and service cleanup utilities.
 
@@ -90,7 +90,7 @@ Process management and service cleanup utilities.
 
 **Usage:**
 ```bash
-python process_manager.py
+python -m ai_trading.process_manager
 ```
 
 ### 5. Optimized Startup (`optimized_startup.py`)
@@ -202,7 +202,7 @@ python optimized_startup.py
 python system_diagnostic.py
 
 # Monitor processes
-python process_manager.py
+python -m ai_trading.process_manager
 ```
 
 ### Development
@@ -237,14 +237,14 @@ result = emergency_memory_cleanup()
 
 ### Process Conflicts
 ```bash
-python process_manager.py
+python -m ai_trading.process_manager
 # Follow prompts for duplicate cleanup
 ```
 
 ### Service Failures
 ```bash
 # Check service status
-python process_manager.py
+python -m ai_trading.process_manager
 
 # Manual service restart
 sudo systemctl restart ai-trading-bot.service
@@ -255,7 +255,7 @@ sudo systemctl restart ai-trading-bot.service
 - `system_diagnostic.py`: System health monitoring
 - `memory_optimizer.py`: Memory management and optimization
 - `performance_monitor.py`: Real-time performance monitoring
-- `process_manager.py`: Process and service management
+- `ai_trading/process_manager.py`: Process and service management
 - `optimized_startup.py`: Production startup script
 - `performance_demo.py`: Demonstration of all features
 

--- a/risk_parameter_audit_report.md
+++ b/risk_parameter_audit_report.md
@@ -117,7 +117,7 @@
   Line: self.latency_tracker: Dict[str, deque] = defaultdict(lambda: deque(maxlen=1000))
 - production_monitoring.py:267 - 1000 (old MAX_POSITION_SIZE)
   Line: elapsed = (time.perf_counter() - start_time) * 1000  # Convert to ms
-- process_manager.py:347 - 1000 (old MAX_POSITION_SIZE)
+- ai_trading/process_manager.py:347 - 1000 (old MAX_POSITION_SIZE)
   Line: if total_memory > 1000:
 - profile_indicators.py:28 - 1000 (old MAX_POSITION_SIZE)
   Line: 'volume': np.random.randint(1000, 10000, size=100_000)

--- a/scripts/audit.py
+++ b/scripts/audit.py
@@ -76,7 +76,7 @@ def log_trade(symbol, qty, side, fill_price, timestamp, extra_info=None, exposur
     except PermissionError as exc:
         logger.error('ERROR [audit] permission denied writing %s: %s', TRADE_LOG_FILE, exc)
         try:
-            from process_manager import ProcessManager
+            from ai_trading.process_manager import ProcessManager
             pm = ProcessManager()
             repair_result = pm.fix_file_permissions([TRADE_LOG_FILE])
             if repair_result['paths_fixed']:

--- a/scripts/process_manager.py
+++ b/scripts/process_manager.py
@@ -1,3 +1,0 @@
-"""Legacy re-export for ProcessManager."""
-from ai_trading.process_manager import ProcessManager
-__all__ = ['ProcessManager']


### PR DESCRIPTION
## Summary
- remove old `scripts/process_manager.py`
- update audit script to use `ai_trading.process_manager`
- refresh docs to reference the new module path

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae295602108330a8a8553abf80ed5c