### PR TITLE
Use lowercase hourly resample codes in tests

### DIFF
--- a/tests/test_data_cache.py
+++ b/tests/test_data_cache.py
@@ -20,10 +20,10 @@ def test_disk_cache_basic(tmp_path):
     df = pd.DataFrame({"timestamp":[1], "open":[2], "high":[3], "low":[1], "close":[2.5], "volume":[1000]})
 
     # Put data in disk cache
-    mcache.put_disk(cache_dir, "TSLA", "1H", "2024-01-01", "2024-01-02", df)
+    mcache.put_disk(cache_dir, "TSLA", "1h", "2024-01-01", "2024-01-02", df)
 
     # Retrieve from disk cache
-    retrieved = mcache.get_disk(cache_dir, "TSLA", "1H", "2024-01-01", "2024-01-02")
+    retrieved = mcache.get_disk(cache_dir, "TSLA", "1h", "2024-01-01", "2024-01-02")
     assert retrieved is not None
     assert list(retrieved.columns) == list(df.columns)
     assert len(retrieved) == len(df)
@@ -31,10 +31,10 @@ def test_disk_cache_basic(tmp_path):
 def test_cache_key_generation():
     """Test cache key generation with special characters"""
     key1 = mcache._key("SPY", "1D", "2024-01-01", "2024-01-31")
-    key2 = mcache._key("BTC/USD", "1H", "2024:01:01T10:30:00", "2024:01:01T11:30:00")
+    key2 = mcache._key("BTC/USD", "1h", "2024:01:01T10:30:00", "2024:01:01T11:30:00")
 
     assert key1 == "SPY|1D|2024-01-01|2024-01-31"
-    assert key2 == "BTC/USD|1H|2024:01:01T10:30:00|2024:01:01T11:30:00"
+    assert key2 == "BTC/USD|1h|2024:01:01T10:30:00|2024:01:01T11:30:00"
 
 def test_memory_cache_thread_safety():
     """Test that memory cache handles concurrent access safely"""

--- a/tests/test_metalearning_strategy.py
+++ b/tests/test_metalearning_strategy.py
@@ -24,7 +24,7 @@ def create_mock_price_data(days=100, start_price=100):
     # AI-AGENT-REF: Use timezone-aware datetime instead of naive
     start_date = datetime.now(UTC) - timedelta(days=days)
     end_date = datetime.now(UTC)
-    dates = pd.date_range(start=start_date, end=end_date, freq='1H')  # Hourly data for reasonable size
+    dates = pd.date_range(start=start_date, end=end_date, freq='1h')  # Hourly data for reasonable size
 
     # Generate realistic price movements
     np.random.seed(42)  # For reproducible tests


### PR DESCRIPTION
## Summary
- Replace uppercase `1H` with lowercase `1h` in data cache and MetaLearning strategy tests
- Update cache key expectations to match lowercase hour code

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68afbc16344c8330b6526509a2d1d551