### PR TITLE
refactor: remove legacy bot_engine root path

### DIFF
--- a/scripts/final_validation_report.py
+++ b/scripts/final_validation_report.py
@@ -1,17 +1,19 @@
 import logging
-'\nFinal validation script for critical trading bot issue fixes.\nDemonstrates that each fix addresses the specific issues mentioned in the problem statement.\n'
+from pathlib import Path
 import os
 import sys
+
+"""Final validation script for critical trading bot issue fixes.
+Demonstrates that each fix addresses the specific issues mentioned in the problem statement."""
 
 def validate_issue_1_meta_learning():
     """Validate Issue 1: Meta-Learning System Not Functioning"""
     logging.info('🔍 Issue 1: Meta-Learning System Not Functioning')
     logging.info("   Problem: 'METALEARN_EMPTY_TRADE_LOG - No valid trades found' despite successful trades")
     logging.info('   Root Cause: Audit-to-meta conversion not triggered automatically')
-    bot_engine_path = 'bot_engine.py'
-    if os.path.exists(bot_engine_path):
-        with open(bot_engine_path) as f:
-            content = f.read()
+    bot_engine_path = Path('ai_trading/core/bot_engine.py')
+    if bot_engine_path.exists():
+        content = bot_engine_path.read_text()
         if 'from meta_learning import validate_trade_data_quality' in content:
             logging.info('   ✅ Fix: Meta-learning trigger added to TradeLogger.log_exit()')
             if 'METALEARN_TRIGGER_CONVERSION' in content:
@@ -25,10 +27,9 @@ def validate_issue_2_sentiment_circuit_breaker():
     logging.info('\n🔍 Issue 2: Sentiment Circuit Breaker Stuck Open')
     logging.info('   Problem: Opens after 3 failures, stays open for entire cycle')
     logging.info('   Root Cause: Threshold too low (3) and recovery timeout insufficient (300s)')
-    bot_engine_path = 'bot_engine.py'
-    if os.path.exists(bot_engine_path):
-        with open(bot_engine_path) as f:
-            content = f.read()
+    bot_engine_path = Path('ai_trading/core/bot_engine.py')
+    if bot_engine_path.exists():
+        content = bot_engine_path.read_text()
         if 'SENTIMENT_FAILURE_THRESHOLD = 8' in content:
             logging.info('   ✅ Fix: Failure threshold increased 3 → 8 (+167% tolerance)')
             if 'SENTIMENT_RECOVERY_TIMEOUT = 900' in content:
@@ -65,10 +66,9 @@ def validate_issue_4_position_limits():
     logging.info("   Problem: Bot stops at 10 positions with 'SKIP_TOO_MANY_POSITIONS'")
     logging.info('   Root Cause: MAX_PORTFOLIO_POSITIONS too low for modern portfolio sizes')
     fixes_found = 0
-    bot_engine_path = 'bot_engine.py'
-    if os.path.exists(bot_engine_path):
-        with open(bot_engine_path) as f:
-            content = f.read()
+    bot_engine_path = Path('ai_trading/core/bot_engine.py')
+    if bot_engine_path.exists():
+        content = bot_engine_path.read_text()
         if '"20"' in content and 'MAX_PORTFOLIO_POSITIONS' in content:
             logging.info('   ✅ Fix: bot_engine.py default increased to 20 positions')
             fixes_found += 1

--- a/scripts/validate_final_polish.py
+++ b/scripts/validate_final_polish.py
@@ -2,16 +2,16 @@ import logging
 "\nBasic validation tests that don't require full config setup.\n"
 import os
 import tempfile
+from pathlib import Path
 
 def test_basic_validations():
     """Run basic validations that don't require config."""
     logging.info('=== Final Polish Validation Tests ===')
-    with open('bot_engine.py') as f:
-        content = f.read()
-    if len(content.strip().split('\n')) <= 5 and 'from ai_trading.core.bot_engine import *' in content:
-        logging.info('✓ Bot engine shim is correctly minimal')
+    bot_engine_path = Path('ai_trading/core/bot_engine.py')
+    if bot_engine_path.exists():
+        logging.info('✓ Bot engine module is present')
     else:
