### PR TITLE
chore: remove legacy module tests

### DIFF
--- a/tests/test_centralized_config.py
+++ b/tests/test_centralized_config.py
@@ -240,12 +240,5 @@ def test_trading_config_to_dict_includes_capital_and_drawdown():
     assert isinstance(data["max_drawdown_threshold"], int | float)
 
 
-def test_botmode_init_without_legacy_method():
-    """BotMode should initialize without legacy parameter method."""
-    from ai_trading.core import bot_engine
-
-    bot_engine.BotMode("balanced")  # Should not raise
-
-
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_centralized_logging_no_duplicates.py
+++ b/tests/test_centralized_logging_no_duplicates.py
@@ -1,7 +1,4 @@
-"""
-Test centralized logging system to ensure no duplicate logging setup.
-"""
-import importlib
+"""Test centralized logging system to ensure no duplicate logging setup."""
 import logging
 import os
 import threading
@@ -71,24 +68,6 @@ def test_centralized_logging_prevents_duplicates():
         root_logger.handlers = original_handlers
 
 
-def test_deprecated_modules_removed():
-    """Test that deprecated logging modules can no longer be imported."""
-
-    # Test that ai_trading.logging_config cannot be imported
-    try:
-        importlib.import_module("ai_trading.logging_config")
-        assert False, "ai_trading.logging_config should not be importable after removal"
-    except ImportError:
-        pass  # Expected
-
-    # Test that ai_trading.logger cannot be imported
-    try:
-        importlib.import_module("ai_trading.logger")
-        assert False, "ai_trading.logger should not be importable after removal"
-    except ImportError:
-        pass  # Expected
-
-
 def test_centralized_logging_thread_safety():
     """Test that centralized logging setup is thread-safe."""
     if not CENTRALIZED_LOGGING_AVAILABLE:
@@ -148,5 +127,4 @@ def test_centralized_logging_thread_safety():
 
 if __name__ == "__main__":
     test_centralized_logging_prevents_duplicates()
-    test_deprecated_modules_removed()
     test_centralized_logging_thread_safety()


### PR DESCRIPTION
## Summary
- prune deprecated module checks from centralized logging tests
- drop legacy BotMode initialization test

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_centralized_logging_no_duplicates.py::test_centralized_logging_prevents_duplicates tests/test_centralized_logging_no_duplicates.py::test_centralized_logging_thread_safety tests/test_centralized_config.py::TestCentralizedConfig::test_bot_mode_integration -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae862c074c8330a88351be3e5e891b