### PR TITLE
chore(ci): use Python 3.12 for bootstrap and smoke workflows

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Bootstrap deps
         run: bash scripts/bootstrap.sh
       - name: Compile

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with: { python-version: "3.12" }
       - run: pip install -U pip
       - run: pip install .[base] || pip install .
       - run: python -c "import ai_trading; import ai_trading.core.bot_engine; print('IMPORT_OK')"


### PR DESCRIPTION
## Summary
- bump bootstrap workflow to Python 3.12
- bump smoke workflow to Python 3.12
- confirm no workflows use older Python versions

## Testing
- `./run_checks.sh` *(fails: many test failures and interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68af91b1f4cc8330b359270d9e2a5ac1