### PR TITLE
refactor: add staleness guard module

### DIFF
--- a/ai_trading/guards/__init__.py
+++ b/ai_trading/guards/__init__.py
@@ -1,0 +1,3 @@
+from .staleness import ensure_data_fresh, _ensure_data_fresh
+
+__all__ = ["ensure_data_fresh", "_ensure_data_fresh"]

--- a/ai_trading/guards/staleness.py
+++ b/ai_trading/guards/staleness.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Sequence
+from zoneinfo import ZoneInfo
+
+from ai_trading.utils.lazy_imports import load_pandas
+
+pd = load_pandas()
+logger = logging.getLogger(__name__)
+
+
+def _ensure_data_fresh(
+    df: pd.DataFrame | None,
+    max_age_seconds: int,
+    *,
+    symbol: str | None = None,
+    now: datetime | None = None,
+    tz: str | ZoneInfo | None = None,
+) -> None:
+    """Raise ``RuntimeError`` if ``df`` is stale or empty.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing market data. Must have a DatetimeIndex or a
+        ``timestamp`` column.
+    max_age_seconds:
+        Maximum allowed age in seconds for the most recent data point.
+    symbol:
+        Optional symbol used in log messages and error context.
+    now:
+        Current time. Defaults to ``datetime.now`` in ``tz``.
+    tz:
+        Timezone for ``now``. Accepts ``ZoneInfo`` or a string identifier.
+    """
+    if df is None or getattr(df, "empty", True):
+        raise RuntimeError("no_data")
+
+    # Determine "now" with timezone handling
+    if tz is None:
+        tzinfo = UTC
+    elif isinstance(tz, str):
+        tzinfo = ZoneInfo(tz)
+    else:
+        tzinfo = tz
+    now = now or datetime.now(tzinfo)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=tzinfo)
+
+    # Extract timestamp from index or column
+    if isinstance(df.index, pd.DatetimeIndex) and len(df.index) > 0:
+        last_ts = df.index[-1]
+    elif "timestamp" in df.columns and len(df) > 0:
+        last_ts = pd.to_datetime(df["timestamp"].iloc[-1])
+    else:
+        raise RuntimeError("no_timestamp")
+
+    if last_ts.tzinfo is None:
+        last_ts = last_ts.replace(tzinfo=UTC)
+
+    age_secs = int((now - last_ts.astimezone(now.tzinfo)).total_seconds())
+    if age_secs > max_age_seconds:
+        raise RuntimeError(f"age={age_secs}s")
+
+    logger.debug("Data freshness OK [UTC now=%s]", now.astimezone(UTC).isoformat())
+
+
+def ensure_data_fresh(
+    fetcher: object,
+    symbols: Sequence[str],
+    max_age_seconds: int,
+    *,
+    now: datetime | None = None,
+    tz: str | ZoneInfo | None = None,
+) -> None:
+    """Validate freshness for each symbol using ``fetcher.get_minute_df``.
+
+    Raises ``RuntimeError`` summarizing any stale symbols.
+    """
+    if tz is None:
+        tzinfo = UTC
+    elif isinstance(tz, str):
+        tzinfo = ZoneInfo(tz)
+    else:
+        tzinfo = tz
+    now = now or datetime.now(tzinfo)
+    start = now - timedelta(minutes=1)
+    stale: list[str] = []
+
+    for sym in symbols:
+        try:
+            df = fetcher.get_minute_df(sym, start, now)
+        except Exception as e:  # noqa: BLE001 - propagate as runtime error
+            stale.append(f"{sym}(error={e})")
+            continue
+        try:
+            _ensure_data_fresh(
+                df,
+                max_age_seconds,
+                symbol=sym,
+                now=now,
+                tz=tzinfo,
+            )
+        except RuntimeError as e:
+            stale.append(f"{sym}({e})")
+
+    if stale:
+        details = ", ".join(stale)
+        logger.warning(
+            "Data staleness detected [UTC now=%s]: %s",
+            now.astimezone(UTC).isoformat(),
+            details,
+        )
+        raise RuntimeError(f"Stale data for symbols: {details}")
+
+    logger.debug("Data freshness OK [UTC now=%s]", now.astimezone(UTC).isoformat())

