### PR TITLE
feat(settings): add portfolio feature toggle

### DIFF
--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -75,7 +75,16 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices('ALPACA_API_URL', 'ALPACA_BASE_URL'),
     )
     trading_mode: str = Field(default='balanced', alias='TRADING_MODE')
-    webhook_secret: str | None = Field(default=None, alias='WEBHOOK_SECRET')
+    WEBHOOK_SECRET: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices('WEBHOOK_SECRET', 'AI_TRADING_WEBHOOK_SECRET'),
+    )
+    ENABLE_PORTFOLIO_FEATURES: bool = Field(
+        False,
+        validation_alias=AliasChoices(
+            'ENABLE_PORTFOLIO_FEATURES', 'AI_TRADING_ENABLE_PORTFOLIO_FEATURES'
+        ),
+    )
     testing: bool = Field(False, alias='TESTING')
     shadow_mode: bool = Field(False, alias='SHADOW_MODE')
     disable_daily_retrain: bool = Field(False, alias='DISABLE_DAILY_RETRAIN')

--- a/tests/test_cfg_required_fields.py
+++ b/tests/test_cfg_required_fields.py
@@ -9,3 +9,5 @@ def test_cfg_required_fields_exist():
     assert hasattr(cfg, "shadow_mode")
     assert hasattr(cfg, "healthcheck_port")
     assert hasattr(cfg, "min_health_rows")
+    assert hasattr(cfg, "WEBHOOK_SECRET")
+    assert hasattr(cfg, "ENABLE_PORTFOLIO_FEATURES")


### PR DESCRIPTION
## Summary
- expose WEBHOOK_SECRET and ENABLE_PORTFOLIO_FEATURES in runtime settings
- validate presence of new settings in configuration test

## Testing
- `ruff check ai_trading/settings.py tests/test_cfg_required_fields.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68afbc148758833088ab4e84772c4af9