### PR TITLE
Add cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ scikit-learn==1.5.1
 scipy==1.13.1
 threadpoolctl==3.5.0
 pandas==2.2.2
+cryptography>=41


### PR DESCRIPTION
## Summary
- add `cryptography>=41` to core requirements so security helpers can use the library

## Testing
- `./run_checks.sh` *(fails: many tests failing, KeyboardInterrupt)*
- `python -m pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b08884d5288330976129aefb89a013