-        logging.info('✗ Bot engine shim is not minimal')
+        logging.info('✗ Bot engine module missing')
     with open('.github/workflows/ci.yml') as f:
         ci_content = f.read()
     if 'matrix:' in ci_content and 'python-version:' in ci_content and ('3.12.3' in ci_content) and ("'3.12'" in ci_content):

--- a/scripts/validate_fixes.py
+++ b/scripts/validate_fixes.py
@@ -1,18 +1,22 @@
 import logging
-'\nSimple validation script for critical trading bot fixes.\n\nThis script validates that the fixes are properly implemented by checking\nthe actual code changes rather than running complex tests.\n'
+from pathlib import Path
 import os
 import re
 import sys
 
+"""Simple validation script for critical trading bot fixes.
+
+This script validates that the fixes are properly implemented by checking
+the actual code changes rather than running complex tests."""
+
 def validate_drawdown_circuit_breaker_fix():
     """Validate that the drawdown circuit breaker UnboundLocalError is fixed."""
     logging.info('1. Validating drawdown circuit breaker fix...')
-    bot_engine_path = '/home/runner/work/ai-trading-bot/ai-trading-bot/bot_engine.py'
-    if not os.path.exists(bot_engine_path):
+    bot_engine_path = Path('ai_trading/core/bot_engine.py')
+    if not bot_engine_path.exists():
         logging.info('   ❌ bot_engine.py not found')
         return False
-    with open(bot_engine_path) as f:
-        content = f.read()
+    content = bot_engine_path.read_text()
     fix_pattern = '# AI-AGENT-REF: Get status once to avoid UnboundLocalError in else block\\s*status = ctx\\.drawdown_circuit_breaker\\.get_status\\(\\)'
     if re.search(fix_pattern, content):
         logging.info('   ✅ Status variable scoping fix found')
@@ -49,21 +53,19 @@ def validate_drawdown_circuit_breaker_fix():
 def validate_meta_learning_price_validation_fix():
     """Validate that meta-learning price validation improvements are implemented."""
     logging.info('2. Validating meta-learning price validation fix...')
-    meta_learning_path = '/home/runner/work/ai-trading-bot/ai-trading-bot/meta_learning.py'
-    bot_engine_path = '/home/runner/work/ai-trading-bot/ai-trading-bot/bot_engine.py'
+    meta_learning_path = Path('ai_trading/meta_learning.py')
+    bot_engine_path = Path('ai_trading/core/bot_engine.py')
     fixes_found = 0
-    if os.path.exists(meta_learning_path):
-        with open(meta_learning_path) as f:
-            content = f.read()
+    if meta_learning_path.exists():
+        content = meta_learning_path.read_text()
         if 'This may indicate data quality issues or insufficient trading history' in content:
             logging.info('   ✅ Meta-learning enhanced error message found')
             fixes_found += 1
         if 'logger.warning(' in content and 'METALEARN_INVALID_PRICES' in content:
             logging.info('   ✅ Meta-learning uses warning instead of error')
             fixes_found += 1
-    if os.path.exists(bot_engine_path):
-        with open(bot_engine_path) as f:
-            content = f.read()
+    if bot_engine_path.exists():
+        content = bot_engine_path.read_text()
         if 'This suggests price data corruption or insufficient trading history' in content:
             logging.info('   ✅ Bot engine enhanced error message found')
             fixes_found += 1
@@ -77,12 +79,11 @@ def validate_meta_learning_price_validation_fix():
 def validate_data_fetching_optimization_fix():
     """Validate that data fetching optimizations are implemented."""
     logging.info('3. Validating data fetching optimization fix...')
-    data_fetcher_path = '/home/runner/work/ai-trading-bot/ai-trading-bot/data_fetcher.py'
-    if not os.path.exists(data_fetcher_path):
+    data_fetcher_path = Path('ai_trading/data_fetcher.py')
+    if not data_fetcher_path.exists():
         logging.info('   ❌ data_fetcher.py not found')
         return False
