### PR TITLE
Handle open order lookups via helper

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -817,6 +817,9 @@ def cleanup_memory():
 
 ```python
 # Check available funds
+from ai_trading.core.bot_engine import list_open_orders
+
+
 def check_buying_power():
     account = api.get_account()
     print(f"Buying power: ${account.buying_power}")
@@ -824,9 +827,12 @@ def check_buying_power():
     print(f"Portfolio value: ${account.portfolio_value}")
 
     # Check pending orders
-    orders = api.list_orders(status='open')
-    pending_value = sum(float(order.qty) * float(order.limit_price or 0)
-                       for order in orders if order.side == 'buy')
+    orders = list_open_orders(api)
+    pending_value = sum(
+        float(order.qty) * float(order.limit_price or 0)
+        for order in orders
+        if order.side == 'buy'
+    )
     print(f"Pending orders value: ${pending_value}")
 ```
 


### PR DESCRIPTION
## Summary
- wrap `TradingClient.get_orders` to support `status="open"`
- add `list_open_orders` helper and use it for open-order checks
- update tests and troubleshooting docs for new helper

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/unit/test_run_all_trades_api_error.py tests/unit/test_run_all_trades_warning.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_run_all_trades_api_error.py tests/unit/test_run_all_trades_warning.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af254236e48330ab5db36b2b415022