### PR TITLE
refactor: drop bot_engine re-export shims

### DIFF
--- a/compat/__init__.py
+++ b/compat/__init__.py
@@ -1,0 +1,5 @@
+"""Compatibility helpers for legacy import paths.
+
+Modules in this package provide shims for deprecated paths and are
+not intended for production use.
+"""

--- a/compat/bot_engine.py
+++ b/compat/bot_engine.py
@@ -1,0 +1,18 @@
+"""Legacy re-exports removed from :mod:`ai_trading.core.bot_engine`.
+
+These aliases are provided for external code that relied on the old
+import locations. They are outside the production package and will be
+removed in a future release.
+"""
+
+from ai_trading.data.bars import StockBarsRequest, TimeFrame, safe_get_stock_bars
+from ai_trading.core.runtime import BotRuntime, build_runtime, enhance_runtime_with_context
+
+__all__ = [
+    "StockBarsRequest",
+    "TimeFrame",
+    "safe_get_stock_bars",
+    "BotRuntime",
+    "build_runtime",
+    "enhance_runtime_with_context",
+]

--- a/tests/test_stubs_and_prices.py
+++ b/tests/test_stubs_and_prices.py
@@ -1,7 +1,7 @@
 import pytest
 pd = pytest.importorskip("pandas")
 def test_timeframe_has_basic_members():
-    from ai_trading.core.bot_engine import TimeFrame
+    from ai_trading.data.bars import TimeFrame
 
     assert hasattr(TimeFrame, "Day")
     assert hasattr(TimeFrame, "Minute")


### PR DESCRIPTION
## Summary
- stop exporting legacy `TimeFrame`, `StockBarsRequest`, and `safe_get_stock_bars` from `core.bot_engine`
- move removed aliases into `compat/bot_engine.py`
- update tests to import `TimeFrame` from `ai_trading.data.bars`

## Testing
- `tools/ci/guard_shims.sh` *(fails: __getattr__ in config and Mock classes remain)*
- `make test-all` *(fails: 127 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b0998e20e483308a398f726b4ceff6