### PR TITLE
Guard against unauthorized SIP feed requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,9 @@ python verify_config.py
    ALPACA_SECRET_KEY=your_actual_secret_key_here
    ALPACA_API_URL=https://paper-api.alpaca.markets  # Paper trading
    ALPACA_DATA_FEED=iex
+   # Set the following only if your Alpaca account has SIP permissions
+   # ALPACA_DATA_FEED=sip
+   # ALPACA_ALLOW_SIP=1
    ALPACA_ADJUSTMENT=all
    DATA_LOOKBACK_DAYS_DAILY=200
    DATA_LOOKBACK_DAYS_MINUTE=5

--- a/ai_trading/health_monitor.py
+++ b/ai_trading/health_monitor.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any
 from ai_trading.monitoring.system_health import _HAS_PSUTIL, snapshot_basic
+from ai_trading.config import get_settings
 
 if _HAS_PSUTIL:
     import psutil
@@ -529,10 +530,17 @@ class HealthMonitor:
 
     def _check_market_data(self) -> dict[str, Any]:
         """Check market data feed health."""
+        feed = get_settings().alpaca_data_feed
+        if feed != "iex":
+            return {
+                "status": HealthStatus.WARNING.value,
+                "message": "Unauthorized Alpaca feed configured",
+                "details": {"feed": feed},
+            }
         return {
             "status": HealthStatus.HEALTHY.value,
             "message": "Market data feed operational",
-            "details": {"feed_status": "connected"},
+            "details": {"feed": feed},
         }
 
     def get_overall_health(self) -> dict[str, Any]:

--- a/ai_trading/scripts/self_check.py
+++ b/ai_trading/scripts/self_check.py
@@ -1,5 +1,5 @@
-import os
 import datetime as dt
+import os
 from zoneinfo import ZoneInfo
 
 from alpaca.common.exceptions import APIError
@@ -24,6 +24,9 @@ def _bars_time_window(timeframe: TimeFrame) -> tuple[dt.datetime, dt.datetime]:
 
 def main() -> None:
     feed = get_env("ALPACA_DATA_FEED", "iex")
+    if feed.lower() == "sip" and not get_env("ALPACA_ALLOW_SIP", "0", cast=bool):
+        logger.warning("SIP_FEED_DISABLED", extra={"requested": "sip", "using": "iex"})
+        feed = "iex"
     client = StockHistoricalDataClient(
         get_env("ALPACA_API_KEY"),
         get_env("ALPACA_SECRET_KEY"),

--- a/tests/test_settings_config.py
+++ b/tests/test_settings_config.py
@@ -22,6 +22,16 @@ def test_settings_defaults(monkeypatch):
     assert s.dollar_risk_limit == 0.05
 
 
+def test_sip_feed_falls_back(monkeypatch, caplog):
+    """SIP feed requests fall back to IEX when not explicitly allowed."""  # AI-AGENT-REF
+    monkeypatch.setenv("ALPACA_DATA_FEED", "sip")
+    monkeypatch.delenv("ALPACA_ALLOW_SIP", raising=False)
+    with caplog.at_level("WARNING"):
+        s = Settings()
+    assert s.alpaca_data_feed == "iex"
+    assert "SIP_FEED_DISABLED" in caplog.text
+
+
 def test_settings_invalid_risk(monkeypatch):
     """Invalid risk values raise ValidationError."""  # AI-AGENT-REF
     monkeypatch.setenv("CAPITAL_CAP", "0")


### PR DESCRIPTION
## Summary
- Force Alpaca data feed to IEX unless `ALPACA_ALLOW_SIP=1`
- Warn via health check when a non-IEX feed is configured
- Extend self check and docs for optional SIP access
- Test SIP fallback logic

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4a387fe48330a488edd59dbed94d