### PR TITLE
chore: compile tests during bootstrap

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Bootstrap deps
         run: bash scripts/bootstrap.sh
       - name: Compile
-        run: python -m compileall ai_trading
+        run: python -m compileall ai_trading tests -q
       - name: Test
         run: pytest -q
       - name: Runner import


### PR DESCRIPTION
## Summary
- ensure CI bootstrap workflow syntax-checks both source and tests

## Testing
- `bash run_checks.sh` *(fails: 258 failed, 636 passed, 18 skipped, 1 xfailed, 31 errors in 32.95s)*

------
https://chatgpt.com/codex/tasks/task_e_68afafd4ee248330b0ad32712003ced5