### PR TITLE
refactor: update data fetcher path

### DIFF
--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -157,10 +157,10 @@ def test_http_timeouts():
     except (pd.errors.EmptyDataError, KeyError, ValueError, TypeError, OSError, PermissionError, ZeroDivisionError, OverflowError):
         return False
 
-def test_data_fetcher_helpers():
-    """Test that data_fetcher helpers are exported."""
+def test_data_fetch_helpers():
+    """Test that data.fetch helpers are exported."""
     try:
-        data_fetcher_path = Path('ai_trading/data_fetcher.py')
+        data_fetcher_path = Path('ai_trading/data/fetch.py')
         if data_fetcher_path.exists():
             content = data_fetcher_path.read_text()
             assert 'def get_cached_minute_timestamp' in content
@@ -173,7 +173,7 @@ def test_data_fetcher_helpers():
 def main():
     """Run all integration tests."""
     os.environ['TESTING'] = '1'
-    tests = [test_model_registry, test_disable_daily_retrain, test_executor_sizing, test_minute_cache_helpers, test_import_hardening, test_http_timeouts, test_data_fetcher_helpers]
+    tests = [test_model_registry, test_disable_daily_retrain, test_executor_sizing, test_minute_cache_helpers, test_import_hardening, test_http_timeouts, test_data_fetch_helpers]
     passed = 0
     failed = 0
     for test in tests:

--- a/scripts/problem_statement_validation.py
+++ b/scripts/problem_statement_validation.py
@@ -80,7 +80,7 @@ def check_timeouts():
 def check_minute_cache():
     """Check minute-cache freshness helpers and validation."""
     logging.info('✓ Minute-cache freshness:')
-    data_fetcher_path = Path('ai_trading/data_fetcher.py')
+    data_fetcher_path = Path('ai_trading/data/fetch.py')
     if data_fetcher_path.exists():
         content = data_fetcher_path.read_text()
         assert 'def get_cached_minute_timestamp' in content

--- a/scripts/validate_critical_fixes.py
+++ b/scripts/validate_critical_fixes.py
@@ -60,12 +60,12 @@ def test_alpaca_api_endpoints():
     """Test that Alpaca API endpoints are correctly configured."""
     logging.info('🌐 Testing Alpaca API Configuration...')
     try:
-        data_fetcher_path = Path('ai_trading/data_fetcher.py')
+        data_fetcher_path = Path('ai_trading/data/fetch.py')
         data_fetcher_content = data_fetcher_path.read_text()
         if 'data.alpaca.markets' in data_fetcher_content:
-            logging.info('  ✅ ai_trading/data_fetcher.py correctly uses data.alpaca.markets for market data')
+            logging.info('  ✅ ai_trading/data/fetch.py correctly uses data.alpaca.markets for market data')
         else:
-            logging.info('  ❌ ai_trading/data_fetcher.py does not use data.alpaca.markets')
+            logging.info('  ❌ ai_trading/data/fetch.py does not use data.alpaca.markets')
             return False
         config_path = Path('ai_trading/config/alpaca.py')
         config_content = config_path.read_text()

--- a/scripts/validate_fixes.py
+++ b/scripts/validate_fixes.py
@@ -75,9 +75,9 @@ def validate_meta_learning_price_validation_fix():
 def validate_data_fetching_optimization_fix():
     """Validate that data fetching optimizations are implemented."""
     logging.info('3. Validating data fetching optimization fix...')
-    data_fetcher_path = Path('ai_trading/data_fetcher.py')
+    data_fetcher_path = Path('ai_trading/data/fetch.py')
     if not data_fetcher_path.exists():
-        logging.info('   ❌ data_fetcher.py not found')
+        logging.info('   ❌ data/fetch.py not found')
         return False
     content = data_fetcher_path.read_text()
     fixes_found = 0

--- a/scripts/verify_critical_fixes.py
+++ b/scripts/verify_critical_fixes.py
@@ -3,16 +3,16 @@ import logging
 from pathlib import Path
 
 def test_timestamp_fix_in_data_fetcher():
-    """Verify the RFC3339 timestamp fix is in data_fetcher.py"""
-    with Path('ai_trading/data_fetcher.py').open() as f:
+    """Verify the RFC3339 timestamp fix is in data/fetch.py"""
+    with Path('ai_trading/data/fetch.py').open() as f:
         content = f.read()
-    assert ".replace('+00:00', 'Z')" in content, 'RFC3339 timestamp fix not found in data_fetcher.py'
+    assert ".replace('+00:00', 'Z')" in content, 'RFC3339 timestamp fix not found in data/fetch.py'
     lines = content.split('\n')
     start_fixed = any((".replace('+00:00', 'Z')" in line and 'start' in line for line in lines))
     end_fixed = any((".replace('+00:00', 'Z')" in line and 'end' in line for line in lines))
     assert start_fixed, 'Start timestamp fix not found'
     assert end_fixed, 'End timestamp fix not found'
-    logging.info('✓ RFC3339 timestamp fix verified in data_fetcher.py')
+    logging.info('✓ RFC3339 timestamp fix verified in data/fetch.py')
 
 def test_position_sizing_fix_in_bot_engine():
     """Verify the position sizing fixes are in bot_engine.py"""
@@ -47,7 +47,7 @@ def test_stale_data_bypass_fix():
 def test_all_fixes_integrated():
     """Verify all critical fixes are properly integrated"""
     files_to_check = [
-        Path('ai_trading/data_fetcher.py'),
+        Path('ai_trading/data/fetch.py'),
         Path('ai_trading/core/bot_engine.py'),
         Path('ai_trading/meta_learning.py'),
     ]


### PR DESCRIPTION
## Summary
- point scripts at `ai_trading/data/fetch.py` instead of the old `data_fetcher.py`
- update messages asserting on data fetch module helpers

## Testing
- `ruff check scripts/verify_critical_fixes.py scripts/validate_fixes.py scripts/validate_critical_fixes.py scripts/problem_statement_validation.py scripts/integration_test.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae89c140248330b0038239e32ea309