### PR TITLE
chore: expand legacy import checks

### DIFF
--- a/ci/scripts/forbid_legacy_imports.sh
+++ b/ci/scripts/forbid_legacy_imports.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-legacy_modules=(trade_execution signals portfolio rebalancer)
+legacy_modules=(trade_execution signals portfolio rebalancer data_fetcher pipeline indicators)
 found=0
 
 while IFS= read -r -d '' f; do


### PR DESCRIPTION
## Summary
- include `data_fetcher`, `pipeline`, and `indicators` in the legacy import guard script

## Testing
- `ci/scripts/forbid_legacy_imports.sh && echo PASSED || echo FAILED` (flags imports of added modules)
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

## Rollback Plan
- revert commit `chore: expand legacy import checks`


------
https://chatgpt.com/codex/tasks/task_e_68af1dc934408330b51896e844d85901