### PR TITLE
refactor: migrate to alpaca-py

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -22,10 +22,7 @@ def create_app():
     def health():
         """Lightweight liveness probe with Alpaca diagnostics."""
         try:
-            try:
-                from ai_trading.alpaca_api import ALPACA_AVAILABLE as sdk_ok
-            except (KeyError, ValueError, TypeError):
-                sdk_ok = False
+            sdk_ok = True
 
             try:
                 from ai_trading.core.bot_engine import _resolve_alpaca_env, trading_client

--- a/ai_trading/broker/alpaca_credentials.py
+++ b/ai_trading/broker/alpaca_credentials.py
@@ -29,38 +29,23 @@ def resolve_alpaca_credentials(env: Mapping[str, str] | None = None) -> AlpacaCr
     )
 
 
-def check_alpaca_available() -> bool:
-    """Return ``True`` if the ``alpaca_trade_api`` SDK is importable."""
-
-    try:  # pragma: no cover - purely a presence check
-        import alpaca_trade_api  # type: ignore  # noqa: F401
-    except ModuleNotFoundError:
-        return False
-    return True
-
-
 def initialize(env: Mapping[str, str] | None = None, *, shadow: bool = False):
-    """Return an ``alpaca_trade_api.REST`` instance.
+    """Return an ``alpaca.trading.client.TradingClient`` instance.
 
