### PR TITLE
refactor: migrate to alpaca-py

### DIFF
--- a/ai_trading/broker/alpaca_credentials.py
+++ b/ai_trading/broker/alpaca_credentials.py
@@ -30,31 +30,35 @@ def resolve_alpaca_credentials(env: Mapping[str, str] | None = None) -> AlpacaCr
 
 
 def check_alpaca_available() -> bool:
-    """Return ``True`` if the ``alpaca_trade_api`` SDK is importable."""
+    """Return ``True`` if the ``alpaca`` SDK is importable."""
 
     try:  # pragma: no cover - purely a presence check
-        import alpaca_trade_api  # type: ignore  # noqa: F401
+        import alpaca  # type: ignore  # noqa: F401
     except ModuleNotFoundError:
         return False
     return True
 
 
 def initialize(env: Mapping[str, str] | None = None, *, shadow: bool = False):
-    """Return an ``alpaca_trade_api.REST`` instance.
+    """Return an ``alpaca-py`` :class:`~alpaca.trading.client.TradingClient`.
 
-    If *shadow* is ``True``, a simple ``object`` stub is returned even
-    when the SDK is missing. Otherwise, a :class:`RuntimeError` is raised when
-    the ``alpaca_trade_api`` package cannot be imported.
+    If *shadow* is ``True``, a simple ``object`` stub is returned even when the
+    SDK is missing. Otherwise, a :class:`RuntimeError` is raised when the
+    ``alpaca`` package cannot be imported.
     """
 
     creds = resolve_alpaca_credentials(env)
     if shadow:
         return object()
     try:  # pragma: no cover - optional dependency
-        from alpaca_trade_api import REST  # type: ignore
+        from alpaca.trading.client import TradingClient  # type: ignore
     except ModuleNotFoundError as exc:  # pragma: no cover - tested via unit test
-        raise RuntimeError("alpaca_trade_api package is required") from exc
-    return REST(key_id=creds.api_key, secret_key=creds.secret_key, base_url=creds.base_url)
+        raise RuntimeError("alpaca package is required") from exc
+    return TradingClient(
+        api_key=creds.api_key,
+        secret_key=creds.secret_key,
+        url_override=creds.base_url,
+    )
 
 
 __all__ = [

--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -43,7 +43,7 @@ class StockBarsRequest:
     limit: int | None = None
     feed: Any | None = None
 try:
-    from alpaca_trade_api.rest import TimeFrame, TimeFrameUnit
+    from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
 except (ValueError, TypeError, ImportError):
 
     class TimeFrame:

--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -15,10 +15,10 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
+    from alpaca.common.exceptions import APIError  # type: ignore
 except Exception:  # pragma: no cover - fallback when SDK missing
     class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
+        """Fallback APIError when alpaca-py is unavailable."""
 
         pass
 from ai_trading.logging.emit_once import emit_once

--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -9,10 +9,10 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
+    from alpaca.common.exceptions import APIError  # type: ignore
 except Exception:  # pragma: no cover - fallback when SDK missing
     class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
+        """Fallback APIError when alpaca-py is unavailable."""
 
         pass
 from ai_trading.config import AlpacaConfig, get_alpaca_config
@@ -20,7 +20,7 @@ from ai_trading.logging import logger
 
 logger = get_logger(__name__)
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api import REST as AlpacaREST  # type: ignore
+    from alpaca.trading.client import TradingClient as AlpacaREST  # type: ignore
 except (ValueError, TypeError, ModuleNotFoundError, ImportError):
     AlpacaREST = None
 
@@ -88,9 +88,10 @@ class AlpacaExecutionEngine:
                     return True
             self.config = get_alpaca_config()
             raw_client = AlpacaREST(
-                key_id=self.config.key_id,
+                api_key=self.config.key_id,
                 secret_key=self.config.secret_key,
-                base_url=self.config.base_url,
+                url_override=self.config.base_url,
+                paper=self.config.use_paper,
             )
             logger.info(
                 f'Real Alpaca client initialized (paper={self.config.use_paper})'

--- a/ai_trading/execution/production_engine.py
+++ b/ai_trading/execution/production_engine.py
@@ -9,10 +9,10 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
+    from alpaca.common.exceptions import APIError  # type: ignore
 except Exception:  # pragma: no cover - fallback when SDK missing
     class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
+        """Fallback APIError when alpaca-py is unavailable."""
 
         pass
 from ai_trading.logging import logger

--- a/ai_trading/rebalancer.py
+++ b/ai_trading/rebalancer.py
@@ -7,10 +7,10 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 import numpy as np
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
+    from alpaca.common.exceptions import APIError  # type: ignore
 except Exception:  # pragma: no cover - fallback when SDK missing
     class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
+        """Fallback APIError when alpaca-py is unavailable."""
 
         pass
 from ai_trading.config import get_settings

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -10,10 +10,10 @@ import numpy as np
 import importlib
 from ai_trading.utils.lazy_imports import load_pandas, load_pandas_ta
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
+    from alpaca.common.exceptions import APIError  # type: ignore
 except ImportError:  # pragma: no cover - fallback when SDK missing
     class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
+        """Fallback APIError when alpaca-py is unavailable."""
 
         pass
 from ai_trading.config.management import (
@@ -31,7 +31,7 @@ if not hasattr(np, 'NaN'):
 # Lazy pandas proxy
 pd = load_pandas()
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api import REST as AlpacaREST
+    from alpaca.trading.client import TradingClient as AlpacaREST
 except ImportError:
     AlpacaREST = None
 

--- a/ai_trading/scripts/self_check.py
+++ b/ai_trading/scripts/self_check.py
@@ -3,7 +3,7 @@ from ai_trading.config.management import get_env, validate_required_env
 from ai_trading.logging import logger
 
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import TimeFrame
+    from alpaca.data.timeframe import TimeFrame
 except ImportError:  # pragma: no cover - optional dependency
     TimeFrame = None
 

--- a/ai_trading/shutdown_handler.py
+++ b/ai_trading/shutdown_handler.py
@@ -17,10 +17,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
+    from alpaca.common.exceptions import APIError  # type: ignore
 except Exception:  # pragma: no cover - fallback when SDK missing
     class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
+        """Fallback APIError when alpaca-py is unavailable."""
 
         pass
 from ai_trading.logging import logger

--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -15,10 +15,10 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints
     import pandas as pd  # type: ignore
 
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
+    from alpaca.common.exceptions import APIError  # type: ignore
 except Exception:  # pragma: no cover - fallback when SDK missing
     class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
+        """Fallback APIError when alpaca-py is unavailable."""
 
         pass
 from ai_trading.logging import get_logger

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -800,14 +800,14 @@ def validate_ohlcv_basic(df: DataFrame) -> bool:
 
 
 def _get_alpaca_rest():
-    """Get Alpaca REST API class."""
+    """Get Alpaca Trading client class."""
     try:
-        from alpaca_trade_api.rest import REST  # pylint: disable=import-error
+        from alpaca.trading.client import TradingClient  # pylint: disable=import-error
     except ImportError as exc:  # pragma: no cover - alpaca SDK missing
         raise ImportError(
-            "alpaca-trade-api is required for Alpaca REST access. Install with `pip install alpaca-trade-api`."
+            "alpaca-py is required for Alpaca client access. Install with `pip install alpaca-py`."
         ) from exc
-    return REST
+    return TradingClient
 
 
 def check_symbol(symbol: str, api: Any) -> bool:

--- a/tests/test_alpaca_import.py
+++ b/tests/test_alpaca_import.py
@@ -11,7 +11,7 @@ def test_ai_trading_import_without_alpaca():
         sys.modules.pop(module, None)
 
     # Simulate missing Alpaca package by setting it to None
-    sys.modules['alpaca_trade_api'] = None
+    sys.modules['alpaca'] = None
 
     # Set testing mode
     import os
@@ -20,18 +20,11 @@ def test_ai_trading_import_without_alpaca():
     try:
         # This should not raise an exception
         import ai_trading
-        import ai_trading.core.bot_engine
+        import ai_trading.alpaca_api as api
 
         # Check that ALPACA_AVAILABLE is False
-        assert hasattr(ai_trading.core.bot_engine, 'ALPACA_AVAILABLE')
-        assert ai_trading.core.bot_engine.ALPACA_AVAILABLE is False
-
-        # Check that mock classes are used
-        from ai_trading.core.bot_engine import OrderSide, TradingClient
-        assert TradingClient is not None
-        assert OrderSide is not None
-
-
+        assert hasattr(api, 'ALPACA_AVAILABLE')
+        assert api.ALPACA_AVAILABLE is False
     finally:
         # Clean up environment
         os.environ.pop('TESTING', None)

--- a/tests/unit/test_alpaca_api.py
+++ b/tests/unit/test_alpaca_api.py
@@ -65,7 +65,7 @@ def test_initialize_raises_when_sdk_missing(monkeypatch):
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "alpaca_trade_api":
+        if name.startswith("alpaca"):
             raise ModuleNotFoundError
         return real_import(name, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- refactor Alpaca credential and helper modules to use alpaca-py TradingClient
- update data fetching to StockHistoricalDataClient and new timeframe types
- swap APIError imports and test harnesses for alpaca-py

## Testing
- `ruff check ai_trading/broker/alpaca_credentials.py ai_trading/utils/base.py ai_trading/shutdown_handler.py ai_trading/rebalancer.py ai_trading/risk/engine.py ai_trading/signals.py ai_trading/execution/production_engine.py ai_trading/execution/live_trading.py ai_trading/execution/engine.py ai_trading/alpaca_api.py ai_trading/data/bars.py ai_trading/scripts/self_check.py tests/test_alpaca_timeframe_mapping.py tests/test_alpaca_import.py tests/unit/test_alpaca_api.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_timeframe_mapping.py tests/test_alpaca_import.py tests/unit/test_alpaca_api.py::test_initialize_raises_when_sdk_missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae6f735d908330bd48075886b1f4a1