### PR TITLE
Pin CUDA runtime packages for RL extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ pip install -r requirements-test.txt -c constraints-dev.txt
 pip install -e .
 
 # Optional RL extras
-# pip install -r requirements-extras-rl.txt
+# WITH_RL=1 pip install -r requirements-extras-rl.txt -c constraints-dev.txt
 
 # Optional training extras
 # pip install -r requirements-extras-train.txt
@@ -255,6 +255,9 @@ pip install -e .
 # Verify installation
 pip list | grep -E "(pandas|numpy|alpaca|scikit-learn)"
 ```
+
+RL extras include NVIDIA CUDA libraries pinned for `torch==2.3.1`; pass
+`-c constraints-dev.txt` during installation to avoid CUDA mismatch warnings.
 
 ### Technical Analysis Library
 

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -107,6 +107,30 @@ numpy==1.26.4
     #   pandas
     #   scikit-learn
     #   scipy
+nvidia-cublas-cu12==12.1.3.1
+    # via torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via torch
+nvidia-nccl-cu12==2.20.5
+    # via torch
+nvidia-nvjitlink-cu12==12.9.86
+    # via nvidia-cusolver-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 packaging==24.1
     # via
     #   -r requirements-dev.txt

--- a/constraints.txt
+++ b/constraints.txt
@@ -80,6 +80,30 @@ numpy==1.26.4
     #   pandas
     #   scikit-learn
     #   scipy
+nvidia-cublas-cu12==12.1.3.1
+    # via torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via torch
+nvidia-nccl-cu12==2.20.5
+    # via torch
+nvidia-nvjitlink-cu12==12.9.86
+    # via nvidia-cusolver-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 packaging==25.0
     # via deprecation
 pandas==2.2.2

--- a/requirements-extras-rl.txt
+++ b/requirements-extras-rl.txt
@@ -2,5 +2,17 @@
 # AI-AGENT-REF: install only when WITH_RL=1
 # Install via: WITH_RL=1 make test-collect-report  (or `make extras-rl`)
 torch==2.3.1
+nvidia-cublas-cu12==12.1.3.1
+nvidia-cuda-runtime-cu12==12.1.105
+nvidia-cuda-nvrtc-cu12==12.1.105
+nvidia-cuda-cupti-cu12==12.1.105
+nvidia-cudnn-cu12==8.9.2.26
+nvidia-cufft-cu12==11.0.2.54
+nvidia-curand-cu12==10.3.2.106
+nvidia-cusolver-cu12==11.4.5.107
+nvidia-cusparse-cu12==12.1.0.106
+nvidia-nccl-cu12==2.20.5
+nvidia-nvtx-cu12==12.1.105
+nvidia-nvjitlink-cu12==12.9.86
 stable-baselines3==2.3.2
 gymnasium==0.29.1


### PR DESCRIPTION
## Summary
- pin NVIDIA CUDA packages alongside `torch==2.3.1` in `requirements-extras-rl.txt`
- mirror those CUDA pins in `constraints.txt` and `constraints-dev.txt`
- document RL extras installation using constraints to avoid CUDA mismatch warnings

## Testing
- `python -m pip install --dry-run -r requirements-extras-rl.txt -c constraints-dev.txt` *(terminated after large downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68af80fdb71083309033e64722fdf610