### PR TITLE
Enforce alpaca-py usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@
 - **Structured logging only**. Use existing JSON logging helpers; do not print().
 - **Use `runtime`** (an instance of `BotRuntime`) across hot paths. **Do not introduce `ctx`**.
 - Keep `ai_trading` imports stable; avoid dynamic `exec`/`eval`.
+- **Single Alpaca SDK**: use only `alpaca-py`. Remove legacy `alpaca-trade-api` (`pip uninstall -y alpaca-trade-api`).
 
 ## Runtime & Config
 - `TradingConfig`: read-only settings (broker creds, paths, limits).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY . .
-RUN pip install -r requirements.txt && pip install .[ml]
+RUN pip uninstall -y alpaca-trade-api || true \
+    && pip install -r requirements.txt \
+    && pip install .[ml]
 CMD ["python", "-m", "ai_trading"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Set `RUN_HEALTHCHECK=1` to launch the lightweight Flask app that serves:
 * `GET /metrics` &mdash; Prometheus metrics (returns **501** if metrics are disabled)
 
 Use **one** Alpaca SDK in production (recommended: `alpaca-py`).
+Remove legacy `alpaca-trade-api` if present (`pip uninstall -y alpaca-trade-api`).
 ### Self-check
 
 Verify Alpaca connectivity and data access:

--- a/ci/scripts/forbid_alpaca_trade_api.sh
+++ b/ci/scripts/forbid_alpaca_trade_api.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail if legacy alpaca-trade-api is installed
+if pip show alpaca-trade-api >/dev/null 2>&1; then
+  echo "alpaca-trade-api detected; only alpaca-py is supported" >&2
+  exit 1
+fi

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 # AI-AGENT-REF: install runtime and dev dependencies
+python -m pip uninstall -y alpaca-trade-api || true
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt -r requirements-dev.txt
+ci/scripts/forbid_alpaca_trade_api.sh
 
 # AI-AGENT-REF: lint and run tests
 ruff --select E9,F63,F7,F82,BLE001,DTZ005 --force-exclude . || true

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 # AI-AGENT-REF: install runtime + dev dependencies quickly
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+python -m pip uninstall -y alpaca-trade-api || true
 python -m pip install --upgrade pip
 python -m pip install -r "$ROOT_DIR/requirements-dev.txt"
+"$ROOT_DIR/ci/scripts/forbid_alpaca_trade_api.sh"
 
 echo "[bootstrap] dependencies installed" >&2

--- a/scripts/setup_dependencies.sh
+++ b/scripts/setup_dependencies.sh
@@ -3,6 +3,9 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+
 echo "Setting up system dependencies for AI Trading Bot..."
 
 # Detect the operating system
@@ -51,8 +54,10 @@ fi
 
 # Install Python dependencies
 echo "Installing Python dependencies..."
+pip uninstall -y alpaca-trade-api || true
 pip install --upgrade pip
 pip install -r requirements.txt
+"$ROOT_DIR/ci/scripts/forbid_alpaca_trade_api.sh"
 
 # Verify TA-Lib installation
 echo "Verifying TA-Lib installation..."


### PR DESCRIPTION
## Summary
- uninstall any `alpaca-trade-api` before installing dependencies and verify it's absent
- fail CI if legacy `alpaca-trade-api` sneaks into the environment
- document that only `alpaca-py` is supported

## Testing
- `python -m pip uninstall -y alpaca-trade-api || true`
- `python -m pip install -r requirements.txt -r requirements-dev.txt`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'ai_trading.data.sanitize')*


------
https://chatgpt.com/codex/tasks/task_e_68af7f57941883308b92e54183bb8231