### PR TITLE
Add data fetch metrics counters

### DIFF
--- a/ai_trading/data/metrics.py
+++ b/ai_trading/data/metrics.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Metrics:
+    """Simple in-memory counters for data fetch events."""
+
+    rate_limit: int = 0
+    timeout: int = 0
+    unauthorized: int = 0
+    empty_payload: int = 0
+
+
+metrics = Metrics()
+
+__all__ = ["Metrics", "metrics"]


### PR DESCRIPTION
## Summary
- add simple Metrics dataclass tracking rate limit, timeout, unauthorized, and empty payload events
- expose metrics via `ai_trading.data.fetch` and increment counters during data fetches

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca' / skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68afb901fb308330a1544469af3b743b