### PR TITLE
feat: add optional retry wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ All Python packages are specified in `requirements.txt`, including:
 - **pandas-market-calendars**: Exchange session calendars
 - **scikit-learn**: Machine learning algorithms
 - **alpaca-trade-api**: Broker integration
+- **tenacity** *(optional)*: Robust retry helpers; falls back to a lightweight internal version if absent
 
 **Note**: The ta library provides cross-platform compatibility without requiring system-level C library installations.
 

--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -124,7 +124,7 @@ skipped.
 | Meta learning | `numpy`, `torch`, `sklearn` | `tests/test_meta_learning.py`, `tests/slow/test_meta_learning_heavy.py` |
 | Reinforcement learning | `stable_baselines3`, `gymnasium`, `torch` | `tests/test_rl_import_performance.py` |
 | Alpaca SDK | `alpaca_trade_api`, `alpaca_api` | `tests/unit/test_alpaca_api.py` |
-| Retry utilities | `tenacity` | `tests/test_tenacity_import.py` |
+| Retry utilities | optional `tenacity` via `ai_trading.utils.retry` | `tests/test_tenacity_import.py` |
 | Calendars | `pandas_market_calendars` | `tests/test_market_calendar_wrapper.py` |
 
 ## Unit Testing

--- a/ai_trading/analysis/sentiment.py
+++ b/ai_trading/analysis/sentiment.py
@@ -8,7 +8,13 @@ import time as pytime
 from datetime import datetime
 from threading import Lock
 import requests
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential, wait_random
+from ai_trading.utils.retry import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    wait_random,
+)
 from ai_trading.logging import logger
 from ai_trading.settings import get_news_api_key
 from ai_trading.config import get_settings

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1307,75 +1307,15 @@ def sleep_and_retry(func):
         return _sr(func)(*a, **k)
 
     return wrapped
-
-
-def retry(*dargs, **dkwargs):
-    def decorator(func):
-        def wrapped(*a, **k):
-            from tenacity import retry as _retry
-
-            return _retry(*dargs, **dkwargs)(func)(*a, **k)
-
-        return wrapped
-
-    return decorator
-
-
-def stop_after_attempt(*args, **kwargs):
-    from tenacity import stop_after_attempt as _saa
-
-    return _saa(*args, **kwargs)
-
-
-def wait_exponential(*args, **kwargs):
-    from tenacity import wait_exponential as _we
-
-    return _we(*args, **kwargs)
-
-
-def wait_random(*args, **kwargs):
-    from tenacity import wait_random as _wr
-
-    return _wr(*args, **kwargs)
-
-
-def retry_if_exception_type(*args, **kwargs):
-    from tenacity import retry_if_exception_type as _riet
-
-    return _riet(*args, **kwargs)
-
-
-# Tenacity retry error import with validation
-try:
-    # Import RetryError from tenacity.  In some test environments Tenacity may be
-    # monkeypatched so that RetryError is not actually an exception class.  To
-    # avoid ``TypeError: catching classes that do not inherit from BaseException``
-    # when using ``except RetryError``, verify that the imported symbol is a
-    # proper exception type.  Fall back to a simple Exception subclass when
-    # Tenacity is unavailable or invalid.
-    from tenacity import RetryError as _TenacityRetryError  # type: ignore[assignment]
-
-    if not isinstance(_TenacityRetryError, type) or not issubclass(
-        _TenacityRetryError, BaseException
-    ):
-        raise TypeError("Invalid RetryError type")
-    RetryError = _TenacityRetryError  # type: ignore[assignment]
-except (
-    FileNotFoundError,
-    PermissionError,
-    IsADirectoryError,
-    JSONDecodeError,
-    ValueError,
-    KeyError,
-    TypeError,
-    OSError,
-):  # AI-AGENT-REF: narrow exception
-
-    class RetryError(
-        Exception
-    ):  # pragma: no cover - fallback when tenacity.RetryError is invalid
-        """Fallback RetryError used when Tenacity's RetryError is unavailable or not an exception."""
-
+# Retry helpers (optional Tenacity)
+from ai_trading.utils.retry import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    wait_random,
+    RetryError,
+)
 
 # AI-AGENT-REF: lazy ichimoku setup to avoid pandas_ta import in tests
 if not os.getenv("PYTEST_RUNNING"):

