### PR TITLE
docs: fix bot_engine import examples

### DIFF
--- a/CENTRALIZED_PARAMETERS_SUMMARY.md
+++ b/CENTRALIZED_PARAMETERS_SUMMARY.md
@@ -119,10 +119,10 @@ export TRADING_MODE=aggressive
 
 ### Legacy Compatibility
 ```python
-from bot_engine import BotMode
+from ai_trading.core import bot_engine
 
 # Existing code continues to work
-bot_mode = BotMode("balanced")
+bot_mode = bot_engine.BotMode("balanced")
 params = bot_mode.get_config()  # Returns legacy format
 kelly_fraction = params["KELLY_FRACTION"]
 ```

--- a/PERFORMANCE_OPTIMIZATION.md
+++ b/PERFORMANCE_OPTIMIZATION.md
@@ -742,20 +742,19 @@ class PerformanceProfiler:
     
     def benchmark_trading_cycle(self, num_cycles: int = 10) -> Dict[str, float]:
         """Benchmark complete trading cycle performance."""
-        from bot_engine import run_all_trades_worker
-        from bot_engine import BotState
+        from ai_trading.core import bot_engine
         
         cycle_times = []
         
         for i in range(num_cycles):
-            state = BotState()
+            state = bot_engine.BotState()
             
             start_time = time.perf_counter()
             
             # Run trading cycle (in dry run mode)
             try:
                 with patch.dict(os.environ, {'DRY_RUN': 'true'}):
-                    run_all_trades_worker(state, None)
+                    bot_engine.run_all_trades_worker(state, None)
             except Exception as e:
                 logging.warning(f"Benchmark cycle {i} failed: {e}")
                 continue

--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ pytest -m "integration"  # Integration tests
 python -m cProfile -m ai_trading > profile_output.txt
 
 # Memory profiling
-python -m memory_profiler bot_engine.py
+python -m memory_profiler -m ai_trading.core.bot_engine
 
 # Benchmark indicators
 python profile_indicators.py
@@ -1227,10 +1227,10 @@ p.sort_stats('cumulative').print_stats(20)
 
 # Memory profiling
 pip install memory-profiler
-python -m memory_profiler bot_engine.py
+python -m memory_profiler -m ai_trading.core.bot_engine
 
 # Line-by-line profiling
-kernprof -l -v bot_engine.py
+kernprof -l -v -m ai_trading.core.bot_engine
 
 # Real-time performance monitoring
 python performance_optimizer.py --monitor --duration 3600

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -466,7 +466,7 @@ def analyze_memory_usage():
     import numpy as np
     print(f"After pandas/numpy: {process.memory_info().rss / 1024 / 1024:.2f} MB")
 
-    import bot_engine
+    from ai_trading.core import bot_engine
     print(f"After bot_engine: {process.memory_info().rss / 1024 / 1024:.2f} MB")
 
     # Load test data

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ different ranges for each hyperparameter.
 
 ## Using Optimized Hyperparameters
 
-When starting the live bot (`python bot_engine.py`), the bot will automatically load
+When starting the live bot (`python -m ai_trading.core.bot_engine`), the bot will automatically load
 `best_hyperparams.json` if it exists. Otherwise it falls back to the default
 values in `hyperparams.json`.
 


### PR DESCRIPTION
## Summary
- replace `import bot_engine` examples with `from ai_trading.core import bot_engine`
- update command examples to `python -m ai_trading.core.bot_engine`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0d66c88883308633bcd51b7aa06c