### PR TITLE
Validate trading API list_orders availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
   - Works both as package import and when executed from repo root
 - **Trading Loop**: guard missing Alpaca client and dedupe strategy logs
 - **Alpaca API**: fix submit/retry logic including 429 handling
+- **Alpaca API**: validate `list_orders` availability and map alternative clients before trading loop
 - **Config**: unify centralized defaults and add `from_optimization`
 - **Utils**: re-export `ensure_utc` and enforce type assertions
 - **validate_env**: support execution via `runpy.run_module`


### PR DESCRIPTION
## Summary
- ensure Alpaca trading client exposes `list_orders` and map `get_orders` when needed
- validate API contract before scheduling the trading loop and when canceling orders
- document list_orders validation in changelog

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af226911988330ad3da11eb730f6e1