### PR TITLE
Log warm-up run-cycle completion

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -387,6 +387,7 @@ def main(argv: list[str] | None = None) -> None:
             exc_info=e,
         )
         raise SystemExit(1) from e
+    logger.info("Warm-up run_cycle completed")
     api_ready = threading.Event()
     api_error = threading.Event()
     t = Thread(target=start_api_with_signal, args=(api_ready, api_error), daemon=True)


### PR DESCRIPTION
## Summary
- log a message after the warm-up `run_cycle()` to signal successful completion before entering the main loop

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `ALPACA_API_KEY=foo ALPACA_SECRET_KEY=bar ALPACA_API_URL=https://paper-api.alpaca.markets WEBHOOK_SECRET=secret CAPITAL_CAP=0.5 DOLLAR_RISK_LIMIT=0.1 IMPORT_PREFLIGHT_DISABLED=1 SCHEDULER_ITERATIONS=1 python -m ai_trading.main 2>&1 | tee /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68b0824fb7ec83309543006d00512c7f