### PR TITLE
Log API startup exceptions with traceback

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -276,8 +276,8 @@ def start_api_with_signal(api_ready: threading.Event, api_error: threading.Event
     """Start API server and signal readiness/errors."""
     try:
         start_api(api_ready)
-    except (OSError, RuntimeError) as e:
-        logger.error("Failed to start API: %s", str(e))
+    except Exception:  # noqa: BLE001
+        logger.error("Failed to start API", exc_info=True)
         api_error.set()
 
 


### PR DESCRIPTION
## Summary
- ensure `start_api_with_signal` catches all exceptions and logs traceback when the API fails to start

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*
- `python - <<'PY'
import threading, time
import ai_trading.main as m

def broken_start_api(ready_signal=None):
    raise ImportError('No module named fake')

m.start_api = broken_start_api
ready = threading.Event()
error = threading.Event()
m.start_api_with_signal(ready, error)
# give time for async logger to flush
time.sleep(0.5)
print('api_error_set:', error.is_set())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b0824e9e10833085a2e3c483ab6e74