### PR TITLE
Use module entrypoint for runtime execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM python:3.12-slim
 WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt && pip install .[ml]
-CMD ["python", "run.py"]
+CMD ["python", "-m", "ai_trading"]

--- a/scripts/setup_dependencies.sh
+++ b/scripts/setup_dependencies.sh
@@ -68,5 +68,6 @@ echo "Setup complete!"
 echo ""
 echo "Next steps:"
 echo "1. Copy .env.example to .env and configure your API keys"
-echo "2. Run the trading bot with: python run.py"
+echo "2. Run the trading bot with: python -m ai_trading"
 echo "3. Check logs/ directory for execution logs"
+


### PR DESCRIPTION
## Summary
- Replace Dockerfile CMD to invoke package module directly
- Update setup script instructions to use `python -m ai_trading`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python tools/run_pytest.py --files tests/test_cli_dry_run.py tests/test_import_side_effects.py tests/test_single_instance_lock.py tests/test_env_validation.py` *(fails: missing INDICATOR_IMPORT_OK banner; unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68af35ce3dd88330abe7bc7f255d1b18