### PR TITLE
use StockHistoricalDataClient for bar fetches

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -516,19 +516,14 @@ class BotEngine:
 
     @cached_property
     def data_client(self):
-        """Alpaca TradingClient for historical/market data."""
-        from alpaca.trading.client import TradingClient as _TradingClient  # type: ignore
-
-        base_url = (
-            _get_env_str("ALPACA_API_URL")
-            if os.getenv("ALPACA_API_URL")
-            else _get_env_str("ALPACA_BASE_URL")
+        """Alpaca StockHistoricalDataClient for historical/market data."""
+        from alpaca.data.historical import (
+            StockHistoricalDataClient as _DataClient,  # type: ignore
         )
-        return _TradingClient(
+
+        return _DataClient(
             api_key=_get_env_str("ALPACA_API_KEY"),
             secret_key=_get_env_str("ALPACA_SECRET_KEY"),
-            paper="paper" in base_url.lower(),
-            url_override=base_url,
         )
 
 # AI-AGENT-REF: ensure FinBERT disabled message logged once
@@ -3917,14 +3912,11 @@ class DataFetcher:
             logger.error(f"Missing Alpaca credentials for {symbol}")
             return None
 
-        from alpaca.trading.client import TradingClient as AlpacaREST  # type: ignore
-        base_url = get_settings().alpaca_base_url
-        client = AlpacaREST(
-            api_key=api_key,
-            secret_key=api_secret,
-            paper="paper" in base_url.lower(),
-            url_override=base_url,
+        from alpaca.data.historical import (
+            StockHistoricalDataClient as _DataClient,  # type: ignore
         )
+
+        client = _DataClient(api_key=api_key, secret_key=api_secret)
 
         def _minute_resample() -> pd.DataFrame | None:  # AI-AGENT-REF: minute fallback helper
             try:
@@ -4220,14 +4212,11 @@ class DataFetcher:
             raise RuntimeError(
                 "ALPACA_API_KEY and ALPACA_SECRET_KEY must be set for data fetching"
             )
-        from alpaca.trading.client import TradingClient as AlpacaREST  # type: ignore
-        base_url = get_settings().alpaca_base_url
-        client = AlpacaREST(
-            api_key=api_key,
-            secret_key=api_secret,
-            paper="paper" in base_url.lower(),
-            url_override=base_url,
+        from alpaca.data.historical import (
+            StockHistoricalDataClient as _DataClient,  # type: ignore
         )
+
+        client = _DataClient(api_key=api_key, secret_key=api_secret)
 
         try:
             req = StockBarsRequest(
@@ -4470,14 +4459,11 @@ def prefetch_daily_data(
         raise RuntimeError(
             "ALPACA_API_KEY and ALPACA_SECRET_KEY must be set for data fetching"
         )
-    from alpaca.trading.client import TradingClient as AlpacaREST  # type: ignore
-    base_url = get_settings().alpaca_base_url
-    client = AlpacaREST(
-        api_key=alpaca_key,
-        secret_key=alpaca_secret,
-        paper="paper" in base_url.lower(),
-        url_override=base_url,
+    from alpaca.data.historical import (
+        StockHistoricalDataClient as _DataClient,  # type: ignore
     )
+
+    client = _DataClient(api_key=alpaca_key, secret_key=alpaca_secret)
 
     try:
         req = StockBarsRequest(

--- a/tests/test_alpaca_sdk_compat.py
+++ b/tests/test_alpaca_sdk_compat.py
@@ -62,7 +62,12 @@ prom_stub.Counter = prom_stub.Gauge = prom_stub.Histogram = prom_stub.Summary = 
 prom_stub.start_http_server = lambda *a, **k: None
 sys.modules.setdefault("prometheus_client", prom_stub)
 
-from ai_trading.data.bars import StockBarsRequest, safe_get_stock_bars
+from ai_trading.data.bars import (
+    StockBarsRequest,
+    TimeFrame,
+    TimeFrameUnit,
+    safe_get_stock_bars,
+)
 from ai_trading.core.bot_engine import get_stock_bars_safe
 
 
@@ -86,7 +91,9 @@ def test_safe_get_stock_bars_uses_get_stock_bars():
         def get_stock_bars(self, request):
             return types.SimpleNamespace(df=_make_df())
 
-    req = StockBarsRequest(symbol_or_symbols="SPY", timeframe="1Day")
+    req = StockBarsRequest(
+        symbol_or_symbols="SPY", timeframe=TimeFrame(1, TimeFrameUnit.Day)
+    )
     df = safe_get_stock_bars(Client(), req, "SPY", "TEST")
     assert not df.empty
 
@@ -96,7 +103,9 @@ def test_safe_get_stock_bars_falls_back_to_get_bars():
         def get_bars(self, symbol_or_symbols, timeframe, **kwargs):
             return _make_df()
 
-    req = StockBarsRequest(symbol_or_symbols="SPY", timeframe="1Day")
+    req = StockBarsRequest(
+        symbol_or_symbols="SPY", timeframe=TimeFrame(1, TimeFrameUnit.Day)
+    )
     df = safe_get_stock_bars(Client(), req, "SPY", "TEST")
     assert not df.empty
 


### PR DESCRIPTION
## Summary
- use `StockHistoricalDataClient` for historical bar retrieval in `bot_engine`
- adjust SDK compatibility tests to construct `StockBarsRequest` with `TimeFrame`

## Testing
- `ruff check tests/test_alpaca_sdk_compat.py ai_trading/core/bot_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_sdk_compat.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_68af4dcdd8e48330883eb8abfd8eb766