### PR TITLE
Handle missing calendar dependencies in last_market_session

### DIFF
--- a/ai_trading/utils/time.py
+++ b/ai_trading/utils/time.py
@@ -3,7 +3,6 @@ from datetime import UTC, datetime, timedelta
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from ai_trading.market.calendars import get_calendar_registry
 from ai_trading.utils.lazy_imports import load_pandas
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -21,9 +20,16 @@ class SessionWindow:
     close: pd.Timestamp
 
 def last_market_session(now: pd.Timestamp) -> SessionWindow | None:
-    """Return previous market session window for NYSE."""
+    """Return previous market session window for NYSE.
+
+    Returns ``None`` if pandas or market calendars are unavailable.
+    """
     pd = load_pandas()
     if pd is None:
+        return None
+    try:
+        from ai_trading.market.calendars import get_calendar_registry
+    except Exception:  # ImportError: calendars package missing
         return None
     cal = get_calendar_registry()
     current = now.tz_convert('UTC').date()

--- a/tests/time/test_last_market_session_missing_deps.py
+++ b/tests/time/test_last_market_session_missing_deps.py
@@ -1,0 +1,23 @@
+import builtins
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+import ai_trading.utils.time as t
+
+
+def test_missing_calendars_returns_none(monkeypatch):
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "ai_trading.market.calendars":
+            raise ImportError
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert t.last_market_session(pd.Timestamp.now(tz="UTC")) is None
+
+
+def test_missing_pandas_returns_none(monkeypatch):
+    monkeypatch.setattr(t, "load_pandas", lambda: None)
+    assert t.last_market_session(pd.Timestamp.now(tz="UTC")) is None


### PR DESCRIPTION
## Summary
- Defer `get_calendar_registry` import until `last_market_session` is called
- Gracefully return `None` when pandas or calendar dependencies are missing
- Add tests covering missing calendar and pandas scenarios

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/time/test_last_market_session_import.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/time/test_last_market_session_missing_deps.py -q` *(skipped: could not import 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68ae2af489c4833086642c3fbe68a450