### PR TITLE
chore: tighten workflow permissions and caching

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04
@@ -12,6 +15,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
       - name: Bootstrap deps
         run: bash scripts/bootstrap.sh
       - name: Compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-22.04
@@ -12,6 +15,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
       - name: Install deps
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           python-version: "3.12"
           cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-test.txt
 
       - name: Install deps
         run: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,12 +1,19 @@
 name: smoke
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
       - run: pip install -U pip
       - run: pip install .[base] || pip install .
       - run: python -c "import ai_trading; import ai_trading.core.bot_engine; print('IMPORT_OK')"


### PR DESCRIPTION
## Summary
- add explicit `contents: read` permissions to missing workflows
- enable pip caching with dependency paths in all Python setup steps

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*


------
https://chatgpt.com/codex/tasks/task_e_68af91b6615883308b3df28fdab47d55