### PR TITLE
fix: correct Alpaca list_orders wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - **Trading Loop**: guard missing Alpaca client and dedupe strategy logs
 - **Alpaca API**: fix submit/retry logic including 429 handling
 - **Alpaca API**: validate `list_orders` availability and map alternative clients before trading loop
+- **Alpaca API**: fix `list_orders` wrapper to forward `status` without introducing unsupported `statuses`
 - **Config**: unify centralized defaults and add `from_optimization`
 - **Utils**: re-export `ensure_utc` and enforce type assertions
 - **validate_env**: support execution via `runpy.run_module`

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -187,13 +187,7 @@ def _validate_trading_api(api: Any) -> bool:
     if not hasattr(api, "list_orders"):
         if hasattr(api, "get_orders"):
             def _list_orders_wrapper(*args: Any, **kwargs: Any):  # type: ignore[override]
-                status = kwargs.pop("status", None)
-                if status == "open" and "statuses" not in kwargs:
-                    try:
-                        status_enum = OrderStatus.OPEN  # type: ignore[union-attr]
-                    except Exception:  # pragma: no cover - fallback when enum missing
-                        status_enum = "open"
-                    kwargs["statuses"] = [status_enum]
+                """Proxy ``list_orders`` to ``get_orders`` with compatible kwargs."""
                 return api.get_orders(*args, **kwargs)  # type: ignore[attr-defined]
 
             setattr(api, "list_orders", _list_orders_wrapper)  # type: ignore[attr-defined]

--- a/tests/test_list_orders_wrapper.py
+++ b/tests/test_list_orders_wrapper.py
@@ -1,0 +1,18 @@
+from ai_trading.core.bot_engine import _validate_trading_api, list_open_orders
+
+
+class _FakeClient:
+    def __init__(self):
+        self.kwargs = None
+
+    def get_orders(self, *args, **kwargs):
+        self.kwargs = kwargs
+        return ["ok"]
+
+
+def test_list_orders_wrapper_passes_status():
+    client = _FakeClient()
+    assert _validate_trading_api(client)
+    orders = list_open_orders(client)
+    assert orders == ["ok"]
+    assert client.kwargs == {"status": "open"}


### PR DESCRIPTION
## Summary
- proxy `list_orders` directly to `get_orders` to avoid unsupported `statuses` arg
- document Alpaca wrapper fix in changelog
- add regression test for `list_orders` wrapper

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af35b4ccc88330a95e13f9795dca6b