### PR TITLE
refactor: update alpaca client args

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -123,15 +123,18 @@ def _get_rest(*, bars: bool = False) -> Any:
 
     from alpaca.trading.client import TradingClient
 
+    is_paper = bool(base_url and "paper" in base_url.lower())
     if oauth:
         return TradingClient(
             oauth_token=oauth,
-            base_url=base_url,
+            paper=is_paper,
+            url_override=base_url,
         )
     return TradingClient(
         api_key=key,
         secret_key=secret,
-        base_url=base_url,
+        paper=is_paper,
+        url_override=base_url,
     )
 
 def _bars_time_window(timeframe: Any) -> tuple[str, str]:

--- a/ai_trading/broker/alpaca_credentials.py
+++ b/ai_trading/broker/alpaca_credentials.py
@@ -57,7 +57,8 @@ def initialize(env: Mapping[str, str] | None = None, *, shadow: bool = False):
     return TradingClient(
         api_key=creds.api_key,
         secret_key=creds.secret_key,
-        base_url=creds.base_url,
+        paper="paper" in creds.base_url.lower(),
+        url_override=creds.base_url,
     )
 
 

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -510,7 +510,10 @@ class BotEngine:
         api_key = _get_env_str("ALPACA_API_KEY")
         secret_key = _get_env_str("ALPACA_SECRET_KEY")
         return TradingClient(
-            api_key=api_key, secret_key=secret_key, base_url=base_url
+            api_key=api_key,
+            secret_key=secret_key,
+            paper="paper" in base_url.lower(),
+            url_override=base_url,
         )
 
     @cached_property

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -91,16 +91,19 @@ class RiskEngine:
                     raise RuntimeError(
                         'Provide either ALPACA_API_KEY/ALPACA_SECRET_KEY or ALPACA_OAUTH, not both'
                     )
+                is_paper = 'paper' in base_url.lower()
                 if has_keypair:
                     self.data_client = TradingClient(
                         api_key=api_key,
                         secret_key=secret,
-                        base_url=base_url,
+                        paper=is_paper,
+                        url_override=base_url,
                     )
                 elif oauth:
                     self.data_client = TradingClient(
                         oauth_token=oauth,
-                        base_url=base_url,
+                        paper=is_paper,
+                        url_override=base_url,
                     )
         except (APIError, TypeError, AttributeError, OSError) as e:
             logger.warning('Could not initialize TradingClient: %s', e)

--- a/tests/test_env_contract_py.py
+++ b/tests/test_env_contract_py.py
@@ -46,21 +46,21 @@ def test_all_python_has_explicit_alpaca_creds():
     assert not bad, f"Missing explicit Alpaca creds in: {sorted(set(bad))}"
 
 
-def test_tradingclient_uses_base_url_not_paper():
-    offenders_missing_base = []
-    offenders_with_paper = []
+def test_tradingclient_sets_paper_not_base_url():
+    offenders_missing_paper = []
+    offenders_with_base = []
     rx = re.compile(r"\bTradingClient\s*\((?P<args>[^)]*)\)", re.DOTALL)
     for p in PY:
         t = p.read_text(encoding="utf-8", errors="ignore")
         for m in rx.finditer(t):
             args = m.group("args")
-            if "base_url" not in args:
-                offenders_missing_base.append(p)
-            if "paper=" in args:
-                offenders_with_paper.append(p)
-    assert not offenders_missing_base, (
-        f"TradingClient must set base_url=: {sorted(set(offenders_missing_base))}"
+            if "paper=" not in args:
+                offenders_missing_paper.append(p)
+            if "base_url=" in args:
+                offenders_with_base.append(p)
+    assert not offenders_with_base, (
+        f"TradingClient must not set base_url=: {sorted(set(offenders_with_base))}"
     )
-    assert not offenders_with_paper, (
-        f"TradingClient must not set paper=: {sorted(set(offenders_with_paper))}"
-    )  # AI-AGENT-REF: enforce base_url without paper flag
+    assert not offenders_missing_paper, (
+        f"TradingClient must set paper=: {sorted(set(offenders_missing_paper))}"
+    )  # AI-AGENT-REF: enforce paper flag without base_url


### PR DESCRIPTION
## Summary
- replace deprecated `base_url` with `paper`/`url_override` for `alpaca-py` `TradingClient`
- enforce new constructor usage across codebase
- update env contract test for new arguments

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_env_contract_py.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'sklearn', joblib, cachetools; lint shim artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68af54a9d3448330a6a8904168aa4490