### PR TITLE
refactor: update script module paths

### DIFF
--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -298,7 +298,7 @@ def _check_trading_system(self) -> HealthCheckResult:
         except ImportError as e:
             issues.append(f'risk_engine import failed: {e}')
             details['risk_engine'] = f'FAILED: {e}'
-        critical_files = ['config.py', 'hyperparams.json', 'best_hyperparams.json']
+        critical_files = ['ai_trading/settings.py', 'hyperparams.json', 'best_hyperparams.json']
         for file_path in critical_files:
             if os.path.exists(file_path):
                 details[f'file_{file_path}'] = 'EXISTS'

--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -160,7 +160,7 @@ def test_http_timeouts():
 def test_data_fetcher_helpers():
     """Test that data_fetcher helpers are exported."""
     try:
-        data_fetcher_path = Path('data_fetcher.py')
+        data_fetcher_path = Path('ai_trading/data_fetcher.py')
         if data_fetcher_path.exists():
             content = data_fetcher_path.read_text()
             assert 'def get_cached_minute_timestamp' in content

--- a/scripts/problem_statement_validation.py
+++ b/scripts/problem_statement_validation.py
@@ -19,11 +19,11 @@ def check_model_registry():
 def check_env_flag():
     """Check DISABLE_DAILY_RETRAIN is correctly implemented."""
     logging.info('✓ Correct env toggle:')
-    config_path = Path('config.py')
+    config_path = Path('ai_trading/settings.py')
     if config_path.exists():
         content = config_path.read_text()
-        assert 'DISABLE_DAILY_RETRAIN = os.getenv("DISABLE_DAILY_RETRAIN", "false").lower() in ("true", "1")' in content
-        logging.info('  - DISABLE_DAILY_RETRAIN read from correct key with safe default ✓')
+        assert "disable_daily_retrain: bool = Field(False, alias='DISABLE_DAILY_RETRAIN')" in content
+        logging.info('  - DISABLE_DAILY_RETRAIN configured via Settings alias ✓')
 
 def check_import_hardening():
     """Check that imports are hardened across key modules."""

--- a/scripts/production_validator.py
+++ b/scripts/production_validator.py
@@ -262,7 +262,7 @@ class ChaosEngineer:
         """Check if data integrity is preserved."""
         try:
             import os
-            critical_files = ['config.py', 'hyperparams.json']
+            critical_files = ['ai_trading/settings.py', 'hyperparams.json']
             for file_path in critical_files:
                 if os.path.exists(file_path):
                     with open(file_path) as f:
@@ -517,7 +517,7 @@ class ProductionValidator:
     def _check_configuration_compliance(self) -> float:
         """Check configuration compliance."""
         import os
-        required_files = ['config.py', 'hyperparams.json']
+        required_files = ['ai_trading/settings.py', 'hyperparams.json']
         existing_files = sum((1 for f in required_files if os.path.exists(f)))
         return existing_files / len(required_files) * 100
 

--- a/scripts/validate_critical_fixes.py
+++ b/scripts/validate_critical_fixes.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 import traceback
+from pathlib import Path
 os.environ.setdefault('ALPACA_API_KEY', 'test')
 os.environ.setdefault('ALPACA_SECRET_KEY', 'test')
 os.environ.setdefault('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
@@ -59,19 +60,19 @@ def test_alpaca_api_endpoints():
     """Test that Alpaca API endpoints are correctly configured."""
     logging.info('🌐 Testing Alpaca API Configuration...')
     try:
-        with open('data_fetcher.py') as f:
-            data_fetcher_content = f.read()
+        data_fetcher_path = Path('ai_trading/data_fetcher.py')
+        data_fetcher_content = data_fetcher_path.read_text()
         if 'data.alpaca.markets' in data_fetcher_content:
-            logging.info('  ✅ data_fetcher.py correctly uses data.alpaca.markets for market data')
+            logging.info('  ✅ ai_trading/data_fetcher.py correctly uses data.alpaca.markets for market data')
         else:
-            logging.info('  ❌ data_fetcher.py does not use data.alpaca.markets')
+            logging.info('  ❌ ai_trading/data_fetcher.py does not use data.alpaca.markets')
             return False
-        with open('config.py') as f:
-            config_content = f.read()
+        config_path = Path('ai_trading/config/alpaca.py')
+        config_content = config_path.read_text()
         if 'paper-api.alpaca.markets' in config_content:
-            logging.info('  ✅ config.py correctly uses paper-api.alpaca.markets for trading')
+            logging.info('  ✅ ai_trading/config/alpaca.py correctly uses paper-api.alpaca.markets for trading')
         else:
-            logging.info('  ❌ config.py does not use paper-api.alpaca.markets')
+            logging.info('  ❌ ai_trading/config/alpaca.py does not use paper-api.alpaca.markets')
             return False
         logging.info('  ✅ Alpaca API endpoints are correctly configured')
         return True


### PR DESCRIPTION
## Summary
- use packaged `ai_trading/data_fetcher.py` in validation and integration scripts
- reference `ai_trading/settings.py` for DISABLE_DAILY_RETRAIN flag and critical file checks
- update health and production validators to treat packaged settings as critical

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b7384bc833080b68fdb8c54bc0f