### PR TITLE
docs: streamline Alpaca credential guidance

### DIFF
--- a/STARTUP_FIXES_DEPLOYMENT_GUIDE.md
+++ b/STARTUP_FIXES_DEPLOYMENT_GUIDE.md
@@ -5,8 +5,8 @@
 This implementation addresses import-time crashes and ensures predictable startup under systemd by implementing:
 
 1. **Deferred credential validation** - No sys.exit during import
-2. **Early .env loading** - Before heavy module imports and Settings construction  
-3. **Dual credential schema support** - Both ALPACA_* and APCA_* variable names
+2. **Early .env loading** - Before heavy module imports and Settings construction
+3. **Unified credential schema** - Uses ALPACA_* variable names
 4. **UTC timestamp fixes** - Single "Z" suffix instead of double "ZZ"
 5. **Lazy imports** - Heavy modules loaded only when needed
 6. **Comprehensive testing** - Prevents regression
@@ -26,7 +26,7 @@ Expected output:
 ```
 🎉 ALL TESTS PASSED!
 ✓ Service no longer crashes at import
-✓ Bot starts with either ALPACA_* or APCA_* credentials
+✓ Bot starts with ALPACA_* credentials
 ✓ Credentials are handled securely with redacted logging
 ✓ UTC timestamps have single trailing Z (no 'ZZ')
 ✓ Lazy imports prevent import-time side effects
@@ -61,8 +61,8 @@ Check that credentials are loaded correctly:
 # Get the service PID
 PID=$(systemctl show -p MainPID --value ai-trading.service)
 
-# Check environment variables (should show either ALPACA_* or APCA_* variables)
-sudo tr '\0' '\n' </proc/$PID/environ | grep -E 'APCA|ALPACA|BASE_URL'
+# Check environment variables (should show ALPACA_* variables)
+sudo tr '\0' '\n' </proc/$PID/environ | grep -E 'ALPACA|BASE_URL'
 ```
 
 ### 4. Test Environment Integration
@@ -74,7 +74,7 @@ Run the focused tests:
 source venv/bin/activate
 
 # Run specific test categories
-pytest -q -k "env_order or dual_schema or utc_timefmt"
+pytest -q -k "env_order or utc_timefmt"
 ```
 
 ## Key Implementation Changes
@@ -105,16 +105,16 @@ def _initialize_alpaca_clients():
             raise e  # ✅ Runtime validation only
 ```
 
-### 2. Dual Credential Schema Support
+### 2. Credential Resolution
 
 **New function in config/management.py:**
 ```python
 def _resolve_alpaca_env() -> tuple[str | None, str | None, str | None]:
-    """Resolve credentials supporting both ALPACA_* and APCA_* schemes."""
-    api_key = os.getenv("ALPACA_API_KEY") or os.getenv("APCA_API_KEY_ID")
-    secret_key = os.getenv("ALPACA_SECRET_KEY") or os.getenv("APCA_API_SECRET_KEY") 
-    base_url = os.getenv("ALPACA_BASE_URL") or os.getenv("APCA_API_BASE_URL")
-    # ... (ALPACA_* takes precedence)
+    """Resolve credentials from ALPACA_* environment variables."""
+    api_key = os.getenv("ALPACA_API_KEY")
+    secret_key = os.getenv("ALPACA_SECRET_KEY")
+    base_url = os.getenv("ALPACA_BASE_URL")
+    return api_key, secret_key, base_url
 ```
 
 ### 3. Early .env Loading
@@ -154,17 +154,15 @@ def utc_now_iso() -> str:
     return now.isoformat().replace('+00:00', 'Z')  # ✅ Single Z
 ```
 
-## Environment Variable Support
+## Environment Variables
 
-Both naming conventions are now supported:
+The service reads the following Alpaca credentials:
 
-| ALPACA_* (Preferred) | APCA_* (Alternative) | Purpose |
-|---------------------|---------------------|---------|
-| `ALPACA_API_KEY` | `APCA_API_KEY_ID` | API key |
-| `ALPACA_SECRET_KEY` | `APCA_API_SECRET_KEY` | Secret key |
-| `ALPACA_BASE_URL` | `APCA_API_BASE_URL` | Base URL |
-
-**Precedence:** ALPACA_* variables take precedence if both are present.
+| Variable | Purpose |
+|----------|---------|
+| `ALPACA_API_KEY` | API key |
+| `ALPACA_SECRET_KEY` | Secret key |
+| `ALPACA_BASE_URL` | Base URL |
 
 ## Error Handling
 
@@ -198,7 +196,7 @@ All existing functionality is preserved:
 2. Verify credentials are set:
    ```bash
    # Should show masked values
-   sudo systemctl show-environment | grep -E 'ALPACA|APCA'
+   sudo systemctl show-environment | grep ALPACA
    ```
 
 3. Test import manually:
@@ -209,10 +207,10 @@ All existing functionality is preserved:
 
 ### Credential Issues
 
-1. Check both naming schemes:
+1. Check credentials:
    ```bash
    echo "ALPACA_API_KEY: ${ALPACA_API_KEY:0:8}***"
-   echo "APCA_API_KEY_ID: ${APCA_API_KEY_ID:0:8}***"
+   echo "ALPACA_SECRET_KEY: ${ALPACA_SECRET_KEY:0:8}***"
    ```
 
 2. Verify .env file is loaded:
@@ -236,7 +234,7 @@ All existing functionality is preserved:
 
 ✅ **All validation tests pass**  
 ✅ **Service starts without import-time crashes**  
-✅ **Both credential schemas work**  
+✅ **ALPACA_* credentials resolve correctly**
 ✅ **UTC timestamps have single Z**  
 ✅ **Lazy imports prevent side effects**  
 ✅ **Backward compatibility maintained**


### PR DESCRIPTION
## Summary
- document unified ALPACA_* credential usage
- drop legacy APCA references from startup fixes deployment guide

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing modules like ai_trading.indicators.compute_atr, cachetools, etc.)*

## Rollback
- Revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b07cc25ee08330aadd4586aec8b301