### PR TITLE
Add indicator factory for dynamic creation

### DIFF
--- a/ai_trading/indicators/__init__.py
+++ b/ai_trading/indicators/__init__.py
@@ -1,0 +1,3 @@
+from .manager import IndicatorManager, Indicator
+
+__all__ = ["IndicatorManager", "Indicator"]

--- a/ai_trading/indicators/manager.py
+++ b/ai_trading/indicators/manager.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Protocol, Type
+
+from ai_trading.indicator_manager import (
+    StreamingSMA,
+    StreamingEMA,
+    StreamingRSI,
+    IncrementalSMA,
+    IncrementalEMA,
+    IncrementalRSI,
+)
+
+
+class Indicator(Protocol):
+    """Protocol for indicator implementations."""
+
+    def update(self, value: float) -> float | None:
+        """Update indicator with new value."""
+
+
+class IndicatorManager:
+    """Factory for creating indicator instances."""
+
+    _INDICATORS: dict[str, Type[Indicator]] = {
+        "sma": StreamingSMA,
+        "ema": StreamingEMA,
+        "rsi": StreamingRSI,
+        "incremental_sma": IncrementalSMA,
+        "incremental_ema": IncrementalEMA,
+        "incremental_rsi": IncrementalRSI,
+    }
+
+    def create_indicator(self, name: str, **params) -> Indicator:
+        """Instantiate an indicator by name.
+
+        Args:
+            name: Identifier of the indicator (case-insensitive).
+            **params: Parameters passed to the indicator's constructor.
+
+        Returns:
+            Indicator: Instantiated indicator object.
+
+        Raises:
+            ValueError: If the indicator name is unknown.
+        """
+        cls = self._INDICATORS.get(name.lower())
+        if cls is None:
+            raise ValueError(f"Unknown indicator: {name}")
+        return cls(**params)
+
+
+__all__ = ["Indicator", "IndicatorManager"]


### PR DESCRIPTION
## Summary
- add `IndicatorManager.create_indicator` factory
- expose `ai_trading.indicators` package

## Testing
- `python -m pip install -U pip`
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68afb907c2b08330923ae183e2154bf8