### PR TITLE
Enforce exclusive Alpaca auth methods

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@
 
 # === ALPACA TRADING API ===
 # Get these from https://app.alpaca.markets/paper/dashboard/overview
+# Choose exactly one auth method below.
+# Option 1: OAuth token (comment out API key/secret lines)
+# ALPACA_OAUTH=your_oauth_token_here
+
+# Option 2: API key + secret (leave ALPACA_OAUTH commented out)
 ALPACA_API_KEY=your_alpaca_api_key_here
 ALPACA_SECRET_KEY=your_alpaca_secret_key_here
 ALPACA_BASE_URL=https://paper-api.alpaca.markets

--- a/README.md
+++ b/README.md
@@ -670,11 +670,11 @@ python verify_config.py
 
 3. **Required Configuration**
    ```bash
-   # Alpaca API Configuration (choose ONE credential type)
-   # Option 1: OAuth token
+   # Alpaca API Configuration (choose exactly ONE auth method)
+   # Option 1: OAuth token (comment out API key/secret below)
    # ALPACA_OAUTH=your_oauth_token_here
 
-   # Option 2: API key + secret
+   # Option 2: API key + secret (leave ALPACA_OAUTH commented out)
    ALPACA_API_KEY=your_actual_api_key_here
    ALPACA_SECRET_KEY=your_actual_secret_key_here
    ALPACA_API_URL=https://paper-api.alpaca.markets  # Paper trading

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -85,9 +85,11 @@ class RiskEngine:
             api_key = getattr(s, 'alpaca_api_key', None)
             base_url = getattr(s, 'alpaca_base_url', None)
             oauth = get_env('ALPACA_OAUTH')
+            if oauth and (api_key or secret):
+                raise ValueError(
+                    'ALPACA_OAUTH cannot be used with ALPACA_API_KEY/ALPACA_SECRET_KEY'
+                )
             has_keypair = api_key and secret
-            if oauth and has_keypair:
-                raise ValueError('Set only ALPACA_OAUTH or ALPACA_API_KEY/ALPACA_SECRET_KEY, not both')
             if base_url and oauth:
                 self.data_client = TradingClient(oauth=oauth, base_url=base_url)
             elif base_url and has_keypair:

--- a/docs/API_KEY_SETUP.md
+++ b/docs/API_KEY_SETUP.md
@@ -21,6 +21,10 @@ This trading bot requires API keys from Alpaca Markets to function. This guide e
 - `ALPACA_BASE_URL`: Alpaca API endpoint URL
 - `WEBHOOK_SECRET`: Secret for webhook authentication
 
+Configure exactly one authentication method: either `ALPACA_OAUTH` **or** the
+`ALPACA_API_KEY`/`ALPACA_SECRET_KEY` pair. Defining both will cause a startup
+configuration error.
+
 ### Optional
 - `FINNHUB_API_KEY`: For additional market data
 - `NEWS_API_KEY`: For news sentiment analysis
@@ -51,10 +55,10 @@ Edit `.env` and replace these values:
 # Production environment configuration
 # IMPORTANT: Replace these sample values with your real API keys
 # Get your keys from: https://app.alpaca.markets/paper/dashboard/overview
-# Option 1: OAuth token
+# Option 1: OAuth token (comment out API key/secret below)
 # ALPACA_OAUTH=YOUR_OAUTH_TOKEN
 
-# Option 2: API key and secret
+# Option 2: API key and secret (leave ALPACA_OAUTH commented out)
 ALPACA_API_KEY=YOUR_ACTUAL_API_KEY_HERE
 ALPACA_SECRET_KEY=YOUR_ACTUAL_SECRET_KEY_HERE
 ALPACA_BASE_URL=https://paper-api.alpaca.markets


### PR DESCRIPTION
## Summary
- Guard against configuring both OAuth token and API key/secret by raising a clear error in `RiskEngine` before initializing `TradingClient`.
- Clarify Alpaca authentication options in README and API key setup guide, stressing that only one method should be enabled at a time.
- Update `.env.example` to show mutually exclusive OAuth and API key configurations.

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af29447fa48330954f9444dbbb7c40