### PR TITLE
Add startup config validation for timeframe and data feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,9 @@ python -m ai_trading.tools.env_validate
 python verify_config.py
 ```
 
+The CLI validates `DATA_FEED` and `TIMEFRAME` at startup using Pydantic and
+exits early with a clear error message when these values are invalid.
+
 ---
 
 ## 🔑 Configuration

--- a/ai_trading/__main__.py
+++ b/ai_trading/__main__.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Callable
+from typing import Any, Literal
 
 import requests
+from pydantic import BaseModel, ValidationError, field_validator
+
 from ai_trading.logging import get_logger
 
 logger = get_logger(__name__)
@@ -56,6 +59,49 @@ def _run_loop(fn: Callable[[], None], args: argparse.Namespace, label: str) -> N
         raise
 
 
+class _StartupConfig(BaseModel):
+    """Minimal runtime configuration validated at startup."""
+
+    timeframe: Literal["1Min", "1Day"]
+    data_feed: Literal["iex", "sip"]
+
+    @field_validator("timeframe", mode="before")
+    @classmethod
+    def _norm_timeframe(cls, v: Any) -> str:
+        s = str(v).strip().lower()
+        if s in {"1min", "1m", "minute", "1 minute"}:
+            return "1Min"
+        if s in {"1day", "1d", "day", "1 day"}:
+            return "1Day"
+        raise ValueError(f"Unsupported timeframe: {v}")
+
+    @field_validator("data_feed", mode="before")
+    @classmethod
+    def _norm_feed(cls, v: Any) -> str:
+        s = str(v).strip().lower()
+        if s in {"iex", "sip"}:
+            return s
+        raise ValueError(f"Unsupported data_feed: {v}")
+
+
+def _validate_startup_config() -> _StartupConfig:
+    """Validate runtime config and exit fast on errors."""
+
+    from ai_trading.config.management import get_env
+    from ai_trading.settings import get_settings
+
+    feed_default = get_settings().alpaca_data_feed
+    cfg = {
+        "timeframe": get_env("TIMEFRAME", "1Min"),
+        "data_feed": get_env("DATA_FEED", feed_default),
+    }
+    try:
+        return _StartupConfig(**cfg)
+    except ValidationError as e:  # pragma: no cover - exercised in tests
+        logger.error("CONFIG_VALIDATION_FAILED", extra={"errors": e.errors()})
+        raise SystemExit(f"Invalid configuration: {e}") from e
+
+
 def run_trade() -> None:
     """Entrypoint for live trading loop."""
 
@@ -65,6 +111,7 @@ def run_trade() -> None:
         logger.info("AI Trade: Dry run - exiting")
         logger.info("INDICATOR_IMPORT_OK")
         import logging, time
+
         time.sleep(0.1)
         logging.shutdown()
         sys.exit(0)
@@ -75,7 +122,9 @@ def run_trade() -> None:
     from ai_trading.env import ensure_dotenv_loaded
 
     ensure_dotenv_loaded()
+    _validate_startup_config()
     from ai_trading import main as _main
+
     _main.preflight_import_health()
 
     _run_loop(_main.run_cycle, args, "Trade")
@@ -90,6 +139,7 @@ def run_backtest() -> None:
         logger.info("AI Backtest: Dry run - exiting")
         logger.info("INDICATOR_IMPORT_OK")
         import logging, time
+
         time.sleep(0.1)
         logging.shutdown()
         sys.exit(0)
@@ -100,7 +150,9 @@ def run_backtest() -> None:
     from ai_trading.env import ensure_dotenv_loaded
 
     ensure_dotenv_loaded()
+    _validate_startup_config()
     from ai_trading import main as _main
+
     _main.preflight_import_health()
 
     _run_loop(_main.run_cycle, args, "Backtest")
@@ -115,6 +167,7 @@ def run_healthcheck() -> None:
         logger.info("AI Health: Dry run - exiting")
         logger.info("INDICATOR_IMPORT_OK")
         import logging, time
+
         time.sleep(0.1)
         logging.shutdown()
         sys.exit(0)
@@ -125,8 +178,10 @@ def run_healthcheck() -> None:
     from ai_trading.env import ensure_dotenv_loaded
 
     ensure_dotenv_loaded()
+    _validate_startup_config()
     from ai_trading.health_monitor import run_health_check
     from ai_trading import main as _main
+
     _main.preflight_import_health()
 
     _run_loop(run_health_check, args, "Health check")
@@ -141,6 +196,7 @@ def main() -> None:
         logger.info("AI Main: Dry run - exiting")
         logger.info("INDICATOR_IMPORT_OK")
         import logging, time
+
         time.sleep(0.1)
         logging.shutdown()
         sys.exit(0)
@@ -151,7 +207,9 @@ def main() -> None:
     from ai_trading.env import ensure_dotenv_loaded
 
     ensure_dotenv_loaded()
+    _validate_startup_config()
     from ai_trading import main as _main
+
     _main.preflight_import_health()
 
     _run_loop(_main.run_cycle, args, "Main")
@@ -171,4 +229,3 @@ if __name__ == "__main__":
     except Exception:
         logger.exception("unexpected startup error")
         raise
-

--- a/tests/test_startup_config_validation.py
+++ b/tests/test_startup_config_validation.py
@@ -1,0 +1,27 @@
+import pytest
+
+from ai_trading.__main__ import _validate_startup_config
+from ai_trading.settings import get_settings
+
+
+def _clear_settings_cache():
+    try:
+        get_settings.cache_clear()
+    except AttributeError:
+        pass
+
+
+def test_invalid_timeframe_raises(monkeypatch):
+    monkeypatch.setenv("TIMEFRAME", "10Min")
+    monkeypatch.setenv("DATA_FEED", "iex")
+    _clear_settings_cache()
+    with pytest.raises(SystemExit):
+        _validate_startup_config()
+
+
+def test_invalid_data_feed_raises(monkeypatch):
+    monkeypatch.setenv("TIMEFRAME", "1Min")
+    monkeypatch.setenv("DATA_FEED", "badfeed")
+    _clear_settings_cache()
+    with pytest.raises(SystemExit):
+        _validate_startup_config()


### PR DESCRIPTION
## Summary
- validate `DATA_FEED` and `TIMEFRAME` with a Pydantic model before any bot loop runs
- document startup validation in README
- test invalid config values fail fast

## Testing
- `python -m pre_commit run --files ai_trading/__main__.py tests/test_startup_config_validation.py README.md` *(fails: repo-guard -> ai_trading/strategy_allocator.py: mutable default; check-no-legacy-symbols script missing)*
- `ruff check ai_trading/__main__.py tests/test_startup_config_validation.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_startup_config_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af5fc1091c8330aefe0ac1d47262a8