### PR TITLE
Remove deprecated Alpaca OAuth references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,7 @@
 
 # === ALPACA TRADING API ===
 # Get these from https://app.alpaca.markets/paper/dashboard/overview
-# Choose exactly one auth method below.
-# Option 1: OAuth token (comment out API key/secret lines)
-# ALPACA_OAUTH=your_oauth_token_here
-
-# Option 2: API key + secret (leave ALPACA_OAUTH commented out)
+# Provide your Alpaca API key and secret
 ALPACA_API_KEY=your_alpaca_api_key_here
 ALPACA_SECRET_KEY=your_alpaca_secret_key_here
 ALPACA_BASE_URL=https://paper-api.alpaca.markets

--- a/README.md
+++ b/README.md
@@ -670,11 +670,7 @@ python verify_config.py
 
 3. **Required Configuration**
    ```bash
-   # Alpaca API Configuration (choose exactly ONE auth method)
-   # Option 1: OAuth token (comment out API key/secret below)
-   # ALPACA_OAUTH=your_oauth_token_here
-
-   # Option 2: API key + secret (leave ALPACA_OAUTH commented out)
+   # Alpaca API Configuration
    ALPACA_API_KEY=your_actual_api_key_here
    ALPACA_SECRET_KEY=your_actual_secret_key_here
    ALPACA_API_URL=https://paper-api.alpaca.markets  # Paper trading
@@ -702,9 +698,7 @@ python verify_config.py
   MAX_POSITION_SIZE=5000              # Absolute USD cap per position (1-10000; derived from CAPITAL_CAP if unset)
   ```
 
-   Only provide one credential set: either `ALPACA_OAUTH` or the `ALPACA_API_KEY`/`ALPACA_SECRET_KEY` pair.
-
-  Supplying both will raise a startup error; choose one authentication method.
+  OAuth credentials are no longer supported; provide your API key and secret.
 
   `MAX_POSITION_SIZE` must be a positive dollar value (>0). Values ≤0 are rejected.
   If omitted, the bot derives a value from `CAPITAL_CAP` and available equity. Optionally

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -84,15 +84,8 @@ class RiskEngine:
             secret = get_alpaca_secret_key_plain()
             api_key = getattr(s, 'alpaca_api_key', None)
             base_url = getattr(s, 'alpaca_base_url', None)
-            oauth = get_env('ALPACA_OAUTH')
-            if oauth and (api_key or secret):
-                raise ValueError(
-                    'ALPACA_OAUTH cannot be used with ALPACA_API_KEY/ALPACA_SECRET_KEY'
-                )
             has_keypair = api_key and secret
-            if base_url and oauth:
-                self.data_client = TradingClient(oauth=oauth, base_url=base_url)
-            elif base_url and has_keypair:
+            if base_url and has_keypair:
                 self.data_client = TradingClient(api_key, secret, base_url)
         except (APIError, TypeError, AttributeError, OSError) as e:
             logger.warning('Could not initialize TradingClient: %s', e)

--- a/docs/API_KEY_SETUP.md
+++ b/docs/API_KEY_SETUP.md
@@ -15,15 +15,10 @@ This trading bot requires API keys from Alpaca Markets to function. This guide e
 ## 📋 Required API Keys
 
 ### Primary (Required)
-- `ALPACA_OAUTH`: OAuth token (alternative to API key/secret)
-- `ALPACA_API_KEY`: Your Alpaca Markets API key (required if not using OAuth)
-- `ALPACA_SECRET_KEY`: Your Alpaca Markets secret key (required if not using OAuth)
+- `ALPACA_API_KEY`: Your Alpaca Markets API key
+- `ALPACA_SECRET_KEY`: Your Alpaca Markets secret key
 - `ALPACA_BASE_URL`: Alpaca API endpoint URL
 - `WEBHOOK_SECRET`: Secret for webhook authentication
-
-Configure exactly one authentication method: either `ALPACA_OAUTH` **or** the
-`ALPACA_API_KEY`/`ALPACA_SECRET_KEY` pair. Defining both will cause a startup
-configuration error.
 
 ### Optional
 - `FINNHUB_API_KEY`: For additional market data
@@ -55,10 +50,6 @@ Edit `.env` and replace these values:
 # Production environment configuration
 # IMPORTANT: Replace these sample values with your real API keys
 # Get your keys from: https://app.alpaca.markets/paper/dashboard/overview
-# Option 1: OAuth token (comment out API key/secret below)
-# ALPACA_OAUTH=YOUR_OAUTH_TOKEN
-
-# Option 2: API key and secret (leave ALPACA_OAUTH commented out)
 ALPACA_API_KEY=YOUR_ACTUAL_API_KEY_HERE
 ALPACA_SECRET_KEY=YOUR_ACTUAL_SECRET_KEY_HERE
 ALPACA_BASE_URL=https://paper-api.alpaca.markets
@@ -80,8 +71,6 @@ Example formats (these are NOT real keys):
 ALPACA_API_KEY=PKTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ
 ALPACA_SECRET_KEY=SKTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD
 ```
-
-> Provide either `ALPACA_OAUTH` or the `ALPACA_API_KEY`/`ALPACA_SECRET_KEY` pair. Supplying both is not supported.
 
 ## 🧪 Development vs Production
 


### PR DESCRIPTION
## Summary
- drop ALPACA_OAUTH support from risk engine
- update environment template and docs to require Alpaca API key/secret

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af2c522cd4833090c4c08c28cdda2b