### PR TITLE
Switch to alpaca-py clients

### DIFF
--- a/ai_trading/broker/alpaca_credentials.py
+++ b/ai_trading/broker/alpaca_credentials.py
@@ -30,31 +30,35 @@ def resolve_alpaca_credentials(env: Mapping[str, str] | None = None) -> AlpacaCr
 
 
 def check_alpaca_available() -> bool:
-    """Return ``True`` if the ``alpaca_trade_api`` SDK is importable."""
+    """Return ``True`` if the :mod:`alpaca` SDK is importable."""
 
     try:  # pragma: no cover - purely a presence check
-        import alpaca_trade_api  # type: ignore  # noqa: F401
+        from alpaca.trading.client import TradingClient  # type: ignore  # noqa: F401
     except ModuleNotFoundError:
         return False
     return True
 
 
 def initialize(env: Mapping[str, str] | None = None, *, shadow: bool = False):
-    """Return an ``alpaca_trade_api.REST`` instance.
+    """Return an :class:`alpaca.trading.client.TradingClient` instance.
 
     If *shadow* is ``True``, a simple ``object`` stub is returned even
     when the SDK is missing. Otherwise, a :class:`RuntimeError` is raised when
-    the ``alpaca_trade_api`` package cannot be imported.
+    the ``alpaca`` package cannot be imported.
     """
 
     creds = resolve_alpaca_credentials(env)
     if shadow:
         return object()
     try:  # pragma: no cover - optional dependency
-        from alpaca_trade_api import REST  # type: ignore
+        from alpaca.trading.client import TradingClient  # type: ignore
     except ModuleNotFoundError as exc:  # pragma: no cover - tested via unit test
-        raise RuntimeError("alpaca_trade_api package is required") from exc
-    return REST(key_id=creds.api_key, secret_key=creds.secret_key, base_url=creds.base_url)
+        raise RuntimeError("alpaca package is required") from exc
+    return TradingClient(
+        api_key=creds.api_key,
+        secret_key=creds.secret_key,
+        base_url=creds.base_url,
+    )
 
 
 __all__ = [

--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -34,17 +34,19 @@ def _log_fallback_window_debug(logger, day_et: date, start_utc: datetime, end_ut
     except (ValueError, TypeError):
         pass
 
-@dataclass
-class StockBarsRequest:
-    symbol_or_symbols: Any
-    timeframe: Any
-    start: Any | None = None
-    end: Any | None = None
-    limit: int | None = None
-    feed: Any | None = None
 try:
-    from alpaca_trade_api.rest import TimeFrame, TimeFrameUnit
+    from alpaca.data.timeframe import TimeFrame, TimeFrameUnit  # type: ignore
+    from alpaca.data.requests import StockBarsRequest  # type: ignore
 except (ValueError, TypeError, ImportError):
+
+    @dataclass
+    class StockBarsRequest:
+        symbol_or_symbols: Any
+        timeframe: Any
+        start: Any | None = None
+        end: Any | None = None
+        limit: int | None = None
+        feed: Any | None = None
 
     class TimeFrame:
 

--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -9,10 +9,10 @@ import time
 from datetime import UTC, datetime
 from typing import Any
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
+    from alpaca.common.exceptions import APIError  # type: ignore
 except Exception:  # pragma: no cover - fallback when SDK missing
     class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
+        """Fallback APIError when alpaca-py is unavailable."""
 
         pass
 from ai_trading.config import AlpacaConfig, get_alpaca_config
@@ -20,7 +20,7 @@ from ai_trading.logging import logger
 
 logger = get_logger(__name__)
 try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api import REST as AlpacaREST  # type: ignore
+    from alpaca.trading.client import TradingClient as AlpacaREST  # type: ignore
 except (ValueError, TypeError, ModuleNotFoundError, ImportError):
     AlpacaREST = None
 
@@ -88,7 +88,7 @@ class AlpacaExecutionEngine:
                     return True
             self.config = get_alpaca_config()
             raw_client = AlpacaREST(
-                key_id=self.config.key_id,
+                api_key=self.config.key_id,
                 secret_key=self.config.secret_key,
                 base_url=self.config.base_url,
             )

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -800,14 +800,14 @@ def validate_ohlcv_basic(df: DataFrame) -> bool:
 
 
 def _get_alpaca_rest():
-    """Get Alpaca REST API class."""
+    """Get Alpaca :class:`TradingClient` class."""
     try:
-        from alpaca_trade_api.rest import REST  # pylint: disable=import-error
+        from alpaca.trading.client import TradingClient  # pylint: disable=import-error
     except ImportError as exc:  # pragma: no cover - alpaca SDK missing
         raise ImportError(
-            "alpaca-trade-api is required for Alpaca REST access. Install with `pip install alpaca-trade-api`."
+            "alpaca-py is required for Alpaca access. Install with `pip install alpaca-py`."
         ) from exc
-    return REST
+    return TradingClient
 
 
 def check_symbol(symbol: str, api: Any) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,14 @@ except Exception:  # pragma: no cover - only hit in test bootstrap
         "alpaca.data.requests",
         _importlib.import_module("tests.vendor_stubs.alpaca.data.requests"),
     )
+    _sys.modules.setdefault(
+        "alpaca.common",
+        _importlib.import_module("tests.vendor_stubs.alpaca.common"),
+    )
+    _sys.modules.setdefault(
+        "alpaca.common.exceptions",
+        _importlib.import_module("tests.vendor_stubs.alpaca.common.exceptions"),
+    )
     from alpaca.trading.client import TradingClient  # noqa: F401
     from alpaca.data.timeframe import TimeFrame, TimeFrameUnit  # noqa: F401
 

--- a/tests/unit/test_alpaca_api.py
+++ b/tests/unit/test_alpaca_api.py
@@ -1,5 +1,6 @@
 import builtins
 import importlib
+import sys
 
 import pytest
 from tests.optdeps import require
@@ -70,6 +71,9 @@ def test_initialize_raises_when_sdk_missing(monkeypatch):
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "alpaca", raising=False)
+    monkeypatch.delitem(sys.modules, "alpaca.trading", raising=False)
+    monkeypatch.delitem(sys.modules, "alpaca.trading.client", raising=False)
 
     with pytest.raises(RuntimeError):
         alpaca_credentials.initialize(shadow=False)

--- a/tests/vendor_stubs/alpaca/common/__init__.py
+++ b/tests/vendor_stubs/alpaca/common/__init__.py
@@ -1,0 +1,4 @@
+"""Minimal stub for alpaca.common package."""
+from .exceptions import APIError
+
+__all__ = ["APIError"]

--- a/tests/vendor_stubs/alpaca/common/exceptions.py
+++ b/tests/vendor_stubs/alpaca/common/exceptions.py
@@ -1,0 +1,7 @@
+"""Exception stubs for alpaca.common."""
+
+class APIError(Exception):
+    """Generic API error stub."""
+    pass
+
+__all__ = ["APIError"]


### PR DESCRIPTION
## Summary
- replace legacy `alpaca_trade_api` usage with `alpaca-py` `TradingClient`
- adjust live trading engine and utilities for `alpaca.common.exceptions.APIError`
- add `alpaca.common` test stubs and update tests for missing SDK handling

## Testing
- `ruff check ai_trading/broker/alpaca_credentials.py ai_trading/utils/base.py ai_trading/data/bars.py ai_trading/execution/live_trading.py tests/conftest.py tests/vendor_stubs/alpaca/common/__init__.py tests/vendor_stubs/alpaca/common/exceptions.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_alpaca_api.py::test_initialize_raises_when_sdk_missing tests/test_clients_memoized.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae771cc6a0833093cf61c46078afd9