### PR TITLE
Use TimeFrame enums for bar requests

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -54,9 +54,16 @@ except (ValueError, TypeError, ImportError):
             self.n = n
             self.unit = unit
 
+        def __str__(self) -> str:  # pragma: no cover - simple utility
+            return f"{self.n}{self.unit}"
+
     class TimeFrameUnit:
-        Day = 'Day'
-        Minute = 'Minute'
+        Day = "Day"
+        Minute = "Min"
+
+    # Provide enum-style helpers for compatibility
+    TimeFrame.Day = TimeFrame(1, TimeFrameUnit.Day)
+    TimeFrame.Minute = TimeFrame(1, TimeFrameUnit.Minute)
 COMMON_EXC = (ValueError, KeyError, AttributeError, TypeError, RuntimeError, ImportError, OSError, ConnectionError, TimeoutError)
 
 def _ensure_df(obj: Any) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- map configuration strings to TimeFrame enums via `_parse_timeframe`
- build `StockBarsRequest` with TimeFrame.Day/TimeFrame.Minute instead of string literals
- provide enum-style shims when `alpaca-py` is missing and test enum acceptance

## Testing
- `ruff check ai_trading/core/bot_engine.py ai_trading/data/bars.py tests/test_alpaca_sdk_compat.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

## Rollback Plan
- Revert this PR if bar fetching fails or regression is observed.

------
https://chatgpt.com/codex/tasks/task_e_68af5fc0af70833095333866e42caa84