### PR TITLE
Add yfinance dependency for market data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ scikit-learn==1.5.1
 scipy==1.13.1
 threadpoolctl==3.5.0
 pandas==2.2.2
+yfinance>=0.2.38,<0.3  # AI-AGENT-REF: Yahoo Finance data fetch


### PR DESCRIPTION
## Summary
- add yfinance to requirements for Yahoo Finance data fetching

## Testing
- `python -m pip install -r requirements.txt`
- `python - <<'PY'
import yfinance as yf
print(yf.Ticker('AAPL').history(period='1d').head())
PY`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 40 errors during collection)*
- `RUN_HEALTHCHECK=1 python -m ai_trading.app &` *(missing env variables but returns JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68b0889756d88330b0c667f015d927c1