### PR TITLE
Skip minute data fetch when no symbols screened

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -13231,6 +13231,10 @@ def run_all_trades_worker(state: BotState, runtime) -> None:
                 )
                 return
 
+            if not symbols:
+                logger.info("SKIP_MINUTE_FETCH", extra={"reason": "no_symbols"})
+                return
+
             retries = 3
             processed, row_counts = [], {}
             for attempt in range(retries):


### PR DESCRIPTION
## Summary
- Guard minute-data retrieval by skipping when screening returns no symbols
- Log `SKIP_MINUTE_FETCH` to avoid redundant retries on empty symbol lists

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `RUN_HEALTHCHECK=1 python -m ai_trading.app &` and `curl -sf http://127.0.0.1:9001/healthz`

------
https://chatgpt.com/codex/tasks/task_e_68af5ae2cf608330835694bcb546108b