--- a/scripts/problem_statement_validation.py
+++ b/scripts/problem_statement_validation.py
@@ -89,13 +89,11 @@ def check_minute_cache():
         assert 'def get_cached_minute_timestamp' in content
         assert 'def last_minute_bar_age_seconds' in content
         logging.info('  - Exported helpers from ai_trading.data.fetch ✓')
-    bot_engine_path = Path('ai_trading/core/bot_engine.py')
-    if bot_engine_path.exists():
-        content = bot_engine_path.read_text()
-        assert 'def _ensure_data_fresh(symbols, max_age_seconds: int)' in content
-        assert 'from ai_trading.data.fetch import last_minute_bar_age_seconds' in content
-        assert 'utc_now_iso()' in content
-        logging.info('  - Fail fast in bot_engine.py when cached minute data is stale ✓')
+    staleness_path = Path('ai_trading/guards/staleness.py')
+    if staleness_path.exists():
+        content = staleness_path.read_text()
+        assert 'def _ensure_data_fresh(' in content
+        logging.info('  - Fail fast when cached data is stale ✓')
         logging.info('  - Logs UTC timestamps ✓')
 
 def check_new_env_vars():

--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 from ai_trading.core import bot_engine
+from ai_trading.guards import staleness
 
 
 def _sample_df():
@@ -10,7 +11,7 @@ def _sample_df():
 
 def test_fetch_minute_df_safe_returns_dataframe(monkeypatch):
     monkeypatch.setattr(bot_engine, "get_minute_df", lambda s, start, end: _sample_df())
-    monkeypatch.setattr(bot_engine, "_ensure_data_fresh", lambda symbols, max_age_seconds: None)
+    monkeypatch.setattr(staleness, "_ensure_data_fresh", lambda df, max_age_seconds, *, symbol=None, now=None, tz=None: None)
     result = bot_engine.fetch_minute_df_safe("AAPL")
     assert isinstance(result, pd.DataFrame)
     assert not result.empty
@@ -18,6 +19,6 @@ def test_fetch_minute_df_safe_returns_dataframe(monkeypatch):
 
 def test_fetch_minute_df_safe_raises_on_empty(monkeypatch):
     monkeypatch.setattr(bot_engine, "get_minute_df", lambda s, start, end: pd.DataFrame())
-    monkeypatch.setattr(bot_engine, "_ensure_data_fresh", lambda symbols, max_age_seconds: None)
+    monkeypatch.setattr(staleness, "_ensure_data_fresh", lambda df, max_age_seconds, *, symbol=None, now=None, tz=None: None)
     with pytest.raises(bot_engine.DataFetchError):
         bot_engine.fetch_minute_df_safe("AAPL")

--- a/tests/test_staleness_guard.py
+++ b/tests/test_staleness_guard.py
@@ -1,209 +1,101 @@
-"""
-Tests for data staleness guard functionality.
-"""
+"""Tests for data staleness guard functionality."""
 import datetime
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
 pd = pytest.importorskip("pandas")
+
+from ai_trading.guards.staleness import ensure_data_fresh, _ensure_data_fresh
 
 
 class TestStalenessGuard:
     """Test data staleness validation functionality."""
 
     def test_staleness_guard_fresh_data(self):
-        """Test staleness guard with fresh data."""
-        # Import the function we're testing
-        from ai_trading.core.bot_engine import _ensure_data_fresh
-
-        # Create a mock fetcher that returns fresh data
+        """Fresh data should not raise."""
         now = datetime.datetime.now(datetime.UTC)
-        fresh_timestamp = now - datetime.timedelta(seconds=30)  # 30 seconds old
-
-        # Create test dataframe with fresh timestamp
-        df = pd.DataFrame({
-            'open': [100.0],
-            'high': [101.0],
-            'low': [99.0],
-            'close': [100.5],
-            'volume': [1000],
-            'timestamp': [fresh_timestamp]
-        })
-
-        # Mock fetcher
+        fresh_ts = now - datetime.timedelta(seconds=30)
+        df = pd.DataFrame({"timestamp": [fresh_ts], "close": [100.0]})
         mock_fetcher = Mock()
         mock_fetcher.get_minute_df = Mock(return_value=df)
-
-        # Should not raise any exception for fresh data
-        try:
-            _ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
-            success = True
-        except (ValueError, TypeError):
-            success = False
-
-        assert success, "Should not raise exception for fresh data"
+        ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
 
     def test_staleness_guard_stale_data(self):
