### PR TITLE
enforce exclusive alpaca credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,8 @@ python verify_config.py
 
    Only provide one credential set: either `ALPACA_OAUTH` or the `ALPACA_API_KEY`/`ALPACA_SECRET_KEY` pair.
 
+  Supplying both will raise a startup error; choose one authentication method.
+
   `MAX_POSITION_SIZE` must be a positive dollar value (>0). Values ≤0 are rejected.
   If omitted, the bot derives a value from `CAPITAL_CAP` and available equity. Optionally
   set `MAX_POSITION_SIZE_PCT` to cap positions as a percentage of the portfolio.

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -85,13 +85,14 @@ class RiskEngine:
             api_key = getattr(s, 'alpaca_api_key', None)
             base_url = getattr(s, 'alpaca_base_url', None)
             oauth = get_env('ALPACA_OAUTH')
-            if oauth and (api_key or secret):
-                logger.error('Both OAuth token and API key/secret provided; skipping TradingClient init')
-            elif base_url and oauth:
+            has_keypair = api_key and secret
+            if oauth and has_keypair:
+                raise ValueError('Set only ALPACA_OAUTH or ALPACA_API_KEY/ALPACA_SECRET_KEY, not both')
+            if base_url and oauth:
                 self.data_client = TradingClient(oauth=oauth, base_url=base_url)
-            elif base_url and api_key and secret:
+            elif base_url and has_keypair:
                 self.data_client = TradingClient(api_key, secret, base_url)
-        except (APIError, ValueError, TypeError, AttributeError, OSError) as e:
+        except (APIError, TypeError, AttributeError, OSError) as e:
             logger.warning('Could not initialize TradingClient: %s', e)
         self._returns: list[float] = []
         self._drawdowns: list[float] = []


### PR DESCRIPTION
## Summary
- raise an error when both ALPACA_OAUTH and API key/secret are provided
- document that only one Alpaca credential method may be set

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `RUN_HEALTHCHECK=1 python -m ai_trading.app &` with `curl -sf http://127.0.0.1:9001/healthz`

------
https://chatgpt.com/codex/tasks/task_e_68af254219a88330881e7d23979848dd