### PR TITLE
feat: default signal strength

### DIFF
--- a/ai_trading/strategies/base.py
+++ b/ai_trading/strategies/base.py
@@ -20,8 +20,20 @@ class StrategySignal:
     and metadata for institutional decision making.
     """
 
-    def __init__(self, symbol: str, side: OrderSide, strength: float, confidence: float=1.0, **kwargs):
-        """Initialize trading signal."""
+    def __init__(self, symbol: str, side: OrderSide, strength: float=1.0, confidence: float=1.0, **kwargs):
+        """Initialize trading signal.
+
+        Parameters
+        ----------
+        symbol : str
+            Asset ticker symbol.
+        side : OrderSide
+            Direction of the trade (``OrderSide.BUY`` or ``OrderSide.SELL``).
+        strength : float, optional
+            Raw signal strength in the ``[0, 1]`` range. Defaults to ``1.0``.
+        confidence : float, optional
+            Confidence weight in the ``[0, 1]`` range. Defaults to ``1.0``.
+        """
         self.id = str(uuid.uuid4())
         self.symbol = symbol
         self.side = side

--- a/ai_trading/strategies/moving_average_crossover.py
+++ b/ai_trading/strategies/moving_average_crossover.py
@@ -46,4 +46,4 @@ class MovingAverageCrossoverStrategy:
         action = self._latest_cross(short, long)
         if not action:
             return []
-        return [StrategySignal(symbol=sym, side=action, strength=1.0)]
+        return [StrategySignal(symbol=sym, side=action)]


### PR DESCRIPTION
## Summary
- default StrategySignal strength to 1.0
- use default strength in moving-average crossover strategy

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'alpaca', tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68afb90883e88330964ca1530953e847