### PR TITLE
feat: use Alpaca data client for bar retrieval

### DIFF
--- a/tests/test_alpaca_auth_credentials.py
+++ b/tests/test_alpaca_auth_credentials.py
@@ -3,6 +3,7 @@ require("numpy")
 require("pydantic")
 import pytest
 from ai_trading.risk.engine import RiskEngine
+from ai_trading.settings import get_settings
 
 
 def test_trading_client_api_key_only(monkeypatch):
@@ -17,6 +18,7 @@ def test_trading_client_api_key_only(monkeypatch):
     monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
     monkeypatch.delenv("ALPACA_OAUTH", raising=False)
     monkeypatch.setattr("ai_trading.risk.engine.TradingClient", Dummy)
+    get_settings.cache_clear()
 
     RiskEngine()
 
@@ -37,6 +39,7 @@ def test_trading_client_oauth_only(monkeypatch):
     monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
     monkeypatch.setenv("ALPACA_OAUTH", "tok")
     monkeypatch.setattr("ai_trading.risk.engine.TradingClient", Dummy)
+    get_settings.cache_clear()
 
     RiskEngine()
 
@@ -50,6 +53,74 @@ def test_trading_client_conflicting_credentials(monkeypatch):
     monkeypatch.setenv("ALPACA_API_KEY", "key")
     monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
     monkeypatch.setenv("ALPACA_OAUTH", "tok")
+    get_settings.cache_clear()
 
     with pytest.raises(RuntimeError):
         RiskEngine()
