### PR TITLE
Add statsmodels dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ scikit-learn==1.5.1
 scipy==1.13.1
 threadpoolctl==3.5.0
 pandas==2.2.2
+statsmodels==0.14.5


### PR DESCRIPTION
## Summary
- add statsmodels to core dependencies so pair-trading routines can operate

## Testing
- `python -m pip install -U pip`
- `pip install -r requirements.txt`
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` *(fails: ImportError: cannot import name 'compute_atr' from 'ai_trading.indicators')*
- `RUN_HEALTHCHECK=1 python -m ai_trading.app &`
- `curl -sf http://127.0.0.1:9001/healthz`


------
https://chatgpt.com/codex/tasks/task_e_68b0888b20b4833086da7ed2a499270f