### PR TITLE
Add finnhub-python dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ idna>=3.4,<4
 psutil>=5.9,<6
 portalocker==2.7.0
 alpaca-py==0.42.0  # AI-AGENT-REF: include Alpaca SDK
+finnhub-python>=2.4,<3  # AI-AGENT-REF: optional Finnhub provider
 joblib>=1.3,<2
 Flask>=3,<4
 beautifulsoup4>=4.12,<5


### PR DESCRIPTION
## Summary
- add finnhub-python package so optional Finnhub provider is available

## Testing
- `python -m pip install -U pip` *(already satisfied)*
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')*
- `pip install finnhub-python`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

## Rollback Plan
- Revert this PR.

------
https://chatgpt.com/codex/tasks/task_e_68b088852bb88330a79e93eed3e6c402