-    with open(data_fetcher_path) as f:
-        content = f.read()
+    content = data_fetcher_path.read_text()
     fixes_found = 0
     if 'MINUTE_CACHE_HIT' in content and 'cache_age_minutes' in content:
         logging.info('   ✅ Enhanced cache hit logging found')
@@ -100,12 +101,11 @@ def validate_data_fetching_optimization_fix():
 def validate_circuit_breaker_error_handling_fix():
     """Validate that enhanced circuit breaker error handling is implemented."""
     logging.info('4. Validating circuit breaker error handling fix...')
-    circuit_breaker_path = '/home/runner/work/ai-trading-bot/ai-trading-bot/ai_trading/risk/circuit_breakers.py'
-    if not os.path.exists(circuit_breaker_path):
+    circuit_breaker_path = Path('ai_trading/risk/circuit_breakers.py')
+    if not circuit_breaker_path.exists():
         logging.info('   ❌ circuit_breakers.py not found')
         return False
-    with open(circuit_breaker_path) as f:
-        content = f.read()
+    content = circuit_breaker_path.read_text()
     fixes_found = 0
     if 'if current_equity is None or not isinstance(current_equity, (int, float)):' in content:
         logging.info('   ✅ Input validation for equity found')

--- a/scripts/validate_fixes_root.py
+++ b/scripts/validate_fixes_root.py
@@ -2,7 +2,10 @@
 import json
 import logging
 import sys
-sys.path.insert(0, '/home/runner/work/ai-trading-bot/ai-trading-bot')
+from pathlib import Path
+
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
 
 def test_json_dumps_ensure_ascii():
     """Test that json.dumps with ensure_ascii=False preserves Unicode."""
@@ -18,12 +21,13 @@ def test_json_dumps_ensure_ascii():
 def test_compilation():
     """Test that the modified files compile correctly."""
     import compileall
-    files_to_check = ['/home/runner/work/ai-trading-bot/ai-trading-bot/ai_trading/logging.py', '/home/runner/work/ai-trading-bot/ai-trading-bot/ai_trading/core/bot_engine.py']
+    files_to_check = [
+        repo_root / 'ai_trading' / 'logging.py',
+        repo_root / 'ai_trading' / 'core' / 'bot_engine.py',
+    ]
     for file_path in files_to_check:
-        if not compileall.compile_file(file_path, quiet=True):
+        if not compileall.compile_file(str(file_path), quiet=True):
             return False
-        else:
-            pass
     return True
 
 def test_logging_formatter_imports():
@@ -42,9 +46,8 @@ def test_logging_formatter_imports():
 
 def validate_bot_engine_functions():
     """Validate that the new functions exist in bot_engine without importing."""
-    bot_engine_path = '/home/runner/work/ai-trading-bot/ai-trading-bot/ai_trading/core/bot_engine.py'
-    with open(bot_engine_path) as f:
-        content = f.read()
+    bot_engine_path = repo_root / 'ai_trading' / 'core' / 'bot_engine.py'
+    content = bot_engine_path.read_text()
     required_functions = ['_get_runtime_context_or_none', '_update_risk_engine_exposure']
     for func_name in required_functions:
         if f'def {func_name}(' in content:
@@ -59,9 +62,8 @@ def validate_bot_engine_functions():
 
 def validate_logging_changes():
     """Validate that logging.py has the ensure_ascii=False changes."""
-    logging_path = '/home/runner/work/ai-trading-bot/ai-trading-bot/ai_trading/logging.py'
-    with open(logging_path) as f:
-        content = f.read()
+    logging_path = repo_root / 'ai_trading' / 'logging.py'
+    content = logging_path.read_text()
     ensure_ascii_false_count = content.count('ensure_ascii=False')
     if ensure_ascii_false_count >= 2:
         return True

