### PR TITLE
Ensure warm-up run_cycle flushes logs on failure

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -3,6 +3,7 @@ import argparse
 import os
 import threading
 import time
+import logging
 from threading import Thread
 import signal
 from datetime import datetime, UTC
@@ -374,18 +375,21 @@ def main(argv: list[str] | None = None) -> None:
             "Warm-up run_cycle failed during trading initialization; shutting down",
             exc_info=e,
         )
+        logging.shutdown()
         raise SystemExit(1) from e
     except SystemExit as e:
         logger.error(
             "Warm-up run_cycle triggered SystemExit; shutting down",
             exc_info=e,
         )
+        logging.shutdown()
         raise
     except Exception as e:  # noqa: BLE001
         logger.exception(
             "Warm-up run_cycle failed unexpectedly; shutting down",
             exc_info=e,
         )
+        logging.shutdown()
         raise SystemExit(1) from e
     logger.info("Warm-up run_cycle completed")
     api_ready = threading.Event()


### PR DESCRIPTION
## Summary
- call `logging.shutdown()` before re-raising `SystemExit` if the warm-up `run_cycle` fails
- import `logging` for shutdown support

## Testing
- `ruff check ai_trading/main.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b0854e2b108330913b573dac593f02