### PR TITLE
ci: mirror env vars in bootstrap

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -10,6 +10,12 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-22.04
+    env:
+      AI_TRADING_OFFLINE_TESTS: "1"
+      ALPACA_API_KEY: "test"
+      ALPACA_SECRET_KEY: "test"
+      # If your code looks at this to choose paper/live, force paper/offline
+      ALPACA_ENV: "paper"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- include Alpaca/offline env vars in bootstrap workflow test job

## Testing
- `ruff check .`
- `AI_TRADING_OFFLINE_TESTS=1 ALPACA_API_KEY=test ALPACA_SECRET_KEY=test ALPACA_ENV=paper pytest -q` *(fails: Timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68afaebfcd2483309679c762d322ab22