### PR TITLE
Enable pytest asyncio when plugin autoload is off

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -9,6 +9,8 @@ ruff check .
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
 ```
 
+With plugin autoload disabled, `tools/run_pytest.py` explicitly enables asyncio support by adding the `pytest_asyncio` plugin so asynchronous tests have an event loop available.
+
 ## Table of Contents
 
 - [Testing Philosophy](#testing-philosophy)

--- a/tools/run_pytest.py
+++ b/tools/run_pytest.py
@@ -62,8 +62,10 @@ def build_pytest_cmd(args: argparse.Namespace) -> list[str]:
         # AI-AGENT-REF: suppress warnings for stable smoke output
         cmd += ["-W", "ignore"]
     if os.environ.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1":
-        # Under autoload-off, inject xdist only if available and not already present via addopts
         addopts = os.environ.get("PYTEST_ADDOPTS", "")
+        if ("-p pytest_asyncio" not in addopts) and (iu.find_spec("pytest_asyncio") is not None):
+            cmd += ["-p", "pytest_asyncio.plugin"]
+        # Under autoload-off, inject xdist only if available and not already present via addopts
         no_xdist = os.environ.get("NO_XDIST") == "1"
         if ("-p xdist.plugin" not in addopts) and (iu.find_spec("xdist") is not None) and not no_xdist:
             cmd += ["-p", "xdist.plugin", "-n", os.environ.get("PYTEST_XDIST_N", "auto")]


### PR DESCRIPTION
## Summary
- load `pytest_asyncio` explicitly in `run_pytest.py` when plugin autoload is disabled
- document explicit asyncio plugin loading in `TESTING_FRAMEWORK.md`

## Testing
- `ruff check tools/run_pytest.py`
- `python tools/run_pytest.py --files tmp_async_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afa8f495d88330922083dbab1b93df