### PR TITLE
refactor: narrow allocator references

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1926,15 +1926,14 @@ except (
 
 class StrategyAllocator:
     def __init__(self, *args, **kwargs):
-        # Package-safe resolution: ai_trading.strategies.performance_allocator -> scripts.strategy_allocator -> fail hard
+        # Resolve StrategyAllocator from in-package modules only
         from ai_trading.utils.imports import resolve_strategy_allocator_cls
 
         cls = resolve_strategy_allocator_cls()
         if cls is None:
             raise RuntimeError(
                 "StrategyAllocator not found. Please ensure that either "
-                "ai_trading.strategies.performance_allocator or scripts.strategy_allocator is available. "
-                "Check that scripts/strategy_allocator.py exists and has a StrategyAllocator class."
+                "ai_trading.strategy_allocator or ai_trading.strategies.performance_allocator is available."
             )
         self._alloc = cls(*args, **kwargs)
 
@@ -5430,7 +5429,7 @@ def get_allocator():
         cls = resolve_strategy_allocator_cls()
         if cls is None:
             logger.error(
-                "StrategyAllocator not found (ai_trading.strategies.performance_allocator, scripts.strategy_allocator)."
+                "StrategyAllocator not found (ai_trading.strategy_allocator, ai_trading.strategies.performance_allocator)."
             )
             raise ImportError("StrategyAllocator unavailable")
         allocator = cls()

--- a/ai_trading/strategy_allocator.py
+++ b/ai_trading/strategy_allocator.py
@@ -42,7 +42,8 @@ class StrategyAllocator:
         for attr, default in required.items():
             if not hasattr(self.config, attr) or getattr(self.config, attr, None) is None:
                 logger.warning("Config missing attribute %s, setting default: %s", attr, default)
-                setattr(self.config, attr, default)
+                # TradingConfig is frozen; bypass immutability for defaults
+                object.__setattr__(self.config, attr, default)
 
     def select_signals(self, signals_by_strategy: dict[str, list[Any]]) -> list[Any]:
         """Compatibility wrapper for allocate()."""


### PR DESCRIPTION
## Summary
- Limit StrategyAllocator fallback comments and errors to in-package allocators
- Fix StrategyAllocator config defaults to work with frozen TradingConfig

## Testing
- `ruff check ai_trading/strategy_allocator.py ai_trading/core/bot_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_allocator.py tests/test_public_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af14cd0b448330be2fba5425ab86f1