### PR TITLE
Add audit-exceptions and legacy import scan targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,17 @@ scan-extras:
 	@echo "[make] strict scan for raw install hints"
 	@python tools/scan_extras_hints.py --strict
 
+.PHONY: audit-exceptions legacy-scan
+audit-exceptions:
+	@echo "== audit broad exceptions =="
+	@python tools/audit_exceptions.py --paths ai_trading > artifacts/audit-exceptions.json
+
+legacy-scan:
+	@echo "== legacy import scan =="
+	@ci/scripts/forbid_alpaca_trade_api.sh
+	@ci/scripts/forbid_legacy_imports.sh
+
+
 # Alias for developer convenience
 test: smoke
 


### PR DESCRIPTION
## Summary
- add `audit-exceptions` target to generate a report on broad exception handlers
- add `legacy-scan` target to forbid legacy imports and the deprecated `alpaca-trade-api`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*
- `make audit-exceptions`
- `make legacy-scan`


------
https://chatgpt.com/codex/tasks/task_e_68af91b59768833088e930819d4fb580