### PR TITLE
fix lint-core makefile tab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ tests-self:
 
 lint-core:
 	@echo "== ruff (core) =="
-        @ruff check ai_trading/main.py ai_trading/core/bot_engine.py ai_trading/process_manager.py
+	@ruff check ai_trading/main.py ai_trading/core/bot_engine.py ai_trading/process_manager.py
 
 .PHONY: scan-extras
 scan-extras:


### PR DESCRIPTION
## Summary
- ensure lint-core target uses a tab before the ruff invocation

## Testing
- `make test-all` *(fails: 99 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68af77687394833086d630f806e51da3