### PR TITLE
Load timeout plugin when autoload disabled

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,7 @@ pandas-market-calendars>=4.4
 pytest>=8.2
 pytest-xdist>=3.6
 pytest-asyncio>=0.23
+pytest-timeout>=2.3
 pytest-cov>=5
 pytest-benchmark>=4.0
 hypothesis>=6.92


### PR DESCRIPTION
## Summary
- add pytest-timeout to test requirements
- ensure run_pytest explicitly loads pytest_timeout and pytest_asyncio when plugin autoload is disabled
- keep test-all using PYTEST_DISABLE_PLUGIN_AUTOLOAD=1

## Testing
- `ruff check tools/run_pytest.py`
- `make test-all` *(fails: ImportError: cannot import name 'Settings' from 'ai_trading.config.settings' (unknown location))*

------
https://chatgpt.com/codex/tasks/task_e_68afa8f208608330b784f268fb494535