### PR TITLE
refactor: route data imports through data package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ now_ny = datetime.now(ZoneInfo("America/New_York"))
 Use package imports:
 ```python
 from ai_trading.signals import generate_position_hold_signals
-from ai_trading.data_fetcher import get_minute_df
+from ai_trading.data.fetch import get_minute_df
 from ai_trading.execution.engine import ExecutionEngine
 ```
 Root imports (e.g., `from signals import ...`) have been removed.

--- a/ai_trading/__init__.py
+++ b/ai_trading/__init__.py
@@ -10,7 +10,7 @@ from importlib import import_module as _import_module
 _PUBLIC_MODULES = {
     'config', 'logging', 'utils',
     'alpaca_api', 'data_validation', 'indicators', 'rebalancer', 'audit',
-    'core', 'strategy_allocator', 'predict', 'meta_learning', 'data_fetcher',
+    'core', 'strategy_allocator', 'predict', 'meta_learning',
     'signals', 'settings', 'runner', 'portfolio', 'app', 'ml_model',
     'paths', 'main', 'position_sizing', 'capital_scaling', 'indicator_manager',
     'execution', 'production_system', 'trade_logic',
@@ -18,8 +18,8 @@ _PUBLIC_MODULES = {
 
 _PUBLIC_SYMBOLS = {
     'ExecutionEngine': 'ai_trading.execution.engine:ExecutionEngine',
-    'DataFetchError': 'ai_trading.data_fetcher:DataFetchError',
-    'DataFetchException': 'ai_trading.data_fetcher:DataFetchException',
+    'DataFetchError': 'ai_trading.data.fetch:DataFetchError',
+    'DataFetchException': 'ai_trading.data.fetch:DataFetchException',
 }
 
 __all__ = sorted(set(_PUBLIC_MODULES) | set(_PUBLIC_SYMBOLS))

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -37,12 +37,14 @@ except ImportError:  # pragma: no cover  # AI-AGENT-REF: narrow import handling
 from threading import Lock
 import warnings
 
-import ai_trading.data_fetcher as data_fetcher_module
-from ai_trading.data_fetcher import (
+import ai_trading.data.fetch as data_fetcher_module
+from ai_trading.data.fetch import (
     DataFetchError,
     get_bars,
     get_bars_batch,
     get_minute_df,
+    get_cached_minute_timestamp,
+    last_minute_bar_age_seconds,
 )
 from ai_trading.utils.time import last_market_session
 from ai_trading.capital_scaling import capital_scale, update_if_present
@@ -6115,7 +6117,7 @@ def _ensure_data_fresh(symbols, max_age_seconds: int) -> None:
     Logs UTC timestamps and fails fast if any symbol is stale.
     """
     try:
-        from ai_trading.data_fetcher import last_minute_bar_age_seconds
+        from ai_trading.data.fetch import last_minute_bar_age_seconds
     except (ValueError, TypeError) as e:  # AI-AGENT-REF: soft-fail if import missing
         logger.warning("Data freshness check unavailable; skipping", exc_info=e)
         return

--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.config import get_settings
 from ai_trading.data.market_calendar import previous_trading_session, rth_session_utc
-from ai_trading.data_fetcher import get_bars, get_minute_df
-from ai_trading.data_fetcher import get_bars as http_get_bars
+from ai_trading.data.fetch import get_bars, get_minute_df
+from ai_trading.data.fetch import get_bars as http_get_bars
 from ai_trading.logging import get_logger
 from ai_trading.logging.empty_policy import classify as _empty_classify
 from ai_trading.logging.empty_policy import record as _empty_record

--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Compatibility wrappers for legacy data fetcher APIs.
+
+This module exposes a minimal subset of the old ``ai_trading.data_fetcher``
+interfaces so callers can transition to the ``ai_trading.data`` package without
+importing the deprecated module directly. Each function delegates to
+``ai_trading.data_fetcher`` at call time so test monkeypatches remain effective.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List
+
+from ai_trading import data_fetcher as _df
+
+DataFetchError = _df.DataFetchError
+DataFetchException = _df.DataFetchException
+FinnhubAPIException = getattr(_df, "FinnhubAPIException", Exception)
+
+
+def get_bars(
+    symbol: str,
+    timeframe: str,
+    start: Any,
+    end: Any,
+    *,
+    feed: str | None = None,
+    adjustment: str | None = None,
+):
+    return _df.get_bars(symbol, timeframe, start, end, feed=feed, adjustment=adjustment)
+
+
+def get_bars_batch(
+    symbols: List[str],
+    timeframe: str,
+    start: Any,
+    end: Any,
+    *,
+    feed: str | None = None,
+    adjustment: str | None = None,
+) -> Dict[str, Any]:
+    return _df.get_bars_batch(
+        symbols, timeframe, start, end, feed=feed, adjustment=adjustment
+    )
+
+
+def get_minute_df(symbol: str, start: Any, end: Any, feed: str | None = None):
+    return _df.get_minute_df(symbol, start, end, feed=feed)
+
+
+def get_daily_df(symbol: str, start: Any, end: Any, feed: str | None = None):
+    return get_bars(symbol, "1Day", start, end, feed=feed)
+
+
+def build_fetcher(config: Any):
+    return _df.build_fetcher(config)
+
+
+def get_cached_minute_timestamp(symbol: str) -> int | None:
+    return _df.get_cached_minute_timestamp(symbol)
+
+
+def set_cached_minute_timestamp(symbol: str, ts_epoch_s: int) -> None:
+    _df.set_cached_minute_timestamp(symbol, ts_epoch_s)
+
+
+def clear_cached_minute_timestamp(symbol: str) -> None:
+    _df.clear_cached_minute_timestamp(symbol)
+
+
+def age_cached_minute_timestamps(max_age_seconds: int) -> int:
+    return _df.age_cached_minute_timestamps(max_age_seconds)
+
+
+def last_minute_bar_age_seconds(symbol: str) -> int | None:
+    return _df.last_minute_bar_age_seconds(symbol)
+
+
+def _build_daily_url(symbol: str, start: datetime, end: datetime) -> str:
+    start_s = int(start.timestamp())
+    end_s = int(end.timestamp())
+    return (
+        "https://query1.finance.yahoo.com/v8/finance/chart/"
+        f"{symbol}?period1={start_s}&period2={end_s}&interval=1d"
+    )
+
+
+__all__ = [
+    "DataFetchError",
+    "DataFetchException",
+    "FinnhubAPIException",
+    "get_bars",
+    "get_bars_batch",
+    "get_minute_df",
+    "get_daily_df",
+    "build_fetcher",
+    "get_cached_minute_timestamp",
+    "set_cached_minute_timestamp",
+    "clear_cached_minute_timestamp",
+    "age_cached_minute_timestamps",
+    "last_minute_bar_age_seconds",
+    "_build_daily_url",
+]

--- a/ai_trading/data_fetcher.py
+++ b/ai_trading/data_fetcher.py
@@ -161,11 +161,6 @@ def last_minute_bar_age_seconds(symbol: str) -> int | None:
         return None
     now_s = int(_dt.datetime.now(tz=UTC).timestamp())
     return max(0, now_s - int(ts))
-
-
-def warmup_cache(*_args: Any, **_kwargs: Any) -> None:
-    """Backward-compatibility shim; cache warm-up now occurs lazily."""
-    return None
 _DEFAULT_FEED = 'iex'
 _VALID_FEEDS = ('iex', 'sip')
 
@@ -603,6 +598,5 @@ __all__ = [
     'DataFetchError',
     'DataFetchException',
     'FinnhubAPIException',
-    'warmup_cache',
 ]
 

--- a/ai_trading/data_validation.py
+++ b/ai_trading/data_validation.py
@@ -6,7 +6,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 from ai_trading.utils.lazy_imports import load_pandas
-from ai_trading.data_fetcher import get_bars
+from ai_trading.data.fetch import get_bars
 
 # Lazy pandas proxy for on-demand import
 pd = load_pandas()

--- a/ai_trading/model_loader.py
+++ b/ai_trading/model_loader.py
@@ -39,7 +39,7 @@ def train_and_save_model(symbol: str, models_dir: Path) -> object:
     import pandas as pd
     from sklearn.linear_model import LinearRegression
 
-    from ai_trading.data_fetcher import get_daily_df
+    from ai_trading.data.fetch import get_daily_df
 
     end = datetime.now(UTC)
     start = end - timedelta(days=30)

--- a/ai_trading/runner.py
+++ b/ai_trading/runner.py
@@ -157,7 +157,7 @@ def run_cycle() -> None:
         from ai_trading.core.bot_engine import get_ctx
         from ai_trading.core.runtime import build_runtime, REQUIRED_PARAM_DEFAULTS
         from ai_trading.config.management import TradingConfig
-        from ai_trading.data_fetcher import DataFetchError
+        from ai_trading.data.fetch import DataFetchError
         
         lazy_ctx = get_ctx()
         

--- a/ai_trading/strategies/metalearning.py
+++ b/ai_trading/strategies/metalearning.py
@@ -17,7 +17,7 @@ from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
-from ai_trading.data_fetcher import get_minute_df
+from ai_trading.data.fetch import get_minute_df
 from ..core.enums import OrderSide, RiskLevel
 from .base import BaseStrategy, StrategySignal
 ML_AVAILABLE = True

--- a/ai_trading/tools/fetch_sample_universe.py
+++ b/ai_trading/tools/fetch_sample_universe.py
@@ -13,7 +13,7 @@ def run(symbols: list[str], timeout: float | None=None) -> int:
     """Fetch daily data for ``symbols`` using the pooled HTTP client."""
     if not symbols:
         return 0
-    from ai_trading.data_fetcher import _build_daily_url
+    from ai_trading.data.fetch import _build_daily_url
     end = datetime.now(UTC)
     start = end - timedelta(days=7)
     urls = [_build_daily_url(sym, start, end) for sym in symbols]

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -259,7 +259,7 @@ def get_current_price(symbol: str) -> float:
     if price <= 0:
         logger.warning("get_current_price invalid price %.2f for %s; falling back to last close", price, symbol)
         try:
-            from ai_trading.data_fetcher import get_daily_df
+            from ai_trading.data.fetch import get_daily_df
 
             end = dt.date.today()
             start = end - dt.timedelta(days=5)

--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -116,7 +116,15 @@ def test_import_hardening():
         bot_engine_path = Path('ai_trading/core/bot_engine.py')
         if bot_engine_path.exists():
             content = bot_engine_path.read_text()
-            expected_patterns = ['from ai_trading.meta_learning import optimize_signals', 'from meta_learning import optimize_signals', 'from ai_trading.pipeline import model_pipeline', 'from pipeline import model_pipeline', 'from ai_trading.execution import ExecutionEngine', 'from ai_trading.data_fetcher import', 'from ai_trading.data_fetcher import']
+            expected_patterns = [
+                'from ai_trading.meta_learning import optimize_signals',
+                'from meta_learning import optimize_signals',
+                'from ai_trading.pipeline import model_pipeline',
+                'from pipeline import model_pipeline',
+                'from ai_trading.execution import ExecutionEngine',
+                'from ai_trading.data.fetch import',
+                'from ai_trading.data.fetch import',
+            ]
             for pattern in expected_patterns:
                 assert pattern in content, f'Missing import pattern: {pattern}'
         files_to_check = ['runner.py', 'backtester.py', 'profile_indicators.py']

--- a/scripts/problem_statement_validation.py
+++ b/scripts/problem_statement_validation.py
@@ -28,7 +28,21 @@ def check_env_flag():
 def check_import_hardening():
     """Check that imports are hardened across key modules."""
     logging.info('✓ Hardened imports:')
-    files_to_check = {'ai_trading/core/bot_engine.py': ['from ai_trading.meta_learning import optimize_signals', 'from ai_trading.pipeline import model_pipeline', 'from ai_trading.execution import ExecutionEngine', 'from ai_trading.data_fetcher import', 'from ai_trading.indicators import rsi', 'from ai_trading.signals import generate_position_hold_signals', 'from ai_trading import portfolio', 'from ai_trading.alpaca_api import alpaca_get'], 'runner.py': ['from ai_trading.indicators import'], 'backtester.py': ['import ai_trading.signals as signals', 'import ai_trading.data_fetcher as data_fetcher'], 'profile_indicators.py': ['import ai_trading.signals as signals', 'import ai_trading.indicators as indicators']}
+    files_to_check = {
+        'ai_trading/core/bot_engine.py': [
+            'from ai_trading.meta_learning import optimize_signals',
+            'from ai_trading.pipeline import model_pipeline',
+            'from ai_trading.execution import ExecutionEngine',
+            'from ai_trading.data.fetch import',
+            'from ai_trading.indicators import rsi',
+            'from ai_trading.signals import generate_position_hold_signals',
+            'from ai_trading import portfolio',
+            'from ai_trading.alpaca_api import alpaca_get',
+        ],
+        'runner.py': ['from ai_trading.indicators import'],
+        'backtester.py': ['import ai_trading.signals as signals', 'import ai_trading.data.fetch as data_fetcher'],
+        'profile_indicators.py': ['import ai_trading.signals as signals', 'import ai_trading.indicators as indicators'],
+    }
     for filepath, required_imports in files_to_check.items():
         if Path(filepath).exists():
             content = Path(filepath).read_text()
@@ -77,7 +91,7 @@ def check_minute_cache():
     if bot_engine_path.exists():
         content = bot_engine_path.read_text()
         assert 'def _ensure_data_fresh(symbols, max_age_seconds: int)' in content
-        assert 'from ai_trading.data_fetcher import get_cached_minute_timestamp, last_minute_bar_age_seconds' in content
+        assert 'from ai_trading.data.fetch import get_cached_minute_timestamp, last_minute_bar_age_seconds' in content
         assert '_dt.datetime.now(_dt.timezone.utc).isoformat()' in content
         logging.info('  - Fail fast in bot_engine.py when cached minute data is stale ✓')
         logging.info('  - Logs UTC timestamps ✓')

--- a/scripts/run_wfa.py
+++ b/scripts/run_wfa.py
@@ -20,7 +20,7 @@ except Exception:  # pragma: no cover
     pd = _PD()  # type: ignore
 try:
     from ai_trading.config.management import TradingConfig
-    from ai_trading.data_fetcher import DataFetcher
+    from ai_trading.core.bot_engine import DataFetcher
     from ai_trading.evaluation.walkforward import WalkForwardEvaluator
     from ai_trading.logging import logger
     from ai_trading.signals import SignalDecisionPipeline, generate_cost_aware_signals


### PR DESCRIPTION
## Summary
- add ai_trading.data.fetch wrapper for legacy data fetcher APIs
- route all internal imports through ai_trading.data.fetch
- drop unused warmup_cache shim

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5bc8de4c8330a7ea68f3bf3700ab