### PR TITLE
Refactor max position size sourcing

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -76,11 +76,11 @@ except Exception:  # pragma: no cover - fallback when SDK missing
             raise RuntimeError("alpaca-py is required")
 
 from ai_trading.config.management import (
-    derive_cap_from_settings,
     get_env,
     is_shadow_mode,
     TradingConfig,
 )
+from ai_trading.position_sizing import get_max_position_size
 from ai_trading.settings import get_alpaca_secret_key_plain
 
 
@@ -3168,8 +3168,7 @@ LIMIT_ORDER_SLIPPAGE = params.get(
         getattr(state.mode_obj.config, "limit_order_slippage", 0.001),
     ),
 )
-_capital_cap = getattr(S, "capital_cap", getattr(state.mode_obj.config, "capital_cap", 0.04))
-MAX_POSITION_SIZE = derive_cap_from_settings(S, None, 8000.0, _capital_cap)
+MAX_POSITION_SIZE = get_max_position_size(S, state.mode_obj.config)
 SLICE_THRESHOLD = 50
 POV_SLICE_PCT = params.get(
     "POV_SLICE_PCT",

--- a/ai_trading/position_sizing.py
+++ b/ai_trading/position_sizing.py
@@ -207,3 +207,19 @@ def resolve_max_position_size(cfg, tcfg, *, force_refresh: bool=False) -> tuple[
     _CACHE.value, _CACHE.ts = (val, _now_utc())
     return (val, {'mode': mode, 'source': 'alpaca', 'equity': eq, 'capital_cap': cap, 'computed': computed, 'clamp_min': vmin, 'clamp_max': vmax, 'refreshed_at': _CACHE.ts.isoformat()})
 
+
+def get_max_position_size(cfg, tcfg, *, force_refresh: bool = False) -> float:
+    """Return only the resolved ``max_position_size`` value.
+
+    This is a thin convenience wrapper around :func:`resolve_max_position_size`
+    used by modules that only care about the numeric size and not the
+    accompanying metadata. Both the bot engine and external callers should use
+    this helper to ensure consistent sizing logic across the codebase.
+    """
+
+    val, _ = resolve_max_position_size(cfg, tcfg, force_refresh=force_refresh)
+    return val
+
+
+__all__ = ["resolve_max_position_size", "get_max_position_size"]
+

--- a/tests/test_bot_engine_position_size_consistency.py
+++ b/tests/test_bot_engine_position_size_consistency.py
@@ -1,0 +1,12 @@
+import importlib
+
+from ai_trading.position_sizing import get_max_position_size
+
+
+def test_bot_engine_and_position_sizing_agree(monkeypatch):
+    monkeypatch.delenv("AI_TRADING_MAX_POSITION_SIZE", raising=False)
+    be = importlib.reload(importlib.import_module("ai_trading.core.bot_engine"))
+    cfg = be.S
+    tcfg = be.state.mode_obj.config
+    assert be.MAX_POSITION_SIZE == get_max_position_size(cfg, tcfg)
+


### PR DESCRIPTION
## Summary
- add `get_max_position_size` helper in `position_sizing`
- have bot engine compute `MAX_POSITION_SIZE` using shared helper
- test that bot engine and sizing resolve to the same `max_position_size`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot_engine_position_size_consistency.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing optional test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68af766c2bc08330b5879a9bf04565d6