### PR TITLE
Expose bot context property on engine

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -514,6 +514,13 @@ class BotEngine:
 
     def __init__(self) -> None:
         self.logger = get_logger(__name__)
+        # Expose the lazily-initialized global context through this engine
+        self._ctx = get_ctx()
+
+    @property
+    def ctx(self):
+        """Return the lazily-initialized bot context."""
+        return self._ctx
 
     @cached_property
     def trading_client(self):


### PR DESCRIPTION
## Summary
- expose lazily-initialized bot context via `BotEngine.ctx`
- initialize `_ctx` during engine setup

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68afb90c06a08330b62c84174e3af3e5