### PR TITLE
refactor: align Alpaca client URL param

### DIFF
--- a/MIGRATION_NOTES.md
+++ b/MIGRATION_NOTES.md
@@ -133,7 +133,7 @@ The following new environment variables have been added to TradingConfig and can
 
 ### Core Trading Parameters
 - `TRADING_MODE` (default: "paper") - Trading mode: "paper" or "live"
-- `ALPACA_BASE_URL` (default: "https://paper-api.alpaca.markets") - Alpaca API base URL
+- `ALPACA_API_URL` (default: "https://paper-api.alpaca.markets") - Alpaca API endpoint URL (formerly `ALPACA_BASE_URL`)
 - `SLEEP_INTERVAL` (default: 1.0) - Sleep interval between operations in seconds
 - `MAX_RETRIES` (default: 3) - Maximum number of retry attempts
 - `BACKOFF_FACTOR` (default: 2.0) - Exponential backoff factor for retries

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ python algorithm_optimizer.py --symbols SPY --iterations 100
 
 ```bash
 # Set environment for paper trading
-export ALPACA_BASE_URL=https://paper-api.alpaca.markets
+export ALPACA_API_URL=https://paper-api.alpaca.markets
 export TRADING_MODE=paper
 
 # Start bot
@@ -452,7 +452,7 @@ python -m ai_trading
 
 ```bash
 # ⚠️  CAUTION: Real money trading
-export ALPACA_BASE_URL=https://api.alpaca.markets
+export ALPACA_API_URL=https://api.alpaca.markets
 export TRADING_MODE=production
 export MAX_POSITION_PCT=0.03  # Conservative sizing
 
@@ -673,13 +673,14 @@ python verify_config.py
    # Alpaca API Configuration
    ALPACA_API_KEY=your_actual_api_key_here
    ALPACA_SECRET_KEY=your_actual_secret_key_here
-   ALPACA_BASE_URL=https://paper-api.alpaca.markets  # Paper trading
+   ALPACA_API_URL=https://paper-api.alpaca.markets  # Paper trading
    ALPACA_DATA_FEED=iex
    ALPACA_ADJUSTMENT=all
    DATA_LOOKBACK_DAYS_DAILY=200
    DATA_LOOKBACK_DAYS_MINUTE=5
    TZ=UTC
-   # ALPACA_BASE_URL=https://api.alpaca.markets     # Live trading (DANGER!)
+   # ALPACA_API_URL=https://api.alpaca.markets     # Live trading (DANGER!)
+   # ALPACA_BASE_URL is also accepted for backward compatibility
 
    # Bot Configuration
    TRADING_MODE=balanced                    # Trading mode: conservative, balanced, aggressive
