### PR TITLE
Narrow broad exception handlers

### DIFF
--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -77,7 +77,7 @@ class RiskEngine:
                 logger.warning('Invalid exposure_cap_aggressive %s, using default 0.8', exposure_cap)
                 exposure_cap = 0.8
             self.global_limit = exposure_cap
-        except (ValueError, KeyError, TypeError, ZeroDivisionError, OSError) as e:
+        except (TypeError, ValueError) as e:  # config may contain non-numeric values
             logger.error('Error validating exposure_cap_aggressive: %s, using default', e)
             self.global_limit = 0.8
         self.asset_limits: dict[str, float] = {}

--- a/tests/runtime/test_no_broad_except_stage2.py
+++ b/tests/runtime/test_no_broad_except_stage2.py
@@ -10,6 +10,7 @@ MODULES = [
     "ai_trading/execution/order_router.py",
     "ai_trading/position/calculators.py",
     "ai_trading/risk/engine.py",
+    "ai_trading/rl_trading/train.py",
     "ai_trading/monitoring/aggregator.py",
     "ai_trading/monitoring/processor.py",
     "ai_trading/signals/factors.py",


### PR DESCRIPTION
## Summary
- Narrow config validation in risk engine to catch only type errors
- Replace COMMON_EXC with explicit exception tuples in RL training and callbacks
- Extend runtime guard to audit RL trainer for broad excepts

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/runtime/test_no_broad_except_stage2.py tests/runtime/test_no_broad_in_stage2.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: AssertionError in tests/test_current_api.py::test_data_fetcher_active_exports)*
- `python tools/audit_exceptions.py --paths ai_trading/risk/engine.py ai_trading/rl_trading/train.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae2af880f0833097cf66c5f8247b5a