### PR TITLE
Add StrategyAllocator config replacement helper

### DIFF
--- a/ai_trading/strategy_allocator.py
+++ b/ai_trading/strategy_allocator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+from dataclasses import replace
 import logging
 from typing import Any
 
@@ -31,6 +32,13 @@ class StrategyAllocator:
         self.last_direction: dict[str, str] = {}
         self.last_confidence: dict[str, float] = {}
         self.hold_protect: dict[str, int] = {}
+
+    def replace_config(self, **changes: Any) -> TradingConfig:
+        """Return new TradingConfig with ``changes`` applied and set it."""
+        new_cfg = replace(self.config, **changes) if changes else replace(self.config)
+        self.config = copy.deepcopy(new_cfg)
+        self._ensure_config_attributes()
+        return self.config
 
     def _ensure_config_attributes(self) -> None:
         """Ensure config has required attributes with sensible defaults."""

--- a/tests/test_logging_behavior.py
+++ b/tests/test_logging_behavior.py
@@ -56,7 +56,7 @@ def test_cooldown_expired_throttle(monkeypatch, caplog):
     from ai_trading import strategy_allocator  # AI-AGENT-REF: normalized import
     strategy_allocator = importlib.reload(strategy_allocator)
     alloc = strategy_allocator.StrategyAllocator()
-    alloc.config.signal_confirmation_bars = 1  # Allow single confirmation
+    alloc.replace_config(signal_confirmation_bars=1)  # Allow single confirmation
     alloc.hold_protect = {"AAPL": 1}
     # Use a sell signal to test hold_protect functionality
     sig = TradeSignal(symbol="AAPL", side="sell", confidence=1.0, strategy="s")

--- a/tests/test_strategy_allocator_exit.py
+++ b/tests/test_strategy_allocator_exit.py
@@ -33,8 +33,10 @@ def test_exit_confirmation(ensure_real_strategy_allocator):
     strategy_allocator = ensure_real_strategy_allocator
     alloc = strategy_allocator.StrategyAllocator()
     # Explicitly set configuration to ensure test isolation
-    alloc.config.delta_threshold = 0.0  # Allow repeated signals with same confidence
-    alloc.config.signal_confirmation_bars = 2  # Ensure we have expected confirmation bars
+    alloc.replace_config(
+        delta_threshold=0.0,  # Allow repeated signals with same confidence
+        signal_confirmation_bars=2,  # Ensure we have expected confirmation bars
+    )
 
     buy = TradeSignal(symbol="A", side="buy", confidence=1.0, strategy="s")
     sell = TradeSignal(symbol="A", side="sell", confidence=1.0, strategy="s")

--- a/tests/test_strategy_allocator_regression.py
+++ b/tests/test_strategy_allocator_regression.py
@@ -6,6 +6,8 @@ confirmation bug that was causing test_allocator to fail with empty results
 on the second call when min_confidence=0.0.
 """
 
+from types import SimpleNamespace
+
 from ai_trading import strategy_allocator  # AI-AGENT-REF: normalized import
 from ai_trading.strategies import TradeSignal
 
@@ -23,9 +25,11 @@ class TestStrategyAllocatorRegression:
         alloc = strategy_allocator.StrategyAllocator()
 
         # Set exact configuration from original failing test
-        alloc.config.delta_threshold = 0.0
-        alloc.config.signal_confirmation_bars = 2
-        alloc.config.min_confidence = 0.0
+        alloc.replace_config(
+            delta_threshold=0.0,
+            signal_confirmation_bars=2,
+            min_confidence=0.0,
+        )
 
         sig = TradeSignal(symbol="AAPL", side="buy", confidence=1.0, strategy="s1")
 
@@ -46,14 +50,8 @@ class TestStrategyAllocatorRegression:
         Previously, if min_confidence was missing from config, it could cause
         AttributeError or incorrect behavior.
         """
-        alloc = strategy_allocator.StrategyAllocator()
-
-        # Remove min_confidence attribute to simulate missing config
-        if hasattr(alloc.config, 'min_confidence'):
-            delattr(alloc.config, 'min_confidence')
-
-        alloc.config.delta_threshold = 0.0
-        alloc.config.signal_confirmation_bars = 2
+        cfg = SimpleNamespace(delta_threshold=0.0, signal_confirmation_bars=2)
+        alloc = strategy_allocator.StrategyAllocator(config=cfg)
 
         sig = TradeSignal(symbol="AAPL", side="buy", confidence=1.0, strategy="s1")
 
