### PR TITLE
Use StockBarsRequest for get_stock_bars calls

### DIFF
--- a/tests/test_alpaca_sdk_compat.py
+++ b/tests/test_alpaca_sdk_compat.py
@@ -102,18 +102,18 @@ def test_safe_get_stock_bars_falls_back_to_get_bars():
     class Client:
         def get_bars(self, symbol_or_symbols, timeframe, **kwargs):
             return _make_df()
+    class Req:
+        symbol_or_symbols = "SPY"
+        timeframe = TimeFrame(1, TimeFrameUnit.Day)
 
-    req = StockBarsRequest(
-        symbol_or_symbols="SPY", timeframe=TimeFrame(1, TimeFrameUnit.Day)
-    )
-    df = safe_get_stock_bars(Client(), req, "SPY", "TEST")
+    df = safe_get_stock_bars(Client(), Req(), "SPY", "TEST")
     assert not df.empty
 
 
 def test_get_stock_bars_safe_uses_get_stock_bars():
     class API:
-        def get_stock_bars(self, symbol, timeframe):
-            return _make_df()
+        def get_stock_bars(self, request):  # pragma: no cover - simple stub
+            return types.SimpleNamespace(df=_make_df())
 
     df = get_stock_bars_safe(API(), "SPY", "1Day")
     assert not df.empty


### PR DESCRIPTION
## Summary
- refactor get_stock_bars_safe to build a StockBarsRequest and validate SDK compatibility
- adjust Alpaca SDK compat tests for new request-based API

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/test_alpaca_sdk_compat.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_sdk_compat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5ae14994833091071d9ce07b2d2c