### PR TITLE
Pin network deps and block legacy Alpaca API

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -14,6 +14,8 @@ alpaca-py==0.42.0
     # via
     #   -r requirements-dev.txt
     #   -r requirements.txt
+alpaca-trade-api==0
+    # avoid deprecated package
 annotated-types==0.7.0
     # via pydantic
 attrs==25.3.0
@@ -173,6 +175,8 @@ pydantic-settings==2.10.1
     # via -r requirements.txt
 pyluach==2.2.0
     # via exchange-calendars
+pyyaml==6.0.2
+    # via -r requirements.txt
 pytest==8.3.2
     # via
     #   -r requirements-dev.txt
@@ -260,6 +264,8 @@ tzdata==2025.2
     #   pandas-market-calendars
     #   pytz-deprecation-shim
 tzlocal==4.3
+    # via -r requirements.txt
+urllib3==2.5.0
     # via -r requirements.txt
 websockets==15.0.1
     # via alpaca-py

--- a/constraints.txt
+++ b/constraints.txt
@@ -14,6 +14,8 @@ aiosignal==1.4.0
     # via aiohttp
 alpaca-py==0.42.0
     # via -r requirements.txt
+alpaca-trade-api==0
+    # avoid deprecated package
 annotated-types==0.7.0
     # via pydantic
 attrs==25.3.0
@@ -66,7 +68,7 @@ markupsafe==3.0.2
     #   flask
     #   jinja2
     #   werkzeug
-msgpack==1.0.3
+msgpack==1.1.1
     # via alpaca-py
 multidict==6.6.4
     # via
@@ -134,6 +136,8 @@ pydantic-settings==2.10.1
     # via -r requirements.txt
 pyluach==2.2.0
     # via exchange-calendars
+pyyaml==6.0.2
+    # via -r requirements.txt
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements.txt
@@ -186,9 +190,11 @@ tzdata==2025.2
     #   pandas-market-calendars
 tzlocal==4.3
     # via -r requirements.txt
+urllib3==2.5.0
+    # via -r requirements.txt
 websocket-client==1.8.0
     # via alpaca-py
-websockets==10.4
+websockets==15.0.1
     # via alpaca-py
 werkzeug==3.1.3
     # via flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,10 @@ Flask>=3,<4
 beautifulsoup4>=4.12,<5
 lxml>=5,<6
 aiohttp>=3.9,<4
+msgpack>=1.1.1
+pyyaml>=6.0.2
+urllib3>=2.5.0
+websockets>=15.0.1
 # Explicit Pydantic v2 + settings
 pydantic==2.8.2
 pydantic-settings>=2.2,<3


### PR DESCRIPTION
## Summary
- forbid deprecated `alpaca-trade-api`
- pin msgpack, PyYAML, urllib3, and websockets versions in requirements
- align constraints with new pins and block legacy API

## Testing
- `pip uninstall -y alpaca-trade-api`
- `pip install -r requirements.txt -c constraints.txt`
- `pip check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: many tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68afa3e7ba508330bac909721ea0a39b