### PR TITLE
Remove ALPACA_PAPER env and infer broker mode from existing config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,9 @@ MARKET_CALENDAR=XNYS
 # === TRADING CONFIGURATION ===
 # Trading mode (use this; BOT_MODE is deprecated)
 TRADING_MODE=balanced                # Options: aggressive, balanced, conservative
-ALPACA_PAPER=true                   # Set to false for live trading (USE WITH EXTREME CAUTION)
+# Broker mode is inferred from ALPACA_BASE_URL or APP_ENV
+# Use https://paper-api.alpaca.markets for paper trading (default)
+# Use https://api.alpaca.markets for live trading (USE WITH EXTREME CAUTION)
 SHADOW_MODE=false                   # Set to true for simulation without actual trades
 
 # === WEBHOOK AND API ===

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ now_ny = datetime.now(ZoneInfo("America/New_York"))
 from ai_trading.config import management as config
 
 api_port = config.get_env("API_PORT", "9001", cast=int)
-paper = config.get_env("ALPACA_PAPER", "true", cast=bool)
+base_url = config.get_env("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+is_paper = "paper" in base_url.lower() or config.get_env("APP_ENV", "test") != "prod"
 seed = config.SEED  # defaults to 42
 conf_threshold = config.get_env("AI_TRADING_CONF_THRESHOLD", "0.75", cast=float)
 

--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -250,6 +250,15 @@ class TradingConfig:
                     return cast(val) if cast is not str else val
             return default
 
+        base_url = _get(
+            "ALPACA_BASE_URL",
+            str,
+            default="https://paper-api.alpaca.markets",
+            aliases=("ALPACA_API_URL",),
+        )
+        app_env = _get("APP_ENV", str, default="test") or "test"
+        paper_default = "paper" in str(base_url).lower() or app_env.lower() != "prod"
+
         mps = _get("MAX_POSITION_SIZE", float)
         if mps is not None and mps <= 0:
             raise ValueError("MAX_POSITION_SIZE must be positive")
@@ -291,7 +300,7 @@ class TradingConfig:
                 aliases=("AI_TRADING_CONFIDENCE_LEVEL",),
             ),
             max_position_mode=_get("MAX_POSITION_MODE", str, default="STATIC"),
-            paper=_get("PAPER", _to_bool, default=True),
+            paper=_get("PAPER", _to_bool, default=paper_default),
             disable_daily_retrain=_get(
                 "DISABLE_DAILY_RETRAIN", _to_bool, default=False
             ),

--- a/tests/unit/test_trading_config_aliases.py
+++ b/tests/unit/test_trading_config_aliases.py
@@ -24,3 +24,18 @@ def test_trading_config_env_aliases():
     assert snap["data"]["feed"] == "iex"
     assert snap["data"]["provider"] == "alpaca"
 
+
+def test_paper_inferred_from_base_url():
+    env = {"ALPACA_BASE_URL": "https://paper-api.alpaca.markets"}
+    cfg = TradingConfig.from_env(env)
+    assert cfg.paper is True
+
+
+def test_paper_false_when_live_prod():
+    env = {
+        "ALPACA_BASE_URL": "https://api.alpaca.markets",
+        "APP_ENV": "prod",
+    }
+    cfg = TradingConfig.from_env(env)
+    assert cfg.paper is False
+


### PR DESCRIPTION
## Summary
- drop obsolete `ALPACA_PAPER` entry from `.env.example`
- derive paper trading mode from `ALPACA_BASE_URL` or `APP_ENV`
- update docs and tests for new broker-mode inference

## Testing
- `python -m pip install -U pip`
- `pip install -e .` (fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af2c51079883309f86bc63ed04f41a