### PR TITLE
fix: use package path for time utilities

### DIFF
--- a/scripts/validate_runtime_hardening.py
+++ b/scripts/validate_runtime_hardening.py
@@ -8,8 +8,7 @@ from datetime import UTC
 def test_utc_helper():
     """Test UTC timestamp helper functionality."""
     logging.info('Testing UTC timestamp helper...')
-    sys.path.insert(0, 'ai_trading/utils')
-    from timefmt import format_datetime_utc, utc_now_iso
+    from ai_trading.utils.timefmt import format_datetime_utc, utc_now_iso
     timestamp = utc_now_iso()
     assert timestamp.endswith('Z'), 'UTC timestamp should end with Z'
     assert timestamp.count('Z') == 1, 'UTC timestamp should have exactly one Z'


### PR DESCRIPTION
## Summary
- remove manual `sys.path` manipulation in runtime hardening validation script
- import time utilities via `ai_trading.utils.timefmt`

## Testing
- `python -m scripts.validate_runtime_hardening`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af23ebb25c8330b50900b9f575509b