### PR TITLE
Handle exclusive Alpaca credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,7 +670,11 @@ python verify_config.py
 
 3. **Required Configuration**
    ```bash
-   # Alpaca API Configuration
+   # Alpaca API Configuration (choose ONE credential type)
+   # Option 1: OAuth token
+   # ALPACA_OAUTH=your_oauth_token_here
+
+   # Option 2: API key + secret
    ALPACA_API_KEY=your_actual_api_key_here
    ALPACA_SECRET_KEY=your_actual_secret_key_here
    ALPACA_API_URL=https://paper-api.alpaca.markets  # Paper trading
@@ -697,6 +701,8 @@ python verify_config.py
   DOLLAR_RISK_LIMIT=0.05              # Max fraction of equity at risk per position
   MAX_POSITION_SIZE=5000              # Absolute USD cap per position (1-10000; derived from CAPITAL_CAP if unset)
   ```
+
+   Only provide one credential set: either `ALPACA_OAUTH` or the `ALPACA_API_KEY`/`ALPACA_SECRET_KEY` pair.
 
   `MAX_POSITION_SIZE` must be a positive dollar value (>0). Values ≤0 are rejected.
   If omitted, the bot derives a value from `CAPITAL_CAP` and available equity. Optionally

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -82,8 +82,15 @@ class RiskEngine:
         try:
             s = get_settings()
             secret = get_alpaca_secret_key_plain()
-            if getattr(s, 'alpaca_api_key', None) and secret and getattr(s, 'alpaca_base_url', None):
-                self.data_client = TradingClient(s.alpaca_api_key, secret, s.alpaca_base_url)
+            api_key = getattr(s, 'alpaca_api_key', None)
+            base_url = getattr(s, 'alpaca_base_url', None)
+            oauth = get_env('ALPACA_OAUTH')
+            if oauth and (api_key or secret):
+                logger.error('Both OAuth token and API key/secret provided; skipping TradingClient init')
+            elif base_url and oauth:
+                self.data_client = TradingClient(oauth=oauth, base_url=base_url)
+            elif base_url and api_key and secret:
+                self.data_client = TradingClient(api_key, secret, base_url)
         except (APIError, ValueError, TypeError, AttributeError, OSError) as e:
             logger.warning('Could not initialize TradingClient: %s', e)
         self._returns: list[float] = []

--- a/docs/API_KEY_SETUP.md
+++ b/docs/API_KEY_SETUP.md
@@ -15,8 +15,9 @@ This trading bot requires API keys from Alpaca Markets to function. This guide e
 ## 📋 Required API Keys
 
 ### Primary (Required)
-- `ALPACA_API_KEY`: Your Alpaca Markets API key
-- `ALPACA_SECRET_KEY`: Your Alpaca Markets secret key
+- `ALPACA_OAUTH`: OAuth token (alternative to API key/secret)
+- `ALPACA_API_KEY`: Your Alpaca Markets API key (required if not using OAuth)
+- `ALPACA_SECRET_KEY`: Your Alpaca Markets secret key (required if not using OAuth)
 - `ALPACA_BASE_URL`: Alpaca API endpoint URL
 - `WEBHOOK_SECRET`: Secret for webhook authentication
 
@@ -50,6 +51,10 @@ Edit `.env` and replace these values:
 # Production environment configuration
 # IMPORTANT: Replace these sample values with your real API keys
 # Get your keys from: https://app.alpaca.markets/paper/dashboard/overview
+# Option 1: OAuth token
+# ALPACA_OAUTH=YOUR_OAUTH_TOKEN
+
+# Option 2: API key and secret
 ALPACA_API_KEY=YOUR_ACTUAL_API_KEY_HERE
 ALPACA_SECRET_KEY=YOUR_ACTUAL_SECRET_KEY_HERE
 ALPACA_BASE_URL=https://paper-api.alpaca.markets
@@ -71,6 +76,8 @@ Example formats (these are NOT real keys):
 ALPACA_API_KEY=PKTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ
 ALPACA_SECRET_KEY=SKTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD
 ```
+
+> Provide either `ALPACA_OAUTH` or the `ALPACA_API_KEY`/`ALPACA_SECRET_KEY` pair. Supplying both is not supported.
 
 ## 🧪 Development vs Production
 


### PR DESCRIPTION
## Summary
- ensure RiskEngine chooses between OAuth token or API key/secret for TradingClient
- document valid Alpaca credential combinations and update environment examples

## Testing
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(96 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68af22680c888330a314d57d88381d9d