### PR TITLE
chore: expand legacy import guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ from ai_trading.data.fetch import get_minute_df
 from ai_trading.execution.engine import ExecutionEngine
 ```
 Root imports (e.g., `from signals import ...`) have been removed.
+CI enforces this via `ci/scripts/forbid_legacy_imports.sh`, which fails if
+legacy modules like `trade_execution`, `signals`, `portfolio`, or `rebalancer`
+are imported directly.
 
 ## ✨ Key Features
 

--- a/ci/scripts/forbid_legacy_imports.sh
+++ b/ci/scripts/forbid_legacy_imports.sh
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
+
+# Fail the build if deprecated root-level modules are imported. These modules
+# previously existed at the repository root but have been migrated into the
+# `ai_trading` package. Importing them directly (e.g. `from signals import`)
+# would bypass the new package structure.
+
 set -euo pipefail
+
+legacy_modules=(trade_execution signals portfolio rebalancer)
 found=0
+
 while IFS= read -r -d '' f; do
-  if grep -nE "^from[[:space:]]+trade_execution[[:space:]]+import|^import[[:space:]]+trade_execution(\b|,)" "$f" >/dev/null; then
-    echo "Legacy import found in $f:"
-    grep -nE "^from[[:space:]]+trade_execution[[:space:]]+import|^import[[:space:]]+trade_execution(\b|,)" "$f" || true
-    found=1
-  fi
+  for mod in "${legacy_modules[@]}"; do
+    pattern="^from[[:space:]]+${mod}[[:space:]]+import|^import[[:space:]]+${mod}(\\b|,)"
+    if grep -nE "$pattern" "$f" >/dev/null; then
+      echo "Legacy import '$mod' found in $f:"
+      grep -nE "$pattern" "$f" || true
+      found=1
+    fi
+  done
 done < <(git ls-files '*.py' -z)
+
 exit "$found"


### PR DESCRIPTION
## Summary
- guard against legacy imports of trade_execution, signals, portfolio, or rebalancer
- document CI legacy import guard in README

## Testing
- `ci/scripts/forbid_legacy_imports.sh`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0d67dc3083308b9c479b0e9d6600