### PR TITLE
refactor: use canonical execution engine import

### DIFF
--- a/scripts/critical_fixes_validation.py
+++ b/scripts/critical_fixes_validation.py
@@ -18,7 +18,7 @@ class TestCriticalFixesValidation(unittest.TestCase):
         """Test P0 CRITICAL: Quantity calculation bug fix."""
         logging.info('\n🔧 Testing P0 Fix: Quantity Calculation Bug')
         from tests.support.mocks import MockContext, MockOrder
-        from trade_execution import ExecutionEngine
+        from ai_trading.execution.engine import ExecutionEngine
         ctx = MockContext()
         engine = ExecutionEngine(ctx)
         mock_order = MockOrder(filled_qty=2)
@@ -67,7 +67,7 @@ class TestCriticalFixesValidation(unittest.TestCase):
         """Test P2 MEDIUM: Short selling validation foundation."""
         logging.info('\n🔧 Testing P2 Fix: Short Selling Validation (Foundation)')
         from tests.support.mocks import MockContextShortSelling
-        from trade_execution import ExecutionEngine
+        from ai_trading.execution.engine import ExecutionEngine
         ctx = MockContextShortSelling()
         engine = ExecutionEngine(ctx)
         self.assertTrue(hasattr(engine, '_validate_short_selling'), 'Short selling validation method should exist')

--- a/scripts/demo_short_selling_implementation.py
+++ b/scripts/demo_short_selling_implementation.py
@@ -15,7 +15,7 @@ def demonstrate_short_selling():
     """Demonstrate the short selling capability."""
     logging.info('=== Short Selling Capability Demonstration ===')
     try:
-        from trade_execution import ExecutionEngine
+        from ai_trading.execution.engine import ExecutionEngine
         mock_ctx = Mock()
         mock_api = Mock()
         mock_account = Mock()
@@ -61,7 +61,11 @@ def demonstrate_order_monitoring():
     """Demonstrate the order monitoring capability."""
     logging.info('\n=== Order Monitoring Capability Demonstration ===')
     try:
-        from trade_execution import ExecutionEngine, _active_orders, _order_tracking_lock
+        from ai_trading.execution.engine import (
+            ExecutionEngine,
+            _active_orders,
+            _order_tracking_lock,
+        )
         mock_ctx = Mock()
         mock_ctx.api = Mock()
         engine = ExecutionEngine(mock_ctx)


### PR DESCRIPTION
## Summary
- replace deprecated `trade_execution` imports with `ai_trading.execution.engine`
- update short selling demo to pull order tracking helpers from the canonical engine
- switch critical fixes validation to new execution engine import

## Testing
- `ruff check scripts/demo_short_selling_implementation.py scripts/critical_fixes_validation.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `python - <<'PY'
from ai_trading.execution.engine import ExecutionEngine
print('Loaded', ExecutionEngine.__name__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ae3509a4d08330a030fc1bb8d67639