### PR TITLE
feat: modernize Alpaca order shim

### DIFF
--- a/tests/unit/test_run_all_trades_api_error.py
+++ b/tests/unit/test_run_all_trades_api_error.py
@@ -1,16 +1,61 @@
 from __future__ import annotations
 
 import types
+import sys
+
+sklearn_stub = types.ModuleType("sklearn")
+ensemble_stub = types.ModuleType("sklearn.ensemble")
+
+class _GB:  # noqa: D401 - placeholder
+    pass
+
+
+class _RF:  # noqa: D401 - placeholder
+    pass
+
+
+ensemble_stub.GradientBoostingClassifier = _GB
+ensemble_stub.RandomForestClassifier = _RF
+sys.modules.setdefault("sklearn", sklearn_stub)
+sys.modules.setdefault("sklearn.ensemble", ensemble_stub)
+metrics_stub = types.ModuleType("sklearn.metrics")
+metrics_stub.accuracy_score = lambda *a, **k: 0.0
+sys.modules.setdefault("sklearn.metrics", metrics_stub)
+model_selection_stub = types.ModuleType("sklearn.model_selection")
+model_selection_stub.train_test_split = lambda *a, **k: ([], [])
+sys.modules.setdefault("sklearn.model_selection", model_selection_stub)
+preproc_stub = types.ModuleType("sklearn.preprocessing")
+preproc_stub.StandardScaler = type("StandardScaler", (), {})
+sys.modules.setdefault("sklearn.preprocessing", preproc_stub)
 
 import ai_trading.core.bot_engine as eng
 
 
 def test_run_all_trades_handles_api_error(monkeypatch, caplog):
+    # Provide Alpaca stubs so the shim forwards a GetOrdersRequest
+    enums_mod = types.ModuleType("alpaca.trading.enums")
+    requests_mod = types.ModuleType("alpaca.trading.requests")
+
+    class OrderStatus:
+        OPEN = "open"
+
+    class GetOrdersRequest:
+        def __init__(self, *, statuses=None):
+            self.statuses = statuses
+
+    enums_mod.OrderStatus = OrderStatus
+    requests_mod.GetOrdersRequest = GetOrdersRequest
+    monkeypatch.setitem(sys.modules, "alpaca", types.ModuleType("alpaca"))
+    monkeypatch.setitem(sys.modules, "alpaca.trading", types.ModuleType("alpaca.trading"))
+    monkeypatch.setitem(sys.modules, "alpaca.trading.enums", enums_mod)
+    monkeypatch.setitem(sys.modules, "alpaca.trading.requests", requests_mod)
+
     class DummyAPI:
         def __init__(self):
             self.called_with: dict | None = None
 
-        def get_orders(self, **kwargs):
+        def get_orders(self, *args, **kwargs):  # noqa: D401
+            """Capture forwarded kwargs."""
             self.called_with = kwargs
             return []
 
@@ -51,4 +96,5 @@ def test_run_all_trades_handles_api_error(monkeypatch, caplog):
     assert any(str(r.msg).startswith("PREP") for r in caplog.records)
     assert state.running is False
     assert api.called_with is not None
-    assert "statuses" in api.called_with
+    assert "filter" in api.called_with
+    assert api.called_with["filter"].statuses == [OrderStatus.OPEN]

--- a/tests/unit/test_run_all_trades_warning.py
+++ b/tests/unit/test_run_all_trades_warning.py
@@ -3,7 +3,33 @@
 from __future__ import annotations
 
 import types
+import sys
 from unittest.mock import Mock, call
+
+sklearn_stub = types.ModuleType("sklearn")
+ensemble_stub = types.ModuleType("sklearn.ensemble")
+
+class _GB:  # noqa: D401 - minimal placeholder
+    pass
+
+
+class _RF:  # noqa: D401 - minimal placeholder
+    pass
+
+
+ensemble_stub.GradientBoostingClassifier = _GB
+ensemble_stub.RandomForestClassifier = _RF
+sys.modules.setdefault("sklearn", sklearn_stub)
+sys.modules.setdefault("sklearn.ensemble", ensemble_stub)
+metrics_stub = types.ModuleType("sklearn.metrics")
+metrics_stub.accuracy_score = lambda *a, **k: 0.0
+sys.modules.setdefault("sklearn.metrics", metrics_stub)
+model_selection_stub = types.ModuleType("sklearn.model_selection")
+model_selection_stub.train_test_split = lambda *a, **k: ([], [])
+sys.modules.setdefault("sklearn.model_selection", model_selection_stub)
+preproc_stub = types.ModuleType("sklearn.preprocessing")
+preproc_stub.StandardScaler = type("StandardScaler", (), {})
+sys.modules.setdefault("sklearn.preprocessing", preproc_stub)
 
 import ai_trading.core.bot_engine as eng
 
@@ -11,11 +37,30 @@ import ai_trading.core.bot_engine as eng
 def test_run_all_trades_no_warning_with_valid_api(monkeypatch):
     """A valid client with get_orders should not trigger a warning."""
 
+    # Stub Alpaca modules so the shim translates status -> GetOrdersRequest
+    enums_mod = types.ModuleType("alpaca.trading.enums")
+    requests_mod = types.ModuleType("alpaca.trading.requests")
+
+    class OrderStatus:
+        OPEN = "open"
+
+    class GetOrdersRequest:
+        def __init__(self, *, statuses=None):
+            self.statuses = statuses
+
+    enums_mod.OrderStatus = OrderStatus
+    requests_mod.GetOrdersRequest = GetOrdersRequest
+    monkeypatch.setitem(sys.modules, "alpaca", types.ModuleType("alpaca"))
+    monkeypatch.setitem(sys.modules, "alpaca.trading", types.ModuleType("alpaca.trading"))
+    monkeypatch.setitem(sys.modules, "alpaca.trading.enums", enums_mod)
+    monkeypatch.setitem(sys.modules, "alpaca.trading.requests", requests_mod)
+
     class DummyAPI:
         def __init__(self):
             self.called_with: dict | None = None
 
-        def get_orders(self, **kwargs):
+        def get_orders(self, *args, **kwargs):  # noqa: D401
+            """Capture forwarded kwargs."""
             self.called_with = kwargs
             return []
 
@@ -65,5 +110,5 @@ def test_run_all_trades_no_warning_with_valid_api(monkeypatch):
         ]
     )
     assert api.called_with is not None
-    assert "statuses" in api.called_with
-
+    assert "filter" in api.called_with
+    assert api.called_with["filter"].statuses == [OrderStatus.OPEN]


### PR DESCRIPTION
## Summary
- translate `status="open"` to `GetOrdersRequest(OrderStatus.OPEN)` when shimming `get_orders`
- rely on shimmed translation for `list_open_orders`
- verify order filter forwarding in run-all-trades tests

## Testing
- `ruff check .`
- `python -m pytest tests/unit/test_run_all_trades_warning.py tests/unit/test_run_all_trades_api_error.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68af40d8f5e48330afb226bff94c3c69