### PR TITLE
Enforce exclusive Alpaca authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,10 @@
 
 # === ALPACA TRADING API ===
 # Get these from https://app.alpaca.markets/paper/dashboard/overview
-# Provide your Alpaca API key and secret
+# Provide your Alpaca API key and secret OR an OAuth token (not both)
 ALPACA_API_KEY=your_alpaca_api_key_here
 ALPACA_SECRET_KEY=your_alpaca_secret_key_here
+# ALPACA_OAUTH=your_alpaca_oauth_token_here
 ALPACA_BASE_URL=https://paper-api.alpaca.markets
 DATA_LOOKBACK_DAYS_DAILY=200
 DATA_LOOKBACK_DAYS_MINUTE=5

--- a/README.md
+++ b/README.md
@@ -670,9 +670,10 @@ python verify_config.py
 
 3. **Required Configuration**
    ```bash
-   # Alpaca API Configuration
+   # Alpaca API Configuration (use API key/secret or ALPACA_OAUTH)
    ALPACA_API_KEY=your_actual_api_key_here
    ALPACA_SECRET_KEY=your_actual_secret_key_here
+   # ALPACA_OAUTH=your_oauth_token_here
    ALPACA_API_URL=https://paper-api.alpaca.markets  # Paper trading
    ALPACA_DATA_FEED=iex
    ALPACA_ADJUSTMENT=all
@@ -698,7 +699,7 @@ python verify_config.py
   MAX_POSITION_SIZE=5000              # Absolute USD cap per position (1-10000; derived from CAPITAL_CAP if unset)
   ```
 
-  OAuth credentials are no longer supported; provide your API key and secret.
+  Provide either ALPACA_API_KEY/ALPACA_SECRET_KEY or ALPACA_OAUTH. Do not set both.
 
   `MAX_POSITION_SIZE` must be a positive dollar value (>0). Values ≤0 are rejected.
   If omitted, the bot derives a value from `CAPITAL_CAP` and available equity. Optionally

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -85,10 +85,12 @@ class RiskEngine:
             api_key = getattr(s, 'alpaca_api_key', None)
             base_url = getattr(s, 'alpaca_base_url', None)
             oauth = get_env('ALPACA_OAUTH')
-            has_keypair = api_key and secret
+            has_keypair = bool(api_key and secret)
             if base_url:
                 if has_keypair and oauth:
-                    logger.warning('Both API key/secret and OAuth token provided; using API key/secret')
+                    raise RuntimeError(
+                        'Provide either ALPACA_API_KEY/ALPACA_SECRET_KEY or ALPACA_OAUTH, not both'
+                    )
                 if has_keypair:
                     self.data_client = TradingClient(
                         api_key=api_key,

--- a/docs/API_KEY_SETUP.md
+++ b/docs/API_KEY_SETUP.md
@@ -19,6 +19,7 @@ This trading bot requires API keys from Alpaca Markets to function. This guide e
 - `ALPACA_SECRET_KEY`: Your Alpaca Markets secret key
 - `ALPACA_BASE_URL`: Alpaca API endpoint URL
 - `WEBHOOK_SECRET`: Secret for webhook authentication
+- Alternatively, set `ALPACA_OAUTH` with an OAuth token instead of the API key and secret. **Do not** set both.
 
 ### Optional
 - `FINNHUB_API_KEY`: For additional market data
@@ -48,10 +49,12 @@ Edit `.env` and replace these values:
 
 ```env
 # Production environment configuration
-# IMPORTANT: Replace these sample values with your real API keys
+# IMPORTANT: Replace these sample values with your real credentials
 # Get your keys from: https://app.alpaca.markets/paper/dashboard/overview
+# Provide ALPACA_API_KEY/ALPACA_SECRET_KEY or ALPACA_OAUTH (not both)
 ALPACA_API_KEY=YOUR_ACTUAL_API_KEY_HERE
 ALPACA_SECRET_KEY=YOUR_ACTUAL_SECRET_KEY_HERE
+# ALPACA_OAUTH=YOUR_OAUTH_TOKEN_HERE
 ALPACA_BASE_URL=https://paper-api.alpaca.markets
 
 # Optional API keys - replace with your real keys or leave commented out

--- a/tests/test_alpaca_auth_credentials.py
+++ b/tests/test_alpaca_auth_credentials.py
@@ -1,0 +1,55 @@
+from tests.optdeps import require
+require("numpy")
+require("pydantic")
+import pytest
+from ai_trading.risk.engine import RiskEngine
+
+
+def test_trading_client_api_key_only(monkeypatch):
+    calls = {}
+
+    class Dummy:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+    monkeypatch.setenv("ALPACA_API_KEY", "key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
+    monkeypatch.delenv("ALPACA_OAUTH", raising=False)
+    monkeypatch.setattr("ai_trading.risk.engine.TradingClient", Dummy)
+
+    RiskEngine()
+
+    assert calls.get("api_key") == "key"
+    assert calls.get("secret_key") == "secret"
+    assert "oauth_token" not in calls
+
+
+def test_trading_client_oauth_only(monkeypatch):
+    calls = {}
+
+    class Dummy:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+    monkeypatch.setenv("ALPACA_OAUTH", "tok")
+    monkeypatch.setattr("ai_trading.risk.engine.TradingClient", Dummy)
+
+    RiskEngine()
+
+    assert calls.get("oauth_token") == "tok"
+    assert "api_key" not in calls
+    assert "secret_key" not in calls
+
+
+def test_trading_client_conflicting_credentials(monkeypatch):
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+    monkeypatch.setenv("ALPACA_API_KEY", "key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
+    monkeypatch.setenv("ALPACA_OAUTH", "tok")
+
+    with pytest.raises(RuntimeError):
+        RiskEngine()


### PR DESCRIPTION
## Summary
- reject simultaneous ALPACA_API_KEY/ALPACA_SECRET_KEY and ALPACA_OAUTH
- instantiate TradingClient with exactly one credential type
- document OAuth token option and update example env config
- add unit test covering API key vs OAuth flows

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af49faf1e48330a5b64f1bae381bac