### PR TITLE
Pin CUDA dependencies for torch RL extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ pip install -r requirements-test.txt -c constraints-dev.txt
 # Install project in editable mode
 pip install -e .
 
-# Optional RL extras
-# pip install -r requirements-extras-rl.txt
+# Optional RL extras (CUDA pins bundled to match torch)
+pip install -r requirements-extras-rl.txt -c constraints.txt -c constraints-dev.txt
 
 # Optional training extras
 # pip install -r requirements-extras-train.txt

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -20,6 +20,28 @@ joblib==1.5.1
     # via -r requirements/dev.txt
 korean-lunar-calendar==0.3.1
     # via exchange-calendars
+nvidia-cublas-cu12==12.1.3.1 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cuda-cupti-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cufft-cu12==11.0.2.54 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-curand-cu12==10.3.2.106 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-nccl-cu12==2.20.5 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-nvtx-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
 numpy==2.3.2
     # via
     #   -r requirements/dev.txt

--- a/constraints.txt
+++ b/constraints.txt
@@ -72,6 +72,28 @@ multidict==6.6.4
     # via
     #   aiohttp
     #   yarl
+nvidia-cublas-cu12==12.1.3.1 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cuda-cupti-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cufft-cu12==11.0.2.54 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-curand-cu12==10.3.2.106 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-nccl-cu12==2.20.5 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
+nvidia-nvtx-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+    # via torch
 numpy==1.26.4
     # via
     #   -r requirements.txt

--- a/requirements-extras-rl.txt
+++ b/requirements-extras-rl.txt
@@ -2,5 +2,17 @@
 # AI-AGENT-REF: install only when WITH_RL=1
 # Install via: WITH_RL=1 make test-collect-report  (or `make extras-rl`)
 torch==2.3.1
+# Explicit CUDA runtime pins to keep torch happy (avoid mismatch warnings)
+nvidia-cublas-cu12==12.1.3.1 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-cuda-cupti-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-cuda-runtime-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-cudnn-cu12==8.9.2.26 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-cufft-cu12==11.0.2.54 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-curand-cu12==10.3.2.106 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-cusolver-cu12==11.4.5.107 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-cusparse-cu12==12.1.0.106 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-nccl-cu12==2.20.5 ; platform_system == "Linux" and platform_machine == "x86_64"
+nvidia-nvtx-cu12==12.1.105 ; platform_system == "Linux" and platform_machine == "x86_64"
 stable-baselines3==2.3.2
 gymnasium==0.29.1


### PR DESCRIPTION
## Summary
- Pin torch's required CUDA packages in `requirements-extras-rl.txt`
- Add matching CUDA pins to `constraints.txt` and `constraints-dev.txt`
- Document RL extras install using constraints to honor the pins

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: cannot import project modules due to Python >=3.12 requirement)*

## Rollback Plan
- Revert commit `0cbd2bf5`

------
https://chatgpt.com/codex/tasks/task_e_68af7f590c708330ad45b38ca344ac6f