### PR TITLE
Use features.prepare in tests and prediction module

### DIFF
--- a/ai_trading/predict.py
+++ b/ai_trading/predict.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 from functools import lru_cache
+from ai_trading.features import prepare as feature_prepare
+
 try:
     from cachetools import TTLCache
     _CACHETOOLS_AVAILABLE = True
@@ -8,18 +10,18 @@ except Exception:
     _CACHETOOLS_AVAILABLE = False
     _sentiment_cache: dict[str, float] = {}
 
+
 @lru_cache(maxsize=1024)
 def predict(path: str):
     """Minimal prediction interface used in tests."""
-    import importlib
     import pandas as pd
+
     df = pd.read_csv(path)
-    retrain = importlib.import_module('retrain')
-    features = retrain.prepare_indicators(df)
+    features = feature_prepare.prepare_indicators(df)
     model = load_model('default')
     pred = model.predict(features)[0]
     proba = None
-    if hasattr(model, 'predict_proba'):
+    if hasattr(model, "predict_proba"):
         proba = model.predict_proba(features)[0][0]
     return (pred, proba)
 

--- a/tests/test_predict_smoke.py
+++ b/tests/test_predict_smoke.py
@@ -14,9 +14,9 @@ def _import_predict(monkeypatch):
     req_mod.exceptions = types.SimpleNamespace(RequestException=Exception)
     monkeypatch.setitem(sys.modules, "requests", req_mod)
 
-    rt_mod = types.ModuleType("retrain")
-    rt_mod.prepare_indicators = lambda df, freq="intraday": df.assign(feat1=0)
-    monkeypatch.setitem(sys.modules, "retrain", rt_mod)
+    prep_mod = types.ModuleType("ai_trading.features.prepare")
+    prep_mod.prepare_indicators = lambda df, freq="intraday": df.assign(feat1=0)
+    monkeypatch.setitem(sys.modules, "ai_trading.features.prepare", prep_mod)
 
     if "ai_trading.predict" in sys.modules:
         del sys.modules["ai_trading.predict"]


### PR DESCRIPTION
## Summary
- Import `ai_trading.features.prepare` in `predict` instead of dynamic `retrain` lookup
- Update `test_signals` fixture to patch `ai_trading.features.prepare`
- Patch `test_predict_smoke` to stub `ai_trading.features.prepare`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1dc9d0d48330b8b674f91f7ccc51