### PR TITLE
chore: remove legacy pytest marker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,7 +11,5 @@ filterwarnings =
 timeout = 60
 timeout_method = thread
 faulthandler_timeout = 120
-markers =
-    legacy: temporary marker for legacy tests slated for refactor/remove
 testpaths =
     tests


### PR DESCRIPTION
## Summary
- remove legacy marker from pytest config

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae3a839c308330b073011a78a05157