### PR TITLE
Ensure MAX_POSITION_SIZE is explicitly positive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,8 @@ MAX_DAILY_LOSS=0.05
 
 # Absolute USD cap per position (derived from CAPITAL_CAP if unset)
 MAX_POSITION_SIZE=5000
+# Alias used by pydantic Settings model
+AI_TRADING_MAX_POSITION_SIZE=5000
 # Optional: percentage cap per position (0.20 = 20% of portfolio)
 # MAX_POSITION_SIZE_PCT=0.20
 

--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,7 @@ TRADE_LOG_PATH=logs/trades.jsonl
 DOLLAR_RISK_LIMIT=0.05
 CAPITAL_CAP=0.04
 MAX_POSITION_SIZE=5000
+AI_TRADING_MAX_POSITION_SIZE=5000
 
 # Trading mode (use this; BOT_MODE is deprecated)
 TRADING_MODE=balanced

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -111,7 +111,14 @@ class Settings(BaseSettings):
     alpaca_adjustment: Literal['all', 'raw'] = Field('all', env='ALPACA_ADJUSTMENT')
     capital_cap: float = Field(0.04, env='CAPITAL_CAP')
     dollar_risk_limit: float = Field(0.05, env='DOLLAR_RISK_LIMIT')
-    max_position_size: float | None = Field(default=None, description='Absolute max dollars per position. If None, derive from equity * capital_cap; if equity unknown, use static fallback.', alias='MAX_POSITION_SIZE')
+    max_position_size: float | None = Field(
+        5000.0,
+        description=(
+            'Absolute max dollars per position. If None, derive from equity * '
+            'capital_cap; if equity unknown, use static fallback.'
+        ),
+        alias='MAX_POSITION_SIZE',
+    )
     max_position_equity_fallback: float = Field(
         200000.0,
         alias='MAX_POSITION_EQUITY_FALLBACK',


### PR DESCRIPTION
## Summary
- default `MAX_POSITION_SIZE` to a positive value
- document `AI_TRADING_MAX_POSITION_SIZE` in sample env files

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError: no module named 'hypothesis', etc.)*
- `python - <<'PY'
import os, logging
from ai_trading.config.management import TradingConfig
from ai_trading.settings import get_settings
from ai_trading.position_sizing import resolve_max_position_size
logging.basicConfig(level=logging.INFO)
os.environ['MAX_POSITION_SIZE']='5000'
os.environ['AI_TRADING_MAX_POSITION_SIZE']='5000'
get_settings.cache_clear()
settings=get_settings()
tcfg=TradingConfig.from_env()
val, meta=resolve_max_position_size(settings, tcfg)
print({'value':val, **meta})
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af7ac108608330b0175adbeb3c7e92