-        """Test staleness guard with stale data."""
-        from ai_trading.core.bot_engine import _ensure_data_fresh
-
-        # Create a mock fetcher that returns stale data
+        """Stale data should raise runtime error."""
         now = datetime.datetime.now(datetime.UTC)
-        stale_timestamp = now - datetime.timedelta(seconds=600)  # 10 minutes old
-
-        # Create test dataframe with stale timestamp
-        df = pd.DataFrame({
-            'open': [100.0],
-            'high': [101.0],
-            'low': [99.0],
-            'close': [100.5],
-            'volume': [1000],
-            'timestamp': [stale_timestamp]
-        })
-
-        # Mock fetcher
+        stale_ts = now - datetime.timedelta(seconds=600)
+        df = pd.DataFrame({"timestamp": [stale_ts], "close": [100.0]})
         mock_fetcher = Mock()
         mock_fetcher.get_minute_df = Mock(return_value=df)
-
-        # Should raise RuntimeError for stale data
         with pytest.raises(RuntimeError, match="Stale data for symbols"):
-            _ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
+            ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
 
     def test_staleness_guard_no_data(self):
-        """Test staleness guard with no data."""
-        from ai_trading.core.bot_engine import _ensure_data_fresh
-
-        # Mock fetcher that returns None/empty data
+        """None from fetcher should raise."""
         mock_fetcher = Mock()
         mock_fetcher.get_minute_df = Mock(return_value=None)
-
-        # Should raise RuntimeError for no data
         with pytest.raises(RuntimeError, match="Stale data for symbols"):
-            _ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
+            ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
 
     def test_staleness_guard_empty_dataframe(self):
-        """Test staleness guard with empty dataframe."""
-        from ai_trading.core.bot_engine import _ensure_data_fresh
-
-        # Mock fetcher that returns empty dataframe
+        """Empty dataframe should raise."""
         mock_fetcher = Mock()
         mock_fetcher.get_minute_df = Mock(return_value=pd.DataFrame())
-
-        # Should raise RuntimeError for empty data
         with pytest.raises(RuntimeError, match="Stale data for symbols"):
-            _ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
+            ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
 
     def test_staleness_guard_multiple_symbols(self):
-        """Test staleness guard with multiple symbols."""
-        from ai_trading.core.bot_engine import _ensure_data_fresh
-
+        """Mix of fresh, stale, and missing symbols should report all."""
         now = datetime.datetime.now(datetime.UTC)
 
-        # Create mock fetcher that returns different data for different symbols
         def mock_get_minute_df(symbol, start, end):
             if symbol == "AAPL":
-                # Fresh data for AAPL
                 fresh_ts = now - datetime.timedelta(seconds=30)
-                return pd.DataFrame({
-                    'timestamp': [fresh_ts],
-                    'close': [150.0]
-                })
-            elif symbol == "MSFT":
-                # Stale data for MSFT
+                return pd.DataFrame({"timestamp": [fresh_ts], "close": [150.0]})
+            if symbol == "MSFT":
                 stale_ts = now - datetime.timedelta(seconds=600)
-                return pd.DataFrame({
-                    'timestamp': [stale_ts],
-                    'close': [300.0]
-                })
-            else:
-                # No data for other symbols
-                return None
+                return pd.DataFrame({"timestamp": [stale_ts], "close": [300.0]})
+            return None
 
         mock_fetcher = Mock()
         mock_fetcher.get_minute_df = Mock(side_effect=mock_get_minute_df)
-
-        # Should raise RuntimeError mentioning the stale symbol
         with pytest.raises(RuntimeError) as exc_info:
-            _ensure_data_fresh(mock_fetcher, ["AAPL", "MSFT", "GOOGL"], max_age_seconds=300)
-
-        error_msg = str(exc_info.value)
-        assert "MSFT" in error_msg, "Error should mention MSFT as stale"
-        assert "GOOGL" in error_msg, "Error should mention GOOGL as having no data"
+            ensure_data_fresh(
+                mock_fetcher,
+                ["AAPL", "MSFT", "GOOGL"],
+                max_age_seconds=300,
+            )
+        msg = str(exc_info.value)
+        assert "MSFT" in msg
+        assert "GOOGL" in msg
 
     def test_staleness_guard_utc_logging(self):
