### PR TITLE
Add optional plotting extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ pandas = [
   "pandas>=2.0"
 ]
 plot = [
-  "matplotlib>=3.7"
+  "matplotlib==3.10.5"
 ]
 ml = [
   "scikit-learn>=1.4",

--- a/requirements-extras-plot.txt
+++ b/requirements-extras-plot.txt
@@ -1,0 +1,4 @@
+# Optional plotting extras for Ubuntu 24.04 / CPython 3.12
+# AI-AGENT-REF: install only when WITH_PLOT=1
+# Install via: WITH_PLOT=1 pip install -r requirements-extras-plot.txt -c constraints.txt
+matplotlib==3.10.5


### PR DESCRIPTION
## Summary
- add optional plotting requirements file
- pin matplotlib as plot extra in pyproject

## Testing
- `pip install -r requirements.txt`
- `WITH_PLOT=1 pip install -r requirements-extras-plot.txt -c constraints.txt`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 40 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68b08892b2d483309b40e8c054aac10d