### PR TITLE
Fix TradingClient initialization in risk engine

### DIFF
--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -84,9 +84,22 @@ class RiskEngine:
             secret = get_alpaca_secret_key_plain()
             api_key = getattr(s, 'alpaca_api_key', None)
             base_url = getattr(s, 'alpaca_base_url', None)
+            oauth = get_env('ALPACA_OAUTH')
             has_keypair = api_key and secret
-            if base_url and has_keypair:
-                self.data_client = TradingClient(api_key, secret, base_url)
+            if base_url:
+                if has_keypair and oauth:
+                    logger.warning('Both API key/secret and OAuth token provided; using API key/secret')
+                if has_keypair:
+                    self.data_client = TradingClient(
+                        api_key=api_key,
+                        secret_key=secret,
+                        url_override=base_url,
+                    )
+                elif oauth:
+                    self.data_client = TradingClient(
+                        oauth_token=oauth,
+                        url_override=base_url,
+                    )
         except (APIError, TypeError, AttributeError, OSError) as e:
             logger.warning('Could not initialize TradingClient: %s', e)
         self._returns: list[float] = []


### PR DESCRIPTION
## Summary
- pass Alpaca base URL via `url_override` to avoid credential clashes
- guard against supplying both API key/secret and OAuth token when creating `TradingClient`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*
- `python - <<'PY' ... RiskEngine() ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68af2df103808330a7119f7472e771ba