### PR TITLE
Move portfolio RL module into ai_trading package

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -52,6 +52,11 @@ if TYPE_CHECKING:  # pragma: no cover - typing helpers
 open = open
 logger = get_logger(__name__)
 
+try:
+    from ai_trading.portfolio_rl import PortfolioReinforcementLearner
+except Exception:  # pragma: no cover - optional dependency
+    PortfolioReinforcementLearner = None  # type: ignore[assignment]
+
 
 def _import_numpy(optional: bool = False):
     """Import :mod:`numpy` lazily."""
@@ -1080,9 +1085,8 @@ def trigger_rebalance_on_regime(df: 'pd.DataFrame') -> None:
     settings = get_settings()
     if not settings.enable_reinforcement_learning:
         return
-    if find_spec('portfolio_rl') is None:
-        raise RuntimeError('Reinforcement learning enabled but portfolio_rl module unavailable. Set ENABLE_REINFORCEMENT_LEARNING=False to disable')
-    from portfolio_rl import PortfolioReinforcementLearner
+    if PortfolioReinforcementLearner is None:
+        raise RuntimeError('Reinforcement learning enabled but ai_trading.portfolio_rl module unavailable. Set ENABLE_REINFORCEMENT_LEARNING=False to disable')
     rl = PortfolioReinforcementLearner()
     if 'Regime' in df.columns and len(df) > 2:
         if df['Regime'].iloc[-1] != df['Regime'].iloc[-2]:

--- a/ai_trading/portfolio_rl.py
+++ b/ai_trading/portfolio_rl.py
@@ -98,6 +98,7 @@ class PortfolioReinforcementLearner:
                     total = 1.0
                 return [w / total for w in weights]
             return weights
+
         try:
             state_tensor = torch.tensor(state, dtype=torch.float32)
             weights = self.actor(state_tensor).detach().numpy()

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -168,7 +168,7 @@ def test_portfolio_rl_trigger(monkeypatch):
             return x
 
     monkeypatch.setattr(nn, "Linear", lambda *a, **k: FakeLinear())
-    import portfolio_rl
+    import ai_trading.portfolio_rl as portfolio_rl
     monkeypatch.setattr(portfolio_rl, "_TORCH_AVAILABLE", True)
     monkeypatch.setattr(portfolio_rl.optim, "Adam", lambda *a, **k: types.SimpleNamespace(step=lambda: None))
     learner = meta_learning.PortfolioReinforcementLearner()


### PR DESCRIPTION
## Summary
- move portfolio RL helper into `ai_trading` package
- load `PortfolioReinforcementLearner` from `ai_trading.portfolio_rl`
- update tests to reference new module location

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af116eeff4833092135ae44c4b037a