### PR TITLE
Replace BOT_MODE references with TRADING_MODE

### DIFF
--- a/CENTRALIZED_PARAMETERS_SUMMARY.md
+++ b/CENTRALIZED_PARAMETERS_SUMMARY.md
@@ -114,7 +114,7 @@ aggressive_config = TradingConfig.from_env("aggressive")
 # Override any parameter via environment variable
 export KELLY_FRACTION=0.45
 export CONF_THRESHOLD=0.82
-export BOT_MODE=aggressive
+export TRADING_MODE=aggressive
 ```
 
 ### Legacy Compatibility

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -83,7 +83,7 @@ docker-compose -f docker-compose.dev.yml up
 cp .env.example .env.staging
 
 # Configure staging-specific variables
-export BOT_MODE=staging
+export TRADING_MODE=staging
 export ALPACA_BASE_URL=https://paper-api.alpaca.markets
 export LOG_LEVEL=DEBUG
 
@@ -218,7 +218,7 @@ services:
     container_name: ai-trading-bot
     restart: unless-stopped
     environment:
-      - BOT_MODE=production
+      - TRADING_MODE=production
       - PYTHONUNBUFFERED=1
     env_file:
       - .env.production
@@ -291,7 +291,7 @@ spec:
         ports:
         - containerPort: 5000
         env:
-        - name: BOT_MODE
+        - name: TRADING_MODE
           value: "production"
         envFrom:
         - secretRef:
@@ -508,7 +508,7 @@ echo "Deployment successful!"
 ```bash
 # .env.production
 # Trading Configuration
-BOT_MODE=production
+TRADING_MODE=production
 SCHEDULER_SLEEP_SECONDS=60
 MAX_POSITION_PCT=0.05
 MAX_PORTFOLIO_HEAT=0.15
@@ -555,16 +555,16 @@ def validate_production_config() -> Tuple[bool, List[str]]:
         'ALPACA_API_KEY',
         'ALPACA_SECRET_KEY',
         'API_SECRET_KEY',
-        'BOT_MODE'
+        'TRADING_MODE'
     ]
     
     for var in required_vars:
         if not os.getenv(var):
             errors.append(f"Missing required environment variable: {var}")
     
-    # Validate bot mode
-    if os.getenv('BOT_MODE') not in ['production', 'staging']:
-        errors.append("BOT_MODE must be 'production' or 'staging'")
+    # Validate trading mode
+    if os.getenv('TRADING_MODE') not in ['production', 'staging']:
+        errors.append("TRADING_MODE must be 'production' or 'staging'")
     
     # Validate numeric values
     try:

--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ python verify_config.py
    TZ=UTC
    # ALPACA_BASE_URL=https://api.alpaca.markets     # Live trading (DANGER!)
    
-   # Bot Configuration (BOT_MODE is deprecated; use TRADING_MODE)
+   # Bot Configuration
    TRADING_MODE=balanced                    # Trading mode: conservative, balanced, aggressive
    BOT_LOG_FILE=logs/scheduler.log     # Log file location
    LOG_LEVEL=INFO                      # DEBUG, INFO, WARNING, ERROR
