### PR TITLE
ci: use dev requirements only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
+          pip install -r requirements-dev.txt
       - name: Compile
         run: python - <<'PY'
 import subprocess, sys, pathlib


### PR DESCRIPTION
## Summary
- simplify CI setup by installing only development dependencies

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 AI_TRADING_OFFLINE_TESTS=1 ALPACA_API_KEY=test ALPACA_SECRET_KEY=test ALPACA_ENV=paper pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

## Rollback
- Revert commit `3c893a06`

------
https://chatgpt.com/codex/tasks/task_e_68afa8478e088330bde935b110fbca4e