### PR TITLE
refactor: use namespaced import checks

### DIFF
--- a/tests/test_centralized_logging_no_duplicates.py
+++ b/tests/test_centralized_logging_no_duplicates.py
@@ -1,6 +1,7 @@
 """
 Test centralized logging system to ensure no duplicate logging setup.
 """
+import importlib
 import logging
 import os
 import threading
@@ -73,17 +74,17 @@ def test_centralized_logging_prevents_duplicates():
 def test_deprecated_modules_removed():
     """Test that deprecated logging modules can no longer be imported."""
 
-    # Test that logging_config cannot be imported
+    # Test that ai_trading.logging_config cannot be imported
     try:
-        import logging_config
-        assert False, "logging_config should not be importable after removal"
+        importlib.import_module("ai_trading.logging_config")
+        assert False, "ai_trading.logging_config should not be importable after removal"
     except ImportError:
         pass  # Expected
 
-    # Test that logger cannot be imported
+    # Test that ai_trading.logger cannot be imported
     try:
-        import logger
-        assert False, "logger should not be importable after removal"
+        importlib.import_module("ai_trading.logger")
+        assert False, "ai_trading.logger should not be importable after removal"
     except ImportError:
         pass  # Expected
 


### PR DESCRIPTION
## Summary
- ensure deprecated logging modules are checked via namespaced imports

## Testing
- `ruff check tests/test_centralized_logging_no_duplicates.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_centralized_logging_no_duplicates.py::test_deprecated_modules_removed -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae80e0466083309441b5c72fb53022