### PR TITLE
Use parsed TimeFrame for StockBarsRequest

### DIFF
--- a/tests/test_daily_bars_datetime_sanitization.py
+++ b/tests/test_daily_bars_datetime_sanitization.py
@@ -6,13 +6,13 @@ import pytest
 
 pd = pytest.importorskip("pandas")
 
-from ai_trading.data.bars import StockBarsRequest, safe_get_stock_bars
+from ai_trading.data.bars import StockBarsRequest, TimeFrame, safe_get_stock_bars
 
 
 def test_request_timestamps_sanitized_and_passed_to_get_bars():
     start = datetime(2024, 1, 1, tzinfo=UTC)
     end = datetime(2024, 1, 2, tzinfo=UTC)
-    req = StockBarsRequest("SPY", "1Day", start=start, end=end, feed="sip")
+    req = StockBarsRequest("SPY", TimeFrame.Day, start=start, end=end, feed="sip")
 
     captured: dict[str, str] = {}
 
@@ -33,7 +33,7 @@ def test_request_timestamps_sanitized_and_passed_to_get_bars():
 def test_request_timestamps_sanitized_for_get_stock_bars():
     start = datetime(2024, 1, 3, tzinfo=UTC)
     end = datetime(2024, 1, 4, tzinfo=UTC)
-    req = StockBarsRequest("SPY", "1Day", start=start, end=end, feed="sip")
+    req = StockBarsRequest("SPY", TimeFrame.Day, start=start, end=end, feed="sip")
 
     captured: dict[str, str] = {}
 

--- a/tests/test_multi_symbol_request_no_validation.py
+++ b/tests/test_multi_symbol_request_no_validation.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import types
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading.data.bars import StockBarsRequest, safe_get_stock_bars
+from ai_trading.core import bot_engine as be
+
+
+def test_multi_symbol_stockbarsrequest_no_validation_error():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = datetime(2024, 1, 2, tzinfo=UTC)
+    req = StockBarsRequest(
+        symbol_or_symbols=["SPY", "AAPL"],
+        timeframe=be._parse_timeframe("1Day"),
+        start=start,
+        end=end,
+        feed="sip",
+    )
+
+    class DummyClient:
+        def get_stock_bars(self, request):  # pragma: no cover - simple stub
+            idx = pd.date_range(start, periods=1, tz="UTC")
+            data = {
+                ("SPY", "open"): [1.0],
+                ("SPY", "high"): [1.0],
+                ("SPY", "low"): [1.0],
+                ("SPY", "close"): [1.0],
+                ("SPY", "volume"): [1],
+                ("AAPL", "open"): [1.0],
+                ("AAPL", "high"): [1.0],
+                ("AAPL", "low"): [1.0],
+                ("AAPL", "close"): [1.0],
+                ("AAPL", "volume"): [1],
+            }
+            df = pd.DataFrame(data, index=idx)
+            df.columns = pd.MultiIndex.from_tuples(df.columns)
+            return types.SimpleNamespace(df=df)
+
+    df = safe_get_stock_bars(DummyClient(), req, symbol="SPY", context="TEST")
+    assert isinstance(df, pd.DataFrame)


### PR DESCRIPTION
## Summary
- replace string timeframes in daily bar sanitization tests with TimeFrame enums
- add regression test ensuring multi-symbol requests parse timeframe without ValidationError

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af6bbcc3b88330960d9ea826384d7a