### PR TITLE
Fix missing runtime defaults import

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -57,6 +57,8 @@ def run_cycle() -> None:
         BotState,
         run_all_trades_worker,
         get_ctx,
+    )
+    from ai_trading.core.runtime import (
         build_runtime,
         REQUIRED_PARAM_DEFAULTS,
     )


### PR DESCRIPTION
## Summary
- Import REQUIRED_PARAM_DEFAULTS from the correct runtime module to avoid ImportError on startup

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae7f354ca88330b336c420ffe7343b