-        """Test that staleness guard logs UTC timestamps."""
-        from unittest.mock import patch
-
-        from ai_trading.core.bot_engine import _ensure_data_fresh
-
-        # Mock logger to capture log messages
-        with patch('ai_trading.core.bot_engine.logger') as mock_logger:
+        """Ensure logging uses UTC timestamps."""
+        with patch("ai_trading.guards.staleness.logger") as mock_logger:
             now = datetime.datetime.now(datetime.UTC)
-            fresh_timestamp = now - datetime.timedelta(seconds=30)
-
-            df = pd.DataFrame({
-                'timestamp': [fresh_timestamp],
-                'close': [100.0]
-            })
-
-            mock_fetcher = Mock()
-            mock_fetcher.get_minute_df = Mock(return_value=df)
-
-            # Call the function
-            _ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
-
-            # Verify debug log was called with UTC timestamp
+            fresh_ts = now - datetime.timedelta(seconds=30)
+            df = pd.DataFrame({"timestamp": [fresh_ts], "close": [100.0]})
+            _ensure_data_fresh(df, 300, symbol="AAPL", now=now)
             mock_logger.debug.assert_called()
-            debug_call_args = mock_logger.debug.call_args[0]
-            assert "UTC now=" in debug_call_args[0], "Should log UTC timestamp"
-
-            # Verify the timestamp format is ISO
-            assert "T" in debug_call_args[1], "Should use ISO format timestamp"
+            args = mock_logger.debug.call_args[0]
+            assert "UTC now=" in args[0]
+            assert "T" in args[1]
 
     def test_staleness_guard_timezone_handling(self):
-        """Test staleness guard handles timezone-aware and naive timestamps."""
-        from ai_trading.core.bot_engine import _ensure_data_fresh
-
+        """Handle naive and aware timestamps."""
         now = datetime.datetime.now(datetime.UTC)
-
-        # Test with timezone-naive timestamp (should be treated as UTC)
-        naive_timestamp = datetime.datetime.now(datetime.UTC).replace(tzinfo=None) - datetime.timedelta(seconds=30)  # AI-AGENT-REF: Create naive datetime from UTC
-        df_naive = pd.DataFrame({
-            'timestamp': [naive_timestamp],
-            'close': [100.0]
-        })
-
-        # Test with timezone-aware timestamp
-        aware_timestamp = (now - datetime.timedelta(seconds=30)).replace(tzinfo=datetime.UTC)
-        df_aware = pd.DataFrame({
-            'timestamp': [aware_timestamp],
-            'close': [100.0]
-        })
-
-        mock_fetcher = Mock()
-
-        # Test both cases should work without error
-        for df in [df_naive, df_aware]:
-            mock_fetcher.get_minute_df = Mock(return_value=df)
-            try:
-                _ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
-                success = True
-            except (ValueError, TypeError):
-                success = False
-            assert success, "Should handle both timezone-aware and naive timestamps"
+        naive_ts = (now - datetime.timedelta(seconds=30)).replace(tzinfo=None)
+        aware_ts = now - datetime.timedelta(seconds=30)
+        df_naive = pd.DataFrame({"timestamp": [naive_ts], "close": [100.0]})
+        df_aware = pd.DataFrame({"timestamp": [aware_ts], "close": [100.0]})
+        for df in (df_naive, df_aware):
+            _ensure_data_fresh(df, 300, symbol="AAPL", now=now)
 
     def test_staleness_guard_error_handling(self):
-        """Test staleness guard handles fetcher errors gracefully."""
-        from ai_trading.core.bot_engine import _ensure_data_fresh
-
-        # Mock fetcher that raises an exception
+        """Fetcher exceptions should propagate details."""
         mock_fetcher = Mock()
         mock_fetcher.get_minute_df = Mock(side_effect=Exception("Network error"))
-
-        # Should raise RuntimeError with error details
         with pytest.raises(RuntimeError) as exc_info:
-            _ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
-
-        error_msg = str(exc_info.value)
-        assert "error=" in error_msg, "Should include error details in message"
+            ensure_data_fresh(mock_fetcher, ["AAPL"], max_age_seconds=300)
+        assert "error=" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- add `ai_trading.guards.staleness` with `_ensure_data_fresh` and `ensure_data_fresh`
- update `fetch_minute_df_safe` to call new guard with keyword arguments
- adjust validation script and tests for new guard API

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; then skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68afb90ea8f88330bb4a09ea1be14ca4