### PR TITLE
Remove outdated shim reference in validation summary

### DIFF
--- a/scripts/validate_final_polish.py
+++ b/scripts/validate_final_polish.py
@@ -53,7 +53,7 @@ def test_basic_validations():
         del os.environ[test_env_var]
     logging.info('\n=== Validation Summary ===')
     logging.info('✓ Final polish changes implemented successfully')
-    logging.info('✓ Bot engine replaced with shim')
+    logging.info('✓ Bot engine confirmed in package')
     logging.info('✓ Legacy imports updated')
     logging.info('✓ Shebangs standardized')
     logging.info('✓ CI matrix configured for multiple Python 3.12 versions')


### PR DESCRIPTION
## Summary
- clarify final polish validation summary to confirm bot engine presence rather than referencing a removed shim

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae89c20f6c83308e01718239a6af63