### PR TITLE
chore: re-export legacy helpers

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -79,7 +79,20 @@ def _alpaca_available() -> bool:
     """Return ``True`` if the alpaca_trade_api SDK is importable."""
 
     return ALPACA_AVAILABLE
-from ai_trading.data.bars import (_ensure_df, safe_get_stock_bars, _create_empty_bars_dataframe, StockBarsRequest, TimeFrame, TimeFrameUnit, _resample_minutes_to_daily)
+from ai_trading.data.bars import (
+    _ensure_df as _bars_ensure_df,
+    safe_get_stock_bars as _bars_safe_get_stock_bars,
+    _create_empty_bars_dataframe as _bars_create_empty_bars_dataframe,
+    StockBarsRequest,
+    TimeFrame,
+    TimeFrameUnit,
+    _resample_minutes_to_daily as _bars_resample_minutes_to_daily,
+)
+from ai_trading.core.runtime import (
+    BotRuntime as _BotRuntime,
+    build_runtime as _runtime_build_runtime,
+    enhance_runtime_with_context as _runtime_enhance_runtime_with_context,
+)
 
 if os.getenv("BOT_SHOW_DEPRECATIONS", "").lower() in {"1", "true", "yes"}:
     warnings.filterwarnings("default", category=DeprecationWarning)
@@ -122,6 +135,45 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     FinnhubAPIException = Exception  # type: ignore
     FINNHUB_AVAILABLE = False
+
+# Backwards-compatibility shims for relocated helpers
+def ensure_df(obj):
+    """Backward-compatibility shim for ai_trading.data.bars._ensure_df."""
+    return _bars_ensure_df(obj)
+
+
+def create_empty_bars_dataframe():
+    """Backward-compatibility shim for ai_trading.data.bars._create_empty_bars_dataframe."""
+    return _bars_create_empty_bars_dataframe()
+
+
+def resample_minutes_to_daily(df):
+    """Backward-compatibility shim for ai_trading.data.bars._resample_minutes_to_daily."""
+    return _bars_resample_minutes_to_daily(df)
+
+
+def safe_get_stock_bars(*args, **kwargs):
+    """Backward-compatibility shim for ai_trading.data.bars.safe_get_stock_bars."""
+    return _bars_safe_get_stock_bars(*args, **kwargs)
+
+
+BotRuntime = _BotRuntime
+BotRuntime.__doc__ = "Backward-compatibility shim for ai_trading.core.runtime.BotRuntime."
+
+
+def build_runtime(*args, **kwargs):
+    """Backward-compatibility shim for ai_trading.core.runtime.build_runtime."""
+    return _runtime_build_runtime(*args, **kwargs)
+
+
+def enhance_runtime_with_context(*args, **kwargs):
+    """Backward-compatibility shim for ai_trading.core.runtime.enhance_runtime_with_context."""
+    return _runtime_enhance_runtime_with_context(*args, **kwargs)
+
+
+StockBarsRequest.__doc__ = "Backward-compatibility shim for ai_trading.data.bars.StockBarsRequest."
+TimeFrame.__doc__ = "Backward-compatibility shim for ai_trading.data.bars.TimeFrame."
+TimeFrameUnit.__doc__ = "Backward-compatibility shim for ai_trading.data.bars.TimeFrameUnit."
 
 
 def _rf_class():
@@ -236,6 +288,17 @@ __all__ = [
     "DataFetchError",
     "MockSignal",
     "MockContext",
+    # Backwards-compatibility shims
+    "StockBarsRequest",
+    "TimeFrame",
+    "TimeFrameUnit",
+    "safe_get_stock_bars",
+    "ensure_df",
+    "create_empty_bars_dataframe",
+    "resample_minutes_to_daily",
+    "BotRuntime",
+    "build_runtime",
+    "enhance_runtime_with_context",
 ]
 # AI-AGENT-REF: custom exception surfaced by fetch helpers
 

--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -98,6 +98,11 @@ def last_minute_bar_age_seconds(symbol: str) -> int | None:
         return None
     now_s = int(_dt.datetime.now(tz=UTC).timestamp())
     return max(0, now_s - int(ts))
+
+
+def warmup_cache(*_args: Any, **_kwargs: Any) -> None:
+    """Backward-compatibility shim; cache warm-up now occurs lazily."""
+    return None
 _DEFAULT_FEED = 'iex'
 _VALID_FEEDS = ('iex', 'sip')
 
@@ -499,5 +504,5 @@ def is_market_open() -> bool:
     """Simplistic market-hours check used in tests."""
     return True
 
-__all__ = ['_DEFAULT_FEED', '_VALID_FEEDS', 'ensure_datetime', '_yahoo_get_bars', '_fetch_bars', 'get_bars', 'get_bars_batch', 'fetch_minute_yfinance', 'is_market_open', 'get_last_available_bar', 'fh_fetcher', 'get_minute_df', 'build_fetcher', 'DataFetchError']
+__all__ = ['_DEFAULT_FEED', '_VALID_FEEDS', 'ensure_datetime', '_yahoo_get_bars', '_fetch_bars', 'get_bars', 'get_bars_batch', 'fetch_minute_yfinance', 'is_market_open', 'get_last_available_bar', 'fh_fetcher', 'get_minute_df', 'build_fetcher', 'DataFetchError', 'warmup_cache']
 


### PR DESCRIPTION
## Summary
- re-export runtime and bar helpers from new modules in `core.bot_engine`
- add `warmup_cache` no-op stub to data_fetcher for compatibility

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae2af5ef508330bd1b4480ce27f554