### PR TITLE
Add quick verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1475,6 +1475,7 @@ Environment variables controlling startup import checks:
 - `make smoke` — fast, non-blocking checks (lint, tiny test suite).
 - `make scan-extras` — strict scan for raw “install X” hints.
   Non-blocking variant also runs in smoke. To suppress a false positive on a single line, add `# extras:ignore` (or `<!-- extras:ignore -->` in docs).
+- `bash scripts/quick_verify.sh` — compile, lint, type-check, and run tests.
 
 
 ## Development quick start

--- a/scripts/quick_verify.sh
+++ b/scripts/quick_verify.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run fast sanity checks: compilation, lint, type-check, and tests.
+# Fails on usage of legacy imports or alpaca-trade-api.
+set -euo pipefail
+
+ci/scripts/forbid_alpaca_trade_api.sh
+ci/scripts/forbid_legacy_imports.sh
+
+python - <<'PY'
+import subprocess, sys, pathlib
+files = [str(p) for p in pathlib.Path('.').rglob('*.py')]
+subprocess.check_call([sys.executable, '-m', 'py_compile', *files])
+PY
+
+ruff check .
+export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+mypy ai_trading tests
+pytest -q


### PR DESCRIPTION
## Summary
- add `scripts/quick_verify.sh` to compile sources, lint, type check, and run tests
- document the script in README developer tools

## Testing
- `ruff check .`
- `ruff format --check ai_trading/__init__.py`
- `mypy ai_trading tests`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

------
https://chatgpt.com/codex/tasks/task_e_68af91b4a60c8330884f25bba3906811