### PR TITLE
ci: cache pip dependencies in workflows

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-22.04
@@ -12,6 +15,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
+            requirements/*.txt
       - name: Bootstrap deps
         run: bash scripts/bootstrap.sh
       - name: Compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-22.04
@@ -25,6 +28,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
+            requirements/*.txt
       - name: Install deps
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,12 +1,22 @@
 name: smoke
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.12" }
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
+            requirements/*.txt
       - run: pip install -U pip
       - run: pip install .[base] || pip install .
       - run: python -c "import ai_trading; import ai_trading.core.bot_engine; print('IMPORT_OK')"


### PR DESCRIPTION
## Summary
- cache Python deps in GitHub workflows
- limit CI workflow permissions to contents: read

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: many tests)*
- `RUN_HEALTHCHECK=1 python -m ai_trading.app &`
- `curl -sf http://127.0.0.1:9001/healthz`


------
https://chatgpt.com/codex/tasks/task_e_68af9aaee5808330bd8c80569f7d386a