### PR TITLE
Skip SIP fallback when unauthorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,8 @@ python verify_config.py
    # Set the following only if your Alpaca account has SIP permissions
    # ALPACA_DATA_FEED=sip
    # ALPACA_ALLOW_SIP=1
+   # Set if your account lacks SIP access to skip SIP requests entirely
+   # ALPACA_SIP_UNAUTHORIZED=1
    ALPACA_ADJUSTMENT=all
    DATA_LOOKBACK_DAYS_DAILY=200
    DATA_LOOKBACK_DAYS_MINUTE=5
@@ -701,6 +703,10 @@ python verify_config.py
   DOLLAR_RISK_LIMIT=0.05              # Max fraction of equity at risk per position
   MAX_POSITION_SIZE=5000              # Absolute USD cap per position (1-10000; derived from CAPITAL_CAP if unset)
   ```
+
+  Unauthorized SIP requests return an empty DataFrame and automatically
+  disable further SIP retries.  Set `ALPACA_SIP_UNAUTHORIZED=1` to skip SIP
+  requests when your account lacks access.
 
   Provide either ALPACA_API_KEY/ALPACA_SECRET_KEY or ALPACA_OAUTH. Do not set both.
 

--- a/tests/test_sip_unauthorized.py
+++ b/tests/test_sip_unauthorized.py
@@ -17,6 +17,7 @@ class _RespForbidden:
 
 def test_get_bars_unauthorized_sip_returns_empty(monkeypatch):
     """Unauthorized SIP access returns an empty DataFrame."""
+    monkeypatch.setattr(data_fetcher, "_SIP_UNAUTHORIZED", False, raising=False)
 
     def fake_get(url, params=None, headers=None, timeout=None):  # noqa: ARG001
         return _RespForbidden()
@@ -31,6 +32,8 @@ def test_get_bars_unauthorized_sip_returns_empty(monkeypatch):
 
 def test_data_check_skips_unauthorized_symbols(monkeypatch):
     """Symbols returning empty data are skipped during data_check."""
+
+    monkeypatch.setattr(data_fetcher, "_SIP_UNAUTHORIZED", False, raising=False)
 
     class _RespOK:
         status_code = 200

--- a/tests/unit/test_data_fetcher_http.py
+++ b/tests/unit/test_data_fetcher_http.py
@@ -44,26 +44,41 @@ def _dt_range(minutes: int = 5):
 
 
 @pytest.mark.parametrize("status_first", [401, 403])
-def test_sip_unauthorized_triggers_fallback(monkeypatch: pytest.MonkeyPatch, status_first: int):
+def test_sip_unauthorized_returns_empty(monkeypatch: pytest.MonkeyPatch, status_first: int):
+    monkeypatch.setattr(df, "_SIP_UNAUTHORIZED", False, raising=False)
     calls = {"count": 0}
 
     def fake_get(url, params=None, headers=None, timeout=None):
         calls["count"] += 1
-        feed = (params or {}).get("feed")
-        ts_iso = datetime.now(UTC).isoformat()
-        if calls["count"] == 1 and feed == "sip":
-            return _Resp(status_first, payload={"message": "auth required"})
-        return _Resp(200, payload=_bars_payload(ts_iso))
+        return _Resp(status_first, payload={"message": "auth required"})
 
     monkeypatch.setattr(df, "requests", type("R", (), {"get": staticmethod(fake_get)}))
 
     start, end = _dt_range(2)
     out = df.get_bars("TEST", timeframe="1Min", start=start, end=end, feed="sip", adjustment="raw")
-    assert isinstance(out, pd.DataFrame) and not out.empty
-    assert calls["count"] >= 2
+    assert isinstance(out, pd.DataFrame) and out.empty
+    assert calls["count"] == 1
+    assert df._SIP_UNAUTHORIZED is True
+
+
+def test_sip_fallback_skipped_when_marked_unauthorized(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(df, "_SIP_UNAUTHORIZED", True, raising=False)
+    calls = {"count": 0}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        calls["count"] += 1
+        return _Resp(429, payload={"message": "rate limit"})
+
+    monkeypatch.setattr(df, "requests", type("R", (), {"get": staticmethod(fake_get)}))
+
+    start, end = _dt_range(2)
+    with pytest.raises(ValueError, match="rate_limited"):
+        df._fetch_bars("TEST", start, end, "1Min", feed="iex")
+    assert calls["count"] == 1
 
 
 def test_timeout_triggers_fallback(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(df, "_SIP_UNAUTHORIZED", False, raising=False)
     calls = {"count": 0}
 
     class _Timeout(df.Timeout):
@@ -86,6 +101,7 @@ def test_timeout_triggers_fallback(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_429_rate_limit_triggers_fallback(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(df, "_SIP_UNAUTHORIZED", False, raising=False)
     calls = {"count": 0}
 
     def fake_get(url, params=None, headers=None, timeout=None):
@@ -105,6 +121,7 @@ def test_429_rate_limit_triggers_fallback(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_empty_bars_fallback(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(df, "_SIP_UNAUTHORIZED", False, raising=False)
     calls = {"count": 0}
 
     def fake_get(url, params=None, headers=None, timeout=None):


### PR DESCRIPTION
## Summary
- Detect SIP authorization via `ALPACA_SIP_UNAUTHORIZED` or first 401/403 and skip SIP requests
- Document SIP authorization behavior and new `ALPACA_SIP_UNAUTHORIZED` flag
- Update tests to avoid SIP retries when unauthorized

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

## Rollback
- Revert this PR


------
https://chatgpt.com/codex/tasks/task_e_68af4dd423b48330990dc67f03ec6c52