--- a/ai_trading/utils/retry.py
+++ b/ai_trading/utils/retry.py
@@ -4,9 +4,105 @@ import functools
 import random
 import time
 from collections.abc import Callable
-from typing import TypeVar, Literal
+from typing import TypeVar
 
 T = TypeVar("T")
+
+try:  # pragma: no cover - exercised via HAS_TENACITY flag in tests
+    from tenacity import (
+        retry as _retry,
+        stop_after_attempt as _stop_after_attempt,
+        wait_exponential as _wait_exponential,
+        wait_random as _wait_random,
+        retry_if_exception_type as _retry_if_exception_type,
+        RetryError as _RetryError,
+    )
+    if not isinstance(_RetryError, type) or not issubclass(_RetryError, BaseException):
+        raise TypeError("Invalid RetryError type")
+    retry = _retry
+    stop_after_attempt = _stop_after_attempt
+    wait_exponential = _wait_exponential
+    wait_random = _wait_random
+    retry_if_exception_type = _retry_if_exception_type
+    RetryError = _RetryError
+    HAS_TENACITY = True
+except Exception:  # pragma: no cover - fallback path when tenacity missing
+    HAS_TENACITY = False
+
+    class RetryError(Exception):
+        """Fallback RetryError used when Tenacity is unavailable."""
+
+    def stop_after_attempt(max_attempts: int) -> Callable[[int], bool]:
+        def stop(attempt_number: int) -> bool:
+            return attempt_number >= max_attempts
+        return stop
+
+    class _Wait:
+        def __init__(self, fn: Callable[[int], float]):
+            self._fn = fn
+
+        def __call__(self, attempt: int) -> float:
+            return self._fn(attempt)
+
+        def __add__(self, other: "_Wait") -> "_Wait":
+            return _Wait(lambda a: self(a) + other(a))
+
+    def wait_exponential(
+        *,
+        multiplier: float = 1.0,
+        min: float = 0.0,
+        max: float | None = None,
+    ) -> _Wait:
+        def fn(attempt: int) -> float:
+            delay = multiplier * (2 ** (attempt - 1))
+            delay = max(delay, min)
+            if max is not None:
+                delay = min(delay, max)
+            return delay
+        return _Wait(fn)
+
+    def wait_random(*, min: float = 0.0, max: float = 1.0) -> _Wait:
+        def fn(_attempt: int) -> float:
+            return random.uniform(min, max)
+        return _Wait(fn)
+
+    def retry_if_exception_type(
+        exc_types: type[BaseException] | tuple[type[BaseException], ...]
+    ) -> Callable[[BaseException], bool]:
+        if not isinstance(exc_types, tuple):
+            exc_types = (exc_types,)
+
+        def predicate(exc: BaseException) -> bool:
+            return isinstance(exc, exc_types)
+
+        return predicate
+
+    def retry(
+        *,
+        retry: Callable[[BaseException], bool] | None = None,
+        stop: Callable[[int], bool] | None = None,
+        wait: Callable[[int], float] | None = None,
+        reraise: bool = False,
+    ) -> Callable[[Callable[..., T]], Callable[..., T]]:
+        def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+            @functools.wraps(fn)
+            def wrapper(*args, **kwargs):
+                attempt = 0
+                while True:
+                    try:
+                        return fn(*args, **kwargs)
+                    except Exception as exc:  # pragma: no cover - used in fallback
+                        attempt += 1
+                        if retry and not retry(exc):
+                            raise
+                        if stop and stop(attempt):
+                            if reraise:
+                                raise
+                            raise RetryError() from exc
+                        delay = wait(attempt) if wait else 0.0
+                        time.sleep(delay)
+            return wrapper
+        return decorator
 
 
 def retry_call(
@@ -17,7 +113,7 @@ def retry_call(
     max_backoff: float = 2.0,
     jitter: float = 0.1,
     exceptions: tuple[type[BaseException], ...] = (),
-    sleep_fn=time.sleep,
+    sleep_fn: Callable[[float], None] = time.sleep,
     **kwargs,
 ) -> T:
     """Exponential backoff helper for direct function calls."""
@@ -36,38 +132,13 @@ def retry_call(
             delay = min(max_backoff, delay * 2)
 
 
-def retry(
-    retries: int = 3,
-    delay: float = 0.5,
-    backoff: float = 2.0,
-    exceptions=(Exception,),
-    *,
-    mode: Literal["exponential", "fixed", "linear"] = "exponential",
-    **kwargs,
-):
-    """Retry decorator supporting multiple backoff modes."""
-
-    def decorator(fn: Callable):
-        @functools.wraps(fn)
-        def wrapper(*args, **kw):
-            curr_delay = delay
-            for attempt in range(retries):
-                try:
-                    return fn(*args, **kw)
-                except exceptions:
-                    if attempt == retries - 1:
-                        raise
-                    time.sleep(curr_delay)
-                    if mode == "exponential":
-                        curr_delay *= backoff
-                    elif mode == "linear":
-                        curr_delay += backoff
-                    else:  # fixed
-                        curr_delay = curr_delay
-        return wrapper
-
-    return decorator
-
-
-__all__ = ["retry", "retry_call"]
-
+__all__ = [
+    "retry",
+    "stop_after_attempt",
+    "wait_exponential",
+    "wait_random",
+    "retry_if_exception_type",
+    "RetryError",
+    "retry_call",
+    "HAS_TENACITY",
+]

--- a/tests/test_retry_idempotency_integration.py
+++ b/tests/test_retry_idempotency_integration.py
@@ -8,10 +8,10 @@ import pytest
 sys.path.insert(0, '/tmp')
 
 from tests.optdeps import require
+from ai_trading.utils.retry import retry, stop_after_attempt, wait_exponential
 
 # Skip when tenacity isn't installed (CI smoke with SKIP_INSTALL=1)
 require("tenacity")
-from tenacity import retry, stop_after_attempt, wait_exponential
 
 pytestmark = pytest.mark.integration
 

--- a/tests/test_tenacity_import.py
+++ b/tests/test_tenacity_import.py
@@ -1,34 +1,34 @@
 """Test to ensure real tenacity package is imported from PyPI."""
-import pytest
+import inspect
+
 from tests.optdeps import require
+from ai_trading.utils import retry as retry_utils
 
 # Skip when tenacity isn't installed (CI smoke with SKIP_INSTALL=1)
 require("tenacity")
-
-import inspect
 
 
 def test_real_tenacity_import():
     """Test that tenacity is imported from site-packages, not local mock."""
     import tenacity
+
     tenacity_path = inspect.getfile(tenacity)
-    assert 'site-packages' in tenacity_path or '/tmp' in tenacity_path, \
+    assert "site-packages" in tenacity_path or "/tmp" in tenacity_path, (
         f"Using local tenacity mock! Import path: {tenacity_path}"
+    )
+    assert retry_utils.retry is tenacity.retry
 
 
 def test_tenacity_functionality():
-    """Test that real tenacity has expected functionality."""
-    from tenacity import retry, stop_after_attempt, wait_exponential
+    """Test that retry utilities are callable and usable."""
+    from ai_trading.utils.retry import retry, stop_after_attempt, wait_exponential
 
-    # Test that these are callable
     assert callable(retry)
     assert callable(stop_after_attempt)
     assert callable(wait_exponential)
 
-    # Test basic decorator functionality
     @retry(stop=stop_after_attempt(2))
     def test_func():
         return "success"
 
-    result = test_func()
-    assert result == "success"
+    assert test_func() == "success"


### PR DESCRIPTION
## Summary
- wrap Tenacity utilities with optional `ai_trading.utils.retry`
- switch sentiment and core engine to the new retry wrapper
- document Tenacity as an optional dependency with graceful fallback

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: tests/test_current_api.py::test_data_fetcher_active_exports - AssertionError: assert False)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2af0a37083308c65d89f5e446bfa