### PR TITLE
Add resilient Flask-based health check helper

### DIFF
--- a/ai_trading/health.py
+++ b/ai_trading/health.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Lightweight health check HTTP server utilities."""
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from flask import Flask, jsonify
+
+
+@dataclass(slots=True)
+class HealthCheck:
+    """Expose simple `/healthz` endpoint via an internal Flask app.
+
+    Parameters
+    ----------
+    ctx:
+        Optional context object. Attribute access is guarded so that missing
+        properties never raise :class:`AttributeError`.
+    config:
+        Optional configuration mapping passed to the internal Flask
+        application. If omitted, an empty dict is used which avoids `None`
+        lookups when applying configuration.
+    """
+
+    ctx: Any | None = None
+    config: dict[str, Any] | None = None
+    app: Flask = field(init=False)
+
+    def __post_init__(self) -> None:
+        # Ensure we always work with a mapping to avoid ``None`` handling logic
+        # throughout the class.
+        self.config = dict(self.config or {})
+
+        # Create the Flask app and apply the supplied configuration. Flask's
+        # ``config`` attribute is a mutable mapping so ``update`` is safe even
+        # when the dict is empty.
+        self.app = Flask(__name__)
+        self.app.config.update(self.config)
+
+        self._register_routes()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _get_ctx_attr(self, name: str, default: Any = None) -> Any:
+        """Safely fetch an attribute from the provided context object."""
+        if self.ctx is None:
+            return default
+        return getattr(self.ctx, name, default)
+
+    def _register_routes(self) -> None:
+        """Register default health route."""
+
+        @self.app.route("/healthz")
+        def _healthz() -> Any:  # pragma: no cover - simple glue
+            payload = {
+                "ok": True,
+                "ts": datetime.now(UTC).isoformat(),
+                "service": self._get_ctx_attr("service", "ai-trading"),
+            }
+            return jsonify(payload)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Run the health check web server.
+
+        Any missing context attributes (``host``/``port``) are guarded to
+        prevent ``AttributeError`` exceptions during startup.
+        """
+
+        host = self._get_ctx_attr("host", "0.0.0.0")
+        port = int(self._get_ctx_attr("port", 9001))
+        self.app.run(host=host, port=port)
+
+
+__all__ = ["HealthCheck"]

--- a/tests/test_health_module.py
+++ b/tests/test_health_module.py
@@ -1,0 +1,48 @@
+import importlib
+import sys
+import types
+
+
+def _install_flask_stub(monkeypatch):
+    import sys
+    stub = types.ModuleType("flask")
+
+    class _Flask:
+        def __init__(self, *a, **k):
+            self.config = {}
+
+        def route(self, *a, **k):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def run(self, *a, **k):
+            pass
+
+    stub.Flask = _Flask
+    stub.jsonify = lambda *a, **k: {}
+    monkeypatch.setitem(sys.modules, "flask", stub)
+
+
+def test_default_config_and_ctx_guard(monkeypatch):
+    import importlib
+    import sys
+    _install_flask_stub(monkeypatch)
+    importlib.reload(sys.modules.get("ai_trading.health", importlib.import_module("ai_trading.health")))
+    hc_mod = sys.modules["ai_trading.health"]
+    hc = hc_mod.HealthCheck()
+    assert hc.app.config == {}
+    hc.run()
+    monkeypatch.delitem(sys.modules, "ai_trading.health", raising=False)
+
+
+def test_custom_config_applied(monkeypatch):
+    import importlib
+    import sys
+    _install_flask_stub(monkeypatch)
+    importlib.reload(sys.modules.get("ai_trading.health", importlib.import_module("ai_trading.health")))
+    hc_mod = sys.modules["ai_trading.health"]
+    hc = hc_mod.HealthCheck(config={"DEBUG": True})
+    assert hc.app.config["DEBUG"] is True
+    monkeypatch.delitem(sys.modules, "ai_trading.health", raising=False)


### PR DESCRIPTION
## Summary
- add `HealthCheck` helper that spins up a Flask app with safe default config
- guard context attribute lookups to avoid `AttributeError`
- cover `HealthCheck` behavior with dedicated tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_health_module.py -q --noconftest`


------
https://chatgpt.com/codex/tasks/task_e_68afb90610208330a7eadf20b62fc9de