### PR TITLE
refactor: import prepare_indicators directly

### DIFF
--- a/ai_trading/predict.py
+++ b/ai_trading/predict.py
@@ -1,25 +1,30 @@
 from __future__ import annotations
+
 from functools import lru_cache
+
+from ai_trading.features import prepare
+
 try:
     from cachetools import TTLCache
+
     _CACHETOOLS_AVAILABLE = True
     _sentiment_cache = TTLCache(maxsize=1000, ttl=3600)
 except Exception:
     _CACHETOOLS_AVAILABLE = False
     _sentiment_cache: dict[str, float] = {}
 
+
 @lru_cache(maxsize=1024)
 def predict(path: str):
     """Minimal prediction interface used in tests."""
-    import importlib
     import pandas as pd
+
     df = pd.read_csv(path)
-    retrain = importlib.import_module('retrain')
-    features = retrain.prepare_indicators(df)
-    model = load_model('default')
+    features = prepare.prepare_indicators(df)
+    model = load_model("default")
     pred = model.predict(features)[0]
     proba = None
-    if hasattr(model, 'predict_proba'):
+    if hasattr(model, "predict_proba"):
         proba = model.predict_proba(features)[0][0]
     return (pred, proba)
 

--- a/tests/test_predict_smoke.py
+++ b/tests/test_predict_smoke.py
@@ -14,9 +14,9 @@ def _import_predict(monkeypatch):
     req_mod.exceptions = types.SimpleNamespace(RequestException=Exception)
     monkeypatch.setitem(sys.modules, "requests", req_mod)
 
-    rt_mod = types.ModuleType("retrain")
-    rt_mod.prepare_indicators = lambda df, freq="intraday": df.assign(feat1=0)
-    monkeypatch.setitem(sys.modules, "retrain", rt_mod)
+    prep_mod = types.ModuleType("ai_trading.features.prepare")
+    prep_mod.prepare_indicators = lambda df, freq="intraday": df.assign(feat1=0)
+    monkeypatch.setitem(sys.modules, "ai_trading.features.prepare", prep_mod)
 
     if "ai_trading.predict" in sys.modules:
         del sys.modules["ai_trading.predict"]


### PR DESCRIPTION
## Summary
- import `prepare` module from `ai_trading.features` in `predict`
- update smoke test to patch new `prepare` module

## Testing
- `ruff check ai_trading/predict.py tests/test_predict_smoke.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1dc9117c8330a46c0dfb48b22d43