### PR TITLE
fix(risk): pass base_url by keyword

### DIFF
--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -89,11 +89,10 @@ class RiskEngine:
                 raise ValueError(
                     'ALPACA_OAUTH cannot be used with ALPACA_API_KEY/ALPACA_SECRET_KEY'
                 )
-            has_keypair = api_key and secret
-            if base_url and oauth:
+            if oauth:
                 self.data_client = TradingClient(oauth=oauth, base_url=base_url)
-            elif base_url and has_keypair:
-                self.data_client = TradingClient(api_key, secret, base_url)
+            elif api_key and secret:
+                self.data_client = TradingClient(api_key, secret, base_url=base_url)
         except (APIError, TypeError, AttributeError, OSError) as e:
             logger.warning('Could not initialize TradingClient: %s', e)
         self._returns: list[float] = []


### PR DESCRIPTION
## Summary
- initialize `TradingClient` with `base_url` keyword argument
- avoid mixing API key/secret and OAuth credentials

## Testing
- `ALPACA_API_KEY=abc ALPACA_SECRET_KEY=def ALPACA_API_URL=https://example.com WEBHOOK_SECRET=xyz CAPITAL_CAP=1000 DOLLAR_RISK_LIMIT=1000 python - <<'PY'
from ai_trading.risk.engine import RiskEngine
RiskEngine()
print('initialized')
PY`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing modules such as hypothesis, and import issues)*

## Rollback Plan
- Revert this PR.

------
https://chatgpt.com/codex/tasks/task_e_68af2c4e3b488330bec5eb211a3baac4