### PR TITLE
Include numba dependency for JIT indicators

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ scikit-learn==1.5.1
 scipy==1.13.1
 threadpoolctl==3.5.0
 pandas==2.2.2
+numba>=0.57  # AI-AGENT-REF: enable JIT-optimized indicators


### PR DESCRIPTION
## Summary
- add `numba>=0.57` to requirements to enable JIT-optimized indicators

## Testing
- `pip install -r requirements.txt`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: cannot import name 'compute_atr' from 'ai_trading.indicators')*

------
https://chatgpt.com/codex/tasks/task_e_68b0888db1e483308c6da8f5f305c240