### PR TITLE
refactor: update alpaca client base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ import os
 client = TradingClient(
     os.getenv('ALPACA_API_KEY'),
     os.getenv('ALPACA_SECRET_KEY'),
-    paper=True,
+    base_url=os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets'),
 )
 account = client.get_account()
 print(f'✅ Connected! Account: {account.id}')

--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -103,8 +103,7 @@ def _get_rest(*, bars: bool = False) -> Any:
     key = os.getenv("ALPACA_API_KEY")
     secret = os.getenv("ALPACA_SECRET_KEY")
     oauth = os.getenv("ALPACA_OAUTH")
-    base = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
-    paper = "paper" in str(base).lower()
+    base_url = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
     if oauth and (key or secret):
         raise RuntimeError(
             "Provide either ALPACA_API_KEY/ALPACA_SECRET_KEY or ALPACA_OAUTH, not both"
@@ -115,23 +114,24 @@ def _get_rest(*, bars: bool = False) -> Any:
 
         if oauth:
             return StockHistoricalDataClient(
-                oauth_token=oauth, url_override=base, paper=paper
+                oauth_token=oauth,
+                base_url=base_url,
             )
         return StockHistoricalDataClient(
-            api_key=key, secret_key=secret, url_override=base, paper=paper
+            api_key=key, secret_key=secret, base_url=base_url
         )
 
     from alpaca.trading.client import TradingClient
 
     if oauth:
         return TradingClient(
-            oauth_token=oauth, url_override=base, paper=paper
+            oauth_token=oauth,
+            base_url=base_url,
         )
     return TradingClient(
         api_key=key,
         secret_key=secret,
-        url_override=base,
-        paper=paper,
+        base_url=base_url,
     )
 
 def _bars_time_window(timeframe: Any) -> tuple[str, str]:
@@ -252,8 +252,8 @@ class _AlpacaConfig:
     @staticmethod
     def from_env() -> "_AlpacaConfig":
         base = os.getenv("ALPACA_BASE_URL", "https://paper-api.alpaca.markets").rstrip("/")
-        key = os.getenv("ALPACA_API_KEY_ID") or os.getenv("APCA_API_KEY_ID")
-        sec = os.getenv("ALPACA_API_SECRET_KEY") or os.getenv("APCA_API_SECRET_KEY")
+        key = os.getenv("ALPACA_API_KEY_ID")
+        sec = os.getenv("ALPACA_API_SECRET_KEY")
         shadow_env = os.getenv("ALPACA_SHADOW", "")
         shadow = is_shadow_mode() or str(shadow_env).strip().lower() in {"1", "true", "yes", "on"}
         return _AlpacaConfig(base, key, sec, shadow)

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -95,12 +95,12 @@ class RiskEngine:
                     self.data_client = TradingClient(
                         api_key=api_key,
                         secret_key=secret,
-                        url_override=base_url,
+                        base_url=base_url,
                     )
                 elif oauth:
                     self.data_client = TradingClient(
                         oauth_token=oauth,
-                        url_override=base_url,
+                        base_url=base_url,
                     )
         except (APIError, TypeError, AttributeError, OSError) as e:
             logger.warning('Could not initialize TradingClient: %s', e)

--- a/ai_trading/scripts/self_check.py
+++ b/ai_trading/scripts/self_check.py
@@ -28,8 +28,9 @@ def main() -> None:
         logger.warning("SIP_FEED_DISABLED", extra={"requested": "sip", "using": "iex"})
         feed = "iex"
     client = StockHistoricalDataClient(
-        get_env("ALPACA_API_KEY"),
-        get_env("ALPACA_SECRET_KEY"),
+        api_key=get_env("ALPACA_API_KEY"),
+        secret_key=get_env("ALPACA_SECRET_KEY"),
+        base_url=get_env("ALPACA_BASE_URL", "https://paper-api.alpaca.markets"),
     )
     try:
         req_day = StockBarsRequest(

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -22,7 +22,10 @@ def main() -> None:
     ensure_dotenv_loaded()
     api_key = get_env("ALPACA_API_KEY")
     secret_key = get_env("ALPACA_SECRET_KEY")
-    client = StockHistoricalDataClient(api_key, secret_key)
+    base_url = get_env("ALPACA_BASE_URL", "https://paper-api.alpaca.markets")
+    client = StockHistoricalDataClient(
+        api_key=api_key, secret_key=secret_key, base_url=base_url
+    )
 
     symbols = ["AAPL", "MSFT", "GOOG", "AMZN", "NVDA", "TSLA", "META"]
     start = datetime(2023, 1, 1, tzinfo=ZoneInfo("UTC"))

--- a/tests/test_env_contract_py.py
+++ b/tests/test_env_contract_py.py
@@ -15,40 +15,52 @@ def test_no_apca_env_anywhere_in_python():
     offenders = [p for p in FILES if "APCA_" in _t(p)]
     assert not offenders, f"Forbidden APCA_* in: {offenders}"
 
-def _find_bad_ctor(pattern, need_kw):
+def _find_bad_ctor(pattern, need_kw, unless_kw=None):
     rx = re.compile(pattern, re.DOTALL)
     bad = []
     for p in FILES:
         txt = _t(p)
         for m in rx.finditer(txt):
-            if need_kw not in m.group(0):
-                bad.append(p); break
+            segment = m.group(0)
+            if unless_kw and unless_kw in segment:
+                continue
+            if need_kw not in segment:
+                bad.append(p)
+                break
     return bad
 
 def test_all_python_has_explicit_alpaca_creds():
     bad = []
     bad += _find_bad_ctor(r"\bREST\s*\([^)]*\)", "key_id=")
-    bad += _find_bad_ctor(r"\bTradingClient\s*\([^)]*\)", "api_key=")
-    bad += _find_bad_ctor(r"\bStockHistoricalDataClient\s*\([^)]*\)", "api_key=")
-    bad += _find_bad_ctor(r"\bCryptoHistoricalDataClient\s*\([^)]*\)", "api_key=")
+    bad += _find_bad_ctor(
+        r"\bTradingClient\s*\([^)]*\)", "api_key=", unless_kw="oauth_token"
+    )
+    bad += _find_bad_ctor(
+        r"\bStockHistoricalDataClient\s*\([^)]*\)",
+        "api_key=",
+        unless_kw="oauth_token",
+    )
+    bad += _find_bad_ctor(
+        r"\bCryptoHistoricalDataClient\s*\([^)]*\)", "api_key="
+    )
     assert not bad, f"Missing explicit Alpaca creds in: {sorted(set(bad))}"
 
 
-def test_tradingclient_has_no_base_url_and_has_paper_flag():
-    offenders_base = []
-    offenders_missing_paper = []
-    rx = re.compile(r"TradingClient\s*\((?P<args>[^)]*)\)", re.DOTALL)
+def test_tradingclient_uses_base_url_not_paper():
+    offenders_missing_base = []
+    offenders_with_paper = []
+    rx = re.compile(r"\bTradingClient\s*\((?P<args>[^)]*)\)", re.DOTALL)
     for p in PY:
         t = p.read_text(encoding="utf-8", errors="ignore")
         for m in rx.finditer(t):
             args = m.group("args")
-            if "base_url" in args:
-                offenders_base.append(p)
-            if "paper=" not in args:
-                offenders_missing_paper.append(p)
-    assert not offenders_base, (
-        f"TradingClient must not take base_url: {sorted(set(offenders_base))}"
+            if "base_url" not in args:
+                offenders_missing_base.append(p)
+            if "paper=" in args:
+                offenders_with_paper.append(p)
+    assert not offenders_missing_base, (
+        f"TradingClient must set base_url=: {sorted(set(offenders_missing_base))}"
     )
-    assert not offenders_missing_paper, (
-        f"TradingClient must set paper=: {sorted(set(offenders_missing_paper))}"
-    )  # AI-AGENT-REF: enforce paper flag without base_url
+    assert not offenders_with_paper, (
+        f"TradingClient must not set paper=: {sorted(set(offenders_with_paper))}"
+    )  # AI-AGENT-REF: enforce base_url without paper flag

--- a/tests/test_stage1_1.py
+++ b/tests/test_stage1_1.py
@@ -38,5 +38,5 @@ def test_fetch_sentiment_graceful_when_requests_unavailable(monkeypatch):
 def test_alpaca_stubs_are_not_exceptions():
     from ai_trading.core import bot_engine as be
 
-    # TradingClient (and other stubs) should not be Exception subclasses
+    # TradingClient and other stubs should not be Exception subclasses
     assert not issubclass(be.TradingClient, Exception)


### PR DESCRIPTION
## Summary
- replace deprecated `paper`/`url_override` usage with `base_url` when creating Alpaca clients
- ensure every `TradingClient`/`StockHistoricalDataClient` is constructed with explicit `base_url`
- document new `base_url` usage and enforce via updated env contract tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_timeframe_mapping.py tests/test_alpaca_time_params.py tests/test_alpaca_auth_credentials.py tests/test_env_contract_py.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af507a63bc8330b8822a22b2458ec8