### PR TITLE
feat: add hmmlearn dependency

### DIFF
--- a/ai_trading/tools/env_validate.py
+++ b/ai_trading/tools/env_validate.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 import os
 import sys
+import importlib.util
 from collections.abc import Iterable, Mapping
 from ai_trading.logging import get_logger
 logger = get_logger(__name__)
-REQUIRED_KEYS: tuple[str, ...] = ('ALPACA_API_KEY', 'ALPACA_SECRET_KEY', 'ALPACA_BASE_URL')
+REQUIRED_KEYS: tuple[str, ...] = (
+    'ALPACA_API_KEY',
+    'ALPACA_SECRET_KEY',
+    'ALPACA_BASE_URL',
+)
+REQUIRED_PACKAGES: tuple[str, ...] = ('hmmlearn',)
 
 def validate_env(env: Mapping[str, str] | None=None) -> list[str]:
-    """Return list of missing required environment keys."""
+    """Return list of missing required environment keys or packages."""
     env = env or os.environ
-    return [k for k in REQUIRED_KEYS if not env.get(k)]
+    missing = [k for k in REQUIRED_KEYS if not env.get(k)]
+    for pkg in REQUIRED_PACKAGES:
+        if importlib.util.find_spec(pkg) is None:
+            missing.append(pkg)
+    return missing
 
 def main(argv: Iterable[str] | None=None) -> int:
     """CLI entry point returning process exit code."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "scipy==1.13.1",
   "threadpoolctl==3.5.0",
   "pandas==2.2.2",
+  "hmmlearn==0.3.2",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ scikit-learn==1.5.1
 scipy==1.13.1
 threadpoolctl==3.5.0
 pandas==2.2.2
+hmmlearn==0.3.2


### PR DESCRIPTION
## Summary
- add hmmlearn dependency for hidden Markov model signals
- validate environment checks for required hmmlearn package

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'pydantic_settings')*

## Rollback Plan
- Revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b0888990c4833086c5fde3ba3d1319