+
+
+def _inject_dummy_trading(monkeypatch, cls):
+    import types, sys
+
+    mod_client = types.ModuleType("alpaca.trading.client")
+    mod_client.TradingClient = cls
+    mod_trading = types.ModuleType("alpaca.trading")
+    mod_trading.client = mod_client
+    monkeypatch.setitem(sys.modules, "alpaca", types.ModuleType("alpaca"))
+    monkeypatch.setitem(sys.modules, "alpaca.trading", mod_trading)
+    monkeypatch.setitem(sys.modules, "alpaca.trading.client", mod_client)
+
+
+def test_get_rest_api_key_only(monkeypatch):
+    calls: dict[str, str] = {}
+
+    class Dummy:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    _inject_dummy_trading(monkeypatch, Dummy)
+    monkeypatch.setenv("ALPACA_API_KEY", "key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
+    monkeypatch.delenv("ALPACA_OAUTH", raising=False)
+
+    from ai_trading.alpaca_api import _get_rest
+
+    _get_rest()
+    assert calls.get("api_key") == "key"
+    assert calls.get("secret_key") == "secret"
+    assert "oauth_token" not in calls
+
+
+def test_get_rest_oauth_only(monkeypatch):
+    calls: dict[str, str] = {}
+
+    class Dummy:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    _inject_dummy_trading(monkeypatch, Dummy)
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+    monkeypatch.setenv("ALPACA_OAUTH", "tok")
+
+    from ai_trading.alpaca_api import _get_rest
+
+    _get_rest()
+    assert calls.get("oauth_token") == "tok"
+    assert "api_key" not in calls and "secret_key" not in calls
+
+
+def test_get_rest_conflicting_credentials(monkeypatch):
+    class Dummy:
+        def __init__(self, **kwargs):
+            pass
+
+    _inject_dummy_trading(monkeypatch, Dummy)
+    monkeypatch.setenv("ALPACA_API_KEY", "key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
+    monkeypatch.setenv("ALPACA_OAUTH", "tok")
+
+    from ai_trading.alpaca_api import _get_rest
+
+    with pytest.raises(RuntimeError):
+        _get_rest()

--- a/tests/test_alpaca_time_params.py
+++ b/tests/test_alpaca_time_params.py
@@ -17,12 +17,15 @@ class _Resp:
 @patch("ai_trading.alpaca_api._get_rest")
 def test_daily_uses_date_only(mock_rest_cls):
     mock_rest = MagicMock()
-    mock_rest.get_bars.return_value = _Resp(pd.DataFrame({"open": [1.0], "close": [1.1]}))
+    mock_rest.get_stock_bars.return_value = _Resp(
+        pd.DataFrame({"open": [1.0], "close": [1.1]})
+    )
     mock_rest_cls.return_value = mock_rest
 
     df = get_bars_df("SPY", "Day", feed="iex", adjustment="all")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
-    _, kwargs = mock_rest.get_bars.call_args
+    mock_rest_cls.assert_called_once_with(bars=True)
+    _, kwargs = mock_rest.get_stock_bars.call_args
     assert (
         isinstance(kwargs["start"], str)
         and len(kwargs["start"]) == 10
@@ -39,14 +42,17 @@ def test_daily_uses_date_only(mock_rest_cls):
 @patch("ai_trading.alpaca_api._get_rest")
 def test_intraday_uses_rfc3339z(mock_rest_cls):
     mock_rest = MagicMock()
-    mock_rest.get_bars.return_value = _Resp(pd.DataFrame({"open": [1.0], "close": [1.1]}))
+    mock_rest.get_stock_bars.return_value = _Resp(
+        pd.DataFrame({"open": [1.0], "close": [1.1]})
+    )
     mock_rest_cls.return_value = mock_rest
 
     start = dt.datetime(2025, 8, 19, 15, 0, 5, tzinfo=dt.UTC)
     end = dt.datetime(2025, 8, 19, 16, 0, 5, tzinfo=dt.UTC)
     df = get_bars_df("SPY", "5Min", start=start, end=end, feed="iex", adjustment="all")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
-    _, kwargs = mock_rest.get_bars.call_args
+    mock_rest_cls.assert_called_once_with(bars=True)
+    _, kwargs = mock_rest.get_stock_bars.call_args
     assert kwargs["start"].endswith("Z") and "T" in kwargs["start"] and "." not in kwargs["start"]
     assert kwargs["end"].endswith("Z") and "T" in kwargs["end"] and "." not in kwargs["end"]
     assert kwargs["timeframe"] in ("5Min",)

--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -36,11 +36,14 @@ class _Resp:
 @patch("ai_trading.alpaca_api._get_rest")
 def test_day_timeframe_normalized(mock_rest_cls):
     mock_rest = MagicMock()
-    mock_rest.get_bars.return_value = _Resp(pd.DataFrame({"open": [1.0], "close": [1.1]}))
+    mock_rest.get_stock_bars.return_value = _Resp(
+        pd.DataFrame({"open": [1.0], "close": [1.1]})
+    )
     mock_rest_cls.return_value = mock_rest
 
     df = get_bars_df("SPY", "Day", feed="iex", adjustment="all")
-    args, kwargs = mock_rest.get_bars.call_args
+    mock_rest_cls.assert_called_once_with(bars=True)
+    args, kwargs = mock_rest.get_stock_bars.call_args
     assert kwargs["timeframe"] in ("1Day", "1D")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
 
@@ -48,11 +51,14 @@ def test_day_timeframe_normalized(mock_rest_cls):
 @patch("ai_trading.alpaca_api._get_rest")
 def test_tf_object_normalized(mock_rest_cls):
     mock_rest = MagicMock()
-    mock_rest.get_bars.return_value = _Resp(pd.DataFrame({"open": [1.0], "close": [1.1]}))
+    mock_rest.get_stock_bars.return_value = _Resp(
+        pd.DataFrame({"open": [1.0], "close": [1.1]})
+    )
     mock_rest_cls.return_value = mock_rest
 
     df = get_bars_df("SPY", TimeFrame(1, TimeFrameUnit.Day), feed="iex", adjustment="all")
-    args, kwargs = mock_rest.get_bars.call_args
+    mock_rest_cls.assert_called_once_with(bars=True)
+    args, kwargs = mock_rest.get_stock_bars.call_args
     assert kwargs["timeframe"] in ("1Day", "1D")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
 
@@ -60,10 +66,13 @@ def test_tf_object_normalized(mock_rest_cls):
 @patch("ai_trading.alpaca_api._get_rest")
 def test_minute_normalized(mock_rest_cls):
     mock_rest = MagicMock()
-    mock_rest.get_bars.return_value = _Resp(pd.DataFrame({"open": [1.0], "close": [1.1]}))
+    mock_rest.get_stock_bars.return_value = _Resp(
+        pd.DataFrame({"open": [1.0], "close": [1.1]})
+    )
     mock_rest_cls.return_value = mock_rest
 
     df = get_bars_df("SPY", "Minute", feed="iex", adjustment="all")
-    args, kwargs = mock_rest.get_bars.call_args
+    mock_rest_cls.assert_called_once_with(bars=True)
+    args, kwargs = mock_rest.get_stock_bars.call_args
     assert kwargs["timeframe"] in ("1Min", "1Minute")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode


### PR DESCRIPTION
## Summary
- return StockHistoricalDataClient from helper when requesting bars and use keyword TradingClient args
- call `get_stock_bars` in `get_bars_df` and improve error logging
- add tests asserting exclusive auth methods

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_auth_credentials.py tests/test_alpaca_time_params.py tests/test_alpaca_timeframe_mapping.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68af4dd103dc8330ac8aa35d1ca72670