### PR TITLE
refactor: switch to alpaca-py

### DIFF
--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -14,13 +14,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.logging.emit_once import emit_once
 
 logger = get_logger(__name__)

--- a/ai_trading/execution/production_engine.py
+++ b/ai_trading/execution/production_engine.py
@@ -8,13 +8,7 @@ import asyncio
 import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.logging import logger
 from ..core.constants import EXECUTION_PARAMETERS
 from ..core.enums import OrderSide, OrderType, RiskLevel

--- a/ai_trading/rebalancer.py
+++ b/ai_trading/rebalancer.py
@@ -6,13 +6,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
 import numpy as np
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.config import get_settings
 from ai_trading.portfolio import compute_portfolio_weights
 from ai_trading.settings import get_rebalance_interval_min

--- a/ai_trading/shutdown_handler.py
+++ b/ai_trading/shutdown_handler.py
@@ -16,13 +16,7 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from pathlib import Path
 from typing import Any
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.logging import logger
 
 Hook = Callable[[], None]

--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -14,13 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints
     import numpy as np  # type: ignore
     import pandas as pd  # type: ignore
 
-try:  # pragma: no cover - optional dependency
-    from alpaca_trade_api.rest import APIError  # type: ignore
-except Exception:  # pragma: no cover - fallback when SDK missing
-    class APIError(Exception):
-        """Fallback APIError when alpaca-trade-api is unavailable."""
-
-        pass
+from alpaca.common.exceptions import APIError
 from ai_trading.logging import get_logger
 from ai_trading.utils import clamp_timeout as _clamp_timeout
 from ai_trading.utils.lazy_imports import optional_import


### PR DESCRIPTION
## Summary
- refactor signals, shutdown, execution, rebalancer, risk, and alpaca API modules to use `alpaca-py`
- drop conditional alpaca-trade-api fallbacks

## Testing
- `ruff check ai_trading/signals.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_signals.py -q` *(skipped: pandas missing)*
- `ruff check ai_trading/shutdown_handler.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_api_module.py -q`
- `ruff check ai_trading/execution/engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_execution_algorithms_narrow.py -q`
- `ruff check ai_trading/execution/production_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_production_system.py -q` *(fails: async plugin missing)*
- `ruff check ai_trading/rebalancer.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_no_trade_bands.py -q` *(fails: sklearn missing)*
- `ruff check ai_trading/risk/engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_risk_engine_import.py -q`
- `ruff check ai_trading/alpaca_api.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_api_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae78a8dab88330a7c2df8a2b2c8370