### PR TITLE
chore: stop uninstalling alpaca-trade-api

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 # AI-AGENT-REF: install runtime + dev dependencies quickly
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-python -m pip uninstall -y alpaca-trade-api || true
 python -m pip install --upgrade pip
 python -m pip install -r "$ROOT_DIR/requirements-dev.txt"
 "$ROOT_DIR/ci/scripts/forbid_alpaca_trade_api.sh"


### PR DESCRIPTION
## Summary
- drop legacy alpaca-trade-api uninstall step from bootstrap script

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68afb2fa3fa4833080eaca2b0c58f004