### PR TITLE
Use compileall for Python bytecode in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
       - name: Compile
-        run: python - <<'PY'
-import subprocess, sys, pathlib
-files = [str(p) for p in pathlib.Path('.').rglob('*.py')]
-subprocess.check_call([sys.executable, '-m', 'py_compile', *files])
-PY
+        run: python -m compileall . -q
       - name: Lint + Format + Types
         run: |
           ruff --version


### PR DESCRIPTION
## Summary
- simplify Python compilation in CI by using `python -m compileall . -q`

## Testing
- `SKIP=repo-guard,check-no-legacy-symbols python -m pre_commit run --files .github/workflows/ci.yml`
- `ruff --version && ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: Timeout (0:02:00))*

------
https://chatgpt.com/codex/tasks/task_e_68afa8df61288330a49a32e1b7ebcce7