### PR TITLE
Use retrain_model indicators in prediction script

### DIFF
--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -10,7 +10,7 @@ import joblib
 import pandas as pd
 from ai_trading.config.management import TradingConfig, reload_env
 from ai_trading.utils.http import http, HTTP_TIMEOUT
-from scripts.retrain import prepare_indicators
+from scripts.retrain_model import prepare_indicators
 
 config = TradingConfig.from_env()
 _sentiment_lock = Lock()


### PR DESCRIPTION
## Summary
- Point prediction script to `retrain_model.prepare_indicators`

## Testing
- `ruff check scripts/predict.py`
- `python - <<'PY'
import pandas as pd, tempfile, types, sys
retrain_mod = types.ModuleType('scripts.retrain_model')
exec('def prepare_indicators(df, freq="intraday", symbol=None):\n    return df.assign(feat1=0)[["feat1"]]\n', retrain_mod.__dict__)
sys.modules['scripts.retrain_model'] = retrain_mod
http_mod = types.ModuleType('ai_trading.utils.http')
http_mod.http = types.SimpleNamespace(get=lambda *a, **k: types.SimpleNamespace(json=lambda: {'articles': []}, raise_for_status=lambda: None))
http_mod.HTTP_TIMEOUT = 1
sys.modules['ai_trading.utils.http'] = http_mod
import scripts.predict as predict
predict.fetch_sentiment = lambda symbol: 0.0
class DummyModel:
    feature_names_in_ = ['feat1', 'sentiment']
    def predict(self, X):
        return [1]
    def predict_proba(self, X):
        return [[0.0, 1.0]]
predict.load_model = lambda regime: DummyModel()
print('prepare_indicators from:', predict.prepare_indicators.__module__)
tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.csv')
df = pd.DataFrame({'close':[1.0], 'high':[1.0], 'low':[1.0], 'volume':[1.0]})
df.to_csv(tmp.name, index=False)
print(predict.predict(tmp.name))
PY`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_predict_smoke.py::test_predict_function -q`


------
https://chatgpt.com/codex/tasks/task_e_68af14ceb1b883308950e68571a72fa7