### PR TITLE
chore: drop legacy alpaca trade api optdep

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -96,7 +96,7 @@ Moved portfolio optimization and transaction cost modules from `scripts/` to the
 - **Updated:** `ai_trading/portfolio/__init__.py` to export `PortfolioDecision`, `PortfolioOptimizer`, `create_portfolio_optimizer`
 
 **2. Transaction Cost Calculator**
-- **Moved from:** `scripts/transaction_cost_calculator.py` 
+- **Moved from:** `scripts/transaction_cost_calculator.py`
 - **Moved to:** `ai_trading/execution/transaction_costs.py`
 - **Updated:** `ai_trading/signals.py` to import from new location
 
@@ -140,7 +140,7 @@ The following new environment variables have been added to TradingConfig and can
 - `MAX_BACKOFF_INTERVAL` (default: 60.0) - Maximum backoff interval in seconds
 - `PCT` (default: 0.05) - Percentage threshold for various operations
 
-### Model and Scheduler Configuration  
+### Model and Scheduler Configuration
 - `MODEL_PATH` (default: None) - Path to ML model files
 - `SCHEDULER_ITERATIONS` (default: 0) - Number of scheduler iterations (0 = infinite)
 - `SCHEDULER_SLEEP_SECONDS` (default: 60) - Sleep interval between scheduler cycles
@@ -202,11 +202,15 @@ Alpaca SDK imports are now at module top level in `ai_trading/execution/live_tra
 
 **Impact**: Missing Alpaca SDK will cause immediate import errors.
 
+### 6. Tooling Updates
+- Test dependency hints drop the legacy `alpaca_trade_api` package and now
+  expect the modern `alpaca-py` SDK (`import alpaca`).
+
 ## Enhanced Features
 
 ### 1. TradingConfig Enhancements
 - All missing attributes now have proper defaults
-- Environment variable overrides for all parameters  
+- Environment variable overrides for all parameters
 - Safe dictionary export with `to_dict(safe=True)` method that redacts secrets
 - Comprehensive validation for new fields
 

--- a/tests/optdeps.py
+++ b/tests/optdeps.py
@@ -1,24 +1,24 @@
 import pytest
 
 HINT = {
-    "pandas":       'pip install "ai-trading-bot[pandas]"',
-    "matplotlib":   'pip install "ai-trading-bot[plot]"',
-    "sklearn":      'pip install "ai-trading-bot[ml]"',
-    "torch":        'pip install "ai-trading-bot[ml]"',
-    "ta":           'pip install "ai-trading-bot[ta]"',
-    "talib":        'pip install "ai-trading-bot[ta]"',
+    "pandas": 'pip install "ai-trading-bot[pandas]"',
+    "matplotlib": 'pip install "ai-trading-bot[plot]"',
+    "sklearn": 'pip install "ai-trading-bot[ml]"',
+    "torch": 'pip install "ai-trading-bot[ml]"',
+    "ta": 'pip install "ai-trading-bot[ta]"',
+    "talib": 'pip install "ai-trading-bot[ta]"',
     "stable_baselines3": 'pip install "stable-baselines3 gymnasium torch"',
-    "gymnasium":    'pip install "stable-baselines3 gymnasium torch"',
+    "gymnasium": 'pip install "stable-baselines3 gymnasium torch"',
     "alpaca": 'pip install "alpaca-py"',
-    "alpaca_trade_api": 'pip install "alpaca-trade-api"',
-    "alpaca_api":   'pip install "ai-trading-bot"',
-    "tenacity":     'pip install "tenacity"',
+    "alpaca_api": 'pip install "ai-trading-bot"',
+    "tenacity": 'pip install "tenacity"',
     "pandas_market_calendars": 'pip install "pandas-market-calendars"',
-    "pydantic":     'pip install "pydantic"',
-    "requests":     'pip install "requests"',
+    "pydantic": 'pip install "pydantic"',
+    "requests": 'pip install "requests"',
 }
 
 OPTDEPS = HINT  # AI-AGENT-REF: compatibility alias
+
 
 def require(pkg: str):
     """Skip current test module unless `pkg` is importable, with a clear install hint."""


### PR DESCRIPTION
## Summary
- remove `alpaca_trade_api` from optional dependency hints to prefer `alpaca-py`
- note tooling shift to `alpaca-py` in migration notes

## Testing
- `python -m pre_commit run --files tests/optdeps.py MIGRATION_NOTES.md` *(fails: repo-guard, check-no-legacy-symbols)*


------
https://chatgpt.com/codex/tasks/task_e_68ae6f7570a88330a774011983d996e6