@@ -74,9 +72,11 @@ class TestStrategyAllocatorRegression:
         """
         alloc = strategy_allocator.StrategyAllocator()
 
-        alloc.config.min_confidence = None
-        alloc.config.delta_threshold = 0.0
-        alloc.config.signal_confirmation_bars = 2
+        alloc.replace_config(
+            min_confidence=None,
+            delta_threshold=0.0,
+            signal_confirmation_bars=2,
+        )
 
         sig = TradeSignal(symbol="AAPL", side="buy", confidence=1.0, strategy="s1")
 
@@ -106,9 +106,11 @@ class TestStrategyAllocatorRegression:
 
         for min_conf, sig_conf, should_confirm in test_cases:
             alloc = strategy_allocator.StrategyAllocator()
-            alloc.config.delta_threshold = 0.0
-            alloc.config.signal_confirmation_bars = 2
-            alloc.config.min_confidence = min_conf
+            alloc.replace_config(
+                delta_threshold=0.0,
+                signal_confirmation_bars=2,
+                min_confidence=min_conf,
+            )
 
             sig = TradeSignal(symbol="AAPL", side="buy", confidence=sig_conf, strategy="s1")
 
@@ -129,9 +131,11 @@ class TestStrategyAllocatorRegression:
         and don't cause the confirmation logic to fail.
         """
         alloc = strategy_allocator.StrategyAllocator()
-        alloc.config.delta_threshold = 0.0
-        alloc.config.signal_confirmation_bars = 2
-        alloc.config.min_confidence = 0.0
+        alloc.replace_config(
+            delta_threshold=0.0,
+            signal_confirmation_bars=2,
+            min_confidence=0.0,
+        )
 
         # Test high confidence (> 1.0)
         sig_high = TradeSignal(symbol="AAPL", side="buy", confidence=2.0, strategy="s1")
@@ -145,9 +149,11 @@ class TestStrategyAllocatorRegression:
 
         # Test negative confidence
         alloc_fresh = strategy_allocator.StrategyAllocator()
-        alloc_fresh.config.delta_threshold = 0.0
-        alloc_fresh.config.signal_confirmation_bars = 2
-        alloc_fresh.config.min_confidence = 0.0
+        alloc_fresh.replace_config(
+            delta_threshold=0.0,
+            signal_confirmation_bars=2,
+            min_confidence=0.0,
+        )
 
         sig_neg = TradeSignal(symbol="AAPL", side="buy", confidence=-0.5, strategy="s1")
 
@@ -167,9 +173,11 @@ class TestStrategyAllocatorRegression:
         """
         for i in range(3):
             alloc = strategy_allocator.StrategyAllocator()
-            alloc.config.delta_threshold = 0.0
-            alloc.config.signal_confirmation_bars = 2
-            alloc.config.min_confidence = 0.0
+            alloc.replace_config(
+                delta_threshold=0.0,
+                signal_confirmation_bars=2,
+                min_confidence=0.0,
+            )
 
             sig = TradeSignal(symbol="AAPL", side="buy", confidence=1.0, strategy="s1")
 

--- a/tests/test_strategy_allocator_smoke.py
+++ b/tests/test_strategy_allocator_smoke.py
@@ -17,9 +17,11 @@ def test_allocator():
     alloc = strategy_allocator.StrategyAllocator()
 
     # Configuration that properly tests signal confirmation workflow
-    alloc.config.delta_threshold = 0.0        # Allow repeated signals
-    alloc.config.signal_confirmation_bars = 2  # Require 2 bars for proper confirmation testing
-    alloc.config.min_confidence = 0.0         # Ensure confidence threshold is met
+    alloc.replace_config(
+        delta_threshold=0.0,  # Allow repeated signals
+        signal_confirmation_bars=2,  # Require 2 bars for proper confirmation testing
+        min_confidence=0.0,  # Ensure confidence threshold is met
+    )
 
     # AI-AGENT-REF: Add defensive verification to ensure config is applied correctly
     assert alloc.config.signal_confirmation_bars == 2, f"Expected signal_confirmation_bars=2, got {alloc.config.signal_confirmation_bars}"


### PR DESCRIPTION
## Summary
- add `replace_config` method so StrategyAllocator can update its frozen TradingConfig safely
- switch allocator tests to use `replace_config` instead of mutating config attributes directly

## Testing
- `ruff check ai_trading/strategy_allocator.py tests/test_logging_behavior.py tests/test_strategy_allocator_smoke.py tests/test_strategy_allocator_exit.py tests/test_strategy_allocator_regression.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn', 'pydantic_settings', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68afb90fd53c833086e622d7cf79ff68