### PR TITLE
docs: update execution imports

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -71,53 +71,21 @@ class BotState:
         """Update risk management parameters."""
 ```
 
-#### `trade_execution.py` - Order Execution
+#### `execution/engine.py` - Order Execution
 
 ```python
-from trade_execution import execute_order_async, validate_order, get_position_info
+from ai_trading.execution.engine import ExecutionEngine
 
-async def execute_order_async(
-    symbol: str,
-    quantity: float,
-    side: str,
-    order_type: str = 'market',
-    time_in_force: str = 'day',
-    limit_price: Optional[float] = None
-) -> Dict[str, Any]:
-    """
-    Execute trading order asynchronously.
+engine = ExecutionEngine()
 
-    Args:
-        symbol: Trading symbol (e.g., 'AAPL')
-        quantity: Number of shares to trade
-        side: 'buy' or 'sell'
-        order_type: 'market', 'limit', 'stop'
-        time_in_force: 'day', 'gtc', 'ioc', 'fok'
-        limit_price: Price for limit orders
-
-    Returns:
-        Dict containing order status and execution details
-
-    Example:
-        >>> result = await execute_order_async('AAPL', 10, 'buy')
-        >>> print(result['order_id'])
-    """
-
-def validate_order(
-    symbol: str,
-    quantity: float,
-    side: str,
-    current_portfolio: Dict[str, float]
-) -> Tuple[bool, str]:
-    """
-    Validate order before execution.
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-
-def get_position_info(symbol: str) -> Dict[str, Any]:
-    """Get current position information for symbol."""
+result = engine.execute_order(
+    symbol="AAPL",
+    quantity=10,
+    side="buy",
+    order_type="market",
+    time_in_force="day",
+    limit_price=None,
+)
 ```
 
 ### Data Management API

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Use package imports:
 ```python
 from ai_trading.signals import generate_position_hold_signals
 from ai_trading.data_fetcher import get_minute_df
-from ai_trading.trade_execution import recent_buys
+from ai_trading.execution.engine import ExecutionEngine
 ```
 Root imports (e.g., `from signals import ...`) have been removed.
 
@@ -538,20 +538,23 @@ python -m ai_trading --strategy custom_momentum
 ```python
 # example_bot_usage.py
 import asyncio
-from bot_engine import run_all_trades_worker
-from trade_execution import execute_order_async
+from ai_trading.core.bot_engine import run_all_trades_worker
+from ai_trading.execution.engine import ExecutionEngine
+
+engine = ExecutionEngine()
 
 async def custom_trading_logic():
     """Example of programmatic trading."""
-    
+
     # Run analysis on specific symbols
     symbols = ['SPY', 'QQQ', 'IWM']
     results = run_all_trades_worker(symbols, dry_run=True)
-    
+
     # Execute trades based on results
     for symbol, analysis in results.items():
         if analysis['signal_strength'] > 0.8:
-            await execute_order_async(
+            await asyncio.to_thread(
+                engine.execute_order,
                 symbol=symbol,
                 quantity=analysis['recommended_shares'],
                 side='buy'

--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -422,7 +422,7 @@ from unittest.mock import patch
 import alpaca_trade_api as tradeapi
 
 from alpaca_api import AlpacaAPI
-from trade_execution import OrderExecutor
+from ai_trading.execution.engine import ExecutionEngine
 
 
 class TestAlpacaIntegration:
@@ -480,7 +480,7 @@ class TestAlpacaIntegration:
         if not os.getenv('ALPACA_API_KEY'):
             pytest.skip("ALPACA_API_KEY not set")
         
-        executor = OrderExecutor()
+        executor = ExecutionEngine()
         
         # Use a very small quantity for testing
         with patch.dict(os.environ, {'DRY_RUN': 'true'}):

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -277,7 +277,7 @@ if __name__ == "__main__":
 
 ```python
 # debug_order_validation.py
-import trade_execution
+from ai_trading.execution.engine import ExecutionEngine
 import alpaca_trade_api as tradeapi
 import os
 
@@ -308,16 +308,19 @@ def debug_order_issue(symbol, quantity, side):
     else:
         print("No current position")
     
+    engine = ExecutionEngine()
+
     # Validate order
     try:
-        is_valid, error_msg = trade_execution.validate_order(
-            symbol, quantity, side, {}
+        engine.execute_order(
+            symbol=symbol,
+            quantity=quantity,
+            side=side,
         )
-        print(f"Order validation: {'PASS' if is_valid else 'FAIL'}")
-        if not is_valid:
-            print(f"Error: {error_msg}")
-    except Exception as e:
-        print(f"Validation error: {e}")
+        print("Order validation: PASS")
+    except ValueError as e:
+        print("Order validation: FAIL")
+        print(f"Error: {e}")
 
 # Example usage
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace legacy `trade_execution` imports with `ai_trading.execution.engine.ExecutionEngine`
- refresh programmatic trading and troubleshooting examples to use `ExecutionEngine`
- update API docs and testing framework guidance for new execution entry point

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae350aedc48330b1384d717e82b213