### PR TITLE
Handle missing pandas_ta dependency gracefully

### DIFF
--- a/ai_trading/features/prepare.py
+++ b/ai_trading/features/prepare.py
@@ -8,7 +8,15 @@ logger = logging.getLogger(__name__)
 MFI_PERIOD = 14
 
 def prepare_indicators(df: pd.DataFrame, freq: str='daily') -> pd.DataFrame:
-    ta = importlib.import_module('pandas_ta')
+    try:
+        ta = importlib.import_module('pandas_ta')
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        msg = (
+            "pandas_ta is required for indicator calculations. "
+            "Install it via `pip install pandas-ta` or include it from "
+            "requirements-extras-ta.txt."
+        )
+        raise ImportError(msg) from exc
     df = df.copy()
     rename_map = {}
     variants = {'high': ['High', 'HIGH', 'H', 'h'], 'low': ['Low', 'LOW', 'L', 'l'], 'close': ['Close', 'CLOSE', 'C', 'c'], 'open': ['Open', 'OPEN', 'O', 'o'], 'volume': ['Volume', 'VOLUME', 'V', 'v']}

--- a/requirements-extras-ta.txt
+++ b/requirements-extras-ta.txt
@@ -1,0 +1,4 @@
+# Optional technical analysis extras for Ubuntu 24.04 / CPython 3.12
+# AI-AGENT-REF: install only when WITH_TA=1
+# Install via: WITH_TA=1 pip install -r requirements-extras-ta.txt -c constraints.txt
+pandas-ta==0.3.14b0


### PR DESCRIPTION
## Summary
- ensure feature preparation raises a clear error when `pandas_ta` is absent
- add optional `requirements-extras-ta.txt` with pinned `pandas-ta`

## Testing
- `ruff check ai_trading/features/prepare.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

## Rollback
- Revert the commit

------
https://chatgpt.com/codex/tasks/task_e_68af7b46f6f883308137ffd4c20c6f11