### PR TITLE
feat(logging): track configured log file paths

### DIFF
--- a/ai_trading/logging/setup.py
+++ b/ai_trading/logging/setup.py
@@ -1,0 +1,34 @@
+"""Helpers for configuring logging and tracking log file paths."""
+
+from __future__ import annotations
+
+import logging
+from typing import List
+
+# Internal list of log file paths used when configuring logging.
+_logger_paths: list[str] | None = None
+
+
+def get_logger_paths() -> list[str]:
+    """Return a copy of the log file paths registered so far."""
+    return list(_logger_paths or [])
+
+
+def setup_logging(debug: bool = False, log_file: str | None = None) -> logging.Logger:
+    """Configure logging and track any file handlers created.
+
+    This is a thin wrapper around :func:`ai_trading.logging.setup_logging` that
+    records the ``log_file`` argument whenever a ``RotatingFileHandler`` is
+    requested.  Paths are tracked in ``_logger_paths`` which can be retrieved via
+    :func:`get_logger_paths`.
+    """
+    from . import setup_logging as _setup_logging
+
+    global _logger_paths
+    if _logger_paths is None:
+        _logger_paths = []
+
+    if log_file and log_file not in _logger_paths:
+        _logger_paths.append(log_file)
+
+    return _setup_logging(debug=debug, log_file=log_file)

--- a/tests/test_logger_paths.py
+++ b/tests/test_logger_paths.py
@@ -1,0 +1,25 @@
+import logging
+
+import ai_trading.logging as base_logger
+import ai_trading.logging.setup as log_setup
+
+
+def reset_logging_state():
+    base_logger._configured = False
+    base_logger._LOGGING_CONFIGURED = False
+    base_logger._listener = None
+    logging.getLogger().handlers.clear()
+
+
+def test_logger_paths_tracks_files(tmp_path):
+    reset_logging_state()
+    try:
+        log_setup.setup_logging(log_file=str(tmp_path / "test.log"))
+        paths = log_setup.get_logger_paths()
+        assert str(tmp_path / "test.log") in paths
+
+        # Subsequent calls should not duplicate the path
+        log_setup.setup_logging(log_file=str(tmp_path / "test.log"))
+        assert paths == log_setup.get_logger_paths()
+    finally:
+        reset_logging_state()


### PR DESCRIPTION
## Summary
- add `ai_trading.logging.setup` with `get_logger_paths` helper
- record log file paths when configuring a rotating file handler
- test that paths are tracked and deduplicated

## Testing
- `ruff check ai_trading/logging/setup.py tests/test_logger_paths.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_logger_paths.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_logger_paths.py tests/test_logger_file.py tests/test_logger.py tests/test_logging_setup_idempotent.py -q` *(fails: `AssertionError: No rotating handler paths created. Captured: []`)*

## Rollback Plan
- Revert the commit with `git revert` if issues arise.

------
https://chatgpt.com/codex/tasks/task_e_68afbc1b40e083309416f442f9b67d89