### PR TITLE
Use url_override for TradingClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ import os
 client = TradingClient(
     os.getenv('ALPACA_API_KEY'),
     os.getenv('ALPACA_SECRET_KEY'),
-    base_url=os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets'),
+    url_override=os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets'),
 )
 account = client.get_account()
 print(f'✅ Connected! Account: {account.id}')

--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -431,7 +431,7 @@ class TestAlpacaIntegration:
         return TradingClient(
             os.getenv('ALPACA_API_KEY'),
             os.getenv('ALPACA_SECRET_KEY'),
-            base_url='https://paper-api.alpaca.markets',
+            url_override='https://paper-api.alpaca.markets',
         )
 
     @pytest.fixture

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -151,7 +151,7 @@ try:
     client = TradingClient(
         os.getenv('ALPACA_API_KEY'),
         os.getenv('ALPACA_SECRET_KEY'),
-        base_url=os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets'),
+        url_override=os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets'),
     )
     account = client.get_account()
     print(f'Connected to Alpaca. Account: {account.id}')
@@ -290,7 +290,7 @@ def debug_order_issue(symbol, quantity, side):
     client = TradingClient(
         os.getenv('ALPACA_API_KEY'),
         os.getenv('ALPACA_SECRET_KEY'),
-        base_url=os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets'),
+        url_override=os.getenv('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets'),
     )
 
     account = client.get_account()

--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -449,7 +449,7 @@ def submit_order(
         rest = _REST(
             api_key=cfg.key_id,
             secret_key=cfg.secret_key,
-            base_url=cfg.base_url,
+            url_override=cfg.base_url,
         )
         return _sdk_submit(
             rest,

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5787,7 +5787,7 @@ def _initialize_alpaca_clients() -> bool:
             trading_client = AlpacaREST(
                 api_key=key,
                 secret_key=secret,
-                base_url=base_url,
+                url_override=base_url,
             )
             data_client = stock_client_cls(
                 api_key=key, secret_key=secret, base_url=base_url

--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -90,7 +90,7 @@ class AlpacaExecutionEngine:
             raw_client = AlpacaREST(
                 api_key=self.config.key_id,
                 secret_key=self.config.secret_key,
-                base_url=self.config.base_url,
+                url_override=self.config.base_url,
             )
             logger.info(
                 f'Real Alpaca client initialized (paper={self.config.use_paper})'


### PR DESCRIPTION
## Summary
- replace deprecated `base_url` parameter with `url_override` for Alpaca `TradingClient`
- refresh documentation examples to use `url_override`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af56e9cb008330bb1976a09284b618