### PR TITLE
Enforce minimum sleep duration

### DIFF
--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -6,6 +6,7 @@ import logging
 import os
 import math
 import statistics
+import time
 from collections.abc import Iterable
 from functools import lru_cache
 from typing import Any, TYPE_CHECKING
@@ -21,12 +22,8 @@ logger = get_logger(__name__)
 _log = logger
 
 def psleep(_=None) -> None:
-    """Benchmark-friendly noop that accepts/ignores one arg."""
-    try:
-        from ai_trading.utils import sleep as _sleep
-        _sleep(0.0)
-    except (ImportError, AttributeError, OSError) as exc:
-        _log.debug('psleep fallback: %s', exc)
+    """Benchmark-friendly minimal sleep that accepts/ignores one arg."""
+    time.sleep(0.01)
 
 def clamp_timeout(df):
     """Benchmark-friendly helper returning input."""

--- a/ai_trading/utils/timing.py
+++ b/ai_trading/utils/timing.py
@@ -21,12 +21,13 @@ def clamp_timeout(value: Optional[float]) -> float:
 
 
 def _robust_sleep(seconds: Union[int, float]) -> None:
-    """Block for ``seconds`` using the original ``time.sleep``."""  # AI-AGENT-REF: deterministic sleep
+    """Block for ``seconds`` using the original ``time.sleep`` with a minimum delay."""  # AI-AGENT-REF: deterministic sleep
 
-    s = float(seconds)
-    if s <= 0.0:
-        return
-    _real_sleep(s)
+    try:
+        s = float(seconds)
+    except Exception:
+        s = 0.0
+    _real_sleep(max(s, 0.01))
 
 
 _force_local_sleep = str(os.getenv("AI_TRADING_FORCE_LOCAL_SLEEP", "1")).lower() in {"1", "true", "yes", "on"}

--- a/tests/test_utils_sleep_shadowing.py
+++ b/tests/test_utils_sleep_shadowing.py
@@ -15,7 +15,7 @@ def test_sleep_unaffected_by_monkeypatch(monkeypatch) -> None:
 
     monkeypatch.setattr(real_time, "sleep", fake_sleep)
     start = perf_counter()
-    sleep(0.01)
+    sleep(0)  # request 0 -> enforced minimum
     elapsed = perf_counter() - start
     assert slept["count"] == 0
     assert elapsed >= 0.009

--- a/tests/test_utils_timing.py
+++ b/tests/test_utils_timing.py
@@ -15,7 +15,7 @@ def test_timing_exports_exist_and_behave():
     assert clamp_timeout(-1) == pytest.approx(float(HTTP_TIMEOUT))
     # measure sleep roughly (<= 2x tolerance to absorb CI variability)
     start = perf_counter()
-    sleep(0.01)
+    sleep(0)  # request 0 -> enforced minimum
     elapsed = perf_counter() - start
     if elapsed == 0.0:
         pytest.skip("perf_counter frozen")

--- a/tests/unit/test_sleep_binding.py
+++ b/tests/unit/test_sleep_binding.py
@@ -4,6 +4,6 @@ from ai_trading.utils import sleep
 
 def test_utils_sleep_is_measurable():
     start = perf_counter()
-    sleep(0.01)
+    sleep(0)  # request 0 -> enforced minimum
     elapsed = perf_counter() - start
     assert elapsed >= 0.009  # AI-AGENT-REF: ensure busy-wait measurable


### PR DESCRIPTION
## Summary
- ensure ai_trading.utils.timing.sleep always waits at least 10ms
- simplify signals.psleep to use time.sleep with a 10ms delay
- adjust tests to reflect enforced minimum sleep duration

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 127 errors during collection)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_utils_timing.py tests/unit/test_sleep_binding.py tests/test_utils_sleep_shadowing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afbc18ee008330916be939181c4b13