### PR TITLE
refactor: use qualified indicators import

### DIFF
--- a/scripts/production_validator.py
+++ b/scripts/production_validator.py
@@ -496,7 +496,7 @@ class ProductionValidator:
         """Test data processing functionality."""
         try:
             from ai_trading import data_fetcher
-            import indicators
+            from ai_trading import indicators
             return 90
         except ImportError:
             return 40

--- a/tests/test_import_fallbacks.py
+++ b/tests/test_import_fallbacks.py
@@ -84,10 +84,8 @@ def test_profile_indicators_import_fallbacks():
 
     # Check for expected fallback patterns
     expected_patterns = [
-        "import ai_trading.signals as signals",
-        "import signals",
-        "import ai_trading.indicators as indicators",
-        "import indicators",
+        "from ai_trading import signals",
+        "from ai_trading import indicators",
     ]
 
     for pattern in expected_patterns:


### PR DESCRIPTION
## Summary
- import `indicators` from the `ai_trading` package in `production_validator`
- update import-fallback tests to expect qualified `indicators` and `signals`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b7a30f0833098b8b72b8743cf7d