--- a/scripts/validate_problem_statement_fixes.py
+++ b/scripts/validate_problem_statement_fixes.py
@@ -1,8 +1,11 @@
 import logging
-'\nManual validation script for critical trading bot fixes.\nThis script validates that all fixes from the problem statement have been properly implemented.\n'
+from pathlib import Path
 import os
 import re
 import sys
+
+"""Manual validation script for critical trading bot fixes.
+This script validates that all fixes from the problem statement have been properly implemented."""
 os.environ.setdefault('ALPACA_API_KEY', 'test_key')
 os.environ.setdefault('ALPACA_SECRET_KEY', 'test_secret')
 os.environ.setdefault('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
@@ -21,8 +24,7 @@ def validate_sentiment_circuit_breaker():
         actual_recovery = sentiment.SENTIMENT_RECOVERY_TIMEOUT
         logging.info(f"Failure threshold: {actual_failures} (expected: {expected_failures}) - {('✓' if actual_failures == expected_failures else '✗')}")
         logging.info(f"Recovery timeout: {actual_recovery}s (expected: {expected_recovery}s) - {('✓' if actual_recovery == expected_recovery else '✗')}")
-        with open('bot_engine.py') as f:
-            content = f.read()
+        content = Path('ai_trading/core/bot_engine.py').read_text()
         bot_failures = re.search('SENTIMENT_FAILURE_THRESHOLD = (\\d+)', content)
         bot_recovery = re.search('SENTIMENT_RECOVERY_TIMEOUT = (\\d+)', content)
         if bot_failures and bot_recovery:
@@ -39,8 +41,7 @@ def validate_meta_learning():
     logging.info('\nFix 3: Meta-Learning Minimum Trade Requirement')
     logging.info(str('=' * 50))
     try:
-        with open('bot_engine.py') as f:
-            content = f.read()
+        content = Path('ai_trading/core/bot_engine.py').read_text()
         pattern = 'def load_global_signal_performance\\(\\s*min_trades: int = (\\d+)'
         match = re.search(pattern, content)
         if match:
@@ -60,8 +61,7 @@ def validate_pltr_sector():
     logging.info('\nFix 5: PLTR Sector Classification')
     logging.info(str('=' * 50))
     try:
-        with open('bot_engine.py') as f:
-            content = f.read()
+        content = Path('ai_trading/core/bot_engine.py').read_text()
         if '"PLTR": "Technology"' in content:
             logging.info('PLTR sector mapping: Technology ✓')
             return True

--- a/scripts/verify_critical_fixes.py
+++ b/scripts/verify_critical_fixes.py
@@ -1,10 +1,12 @@
 import logging
-'\nVerification test that the critical fixes are properly implemented in the code.\nThis tests the actual code changes without requiring a full environment setup.\n'
+from pathlib import Path
+
+"""Verification test that the critical fixes are properly implemented in the code.
+This tests the actual code changes without requiring a full environment setup."""
 
 def test_timestamp_fix_in_data_fetcher():
     """Verify the RFC3339 timestamp fix is in data_fetcher.py"""
-    with open('data_fetcher.py') as f:
-        content = f.read()
+    content = Path('ai_trading/data_fetcher.py').read_text()
     assert ".replace('+00:00', 'Z')" in content, 'RFC3339 timestamp fix not found in data_fetcher.py'
     lines = content.split('\n')
     start_fixed = any((".replace('+00:00', 'Z')" in line and 'start' in line for line in lines))
@@ -15,8 +17,7 @@ def test_timestamp_fix_in_data_fetcher():
 
 def test_position_sizing_fix_in_bot_engine():
     """Verify the position sizing fixes are in bot_engine.py"""
-    with open('bot_engine.py') as f:
-        content = f.read()
+    content = Path('ai_trading/core/bot_engine.py').read_text()
     assert 'Fix zero quantity calculations' in content, 'Position sizing fix comment not found'
     assert 'balance > 1000 and target_weight > 0.001' in content, 'Minimum position logic not found'
     assert 'max(1, int(1000 / current_price))' in content, 'Minimum $1000 position logic not found'
@@ -26,8 +27,7 @@ def test_position_sizing_fix_in_bot_engine():
 
 def test_meta_learning_fix():
     """Verify the meta learning price conversion fixes are in meta_learning.py"""
-    with open('meta_learning.py') as f:
-        content = f.read()
+    content = Path('ai_trading/meta_learning.py').read_text()
     assert 'Fix meta learning data types' in content, 'Meta learning fix comment not found'
     assert 'pd.to_numeric' in content, 'Price conversion logic not found'
     assert 'errors="coerce"' in content, 'Error handling for price conversion not found'
@@ -36,8 +36,7 @@ def test_meta_learning_fix():
 
 def test_stale_data_bypass_fix():
     """Verify the stale data bypass is in bot_engine.py"""
-    with open('bot_engine.py') as f:
-        content = f.read()
+    content = Path('ai_trading/core/bot_engine.py').read_text()
     assert 'ALLOW_STALE_DATA_STARTUP' in content, 'Stale data bypass environment variable not found'
     assert 'BYPASS_STALE_DATA_STARTUP' in content, 'Stale data bypass logic not found'
     assert 'stale_data = summary.get("stale_data", [])' in content, 'Stale data extraction not found'
@@ -45,11 +44,14 @@ def test_stale_data_bypass_fix():
 
 def test_all_fixes_integrated():
     """Verify all critical fixes are properly integrated"""
-    files_to_check = ['data_fetcher.py', 'bot_engine.py', 'meta_learning.py']
+    files_to_check = [
+        'ai_trading/data_fetcher.py',
+        'ai_trading/core/bot_engine.py',
+        'ai_trading/meta_learning.py',
+    ]
     for filename in files_to_check:
         try:
-            with open(filename) as f:
-                content = f.read()
+            content = Path(filename).read_text()
             compile(content, filename, 'exec')
             logging.info(f'✓ {filename} syntax is valid')
         except SyntaxError as e:

--- a/tests/test_coverage_hack.py
+++ b/tests/test_coverage_hack.py
@@ -6,7 +6,12 @@ logger = logging.getLogger(__name__)
 
 def test_force_full_coverage():
     """Force coverage of critical modules to ensure all code paths are tested."""
-    modules = ["bot_engine.py", "data_fetcher.py", "signals.py", "alpaca_api.py"]
+    modules = [
+        "ai_trading/core/bot_engine.py",
+        "ai_trading/data_fetcher.py",
+        "ai_trading/signals.py",
+        "ai_trading/alpaca_api.py",
+    ]
     for fname in modules:
         path = pathlib.Path(fname)
         if not path.exists():

--- a/tests/test_critical_issue_fixes.py
+++ b/tests/test_critical_issue_fixes.py
@@ -8,6 +8,7 @@ import os
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 
 # Set up minimal environment for imports
 os.environ.setdefault('ALPACA_API_KEY', 'test_key')
@@ -32,27 +33,25 @@ class TestCriticalIssueFixes(unittest.TestCase):
     def test_issue_4_position_limit_increase(self):
         """Test Issue 4: Position limit increased from 10 to 20."""
         # Test that the change exists in the source code by reading the file directly
-        bot_engine_path = "bot_engine.py"
-        if os.path.exists(bot_engine_path):
-            with open(bot_engine_path) as f:
-                content = f.read()
-                # Check that the default value is now 20 instead of 10
-                self.assertIn('"20"', content, "MAX_PORTFOLIO_POSITIONS default should be 20")
+        bot_engine_path = Path("ai_trading/core/bot_engine.py")
+        if bot_engine_path.exists():
+            content = bot_engine_path.read_text()
+            # Check that the default value is now 20 instead of 10
+            self.assertIn('"20"', content, "MAX_PORTFOLIO_POSITIONS default should be 20")
         else:
             self.assertTrue(True)
 
     def test_issue_2_sentiment_circuit_breaker_thresholds(self):
         """Test Issue 2: Sentiment circuit breaker thresholds improved."""
         # Test by reading the source code directly
-        bot_engine_path = "bot_engine.py"
-        if os.path.exists(bot_engine_path):
-            with open(bot_engine_path) as f:
-                content = f.read()
-                # Check that thresholds have been improved
-                self.assertIn('SENTIMENT_FAILURE_THRESHOLD = 8', content,
-                            "SENTIMENT_FAILURE_THRESHOLD should be 8")
-                self.assertIn('SENTIMENT_RECOVERY_TIMEOUT = 900', content,
-                            "SENTIMENT_RECOVERY_TIMEOUT should be 900 (15 minutes)")
+        bot_engine_path = Path("ai_trading/core/bot_engine.py")
+        if bot_engine_path.exists():
+            content = bot_engine_path.read_text()
+            # Check that thresholds have been improved
+            self.assertIn('SENTIMENT_FAILURE_THRESHOLD = 8', content,
+                        "SENTIMENT_FAILURE_THRESHOLD should be 8")
+            self.assertIn('SENTIMENT_RECOVERY_TIMEOUT = 900', content,
+                        "SENTIMENT_RECOVERY_TIMEOUT should be 900 (15 minutes)")
         else:
             self.assertTrue(True)
 
@@ -78,15 +77,14 @@ class TestCriticalIssueFixes(unittest.TestCase):
     def test_issue_1_meta_learning_trigger_exists(self):
         """Test Issue 1: Meta-learning conversion trigger exists."""
         # Test by reading the source code directly
-        bot_engine_path = "bot_engine.py"
-        if os.path.exists(bot_engine_path):
-            with open(bot_engine_path) as f:
-                content = f.read()
-                # Check that the meta-learning trigger code exists
-                self.assertIn('from meta_learning import validate_trade_data_quality', content,
-                            "Meta-learning trigger should import validation function")
-                self.assertIn('METALEARN_TRIGGER_CONVERSION', content,
-                            "Meta-learning trigger should log conversion attempts")
+        bot_engine_path = Path("ai_trading/core/bot_engine.py")
+        if bot_engine_path.exists():
+            content = bot_engine_path.read_text()
+            # Check that the meta-learning trigger code exists
+            self.assertIn('from meta_learning import validate_trade_data_quality', content,
+                        "Meta-learning trigger should import validation function")
+            self.assertIn('METALEARN_TRIGGER_CONVERSION', content,
+                        "Meta-learning trigger should log conversion attempts")
         else:
             self.assertTrue(True)
 

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -89,9 +89,8 @@ def test_talib_imports():
 
 def test_screen_universe_logging():
     """Test that screen_universe function has enhanced logging."""
-
-    with open('bot_engine.py') as f:
-        content = f.read()
+    bot_engine_path = Path('ai_trading/core/bot_engine.py')
+    content = bot_engine_path.read_text()
 
     # Check for enhanced logging statements
     if 'logger.info(f"[SCREEN_UNIVERSE] Starting screening of' in content:

--- a/tests/test_my_fixes.py
+++ b/tests/test_my_fixes.py
@@ -4,6 +4,7 @@
 import math
 import os
 import unittest
+from pathlib import Path
 
 
 class TestMyFixes(unittest.TestCase):
@@ -11,8 +12,8 @@ class TestMyFixes(unittest.TestCase):
 
     def test_meta_learning_thresholds_reduced(self):
         """Test that meta-learning thresholds are reduced to allow easier activation."""
-        with open("bot_engine.py") as f:
-            content = f.read()
+        bot_engine_path = Path("ai_trading/core/bot_engine.py")
+        content = bot_engine_path.read_text()
 
         # Should have reduced min_trades from 3 to 2
         self.assertIn('METALEARN_MIN_TRADES", "2"', content)
@@ -53,8 +54,8 @@ class TestMyFixes(unittest.TestCase):
 
     def test_position_limit_rebalancing(self):
         """Test that position limits allow rebalancing."""
-        with open("bot_engine.py") as f:
-            content = f.read()
+        bot_engine_path = Path("ai_trading/core/bot_engine.py")
+        content = bot_engine_path.read_text()
 
         # Function should accept symbol parameter
         self.assertIn('def too_many_positions(ctx: BotContext, symbol: Optional[str] = None)', content)

--- a/tests/test_problem_statement_fixes.py
+++ b/tests/test_problem_statement_fixes.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""
-Focused test suite for the specific critical trading bot issues described in the problem statement.
-"""
+"""Focused test suite for the specific critical trading bot issues described in
+the problem statement."""
 
 import os
 import sys
 import unittest
+from pathlib import Path
 
 # Set up minimal environment for imports
 os.environ.setdefault('ALPACA_API_KEY', 'test_key')
@@ -44,10 +44,9 @@ class TestProblemStatementFixes(unittest.TestCase):
     def test_meta_learning_minimum_trades_requirement(self):
         """Test that meta-learning minimum trade requirement is reduced to 2."""
         # Test by reading the source code directly to avoid import issues
-        bot_engine_path = "bot_engine.py"
-        if os.path.exists(bot_engine_path):
-            with open(bot_engine_path) as f:
-                content = f.read()
+        bot_engine_path = Path("ai_trading/core/bot_engine.py")
+        if bot_engine_path.exists():
+            content = bot_engine_path.read_text()
 
             # Look for the environment variable default
             import re
@@ -61,15 +60,14 @@ class TestProblemStatementFixes(unittest.TestCase):
             else:
                 self.fail("Could not find METALEARN_MIN_TRADES parameter in load_global_signal_performance")
         else:
-            self.fail("bot_engine.py not found")
+            self.fail(f"{bot_engine_path} not found")
 
     def test_pltr_sector_classification(self):
         """Test that PLTR is classified as Technology sector."""
         # Test by reading the source code directly to avoid import issues
-        bot_engine_path = "bot_engine.py"
-        if os.path.exists(bot_engine_path):
-            with open(bot_engine_path) as f:
-                content = f.read()
+        bot_engine_path = Path("ai_trading/core/bot_engine.py")
+        if bot_engine_path.exists():
+            content = bot_engine_path.read_text()
 
             # Check if PLTR is in the Technology sector mapping
             if '"PLTR": "Technology"' in content:
@@ -77,7 +75,7 @@ class TestProblemStatementFixes(unittest.TestCase):
             else:
                 self.fail("PLTR not found in Technology sector mapping")
         else:
-            self.fail("bot_engine.py not found")
+            self.fail(f"{bot_engine_path} not found")
 
     def test_order_quantity_tracking_clarity(self):
         """Test that order quantity tracking provides clear distinction between

--- a/tests/test_trading_parameter_validation.py
+++ b/tests/test_trading_parameter_validation.py
@@ -11,7 +11,7 @@ def test_validate_trading_parameters_no_name_error():
     """
 
     # Read the bot_engine.py source code
-    src_path = Path(__file__).resolve().parents[1] / 'bot_engine.py'
+    src_path = Path(__file__).resolve().parents[1] / 'ai_trading' / 'core' / 'bot_engine.py'
     source = src_path.read_text()
 
     # Parse the AST
@@ -67,7 +67,7 @@ def test_validate_trading_parameters_no_name_error():
 def test_buy_threshold_definition_order():
     """Specific test to ensure BUY_THRESHOLD is defined before validate_trading_parameters call."""
 
-    src_path = Path(__file__).resolve().parents[1] / 'bot_engine.py'
+    src_path = Path(__file__).resolve().parents[1] / 'ai_trading' / 'core' / 'bot_engine.py'
     source = src_path.read_text()
     lines = source.split('\n')
 


### PR DESCRIPTION
## Summary
- use package path for bot_engine imports across tests and validation scripts
- drop obsolete bot_engine shim check in final polish validator
- normalize helper scripts to read ai_trading/core/bot_engine.py directly

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5bcdce408330980e44d199a2e81e