### PR TITLE
refactor: expose logger adapter properties

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -127,27 +127,33 @@ class SanitizingLoggerAdapter(logging.LoggerAdapter):
             return getattr(logger, name)
 
     @property
-    def handlers(self):
+    def handlers(self) -> list[logging.Handler]:
+        """Delegate handler list to the underlying logger."""
         return self.logger.handlers
 
     @handlers.setter
-    def handlers(self, value):
+    def handlers(self, value: list[logging.Handler]) -> None:
+        """Replace handlers on the underlying logger."""
         self.logger.handlers = value
 
     @property
-    def filters(self):
+    def filters(self) -> list[logging.Filter]:
+        """Delegate filter list to the underlying logger."""
         return self.logger.filters
 
     @filters.setter
-    def filters(self, value):
+    def filters(self, value: list[logging.Filter]) -> None:
+        """Replace filters on the underlying logger."""
         self.logger.filters = value
 
     @property
-    def propagate(self):
+    def propagate(self) -> bool:
+        """Whether the underlying logger propagates messages."""
         return self.logger.propagate
 
     @propagate.setter
-    def propagate(self, value):
+    def propagate(self, value: bool) -> None:
+        """Set propagation behaviour for the underlying logger."""
         self.logger.propagate = value
 
     def process(self, msg, kwargs):

--- a/tests/test_logger_adapter_properties.py
+++ b/tests/test_logger_adapter_properties.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+
+from ai_trading.logging import get_logger
+
+
+def test_get_logger_handlers_is_mutable_and_propagate_toggle() -> None:
+    """Handlers list is mutable and propagate flag can be toggled."""
+    logger = get_logger("ai_trading.tests.adapter_props")
+    original_handlers = list(logger.handlers)
+    try:
+        assert isinstance(logger.handlers, list)
+        sentinel = logging.NullHandler()
+        logger.handlers.append(sentinel)
+        assert sentinel in logger.handlers
+        logger.propagate = False
+        assert logger.propagate is False
+        logger.propagate = True
+        assert logger.propagate is True
+    finally:
+        logger.handlers = original_handlers
+        logger.propagate = True


### PR DESCRIPTION
## Summary
- delegate `handlers`, `filters`, and `propagate` on `SanitizingLoggerAdapter`
- test that adapter exposes mutable handlers list and toggleable propagate flag

## Testing
- `ruff check ai_trading/logging/__init__.py tests/test_logger_adapter_properties.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: tests/test_current_api.py::test_data_fetcher_active_exports)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_logger_adapter_properties.py::test_get_logger_handlers_is_mutable_and_propagate_toggle -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2af30674833085af71fb6dfcc247