@@ -757,7 +757,7 @@ WEBHOOK_URL=https://your-webhook-url.com/trading-alerts
 ### 🧪 Testing Configuration
 
 ```bash
-# .env.testing (BOT_MODE is deprecated; use TRADING_MODE)
+# .env.testing
 TRADING_MODE=paper
 ALPACA_BASE_URL=https://paper-api.alpaca.markets
 DRY_RUN=true

--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -547,7 +547,7 @@ class TestTradingWorkflow:
     """Integration tests for complete trading workflows."""
     
     @pytest.mark.integration
-    @patch.dict(os.environ, {'DRY_RUN': 'true', 'BOT_MODE': 'testing'})
+    @patch.dict(os.environ, {'DRY_RUN': 'true', 'TRADING_MODE': 'testing'})
     def test_complete_trading_cycle(self):
         """Test a complete trading cycle in dry run mode."""
         from bot_engine import BotState, run_all_trades_worker
@@ -1014,7 +1014,7 @@ def setup_test_environment():
     """Setup test environment variables."""
     test_env = {
         'DRY_RUN': 'true',
-        'BOT_MODE': 'testing',
+        'TRADING_MODE': 'testing',
         'LOG_LEVEL': 'ERROR',  # Reduce log noise in tests
         'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets'
     }

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -93,7 +93,7 @@ pip install -e .
 # Check for missing environment variables
 python -c "
 import os
-required = ['ALPACA_API_KEY', 'ALPACA_SECRET_KEY', 'BOT_MODE']
+required = ['ALPACA_API_KEY', 'ALPACA_SECRET_KEY', 'TRADING_MODE']
 missing = [var for var in required if not os.getenv(var)]
 if missing:
     print(f'Missing: {missing}')

--- a/ai_trading/config/aliases.py
+++ b/ai_trading/config/aliases.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 import os
 from ai_trading.logging import get_logger, logger_once
+
 _log = get_logger(__name__)
-_ALIASES = ['TRADING_MODE', 'BOT_MODE', 'bot_mode']
+_ALIASES = ['TRADING_MODE', 'bot_mode']
 _CANON = 'TRADING_MODE'
 
 def resolve_trading_mode(default: str) -> str:
     """Resolve trading mode across aliases with precedence and deprecation logs.
 
-    Precedence: TRADING_MODE > BOT_MODE > bot_mode > default.
+    Precedence: TRADING_MODE > bot_mode > default.
     If conflicting values are present, prefer TRADING_MODE and emit a once log.
     """
     values = {k: os.getenv(k) for k in _ALIASES}
     chosen: tuple[str, str] | None = None
-    for key in (_CANON, 'BOT_MODE', 'bot_mode'):
+    for key in (_CANON, 'bot_mode'):
         v = values.get(key)
         if v:
             chosen = (key, v)

--- a/ai_trading/validation/validate_env.py
+++ b/ai_trading/validation/validate_env.py
@@ -6,8 +6,7 @@ class Settings(BaseModel):
     ALPACA_API_KEY: str = Field(...)
     ALPACA_SECRET_KEY: str = Field(...)
     ALPACA_BASE_URL: str = Field(...)
-    BOT_MODE: str = Field('testing')
-    TRADING_MODE: str = Field('paper')
+    TRADING_MODE: str = Field('testing')
     FORCE_TRADES: bool = Field(False)
 
     @field_validator('ALPACA_API_KEY')
@@ -31,18 +30,11 @@ class Settings(BaseModel):
             raise ValueError('ALPACA_BASE_URL must use HTTPS')
         return v
 
-    @field_validator('BOT_MODE')
-    @classmethod
-    def _bot_mode(cls, v: str) -> str:
-        if v not in {'testing', 'production'}:
-            raise ValueError("BOT_MODE must be one of ['testing', 'production']")
-        return v
-
     @field_validator('TRADING_MODE')
     @classmethod
     def _trading_mode(cls, v: str) -> str:
-        if v not in {'paper', 'live'}:
-            raise ValueError('Invalid TRADING_MODE')
+        if v not in {'testing', 'production'}:
+            raise ValueError("TRADING_MODE must be one of ['testing', 'production']")
         return v
 
     @field_validator('FORCE_TRADES')

--- a/config_get_env_removal_summary.md
+++ b/config_get_env_removal_summary.md
@@ -37,7 +37,7 @@ Fixed the production failure: `AttributeError: module 'ai_trading.config' has no
 ### 3. ai_trading/core/bot_engine.py  
 - **Added settings instance**: `S = get_settings()` (after existing get_settings import)
 - **Replaced 16 config.get_env calls**:
-  - `config.get_env("BOT_MODE", "balanced")` → `S.bot_mode`
+  - `config.get_env("TRADING_MODE", "balanced")` → `S.trading_mode`
   - `float(config.get_env("DISASTER_DD_LIMIT", "0.2"))` → `S.disaster_dd_limit`
   - `abspath(config.get_env("MODEL_PATH", "meta_model.pkl"))` → `abspath(S.model_path)`
   - `int(config.get_env("MAX_PORTFOLIO_POSITIONS", "20"))` → `S.max_portfolio_positions`
