### PR TITLE
Fix data processing indicator import

### DIFF
--- a/scripts/production_validator.py
+++ b/scripts/production_validator.py
@@ -496,7 +496,7 @@ class ProductionValidator:
         """Test data processing functionality."""
         try:
             from ai_trading.data import fetch as data_fetcher
-            import indicators
+            from ai_trading import indicators
             return 90
         except ImportError:
             return 40


### PR DESCRIPTION
## Summary
- correct data processing test to import indicators from ai_trading package

## Testing
- `python scripts/production_validator.py && echo 'SCRIPT_OK'`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af116fa54c83309f40e2414aaffd61