### PR TITLE
Add order tracking with stale cleanup

### DIFF
--- a/tests/test_order_tracking.py
+++ b/tests/test_order_tracking.py
@@ -1,0 +1,34 @@
+import time
+from unittest.mock import Mock, patch
+
+from ai_trading.execution.engine import ExecutionEngine
+from ai_trading.monitoring.order_health_monitor import _active_orders, _order_tracking_lock
+
+
+def test_track_and_cleanup():
+    """Orders are tracked and stale ones cleaned up."""
+    with _order_tracking_lock:
+        _active_orders.clear()
+    engine = ExecutionEngine()
+    order = Mock()
+    order.id = "o1"
+    order.symbol = "AAPL"
+    order.side = "buy"
+    order.quantity = 10
+    order.status = "new"
+    engine.track_order(order)
+    assert any(o.order_id == "o1" for o in engine.get_pending_orders())
+    engine._update_order_status("o1", "filled")
+    assert engine.get_pending_orders() == []
+    stale = Mock()
+    stale.id = "o2"
+    stale.symbol = "MSFT"
+    stale.side = "sell"
+    stale.quantity = 5
+    stale.status = "new"
+    engine.track_order(stale)
+    with _order_tracking_lock:
+        _active_orders["o2"].submitted_time = time.time() - 1000
+    with patch.object(engine, "_cancel_stale_order", return_value=True):
+        removed = engine.cleanup_stale_orders(max_age_seconds=600)
+    assert removed == 1

--- a/tests/test_short_selling_implementation.py
+++ b/tests/test_short_selling_implementation.py
@@ -135,9 +135,12 @@ class TestShortSellingImplementation(unittest.TestCase):
         mock_order = Mock()
         mock_order.id = "test_order_123"
         mock_order.status = "new"
+        mock_order.symbol = "AAPL"
+        mock_order.side = "buy"
+        mock_order.quantity = 10
 
-        # Test _track_order method
-        engine._track_order(mock_order, "AAPL", "buy", 10)
+        # Test track_order method
+        engine.track_order(mock_order)
 
         # Verify order is tracked
         pending_orders = engine.get_pending_orders()
@@ -158,7 +161,10 @@ class TestShortSellingImplementation(unittest.TestCase):
         old_order = Mock()
         old_order.id = "old_order_456"
         old_order.status = "new"
-        engine._track_order(old_order, "MSFT", "sell", 5)
+        old_order.symbol = "MSFT"
+        old_order.side = "sell"
+        old_order.quantity = 5
+        engine.track_order(old_order)
 
         # Mock the order as old by manipulating the tracking directly
         import time


### PR DESCRIPTION
## Summary
- add `_track_order` and public `track_order` wrapper to monitor orders
- unify stale order cleanup and add helpers for status updates
- test order tracking and stale cleanup paths

## Testing
- `ruff check ai_trading/execution/engine.py tests/test_short_selling_implementation.py tests/test_order_tracking.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: AssertionError: assert False in tests/test_current_api.py::test_data_fetcher_active_exports)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2af7417883309c9d3f43c71fa244