### PR TITLE
refactor: remove bars/runtime shims

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -80,18 +80,17 @@ def _alpaca_available() -> bool:
 
     return ALPACA_AVAILABLE
 from ai_trading.data.bars import (
-    _ensure_df as _bars_ensure_df,
-    safe_get_stock_bars as _bars_safe_get_stock_bars,
-    _create_empty_bars_dataframe as _bars_create_empty_bars_dataframe,
+    _create_empty_bars_dataframe,
+    _resample_minutes_to_daily,
+    safe_get_stock_bars,
     StockBarsRequest,
     TimeFrame,
     TimeFrameUnit,
-    _resample_minutes_to_daily as _bars_resample_minutes_to_daily,
 )
 from ai_trading.core.runtime import (
-    BotRuntime as _BotRuntime,
-    build_runtime as _runtime_build_runtime,
-    enhance_runtime_with_context as _runtime_enhance_runtime_with_context,
+    BotRuntime,
+    build_runtime,
+    enhance_runtime_with_context,
 )
 
 if os.getenv("BOT_SHOW_DEPRECATIONS", "").lower() in {"1", "true", "yes"}:
@@ -135,41 +134,6 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     FinnhubAPIException = Exception  # type: ignore
     FINNHUB_AVAILABLE = False
-
-# Backwards-compatibility shims for relocated helpers
-def ensure_df(obj):
-    """Backward-compatibility shim for ai_trading.data.bars._ensure_df."""
-    return _bars_ensure_df(obj)
-
-
-def create_empty_bars_dataframe():
-    """Backward-compatibility shim for ai_trading.data.bars._create_empty_bars_dataframe."""
-    return _bars_create_empty_bars_dataframe()
-
-
-def resample_minutes_to_daily(df):
-    """Backward-compatibility shim for ai_trading.data.bars._resample_minutes_to_daily."""
-    return _bars_resample_minutes_to_daily(df)
-
-
-def safe_get_stock_bars(*args, **kwargs):
-    """Backward-compatibility shim for ai_trading.data.bars.safe_get_stock_bars."""
-    return _bars_safe_get_stock_bars(*args, **kwargs)
-
-
-BotRuntime = _BotRuntime
-BotRuntime.__doc__ = "Backward-compatibility shim for ai_trading.core.runtime.BotRuntime."
-
-
-def build_runtime(*args, **kwargs):
-    """Backward-compatibility shim for ai_trading.core.runtime.build_runtime."""
-    return _runtime_build_runtime(*args, **kwargs)
-
-
-def enhance_runtime_with_context(*args, **kwargs):
-    """Backward-compatibility shim for ai_trading.core.runtime.enhance_runtime_with_context."""
-    return _runtime_enhance_runtime_with_context(*args, **kwargs)
-
 
 StockBarsRequest.__doc__ = "Backward-compatibility shim for ai_trading.data.bars.StockBarsRequest."
 TimeFrame.__doc__ = "Backward-compatibility shim for ai_trading.data.bars.TimeFrame."
@@ -293,9 +257,6 @@ __all__ = [
     "TimeFrame",
     "TimeFrameUnit",
     "safe_get_stock_bars",
-    "ensure_df",
-    "create_empty_bars_dataframe",
-    "resample_minutes_to_daily",
     "BotRuntime",
     "build_runtime",
     "enhance_runtime_with_context",

--- a/scripts/smoke_runtime.py
+++ b/scripts/smoke_runtime.py
@@ -91,7 +91,7 @@ def test_empty_dataframe_helper():
     """Test the empty DataFrame helper creates valid indexes."""
     try:
         import pandas as pd
-        from ai_trading.core.bot_engine import _create_empty_bars_dataframe
+        from ai_trading.data.bars import _create_empty_bars_dataframe
         empty_df = _create_empty_bars_dataframe('daily')
         assert isinstance(empty_df.index, pd.DatetimeIndex)
         assert str(empty_df.index.tz) == 'UTC'

--- a/tests/test_healthcheck_minute_fallback_handles_none.py
+++ b/tests/test_healthcheck_minute_fallback_handles_none.py
@@ -1,6 +1,6 @@
 import pytest
 pd = pytest.importorskip("pandas")
-from ai_trading.core.bot_engine import _ensure_df
+from ai_trading.data.bars import _ensure_df
 
 from tests.helpers.asserts import assert_df_like
 


### PR DESCRIPTION
## Summary
- drop deprecated bars/runtime shims from `bot_engine`
- call `ai_trading.data.bars` helpers directly in tests and scripts

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

## Rollback
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68ae5bd0f88083308007bd98e3468e9f