-    If *shadow* is ``True``, a simple ``object`` stub is returned even
-    when the SDK is missing. Otherwise, a :class:`RuntimeError` is raised when
-    the ``alpaca_trade_api`` package cannot be imported.
+    If *shadow* is ``True``, a simple ``object`` stub is returned.
     """
 
     creds = resolve_alpaca_credentials(env)
     if shadow:
         return object()
-    try:  # pragma: no cover - optional dependency
-        from alpaca_trade_api import REST  # type: ignore
-    except ModuleNotFoundError as exc:  # pragma: no cover - tested via unit test
-        raise RuntimeError("alpaca_trade_api package is required") from exc
-    return REST(key_id=creds.api_key, secret_key=creds.secret_key, base_url=creds.base_url)
+    from alpaca.trading.client import TradingClient
+
+    return TradingClient(
+        creds.api_key,
+        creds.secret_key,
+        base_url=creds.base_url,
+    )
 
 
-__all__ = [
-    "AlpacaCredentials",
-    "resolve_alpaca_credentials",
-    "check_alpaca_available",
-    "initialize",
-]
+__all__ = ["AlpacaCredentials", "resolve_alpaca_credentials", "initialize"]
 

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -56,18 +56,9 @@ from ai_trading.data.timeutils import (
 )
 from ai_trading.data_validation import is_valid_ohlcv
 from ai_trading.utils import health_check as _health_check
-from ai_trading.alpaca_api import (
-    ALPACA_AVAILABLE,
-    get_bars_df,  # AI-AGENT-REF: canonical bar fetcher (auto start/end)
-)
+from ai_trading.alpaca_api import get_bars_df  # AI-AGENT-REF: canonical bar fetcher (auto start/end)
 from ai_trading.utils.pickle_safe import safe_pickle_load
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 
 from ai_trading.config.management import (
     derive_cap_from_settings,
@@ -75,12 +66,6 @@ from ai_trading.config.management import (
     TradingConfig,
 )
 from ai_trading.settings import get_alpaca_secret_key_plain
-
-
-def _alpaca_available() -> bool:
-    """Return ``True`` if the alpaca_trade_api SDK is importable."""
-
-    return ALPACA_AVAILABLE
 from ai_trading.data.bars import (
     _create_empty_bars_dataframe,
     _resample_minutes_to_daily,
@@ -248,8 +233,6 @@ __all__ = [
     "SENTIMENT_FAILURE_THRESHOLD",
     "_SENTIMENT_CACHE",
     "fetch_sentiment",
-    "ALPACA_AVAILABLE",
-    "_alpaca_available",
     "FINNHUB_AVAILABLE",
     "DataFetchError",
     "MockSignal",
@@ -402,23 +385,23 @@ class BotEngine:
 
     @cached_property
     def trading_client(self):
-        """alpaca-trade-api REST for order/trade ops."""
-        from alpaca_trade_api import REST  # type: ignore
+        """alpaca TradingClient for order/trade ops."""
+        from alpaca.trading.client import TradingClient
 
-        return REST(
-            key_id=_get_env_str("ALPACA_API_KEY"),
-            secret_key=_get_env_str("ALPACA_SECRET_KEY"),
+        return TradingClient(
+            _get_env_str("ALPACA_API_KEY"),
+            _get_env_str("ALPACA_SECRET_KEY"),
             base_url=_get_env_str("ALPACA_BASE_URL"),
         )
 
     @cached_property
     def data_client(self):
-        """alpaca-trade-api REST for historical/market data."""
-        from alpaca_trade_api import REST  # type: ignore
+        """alpaca TradingClient for historical/market data."""
+        from alpaca.trading.client import TradingClient
 
-        return REST(
-            key_id=_get_env_str("ALPACA_API_KEY"),
-            secret_key=_get_env_str("ALPACA_SECRET_KEY"),
+        return TradingClient(
+            _get_env_str("ALPACA_API_KEY"),
+            _get_env_str("ALPACA_SECRET_KEY"),
             base_url=_get_env_str("ALPACA_BASE_URL"),
         )
 
@@ -562,8 +545,6 @@ def maybe_init_brokers() -> None:
     """Initialize clients lazily, only when runtime needs them."""  # AI-AGENT-REF: lazy broker init
     global trading_client, data_client
     if trading_client is not None and data_client is not None:
-        return
-    if not ALPACA_AVAILABLE:
         return
     # actual initialization occurs elsewhere when Alpaca is available
 
@@ -954,16 +935,6 @@ def ensure_portfolio_weights(ctx, symbols):
         return {symbol: 1.0 / len(symbols) for symbol in symbols if symbols}
 
 
-# Log Alpaca availability on startup (only once per process)
-if _alpaca_available():
-    _emit_once(logger, "alpaca_available", logging.INFO, "Alpaca SDK is available")
-else:  # pragma: no cover - executed only when SDK missing
-    _emit_once(
-        logger,
-        "alpaca_missing",
-        logging.WARNING,
-        "Alpaca SDK not installed",
-    )
 # Mirror config to maintain historical constant name
 # REMOVED: MIN_CYCLE = CFG.scheduler_sleep_seconds
 # AI-AGENT-REF: guard environment validation with explicit error logging
@@ -1500,66 +1471,15 @@ def _ensure_alpaca_classes() -> None:
     global Quote, Order, OrderSide, OrderStatus, TimeInForce, MarketOrderRequest, StockLatestQuoteRequest, _ALPACA_IMPORT_ERROR
     if Quote is not None or _ALPACA_IMPORT_ERROR is not None:
         return
-    try:  # pragma: no cover - import resolution
-        from alpaca_trade_api.entity import Quote as _Quote, Order as _Order
-    except Exception as e:  # pragma: no cover - executed only when base dep missing
-        _ALPACA_IMPORT_ERROR = e
-        get_logger(__name__).critical(
-            "required Alpaca trade API classes missing; ensure alpaca-trade-api is installed",
-            exc_info=e,
-        )
-        return
-
-    try:
-        from alpaca_trade_api.enums import (
-            OrderSide as _OrderSide,
-            OrderStatus as _OrderStatus,
-            TimeInForce as _TimeInForce,
-        )
-    except Exception:
-        from enum import Enum
-
-        class _OrderSide(str, Enum):  # pragma: no cover - fallback enum
-            BUY = "buy"
-            SELL = "sell"
-
-        class _OrderStatus(str, Enum):  # pragma: no cover - fallback enum
-            NEW = "new"
-            PARTIALLY_FILLED = "partially_filled"
-            FILLED = "filled"
-            CANCELED = "canceled"
-            REJECTED = "rejected"
-            EXPIRED = "expired"
-
-        class _TimeInForce(str, Enum):  # pragma: no cover - fallback enum
-            DAY = "day"
-            GTC = "gtc"
-
-    try:
-        from alpaca_trade_api.types import MarketOrderRequest as _MarketOrderRequest
-    except Exception:
-        from dataclasses import dataclass
-
-        @dataclass
-        class _MarketOrderRequest:  # pragma: no cover - minimal request object
-            symbol: str
-            qty: int
-            side: _OrderSide
-            time_in_force: _TimeInForce
-            limit_price: float | None = None
-            stop_price: float | None = None
-            client_order_id: str | None = None
-
-    try:  # pragma: no cover - StockLatestQuoteRequest may not exist
-        from alpaca_trade_api.rest import (
-            StockLatestQuoteRequest as _StockLatestQuoteRequest,  # type: ignore
-        )
-    except Exception:
-        from dataclasses import dataclass
-
-        @dataclass
-        class _StockLatestQuoteRequest:  # pragma: no cover - lightweight fallback
-            symbol_or_symbols: Any
+    from alpaca.data.models import Quote as _Quote
+    from alpaca.trading.models import Order as _Order
+    from alpaca.trading.enums import (
+        OrderSide as _OrderSide,
+        OrderStatus as _OrderStatus,
+        TimeInForce as _TimeInForce,
+    )
+    from alpaca.trading.requests import MarketOrderRequest as _MarketOrderRequest
+    from alpaca.data.requests import StockLatestQuoteRequest as _StockLatestQuoteRequest
 
     Quote = _Quote
     Order = _Order
@@ -1584,20 +1504,15 @@ def _alpaca_symbols():
     )
     return _alpaca_get, _start
 
-if ALPACA_AVAILABLE:
-    from ai_trading.rebalancer import (
-        maybe_rebalance as original_rebalance,  # type: ignore
-    )
-else:  # pragma: no cover - no rebalance without Alpaca
-
-    def original_rebalance(*args, **kwargs):
-        return None
+from ai_trading.rebalancer import (
+    maybe_rebalance as original_rebalance,  # type: ignore
+)
 
 
 import pickle
 
 # AI-AGENT-REF: Optional meta-learning — do not crash if unavailable
-if not os.getenv("PYTEST_RUNNING") and ALPACA_AVAILABLE:
+if not os.getenv("PYTEST_RUNNING"):
     try:
         from ai_trading.meta_learning import optimize_signals  # type: ignore
     except (
@@ -2277,7 +2192,7 @@ import warnings
 RUN_HEALTH = RUN_HEALTHCHECK == "1"
 
 # Logging: set root logger to INFO, send to both stderr and a log file
-get_logger("alpaca_trade_api").setLevel(logging.WARNING)
+get_logger("alpaca").setLevel(logging.WARNING)
 get_logger("urllib3").setLevel(logging.WARNING)
 get_logger("requests").setLevel(logging.WARNING)
 
@@ -3777,7 +3692,7 @@ class DataFetcher:
             logger.error(f"Missing Alpaca credentials for {symbol}")
             return None
 
-        from alpaca_trade_api import REST as AlpacaREST  # type: ignore
+        from alpaca.trading.client import TradingClient as AlpacaREST  # type: ignore
 
         client = AlpacaREST(
             api_key,
@@ -4079,7 +3994,7 @@ class DataFetcher:
             raise RuntimeError(
                 "ALPACA_API_KEY and ALPACA_SECRET_KEY must be set for data fetching"
             )
-        from alpaca_trade_api import REST as AlpacaREST  # type: ignore
+        from alpaca.trading.client import TradingClient as AlpacaREST  # type: ignore
 
         client = AlpacaREST(
             api_key,
@@ -4328,7 +4243,7 @@ def prefetch_daily_data(
         raise RuntimeError(
             "ALPACA_API_KEY and ALPACA_SECRET_KEY must be set for data fetching"
         )
-    from alpaca_trade_api import REST as AlpacaREST  # type: ignore
+    from alpaca.trading.client import TradingClient as AlpacaREST  # type: ignore
 
     client = AlpacaREST(
         alpaca_key,
@@ -5621,7 +5536,7 @@ def _initialize_alpaca_clients() -> None:
             logger.info("ALPACA_DIAG", extra=_redact(diag))
             return
         try:
-            from alpaca_trade_api import REST as AlpacaREST
+            from alpaca.trading.client import TradingClient as AlpacaREST
 
             logger.debug("Successfully imported Alpaca SDK class")
         except COMMON_EXC as e:

--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -42,19 +42,7 @@ class StockBarsRequest:
     end: Any | None = None
     limit: int | None = None
     feed: Any | None = None
-try:
-    from alpaca_trade_api.rest import TimeFrame, TimeFrameUnit
-except (ValueError, TypeError, ImportError):
-
-    class TimeFrame:
-
-        def __init__(self, n: int, unit: Any) -> None:
-            self.n = n
-            self.unit = unit
-
-    class TimeFrameUnit:
-        Day = 'Day'
-        Minute = 'Minute'
+from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
 COMMON_EXC = (ValueError, KeyError, AttributeError, TypeError, RuntimeError, ImportError, OSError, ConnectionError, TimeoutError)
 
 def _ensure_df(obj: Any) -> pd.DataFrame:

--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -328,7 +328,6 @@ def build_fetcher(config: Any):
     if _FETCHER_SINGLETON is not None:
         return _FETCHER_SINGLETON
 
-    from ai_trading.alpaca_api import ALPACA_AVAILABLE
     bot_mod = importlib.import_module('ai_trading.core.bot_engine')
     DataFetcher = bot_mod.DataFetcher
     _ensure_http_client()
@@ -337,7 +336,7 @@ def build_fetcher(config: Any):
 
     alpaca_ok = bool(os.getenv('ALPACA_API_KEY') and os.getenv('ALPACA_SECRET_KEY'))
     has_keys = alpaca_ok
-    if ALPACA_AVAILABLE and has_keys:
+    if has_keys:
         logger.info('DATA_FETCHER_BUILD', extra={'source': 'alpaca'})
         fetcher = DataFetcher()
         setattr(fetcher, 'source', 'alpaca')

--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -14,13 +14,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.logging.emit_once import emit_once
 
 logger = get_logger(__name__)

--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -8,21 +8,11 @@ from ai_trading.logging import get_logger
 import time
 from datetime import UTC, datetime
 from typing import Any
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.config import AlpacaConfig, get_alpaca_config
 from ai_trading.logging import logger
 
 logger = get_logger(__name__)
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api import REST as AlpacaREST  # type: ignore
-except (ValueError, TypeError, ModuleNotFoundError, ImportError):
-    AlpacaREST = None
 
 def _req_str(name: str, v: str | None) -> str:
     if not v:
@@ -86,10 +76,12 @@ class AlpacaExecutionEngine:
                     self.trading_client = MockTradingClient(paper=True)
                     self.is_initialized = True
                     return True
+            from alpaca.trading.client import TradingClient
+
             self.config = get_alpaca_config()
-            raw_client = AlpacaREST(
-                key_id=self.config.key_id,
-                secret_key=self.config.secret_key,
+            raw_client = TradingClient(
+                self.config.key_id,
+                self.config.secret_key,
                 base_url=self.config.base_url,
             )
             logger.info(

--- a/ai_trading/execution/production_engine.py
+++ b/ai_trading/execution/production_engine.py
@@ -8,13 +8,7 @@ import asyncio
 import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.logging import logger
 from ..core.constants import EXECUTION_PARAMETERS
 from ..core.enums import OrderSide, OrderType, RiskLevel

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -33,7 +33,7 @@ def preflight_import_health() -> None:
         "ai_trading.risk.engine",
         "ai_trading.rl_trading",
         "ai_trading.telemetry.metrics_logger",
-        "alpaca_trade_api",
+        "alpaca.trading.client",
     ]
     for mod in core_modules:
         try:

--- a/ai_trading/rebalancer.py
+++ b/ai_trading/rebalancer.py
@@ -6,13 +6,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 import numpy as np
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.config import get_settings
 from ai_trading.portfolio import compute_portfolio_weights
 from ai_trading.settings import get_rebalance_interval_min

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -9,13 +9,7 @@ from typing import Any
 import numpy as np
 import importlib
 from ai_trading.utils.lazy_imports import load_pandas, load_pandas_ta
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except ImportError:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.config.management import (
     SEED,
     TradingConfig,
@@ -30,10 +24,6 @@ if not hasattr(np, 'NaN'):
 
 # Lazy pandas proxy
 pd = load_pandas()
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api import REST as AlpacaREST
-except ImportError:
-    AlpacaREST = None
 
 
 def _safe_call(fn, *a, **k):
@@ -89,12 +79,14 @@ class RiskEngine:
         self._volatility_cache: dict[str, tuple] = {}
         self.data_client = None
         try:
+            from alpaca.trading.client import TradingClient
+
             s = get_settings()
             secret = get_alpaca_secret_key_plain()
-            if AlpacaREST and getattr(s, 'alpaca_api_key', None) and secret and getattr(s, 'alpaca_base_url', None):
-                self.data_client = AlpacaREST(s.alpaca_api_key, secret, s.alpaca_base_url)
+            if getattr(s, 'alpaca_api_key', None) and secret and getattr(s, 'alpaca_base_url', None):
+                self.data_client = TradingClient(s.alpaca_api_key, secret, base_url=s.alpaca_base_url)
         except (APIError, ValueError, TypeError, AttributeError, OSError) as e:
-            logger.warning('Could not initialize AlpacaREST: %s', e)
+            logger.warning('Could not initialize TradingClient: %s', e)
         self._returns: list[float] = []
         self._drawdowns: list[float] = []
         self._last_portfolio_cap: float | None = None

--- a/ai_trading/scripts/self_check.py
+++ b/ai_trading/scripts/self_check.py
@@ -2,10 +2,7 @@ from ai_trading.alpaca_api import _bars_time_window, get_bars_df
 from ai_trading.config.management import get_env, validate_required_env
 from ai_trading.logging import logger
 
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import TimeFrame
-except ImportError:  # pragma: no cover - optional dependency
-    TimeFrame = None
+from alpaca.data.timeframe import TimeFrame
 
 
 def main() -> None:

--- a/ai_trading/shutdown_handler.py
+++ b/ai_trading/shutdown_handler.py
@@ -16,13 +16,7 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from pathlib import Path
 from typing import Any
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.logging import logger
 
 Hook = Callable[[], None]

--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -14,13 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints
     import numpy as np  # type: ignore
     import pandas as pd  # type: ignore
 
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.logging import get_logger
 from ai_trading.utils import clamp_timeout as _clamp_timeout
 from ai_trading.utils.lazy_imports import optional_import

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -800,14 +800,10 @@ def validate_ohlcv_basic(df: DataFrame) -> bool:
 
 
 def _get_alpaca_rest():
-    """Get Alpaca REST API class."""
-    try:
-        from alpaca_trade_api.rest import REST  # pylint: disable=import-error
-    except ImportError as exc:  # pragma: no cover - alpaca SDK missing
-        raise ImportError(
-            "alpaca-trade-api is required for Alpaca REST access. Install with `pip install alpaca-trade-api`."
-        ) from exc
-    return REST
+    """Get Alpaca TradingClient class."""
+    from alpaca.trading.client import TradingClient
+
+    return TradingClient
 
 
 def check_symbol(symbol: str, api: Any) -> bool:


### PR DESCRIPTION
## Summary
- replace legacy Alpaca SDK usage with alpaca-py across trading modules
- drop conditional alpaca_trade_api availability checks
- lazily import new Alpaca clients and types where needed

## Testing
- `ruff check ai_trading/broker/alpaca_credentials.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_dual_schema_credentials.py tests/test_config_additional.py -q` *(fails: ImportError: cannot import name '_resolve_alpaca_env')*
- `ruff check ai_trading/execution/engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_execution_engine_check_stops.py -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*
- `ruff check ai_trading/risk/engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_risk_engine_module.py -q`
- `ruff check ai_trading/execution/live_trading.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/institutional/test_live_trading.py -q`
- `ruff check ai_trading/execution/production_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_production_system.py -q` *(fails: async def functions are not natively supported)*
- `ruff check ai_trading/rebalancer.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rebalancer_additional.py -q` *(fails: No module named 'numpy')*
- `ruff check ai_trading/shutdown_handler.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_order_tracking.py -q` *(fails: No module named 'alpaca')*
- `ruff check ai_trading/data/bars.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_timeframe_mapping.py -q`
- `ruff check ai_trading/alpaca_api.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_alpaca_api.py -q` *(fails: No module named 'alpaca')*
- `ruff check ai_trading/signals.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_signals.py -q` *(fails: No module named 'numpy')*
- `ruff check ai_trading/scripts/self_check.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest ai_trading/scripts/self_check.py -q` *(fails: No module named 'requests')*
- `ruff check ai_trading/utils/base.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_and_screen.py -q`
- `ruff check ai_trading/core/bot_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot_engine_unit.py -q` *(fails: No module named 'joblib')*
- `ruff check ai_trading/main.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot.py -q`
- `ruff check ai_trading/data/fetch.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_data_fetch.py -q` *(fails: No module named 'requests')*
- `ruff check ai_trading/app.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_health.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6f73274c833080cc9acce0f89c3d