### PR TITLE
Switch get_bars_df to StockBarsRequest

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -172,6 +172,7 @@ def get_bars_df(
     """Fetch bars for ``symbol`` and return a normalized DataFrame."""
     from alpaca.common.exceptions import APIError
     from alpaca.data.timeframe import TimeFrame, TimeFrameUnit
+    from alpaca.data.requests import StockBarsRequest
 
     _pd = _require_pandas("get_bars_df")
     rest = _get_rest(bars=True)
@@ -187,15 +188,15 @@ def get_bars_df(
         start, end = _bars_time_window(base_tf)
     start_s, end_s = _format_start_end_for_tradeapi(tf, start, end)
     try:
-        df = rest.get_stock_bars(
-            symbol,
+        req = StockBarsRequest(
+            symbol_or_symbols=[symbol],
             timeframe=tf,
             start=start_s,
             end=end_s,
             adjustment=adjustment,
             feed=feed,
-            limit=None,
-        ).df
+        )
+        df = rest.get_stock_bars(req).df
         if isinstance(df, _pd.DataFrame) and (not df.empty):
             return df.reset_index(drop=False)
         return _pd.DataFrame()

--- a/tests/test_alpaca_time_params.py
+++ b/tests/test_alpaca_time_params.py
@@ -25,18 +25,10 @@ def test_daily_uses_date_only(mock_rest_cls):
     df = get_bars_df("SPY", "Day", feed="iex", adjustment="all")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
     mock_rest_cls.assert_called_once_with(bars=True)
-    _, kwargs = mock_rest.get_stock_bars.call_args
-    assert (
-        isinstance(kwargs["start"], str)
-        and len(kwargs["start"]) == 10
-        and kwargs["start"].count("-") == 2
-    )
-    assert (
-        isinstance(kwargs["end"], str)
-        and len(kwargs["end"]) == 10
-        and kwargs["end"].count("-") == 2
-    )
-    assert kwargs["timeframe"] in ("1Day", "1D")
+    (req,), kwargs = mock_rest.get_stock_bars.call_args
+    assert isinstance(req.start, str) and len(req.start) == 10 and req.start.count("-") == 2
+    assert isinstance(req.end, str) and len(req.end) == 10 and req.end.count("-") == 2
+    assert req.timeframe in ("1Day", "1D")
 
 
 @patch("ai_trading.alpaca_api._get_rest")
@@ -52,7 +44,7 @@ def test_intraday_uses_rfc3339z(mock_rest_cls):
     df = get_bars_df("SPY", "5Min", start=start, end=end, feed="iex", adjustment="all")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
     mock_rest_cls.assert_called_once_with(bars=True)
-    _, kwargs = mock_rest.get_stock_bars.call_args
-    assert kwargs["start"].endswith("Z") and "T" in kwargs["start"] and "." not in kwargs["start"]
-    assert kwargs["end"].endswith("Z") and "T" in kwargs["end"] and "." not in kwargs["end"]
-    assert kwargs["timeframe"] in ("5Min",)
+    (req,), kwargs = mock_rest.get_stock_bars.call_args
+    assert req.start.endswith("Z") and "T" in req.start and "." not in req.start
+    assert req.end.endswith("Z") and "T" in req.end and "." not in req.end
+    assert req.timeframe in ("5Min",)

--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -43,8 +43,8 @@ def test_day_timeframe_normalized(mock_rest_cls):
 
     df = get_bars_df("SPY", "Day", feed="iex", adjustment="all")
     mock_rest_cls.assert_called_once_with(bars=True)
-    args, kwargs = mock_rest.get_stock_bars.call_args
-    assert kwargs["timeframe"] in ("1Day", "1D")
+    (req,), kwargs = mock_rest.get_stock_bars.call_args
+    assert req.timeframe in ("1Day", "1D")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
 
 
@@ -58,8 +58,8 @@ def test_tf_object_normalized(mock_rest_cls):
 
     df = get_bars_df("SPY", TimeFrame(1, TimeFrameUnit.Day), feed="iex", adjustment="all")
     mock_rest_cls.assert_called_once_with(bars=True)
-    args, kwargs = mock_rest.get_stock_bars.call_args
-    assert kwargs["timeframe"] in ("1Day", "1D")
+    (req,), kwargs = mock_rest.get_stock_bars.call_args
+    assert req.timeframe in ("1Day", "1D")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
 
 
@@ -73,6 +73,6 @@ def test_minute_normalized(mock_rest_cls):
 
     df = get_bars_df("SPY", "Minute", feed="iex", adjustment="all")
     mock_rest_cls.assert_called_once_with(bars=True)
-    args, kwargs = mock_rest.get_stock_bars.call_args
-    assert kwargs["timeframe"] in ("1Min", "1Minute")
+    (req,), kwargs = mock_rest.get_stock_bars.call_args
+    assert req.timeframe in ("1Min", "1Minute")
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode


### PR DESCRIPTION
## Summary
- Build a StockBarsRequest for get_bars_df and call the Alpaca client with it
- Adapt tests to expect a StockBarsRequest instead of keyword args

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `python - <<'PY' ...` (manual get_bars_df smoke test)

## Rollback Plan
- Revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68af5d590c2483308860ff75cb1ae708