### PR TITLE
Handle expected runtime errors explicitly

### DIFF
--- a/tests/test_position_sizing_error_handling.py
+++ b/tests/test_position_sizing_error_handling.py
@@ -1,0 +1,55 @@
+import types
+from unittest.mock import Mock, patch
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from ai_trading.position_sizing import _get_equity_from_alpaca
+
+
+class _Cfg:
+    alpaca_base_url = "https://api.example.com"
+    alpaca_api_key = "key"
+    alpaca_secret_key_plain = "secret"
+
+
+def _cfg():
+    return _Cfg()
+
+
+def test_get_equity_http_error_returns_zero():
+    cfg = _cfg()
+    resp = Mock()
+    resp.raise_for_status.side_effect = requests.HTTPError(response=Mock(status_code=500))
+    session = Mock(get=Mock(return_value=resp))
+    with patch("ai_trading.position_sizing.get_global_session", return_value=session):
+        assert _get_equity_from_alpaca(cfg) == 0.0
+
+
+def test_get_equity_request_exception_returns_zero():
+    cfg = _cfg()
+    session = Mock()
+    session.get.side_effect = requests.ConnectionError("boom")
+    with patch("ai_trading.position_sizing.get_global_session", return_value=session):
+        assert _get_equity_from_alpaca(cfg) == 0.0
+
+
+def test_get_equity_invalid_json_returns_zero():
+    cfg = _cfg()
+    resp = Mock()
+    resp.raise_for_status.return_value = None
+    resp.json.side_effect = ValueError("no json")
+    session = Mock(get=Mock(return_value=resp))
+    with patch("ai_trading.position_sizing.get_global_session", return_value=session):
+        assert _get_equity_from_alpaca(cfg) == 0.0
+
+
+def test_get_equity_unexpected_exception_propagates():
+    cfg = _cfg()
+    with patch(
+        "ai_trading.position_sizing.get_global_session", side_effect=RuntimeError("boom")
+    ):
+        with pytest.raises(RuntimeError):
+            _get_equity_from_alpaca(cfg)

--- a/tests/test_run_loop_error_handling.py
+++ b/tests/test_run_loop_error_handling.py
@@ -1,0 +1,33 @@
+from argparse import Namespace
+
+import pytest
+import requests
+
+from ai_trading.__main__ import _run_loop
+
+
+def _args():
+    return Namespace(once=True, interval=0)
+
+
+def test_run_loop_swallow_value_error():
+    def fn():
+        raise ValueError("bad")
+
+    _run_loop(fn, _args(), "Test")
+
+
+def test_run_loop_swallow_http_error():
+    def fn():
+        raise requests.HTTPError("oops")
+
+    _run_loop(fn, _args(), "Test")
+
+
+def test_run_loop_unexpected_exception_propagates():
+    def fn():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        _run_loop(fn, _args(), "Test")
+


### PR DESCRIPTION
## Summary
- add explicit HTTP and request error handling in position sizing equity fetch
- make CLI loop handle ValueError and HTTPError without crashing
- test that expected errors are swallowed and unexpected ones surface

## Testing
- `ruff check tests/test_position_sizing_error_handling.py tests/test_run_loop_error_handling.py ai_trading/position_sizing.py ai_trading/__main__.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af35cedb288330ad76627f36c43eef