### PR TITLE
Split Yahoo minute fetches into 8-day chunks

### DIFF
--- a/tests/test_price_snapshot_minute_fallback.py
+++ b/tests/test_price_snapshot_minute_fallback.py
@@ -1,9 +1,11 @@
+import datetime as dt
 from types import SimpleNamespace
 
 import pytest
 
 pd = pytest.importorskip("pandas")
 from ai_trading.portfolio import core as portfolio_core
+from ai_trading.data import fetch as data_fetcher
 from ai_trading import utils as _utils  # type: ignore
 
 
@@ -29,3 +31,37 @@ def test_price_snapshot_minute_fallback(monkeypatch):
 
     price = portfolio_core.get_latest_price(ctx, "SPY")
     assert price == 123.0
+
+
+def test_yahoo_minute_split_long_range(monkeypatch, caplog):
+    monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
+    monkeypatch.setenv("ENABLE_FINNHUB", "0")
+    monkeypatch.setattr(data_fetcher, "_fetch_bars", lambda *a, **k: pd.DataFrame())
+
+    calls: list[tuple[dt.datetime, dt.datetime]] = []
+
+    def fake_yahoo(symbol, start, end, interval):
+        calls.append((start, end))
+        return pd.DataFrame(
+            {
+                "timestamp": [pd.Timestamp(start)],
+                "open": [1.0],
+                "high": [1.0],
+                "low": [1.0],
+                "close": [float(len(calls))],
+                "volume": [0],
+            }
+        )
+
+    monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", fake_yahoo)
+
+    start = dt.datetime(2024, 1, 1)
+    end = dt.datetime(2024, 1, 20)
+    with caplog.at_level("WARNING"):
+        df = data_fetcher.get_minute_df("AAPL", start, end)
+
+    assert list(df["close"]) == [1.0, 2.0, 3.0]
+    assert len(calls) == 3
+    for s, e in calls:
+        assert e - s <= dt.timedelta(days=8)
+    assert any("YF_1" in str(r.msg) for r in caplog.records)


### PR DESCRIPTION
## Summary
- split Yahoo Finance 1m fetches into 8-day chunks and warn when range exceeds limit
- add regression test for long-range minute fetch fallback

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_price_snapshot_minute_fallback.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_price_snapshot_minute_fallback.py tests/test_finnhub_disabled.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4dd717f483309ba1f3a0a2b3d0c2