### PR TITLE
Use alpaca-py in helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Set `RUN_HEALTHCHECK=1` to launch the lightweight Flask app that serves:
 * `GET /metrics` &mdash; Prometheus metrics (returns **501** if metrics are disabled)
 
 Use **one** Alpaca SDK in production (recommended: `alpaca-py`).
+### Self-check
+
+Verify Alpaca connectivity and data access:
+
+```bash
+python ai_trading/scripts/self_check.py
+```
+
+The script fetches a small sample of SPY bars using `alpaca-py` and exits with status **0** on success.
+
 
 ## Config
 

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -4,47 +4,71 @@ This script fetches daily OHLCV bars for a predefined list of tickers and
 stores them as CSV files under ``data/``. Existing files are left untouched.
 """
 from __future__ import annotations
+
+import datetime as dt
 from pathlib import Path
+
 import pandas as pd
-from ai_trading.utils.base import _get_alpaca_rest
-from alpaca_trade_api import TimeFrame
-from ai_trading.env import ensure_dotenv_loaded
+from alpaca.common.exceptions import APIError
+from alpaca.data import StockHistoricalDataClient
+from alpaca.data.requests import StockBarsRequest
+from alpaca.data.timeframe import TimeFrame
+
 from ai_trading.config.management import get_env
+from ai_trading.env import ensure_dotenv_loaded
+
 
 def main() -> None:
     """Fetch bars for each symbol and save to ``data`` directory."""
     ensure_dotenv_loaded()
-    api_key = get_env('ALPACA_API_KEY')
-    secret_key = get_env('ALPACA_SECRET_KEY')
-    base_url = get_env('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
-    api = _get_alpaca_rest()(api_key, secret_key, base_url)
-    symbols = ['AAPL', 'MSFT', 'GOOG', 'AMZN', 'NVDA', 'TSLA', 'META']
-    start = '2023-01-01'
-    end = '2024-01-01'
-    data_dir = Path('data')
+    api_key = get_env("ALPACA_API_KEY")
+    secret_key = get_env("ALPACA_SECRET_KEY")
+    feed = get_env("ALPACA_DATA_FEED", "iex")
+    client = StockHistoricalDataClient(api_key, secret_key)
+    symbols = ["AAPL", "MSFT", "GOOG", "AMZN", "NVDA", "TSLA", "META"]
+    start = dt.datetime.fromisoformat("2023-01-01").replace(tzinfo=dt.timezone.utc)
+    end = dt.datetime.fromisoformat("2024-01-01").replace(tzinfo=dt.timezone.utc)
+    data_dir = Path("data")
     data_dir.mkdir(exist_ok=True)
     for symbol in symbols:
-        out_file = data_dir / f'{symbol}.csv'
+        out_file = data_dir / f"{symbol}.csv"
         if out_file.exists():
             continue
+        req = StockBarsRequest(
+            symbol_or_symbols=symbol,
+            timeframe=TimeFrame.Day,
+            start=start,
+            end=end,
+            adjustment="raw",
+            feed=feed,
+        )
         try:
-            bars = api.get_bars(symbol, TimeFrame.Day, start=start, end=end, adjustment='raw').df
-        except (pd.errors.EmptyDataError, KeyError, ValueError, TypeError):
+            bars = client.get_stock_bars(req).df
+        except (APIError, pd.errors.EmptyDataError, KeyError, ValueError, TypeError):
             continue
         if bars is None or bars.empty:
             continue
         if isinstance(bars.index, pd.MultiIndex):
             bars = bars.xs(symbol, level=0)
         df = bars.reset_index()
-        rename_map = {'timestamp': 'timestamp', 'open': 'Open', 'high': 'High', 'low': 'Low', 'close': 'Close', 'volume': 'Volume'}
+        rename_map = {
+            "timestamp": "timestamp",
+            "open": "Open",
+            "high": "High",
+            "low": "Low",
+            "close": "Close",
+            "volume": "Volume",
+        }
         df = df.rename(columns=rename_map)
-        expected_cols = ['timestamp', 'Open', 'High', 'Low', 'Close', 'Volume']
+        expected_cols = ["timestamp", "Open", "High", "Low", "Close", "Volume"]
         df = df[[c for c in expected_cols if c in df.columns]]
-        if df.empty or 'Close' not in df.columns:
+        if df.empty or "Close" not in df.columns:
             continue
         try:
             df.to_csv(out_file, index=False)
         except OSError:
             pass
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Replace legacy `alpaca_trade_api` usage in helper scripts with `alpaca-py` and `alpaca.common.exceptions`
- Refresh troubleshooting examples to use `alpaca-py` clients
- Document new `self_check` script for connectivity verification

## Testing
- `ALPACA_API_KEY=key ALPACA_SECRET_KEY=secret PYTHONPATH=. PYTEST_RUNNING=1 python ai_trading/scripts/self_check.py || echo FAIL`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f7609d48330ac7913d144b3657e