### PR TITLE
docs: update retrain command path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1056,10 +1056,10 @@ export ENABLE_DAILY_RETRAIN=true   # Enable (default)
 export DISABLE_DAILY_RETRAIN=1     # Disable
 
 # Manual retraining
-python retrain.py --symbols SPY,QQQ --days 90
+python scripts/retrain_model.py --symbols SPY,QQQ --days 90
 
 # Schedule retraining
-echo "0 2 * * * /opt/ai-trading-bot/venv/bin/python retrain.py" | crontab -
+echo "0 2 * * * /opt/ai-trading-bot/venv/bin/python scripts/retrain_model.py" | crontab -
 ```
 
 ### Maintenance Tasks


### PR DESCRIPTION
## Summary
- update Automatic Retraining section to use `python scripts/retrain_model.py`
- adjust cron scheduling example for new script path

## Testing
- `ruff check README.md` *(fails: README contains non-Python content)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1dcb3658833089adb8ef5d0a182a