### PR TITLE
Add training extras for model workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ pip install -e .
 # Optional RL extras
 # pip install -r requirements-extras-rl.txt
 
+# Optional training extras
+# pip install -r requirements-extras-train.txt
+# pip install ai-trading-bot[train]
+
 # Verify installation
 pip list | grep -E "(pandas|numpy|alpaca|scikit-learn)"
 ```
@@ -1410,6 +1414,14 @@ Environment="AI_TRADING_MODEL_PATH=/home/aiuser/ai-trading-bot/trained_model.pkl
 
 `trained_model.pkl` is expected at the project root when using
 `AI_TRADING_MODEL_PATH`. Generate it via the training workflow, for example:
+
+To install optional training dependencies (LightGBM, XGBoost, Optuna), run:
+
+```bash
+pip install ai-trading-bot[train]
+# or
+pip install -r requirements-extras-train.txt
+```
 
 ```bash
 python -m ai_trading.training.train_ml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,13 @@ ta = [
   "ta>=0.11.0",
   "TA-Lib>=0.4.26"
 ]
+train = [
+  "lightgbm==4.6.0",
+  "xgboost==3.0.4",
+  "optuna==4.5.0",
+]
 all = [
-  "ai-trading-bot[pandas,plot,ml,ta]"
+  "ai-trading-bot[pandas,plot,ml,ta,train]"
 ]
 test = ["pytest>=7.4", "pytest-cov>=4.1"]
 

--- a/requirements-extras-train.txt
+++ b/requirements-extras-train.txt
@@ -1,0 +1,6 @@
+# Optional training extras for Ubuntu 24.04 / CPython 3.12
+# AI-AGENT-REF: install only when WITH_TRAINING=1
+# Install via: pip install -r requirements-extras-train.txt (or `pip install ai-trading-bot[train]`)
+lightgbm==4.6.0
+xgboost==3.0.4
+optuna==4.5.0


### PR DESCRIPTION
## Summary
- add `train` optional dependencies with pinned LightGBM, XGBoost, and Optuna versions
- include `requirements-extras-train.txt` for standalone installation
- document how to install training extras in README

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68af7b4976388330875e2e62961f6f97