### PR TITLE
refactor: drop path hacks in tests

### DIFF
--- a/tests/test_critical_fixes_implementation.py
+++ b/tests/test_critical_fixes_implementation.py
@@ -5,7 +5,6 @@ and other critical fixes for production readiness.
 """
 
 import os
-import sys
 import threading
 from unittest.mock import Mock, patch
 
@@ -14,15 +13,12 @@ import pytest
 pd = pytest.importorskip("pandas")
 # Set up test environment variables first
 os.environ.update({
-    'ALPACA_API_KEY': 'test_key_123456789012345',
-    'ALPACA_SECRET_KEY': 'test_secret_123456789012345',
-    'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets',
-    'WEBHOOK_SECRET': 'test_webhook_secret',
-    'FLASK_PORT': '5000'
+    "ALPACA_API_KEY": "test_key_123456789012345",
+    "ALPACA_SECRET_KEY": "test_secret_123456789012345",
+    "ALPACA_BASE_URL": "https://paper-api.alpaca.markets",
+    "WEBHOOK_SECRET": "test_webhook_secret",
+    "FLASK_PORT": "5000",
 })
-
-# Add ai_trading to path
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'ai_trading'))
 
 
 def test_metrics_division_by_zero_protection():
@@ -128,7 +124,6 @@ def test_sentiment_cache_memory_leak_prevention():
 
 def test_circular_buffer_memory_efficiency():
     """Test circular buffer is memory efficient."""
-    sys.path.append('ai_trading')
     from ai_trading.indicator_manager import CircularBuffer
 
     # Test circular buffer bounds
@@ -148,7 +143,6 @@ def test_circular_buffer_memory_efficiency():
 
 def test_incremental_indicators():
     """Test incremental indicator calculations."""
-    sys.path.append('ai_trading')
     from ai_trading.indicator_manager import (
         IncrementalEMA,
         IncrementalRSI,
@@ -190,7 +184,6 @@ def test_incremental_indicators():
 
 def test_market_data_validation():
     """Test market data validation."""
-    sys.path.append('ai_trading')
     from ai_trading.data_validation import MarketDataValidator, ValidationSeverity
 
     validator = MarketDataValidator()
@@ -224,8 +217,7 @@ def test_market_data_validation():
 
 def test_security_manager():
     """Test security manager functionality."""
-    sys.path.append('ai_trading')
-    from security import mask_sensitive_data
+    from ai_trading.security import mask_sensitive_data
 
     # Test data masking
     sensitive_data = {
@@ -250,8 +242,7 @@ def test_configuration_validation():
 
 def test_dependency_injection():
     """Test dependency injection container."""
-    sys.path.append('ai_trading')
-    from core.interfaces import IConfigManager, SimpleDependencyContainer
+    from ai_trading.core.interfaces import IConfigManager, SimpleDependencyContainer
 
     container = SimpleDependencyContainer()
 
@@ -279,8 +270,7 @@ def test_dependency_injection():
 
 def test_performance_optimizations():
     """Test performance optimizations work correctly."""
-    sys.path.append('ai_trading')
-    from indicator_manager import IndicatorManager, IndicatorType
+    from ai_trading.indicator_manager import IndicatorManager, IndicatorType
 
     manager = IndicatorManager()
 

--- a/tests/test_institutional_enhancements.py
+++ b/tests/test_institutional_enhancements.py
@@ -328,10 +328,6 @@ class TestTaxAwareRebalancing(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         try:
-            import os
-            import sys
-            sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
             from ai_trading.rebalancer import TaxAwareRebalancer
             self.TaxAwareRebalancer = TaxAwareRebalancer
             self.imports_available = True
@@ -412,10 +408,6 @@ class TestEnhancedRebalancer(unittest.TestCase):
 
     def test_enhanced_rebalancer_fallback(self):
         """Test that enhanced rebalancer falls back gracefully."""
-        import os
-        import sys
-        sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
         from ai_trading.rebalancer import enhanced_maybe_rebalance, rebalance_portfolio
 
         # Mock context

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
-"""
-Test Money math integration with execution engine.
-"""
+"""Test Money math integration with execution engine."""
 
-import sys
 import pytest
-
-sys.path.append('.')
 
 pytestmark = pytest.mark.integration
 

--- a/tests/test_performance_fixes.py
+++ b/tests/test_performance_fixes.py
@@ -16,8 +16,6 @@ from unittest.mock import Mock
 os.environ["TESTING"] = "1"
 os.environ["PYTEST_CURRENT_TEST"] = "test_performance_fixes"
 
-sys.path.append(".")
-
 
 def test_meta_learning_mixed_format():
     """Test that meta-learning can handle mixed audit/meta-learning log formats."""


### PR DESCRIPTION
## Summary
- remove direct `sys.path` manipulation from tests
- import `ai_trading.*` modules via package paths

## Testing
- `ruff check tests/test_critical_fixes_implementation.py tests/test_performance_fixes.py tests/test_institutional_enhancements.py tests/test_integration.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_critical_fixes_implementation.py tests/test_performance_fixes.py tests/test_institutional_enhancements.py tests/test_integration.py -q` *(fails: ModuleNotFoundError: No module named 'prometheus_client'; ModuleNotFoundError: No module named 'cryptography'; AttributeError: 'IndicatorManager' object has no attribute 'create_indicator'; AssertionError: Trade log file should exist; AttributeError: 'TradingConfig' object has no attribute 'lookback_periods'; ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_68af23ecb7408330b41c044baa2f5a02