### PR TITLE
refactor: drop optional_import shim

### DIFF
--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints
 from alpaca.common.exceptions import APIError
 from ai_trading.logging import get_logger
 from ai_trading.utils import clamp_timeout as _clamp_timeout
-from ai_trading.utils.lazy_imports import optional_import
 logger = get_logger(__name__)
 _log = logger
 
@@ -52,7 +51,11 @@ def _get_numpy():
 
 
 def _get_pandas():
-    return optional_import("pandas")
+    try:  # pragma: no cover - import is tested indirectly
+        import pandas as pd  # type: ignore
+        return pd
+    except ImportError:
+        return None
 
 
 def _get_requests():

--- a/ai_trading/utils/lazy_imports.py
+++ b/ai_trading/utils/lazy_imports.py
@@ -50,11 +50,3 @@ def load_pandas_ta() -> ModuleType | None:
         return None
 
 
-@lru_cache(maxsize=None)
-def optional_import(name: str) -> ModuleType | None:
-    """Return the imported module or ``None`` if not installed."""
-    try:
-        return importlib.import_module(name)
-    except Exception:  # pragma: no cover - optional dependency
-        get_logger(__name__).debug("optional_import failed", extra={"module": name})
-        return None

--- a/ai_trading/utils/optdeps.py
+++ b/ai_trading/utils/optdeps.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 """Lightweight helpers for optional dependencies."""
 
-from importlib import import_module
 from types import ModuleType
 from typing import Any, Mapping, Optional
 
-__all__ = ["optional_import", "module_ok", "OptionalDependencyError"]
+__all__ = ["module_ok", "OptionalDependencyError"]
 
 
 # AI-AGENT-REF: map modules to extras for install hints
@@ -51,49 +50,6 @@ class OptionalDependencyError(ImportError):
         self.extra = extra
         self.feature = feature
         self.purpose = feature  # back-compat
-
-
-# AI-AGENT-REF: derive extras hints on optional imports
-def optional_import(
-    name: str,
-    *,
-    required: bool = False,
-    attr: Optional[str] = None,
-    message: Optional[str] = None,
-    extra: Optional[str] = None,
-    feature: Optional[str] = None,
-    purpose: Optional[str] = None,
-) -> Any | None:
-    """Import a module (and optionally attribute) if available."""
-
-    feature = feature or purpose
-    try:
-        mod = import_module(name)
-    except Exception:
-        if required:
-            resolved_extra = extra or _EXTRAS_BY_PKG.get(name)
-            raise OptionalDependencyError(
-                name,
-                extra=resolved_extra,
-                feature=feature,
-                message=message,
-            )
-        return None
-
-    if attr:
-        try:
-            return getattr(mod, attr)
-        except AttributeError:
-            if required:
-                resolved_extra = extra or _EXTRAS_BY_PKG.get(name)
-                raise OptionalDependencyError(
-                    name,
-                    extra=resolved_extra,
-                    feature=feature,
-                    message=message,
-                )
-            return None
-    return mod
 
 
 def module_ok(mod: Optional[ModuleType | Any]) -> bool:

--- a/tests/unit/test_utils_lazy_import.py
+++ b/tests/unit/test_utils_lazy_import.py
@@ -1,5 +1,4 @@
 import types
-from ai_trading.utils.lazy_imports import optional_import
 
 
 def test_utils_http_lazy_import_no_recursion():
@@ -9,9 +8,4 @@ def test_utils_http_lazy_import_no_recursion():
     assert isinstance(mod, types.ModuleType)
     # cached on second access
     assert utils.http is mod
-
-
-def test_optional_import():
-    assert optional_import("math") is not None
-    assert optional_import("module_does_not_exist") is None
 


### PR DESCRIPTION
## Summary
- remove unused optional_import utilities
- use direct pandas import guard in signals
- drop optional_import test

## Testing
- `ruff check ai_trading/signals.py ai_trading/utils`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae80de954c83309f67646a4f52a1ba