@@ -80,7 +80,7 @@ Fixed the production failure: `AttributeError: module 'ai_trading.config' has no
 ## Environment Variables Handled
 
 The following environment variables are now properly typed and bound:
-- `BOT_MODE`, `DISASTER_DD_LIMIT`, `MODEL_PATH`, `MODEL_RF_PATH`, `MODEL_XGB_PATH`, `MODEL_LGB_PATH`
+- `TRADING_MODE`, `DISASTER_DD_LIMIT`, `MODEL_PATH`, `MODEL_RF_PATH`, `MODEL_XGB_PATH`, `MODEL_LGB_PATH`
 - `MAX_PORTFOLIO_POSITIONS`, `SECTOR_EXPOSURE_CAP`, `MAX_OPEN_POSITIONS`, `WEEKLY_DRAWDOWN_LIMIT` 
 - `VOLUME_THRESHOLD`, `DOLLAR_RISK_LIMIT`, `FINNHUB_RPM`, `TRADE_COOLDOWN_MIN`
 - `MAX_TRADES_PER_HOUR`, `MAX_TRADES_PER_DAY`, `MINUTE_CACHE_TTL`, `HEALTHCHECK_PORT`

--- a/scripts/demonstrate_optimization.py
+++ b/scripts/demonstrate_optimization.py
@@ -97,7 +97,7 @@ def demonstrate_parameter_optimizations():
         logging.info('  • All parameters can be overridden via environment variables')
         logging.info('  • Example: export KELLY_FRACTION=0.5')
         logging.info('  • Example: export CONF_THRESHOLD=0.8')
-        logging.info('  • Example: export BOT_MODE=aggressive')
+        logging.info('  • Example: export TRADING_MODE=aggressive')
         logging.info('  • Runtime configuration changes without code modification')
         logging.info(str('\n' + '-' * 60))
         logging.info('8. PARAMETER VALIDATION')

--- a/tests/config/test_mode_aliases.py
+++ b/tests/config/test_mode_aliases.py
@@ -7,7 +7,7 @@ from ai_trading.logging import logger_once
 
 
 def _clear_env(monkeypatch):
-    for k in ("TRADING_MODE", "BOT_MODE", "bot_mode"):
+    for k in ("TRADING_MODE", "bot_mode"):
         monkeypatch.delenv(k, raising=False)
 
 
@@ -17,8 +17,6 @@ def test_precedence(monkeypatch):
     assert resolve_trading_mode("balanced") == "balanced"
     monkeypatch.setenv("bot_mode", "aggressive")
     assert resolve_trading_mode("balanced") == "aggressive"
-    monkeypatch.setenv("BOT_MODE", "moderate")
-    assert resolve_trading_mode("balanced") == "moderate"
     monkeypatch.setenv("TRADING_MODE", "conservative")
     assert resolve_trading_mode("balanced") == "conservative"
 
@@ -27,7 +25,7 @@ def test_conflict_prefers_canonical(monkeypatch):
     _clear_env(monkeypatch)
     logger_once._emitted_keys.clear()
     monkeypatch.setenv("TRADING_MODE", "balanced")
-    monkeypatch.setenv("BOT_MODE", "aggressive")
+    monkeypatch.setenv("bot_mode", "aggressive")
     assert resolve_trading_mode("moderate") == "balanced"
 
 
@@ -35,7 +33,7 @@ def test_deprecation_logged_once(monkeypatch, caplog):
     _clear_env(monkeypatch)
     logger_once._emitted_keys.clear()
     with caplog.at_level(logging.WARNING):
-        monkeypatch.setenv("BOT_MODE", "aggressive")
+        monkeypatch.setenv("bot_mode", "aggressive")
         assert resolve_trading_mode("balanced") == "aggressive"
         assert caplog.records
     with caplog.at_level(logging.WARNING):

--- a/tests/test_nameerror_integration.py
+++ b/tests/test_nameerror_integration.py
@@ -31,7 +31,7 @@ os.environ.update({
     "ALPACA_BASE_URL": "https://paper-api.alpaca.markets",
     "WEBHOOK_SECRET": "fake-test-webhook-not-real",
     "FLASK_PORT": "9000",
-    "BOT_MODE": "balanced",
+    "TRADING_MODE": "balanced",
     "DOLLAR_RISK_LIMIT": "0.05",
     "TESTING": "1",  # Enable testing mode to avoid expensive validations
     "TRADE_LOG_FILE": "test_trades.csv",

--- a/tests/test_pydantic_v2_migration.py
+++ b/tests/test_pydantic_v2_migration.py
@@ -31,7 +31,6 @@ def test_pydantic_v2_migration_syntax():
         '@field_validator(\'ALPACA_API_KEY\')',
         '@field_validator(\'ALPACA_SECRET_KEY\')',
         '@field_validator(\'ALPACA_BASE_URL\')',
-        '@field_validator(\'BOT_MODE\')',
         '@field_validator(\'TRADING_MODE\')',
         '@field_validator(\'FORCE_TRADES\')'
     ]
@@ -44,7 +43,6 @@ def test_pydantic_v2_migration_syntax():
         '@validator(\'ALPACA_API_KEY\')',
         '@validator(\'ALPACA_SECRET_KEY\')',
         '@validator(\'ALPACA_BASE_URL\')',
-        '@validator(\'BOT_MODE\')',
         '@validator(\'TRADING_MODE\')',
         '@validator(\'FORCE_TRADES\')'
     ]
@@ -66,8 +64,7 @@ def test_validate_env_import():
             'ALPACA_API_KEY': 'TEST_API_KEY_123456789',
             'ALPACA_SECRET_KEY': 'TEST_SECRET_KEY_123456789012345',
             'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets',
-            'BOT_MODE': 'testing',
-            'TRADING_MODE': 'paper',
+            'TRADING_MODE': 'testing',
             'FORCE_TRADES': 'false'
         }):
             from ai_trading.validation import (
@@ -80,7 +77,7 @@ def test_validate_env_import():
             # Verify some basic fields
             assert hasattr(settings, 'ALPACA_API_KEY')
             assert hasattr(settings, 'ALPACA_SECRET_KEY')
-            assert hasattr(settings, 'BOT_MODE')
+            assert hasattr(settings, 'TRADING_MODE')
 
     except ImportError as e:
         pytest.skip(f"Cannot import validate_env module: {e}")
@@ -99,8 +96,7 @@ def test_field_validator_functionality():
             'ALPACA_API_KEY': 'INVALID_KEY',  # Should trigger validation warning
             'ALPACA_SECRET_KEY': 'short',     # Should trigger validation error
             'ALPACA_BASE_URL': 'http://insecure.com',  # Should trigger HTTPS error
-            'BOT_MODE': 'invalid_mode',       # Should trigger validation error
-            'TRADING_MODE': 'invalid',        # Should trigger validation error
+            'TRADING_MODE': 'invalid_mode',   # Should trigger validation error
         }):
             from ai_trading.validation import (
                 validate_env,  # AI-AGENT-REF: normalized import
@@ -115,8 +111,7 @@ def test_field_validator_functionality():
                 # Validation errors are expected with invalid inputs
                 assert "ALPACA_SECRET_KEY appears too short" in str(e) or \
                        "ALPACA_BASE_URL must use HTTPS" in str(e) or \
-                       "BOT_MODE must be one of" in str(e) or \
-                       "Invalid TRADING_MODE" in str(e)
+                       "TRADING_MODE must be one of" in str(e)
 
     except ImportError:
         pytest.skip("Cannot import validate_env module")

--- a/tests/test_submit_order_fix.py
+++ b/tests/test_submit_order_fix.py
@@ -14,7 +14,7 @@ os.environ.update({
     "ALPACA_BASE_URL": "https://paper-api.alpaca.markets",
     "WEBHOOK_SECRET": "fake-test-webhook-not-real",
     "FLASK_PORT": "9000",
-    "BOT_MODE": "balanced",
+    "TRADING_MODE": "balanced",
     "DOLLAR_RISK_LIMIT": "0.05",
     "TESTING": "1",
     "TRADE_LOG_FILE": "test_trades.csv",

--- a/tools/ci/config_get_env_hits.txt
+++ b/tools/ci/config_get_env_hits.txt
@@ -1,4 +1,4 @@
-ai_trading/core/bot_engine.py:499:BOT_MODE = config.get_env("BOT_MODE", "balanced")
+ai_trading/core/bot_engine.py:499:TRADING_MODE = config.get_env("TRADING_MODE", "balanced")
 ai_trading/core/bot_engine.py:1829:DISASTER_DD_LIMIT = float(config.get_env("DISASTER_DD_LIMIT", "0.2"))
 ai_trading/core/bot_engine.py:2193:MODEL_PATH = abspath(config.get_env("MODEL_PATH", "meta_model.pkl"))
 ai_trading/core/bot_engine.py:2194:MODEL_RF_PATH = abspath(config.get_env("MODEL_RF_PATH", "model_rf.pkl"))


### PR DESCRIPTION
## Summary
- replace legacy `BOT_MODE` config with `TRADING_MODE`
- align tests and scripts with `TRADING_MODE`
- remove `BOT_MODE` mentions from docs and examples

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b87ca3c8330a024fb6bc5f6c762