### PR TITLE
Normalize staleness guard timestamps to UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file.
   - Works both as package import and when executed from repo root
 - **Trading Loop**: guard missing Alpaca client and dedupe strategy logs
 - **Alpaca API**: fix submit/retry logic including 429 handling
+- **Staleness Guard**: convert timestamps to UTC with `pandas.to_datetime` and
+  log naive vs aware conversions
 - **Alpaca API**: validate `list_orders` availability and map alternative clients before trading loop
 - **Alpaca API**: fix `list_orders` wrapper to forward `status` without introducing unsupported `statuses`
 - **Config**: unify centralized defaults and add `from_optimization`


### PR DESCRIPTION
## Summary
- ensure staleness guard normalizes `now` and data timestamps via `pandas.to_datetime(..., utc=True)`
- log whether timestamps were naive or timezone-aware before conversion
- document timestamp handling in CHANGELOG

## Testing
- `ruff check ai_trading/guards/staleness.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError: cannot import name 'compute_atr' from 'ai_trading.indicators', ModuleNotFoundError: No module named 'cachetools')*


------
https://chatgpt.com/codex/tasks/task_e_68afbc1e9a388330911d6672d0e02c95