@@ -772,7 +773,7 @@ WEBHOOK_URL=https://your-webhook-url.com/trading-alerts
 ```bash
 # .env.testing
 TRADING_MODE=paper
-ALPACA_BASE_URL=https://paper-api.alpaca.markets
+ALPACA_API_URL=https://paper-api.alpaca.markets
 DRY_RUN=true
 LOG_LEVEL=DEBUG
 MAX_POSITION_PCT=0.01  # Very small positions for testing

--- a/ai_trading/config/__init__.py
+++ b/ai_trading/config/__init__.py
@@ -98,7 +98,7 @@ def validate_environment() -> None:
 def validate_alpaca_credentials() -> None:
     from .management import validate_required_env
 
-    validate_required_env(("ALPACA_API_KEY", "ALPACA_SECRET_KEY", "ALPACA_BASE_URL"))
+    validate_required_env(("ALPACA_API_KEY", "ALPACA_SECRET_KEY", "ALPACA_API_URL"))
 
 def validate_env_vars() -> None:
     return validate_environment()
@@ -113,7 +113,7 @@ def log_config(masked_keys: list[str] | None=None, secrets_to_redact: list[str] 
     from .settings import get_settings as _gs
 
     s = _gs()
-    conf = {'ALPACA_API_KEY': '***' if s.alpaca_api_key else '', 'ALPACA_SECRET_KEY': '***REDACTED***' if s.alpaca_secret_key else '', 'ALPACA_BASE_URL': s.alpaca_base_url or '', 'CAPITAL_CAP': getattr(s, 'capital_cap', None) or 0.25, 'CONF_THRESHOLD': getattr(s, 'conf_threshold', None) or 0.75, 'DAILY_LOSS_LIMIT': getattr(s, 'daily_loss_limit', None) or 0.03}
+    conf = {'ALPACA_API_KEY': '***' if s.alpaca_api_key else '', 'ALPACA_SECRET_KEY': '***REDACTED***' if s.alpaca_secret_key else '', 'ALPACA_API_URL': s.alpaca_base_url or '', 'CAPITAL_CAP': getattr(s, 'capital_cap', None) or 0.25, 'CONF_THRESHOLD': getattr(s, 'conf_threshold', None) or 0.75, 'DAILY_LOSS_LIMIT': getattr(s, 'daily_loss_limit', None) or 0.03}
     if masked_keys is None and secrets_to_redact is not None:
         masked_keys = secrets_to_redact
     if masked_keys:

--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -65,7 +65,7 @@ SEED: int = int(os.environ.get("SEED", "42"))  # AI-AGENT-REF: expose runtime se
 _MANDATORY_ENV_VARS: tuple[str, ...] = (
     "ALPACA_API_KEY",
     "ALPACA_SECRET_KEY",
-    "ALPACA_BASE_URL",
+    "ALPACA_API_URL",
     "WEBHOOK_SECRET",
     "CAPITAL_CAP",
     "DOLLAR_RISK_LIMIT",
@@ -103,8 +103,19 @@ def validate_required_env(
 
     env = dict(env or os.environ)
     required = list(keys or _MANDATORY_ENV_VARS)
-    missing = [k for k in required if not env.get(k, "").strip()]
-    snapshot = {k: _mask(env.get(k, "")) for k in required}
+    missing: list[str] = []
+    snapshot: Dict[str, str] = {}
+    for k in required:
+        if k in {"ALPACA_API_URL", "ALPACA_BASE_URL"}:
+            val = env.get("ALPACA_API_URL") or env.get("ALPACA_BASE_URL", "")
+            if not val.strip():
+                missing.append(k)
+            snapshot[k] = _mask(val)
+            continue
+        val = env.get(k, "")
+        if not val.strip():
+            missing.append(k)
+        snapshot[k] = _mask(val)
     if missing:
         raise RuntimeError(
             "Missing required environment variables: " + ", ".join(missing)

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -411,7 +411,11 @@ class BotEngine:
         return TradingClient(
             api_key=_get_env_str("ALPACA_API_KEY"),
             secret_key=_get_env_str("ALPACA_SECRET_KEY"),
-            base_url=_get_env_str("ALPACA_BASE_URL"),
+            url_override=(
+                _get_env_str("ALPACA_API_URL")
+                if os.getenv("ALPACA_API_URL")
+                else _get_env_str("ALPACA_BASE_URL")
+            ),
         )
 
     @cached_property
@@ -422,7 +426,11 @@ class BotEngine:
         return _TradingClient(
             api_key=_get_env_str("ALPACA_API_KEY"),
             secret_key=_get_env_str("ALPACA_SECRET_KEY"),
-            base_url=_get_env_str("ALPACA_BASE_URL"),
+            url_override=(
+                _get_env_str("ALPACA_API_URL")
+                if os.getenv("ALPACA_API_URL")
+                else _get_env_str("ALPACA_BASE_URL")
+            ),
         )
 
 # AI-AGENT-REF: ensure FinBERT disabled message logged once

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
-from pydantic import Field, SecretStr, computed_field, field_validator
+from pydantic import AliasChoices, Field, SecretStr, computed_field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 try:
     from pydantic.fields import FieldInfo
@@ -67,7 +67,11 @@ class Settings(BaseSettings):
     alpaca_api_key: str | None = Field(default=None, alias='ALPACA_API_KEY')
     alpaca_secret_key: SecretStr | None = Field(default=None, alias='ALPACA_SECRET_KEY')
     redis_url: str | None = Field(default=None, alias='REDIS_URL')
-    alpaca_base_url: str = Field(default='https://paper-api.alpaca.markets', alias='ALPACA_BASE_URL')
+    alpaca_base_url: str = Field(
+        default='https://paper-api.alpaca.markets',
+        alias='ALPACA_API_URL',
+        validation_alias=AliasChoices('ALPACA_API_URL', 'ALPACA_BASE_URL'),
+    )
     trading_mode: str = Field(default='balanced', alias='TRADING_MODE')
     webhook_secret: str | None = Field(default=None, alias='WEBHOOK_SECRET')
     testing: bool = Field(False, alias='TESTING')


### PR DESCRIPTION
## Summary
- switch Alpaca TradingClient instantiation to `url_override` and support new `ALPACA_API_URL` env key
- extend configuration helpers and settings to prefer `ALPACA_API_URL` while accepting legacy `ALPACA_BASE_URL`
- document new environment variable in README and migration notes

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68af1c10908c833081e03f5655998a49