### PR TITLE
Use isoformat helper in tests

### DIFF
--- a/ai_trading/utils/timefmt.py
+++ b/ai_trading/utils/timefmt.py
@@ -55,6 +55,15 @@ def format_datetime_utc(dt: datetime) -> str:
         dt = dt.astimezone(UTC)
     return dt.isoformat().replace('+00:00', 'Z')
 
+
+def isoformat_z(dt: datetime) -> str:
+    """Return RFC3339 timestamp with trailing ``Z``.
+
+    Thin wrapper around :func:`format_datetime_utc` offering a clearer helper
+    name for callers that expect the ``Z``-suffixed UTC representation.
+    """
+    return format_datetime_utc(dt)
+
 def parse_iso_utc(timestamp_str: str) -> datetime | None:
     """
     Parse an ISO-8601 UTC timestamp string.

--- a/tests/test_critical_fixes_focused.py
+++ b/tests/test_critical_fixes_focused.py
@@ -9,6 +9,8 @@ import tempfile
 import unittest
 from datetime import UTC
 
+from ai_trading.utils.timefmt import isoformat_z
+
 from tests.support.mocks import MockContext, MockSignal
 
 # Set testing environment
@@ -229,13 +231,13 @@ def test_rfc3339_timestamp_api_format():
     """Test that the actual API timestamp format is RFC3339 compliant."""
     from datetime import datetime
 
-    # Test the exact format used in data_fetcher.py
+    # Test the exact format used in ai_trading.data.fetch
     start_dt = datetime(2025, 1, 4, 16, 23, 0, tzinfo=UTC)
     end_dt = datetime(2025, 1, 4, 16, 30, 0, tzinfo=UTC)
 
-    # Apply the fix from data_fetcher.py
-    start_param = start_dt.isoformat().replace('+00:00', 'Z')
-    end_param = end_dt.isoformat().replace('+00:00', 'Z')
+    # Apply the fix from ai_trading.data.fetch using isoformat_z helper
+    start_param = isoformat_z(start_dt)
+    end_param = isoformat_z(end_dt)
 
 
     # Verify RFC3339 compliance

--- a/tests/test_critical_fixes_simple.py
+++ b/tests/test_critical_fixes_simple.py
@@ -5,13 +5,15 @@ Tests the specific issues identified in production logs.
 """
 from datetime import UTC, datetime
 
+from ai_trading.utils.timefmt import isoformat_z
+
 
 def test_timestamp_format_includes_timezone():
     """Test that timestamps include proper timezone information for RFC3339 compliance."""
     test_dt = datetime(2025, 1, 4, 16, 23, 0, tzinfo=UTC)
 
-    # Test the fixed timestamp format
-    result = test_dt.isoformat().replace('+00:00', 'Z')
+    # Use helper from ai_trading.utils.timefmt for proper RFC3339 formatting
+    result = isoformat_z(test_dt)
 
 
     # The fix should include 'Z' suffix for RFC3339 compliance
@@ -126,9 +128,9 @@ def test_rfc3339_timestamp_api_format():
     start_dt = datetime(2025, 1, 4, 16, 23, 0, tzinfo=UTC)
     end_dt = datetime(2025, 1, 4, 16, 30, 0, tzinfo=UTC)
 
-    # Apply the fix from data_fetcher.py
-    start_param = start_dt.isoformat().replace('+00:00', 'Z')
-    end_param = end_dt.isoformat().replace('+00:00', 'Z')
+    # Apply the fix from ai_trading.data.fetch using isoformat_z helper
+    start_param = isoformat_z(start_dt)
+    end_param = isoformat_z(end_dt)
 
 
     # Verify RFC3339 compliance

--- a/tests/unit/test_data_fetcher_metrics.py
+++ b/tests/unit/test_data_fetcher_metrics.py
@@ -7,6 +7,7 @@ from datetime import UTC
 import pytest
 
 import ai_trading.data.fetch as df
+from ai_trading.utils.timefmt import isoformat_z
 
 
 @dataclass
@@ -29,7 +30,8 @@ def capmetrics(monkeypatch: pytest.MonkeyPatch):
 
 
 def _bars_payload(ts: dt.datetime) -> dict:
-    ts_s = ts.isoformat().replace("+00:00", "Z")
+    # Format timestamp with ai_trading.utils.timefmt helper
+    ts_s = isoformat_z(ts)
     return {"bars": [{"t": ts_s, "o": 1, "h": 1, "l": 1, "c": 1, "v": 1}]}
 
 


### PR DESCRIPTION
## Summary
- add `isoformat_z` helper to `ai_trading.utils.timefmt`
- refactor tests to use `isoformat_z` instead of manual `isoformat().replace`
- update comments to reference `ai_trading.data.fetch`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1dcab5488330be26b96887a820c8