### PR TITLE
docs: reference ai_trading modules in testing framework

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -580,8 +580,8 @@ import numpy as np
 import pandas as pd
 from memory_profiler import memory_usage
 
-from indicators import calculate_rsi, calculate_macd
-from signals import generate_signal
+from ai_trading.indicators import calculate_rsi, calculate_macd
+from ai_trading.signals import generate_signal
 
 
 class TestPerformanceBenchmarks:


### PR DESCRIPTION
## Summary
- Use `ai_trading.indicators` and `ai_trading.signals` in performance benchmark example

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0b2fac588330b77869467513cd01