### PR TITLE
feat: centralize env validation helpers

### DIFF
--- a/ai_trading/config/__init__.py
+++ b/ai_trading/config/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 from .locks import LockWithTimeout
 # AI-AGENT-REF: re-export config management helpers without triggering optional deps
 from .management import TradingConfig, derive_cap_from_settings
+from ai_trading.validation.require_env import _require_env_vars, require_env_vars
 logger = get_logger(__name__)
 _LOCK_TIMEOUT = 30
 _ENV_LOCK = LockWithTimeout(_LOCK_TIMEOUT)
@@ -65,12 +66,6 @@ def get_env(name: str, default: Any=None, *, reload: bool=False, required: bool=
         raise RuntimeError(f'Missing required env var: {name}')
     return val
 
-def _require_env_vars(*names: str) -> None:
-    missing = [n for n in names if not os.getenv(n)]
-    if missing:
-        msg = f"Missing required environment variables: {', '.join(missing)}"
-        logger.critical(msg)
-        raise RuntimeError(msg)
 
 def _perform_env_validation() -> None:
     from .management import validate_required_env
@@ -121,4 +116,4 @@ def log_config(masked_keys: list[str] | None=None, secrets_to_redact: list[str] 
             if key in conf:
                 conf[key] = '***'
     return conf
-__all__ = ['Settings', 'get_settings', 'broker_keys', 'get_alpaca_config', 'AlpacaConfig', 'TradingConfig', 'derive_cap_from_settings', 'get_env', '_require_env_vars', 'reload_env', 'validate_environment', 'validate_alpaca_credentials', 'validate_env_vars', 'log_config', 'ORDER_FILL_RATE_TARGET', 'MAX_DRAWDOWN_THRESHOLD', 'MODE_PARAMETERS', 'SENTIMENT_ENHANCED_CACHING', 'SENTIMENT_RECOVERY_TIMEOUT_SECS', 'SENTIMENT_FALLBACK_SOURCES', 'META_LEARNING_BOOTSTRAP_ENABLED', 'META_LEARNING_MIN_TRADES_REDUCED', 'SENTIMENT_SUCCESS_RATE_TARGET', 'META_LEARNING_BOOTSTRAP_WIN_RATE']
+__all__ = ['Settings', 'get_settings', 'broker_keys', 'get_alpaca_config', 'AlpacaConfig', 'TradingConfig', 'derive_cap_from_settings', 'get_env', '_require_env_vars', 'require_env_vars', 'reload_env', 'validate_environment', 'validate_alpaca_credentials', 'validate_env_vars', 'log_config', 'ORDER_FILL_RATE_TARGET', 'MAX_DRAWDOWN_THRESHOLD', 'MODE_PARAMETERS', 'SENTIMENT_ENHANCED_CACHING', 'SENTIMENT_RECOVERY_TIMEOUT_SECS', 'SENTIMENT_FALLBACK_SOURCES', 'META_LEARNING_BOOTSTRAP_ENABLED', 'META_LEARNING_MIN_TRADES_REDUCED', 'SENTIMENT_SUCCESS_RATE_TARGET', 'META_LEARNING_BOOTSTRAP_WIN_RATE']

--- a/ai_trading/data_validation.py
+++ b/ai_trading/data_validation.py
@@ -7,10 +7,22 @@ from pathlib import Path
 from typing import Any
 from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.data.fetch import get_bars
+from ai_trading.validation.require_env import should_halt_trading
 
 # Lazy pandas proxy for on-demand import
 pd = load_pandas()
-__all__ = ['check_data_freshness', 'get_stale_symbols', 'validate_trading_data', 'emergency_data_check', 'is_valid_ohlcv', 'validate_trade_log_integrity', 'monitor_real_time_data_quality', 'MarketDataValidator', 'ValidationSeverity']
+__all__ = [
+    "check_data_freshness",
+    "get_stale_symbols",
+    "validate_trading_data",
+    "emergency_data_check",
+    "is_valid_ohlcv",
+    "validate_trade_log_integrity",
+    "monitor_real_time_data_quality",
+    "MarketDataValidator",
+    "ValidationSeverity",
+    "should_halt_trading",
+]
 REQUIRED_PRICE_COLS = ('open', 'high', 'low', 'close', 'volume')
 
 def is_valid_ohlcv(df: pd.DataFrame, min_rows: int=50) -> bool:

--- a/ai_trading/validation/__init__.py
+++ b/ai_trading/validation/__init__.py
@@ -1,5 +1,17 @@
 """Validation utilities and facades."""
 from ai_trading.data_validation import check_data_freshness
-from .require_env import _require_env_vars, require_env_vars
+from .require_env import (
+    _require_env_vars,
+    require_env_vars,
+    should_halt_trading,
+)
 from .validate_env import debug_environment, validate_specific_env_var
-__all__ = ['check_data_freshness', 'require_env_vars', '_require_env_vars', 'debug_environment', 'validate_specific_env_var']
+
+__all__ = [
+    "check_data_freshness",
+    "require_env_vars",
+    "_require_env_vars",
+    "should_halt_trading",
+    "debug_environment",
+    "validate_specific_env_var",
+]

--- a/ai_trading/validation/require_env.py
+++ b/ai_trading/validation/require_env.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Environment variable validation helpers.
+
+This module centralizes small helpers used across the codebase to ensure
+required environment variables are present and to determine whether trading
+should be halted based on environment flags.  Implementations are intentionally
+lightweight to keep startup costs minimal.
+"""
+
+from collections.abc import Mapping
+import os
+from ai_trading.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _require_env_vars(*names: str, env: Mapping[str, str] | None = None) -> None:
+    """Raise ``RuntimeError`` if any of ``names`` are missing in ``env``.
+
+    Parameters
+    ----------
+    names:
+        Environment variable names that must be present.
+    env:
+        Optional mapping to check instead of ``os.environ``.  The tests use the
+        default which reads from the real environment.
+    """
+    env_map = env or os.environ
+    missing = [n for n in names if not env_map.get(n)]
+    if missing:
+        msg = f"Missing required environment variables: {', '.join(missing)}"
+        logger.critical(msg)
+        raise RuntimeError(msg)
+
+
+def require_env_vars(*names: str, env: Mapping[str, str] | None = None) -> bool:
+    """Return ``True`` if all ``names`` exist in ``env``.
+
+    The function proxies to :func:`_require_env_vars` but returns ``False``
+    instead of raising when variables are missing.  This small convenience is
+    used in a few tests.
+    """
+    try:
+        _require_env_vars(*names, env=env)
+    except RuntimeError:
+        return False
+    return True
+
+
+def _truthy(val: str | None) -> bool:
+    return str(val).lower() in {"1", "true", "yes", "on"}
+
+
+def should_halt_trading(env: Mapping[str, str]) -> bool:
+    """Return ``True`` when environment indicates trading should halt.
+
+    A simple guard used in tests; it checks common flag names such as
+    ``HALT_TRADING`` or ``TRADING_HALTED`` for truthy values.  Callers supply
+    the environment mapping explicitly to ease unit testing.
+    """
+    return _truthy(env.get("HALT_TRADING") or env.get("TRADING_HALTED"))
+
+
+__all__ = ["_require_env_vars", "require_env_vars", "should_halt_trading"]


### PR DESCRIPTION
## Summary
- add `should_halt_trading` and env var helpers to new `validation.require_env`
- expose `should_halt_trading` via `data_validation` and `validation` packages
- use shared env requirement helpers in `config`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68afbc1cb3ec8330870aebcdccd2be35