### PR TITLE
Use ISO timestamps in JSON logging

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -324,11 +324,11 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
             from ai_trading.config import get_settings
             S = get_settings()
             if S.log_compact_json:
-                formatter = CompactJsonFormatter('%(asctime)sZ')
+                formatter = CompactJsonFormatter('%Y-%m-%dT%H:%M:%SZ')
             else:
-                formatter = JSONFormatter('%(asctime)sZ')
+                formatter = JSONFormatter('%Y-%m-%dT%H:%M:%SZ')
         except COMMON_EXC:
-            formatter = JSONFormatter('%(asctime)sZ')
+            formatter = JSONFormatter('%Y-%m-%dT%H:%M:%SZ')
 
         class _PhaseFilter(logging.Filter):
 

--- a/scripts/validate_fixes_root.py
+++ b/scripts/validate_fixes_root.py
@@ -36,7 +36,7 @@ def test_logging_formatter_imports():
     """Test that logging module imports and JSONFormatter can be accessed."""
     try:
         import ai_trading.logging as logger_module
-        formatter = logger_module.JSONFormatter('%(asctime)sZ')
+        formatter = logger_module.JSONFormatter('%Y-%m-%dT%H:%M:%SZ')
         rec = logging.LogRecord(name='test', level=logging.INFO, pathname=__file__, lineno=1, msg='Test message with Unicode — characters', args=None, exc_info=None)
         output = formatter.format(rec)
         data = json.loads(output)

--- a/tests/test_ellipsis_fix.py
+++ b/tests/test_ellipsis_fix.py
@@ -32,7 +32,7 @@ class TestEllipsisFix(unittest.TestCase):
 
     def test_json_formatter_unicode_ensure_ascii_false(self):
         """Test that JSON formatter preserves Unicode characters without escaping."""
-        fmt = logger_module.JSONFormatter("%(asctime)sZ")
+        fmt = logger_module.JSONFormatter("%Y-%m-%dT%H:%M:%SZ")
 
         # Create a record with Unicode ellipsis character
         rec = _make_record()

--- a/tests/test_json_formatter.py
+++ b/tests/test_json_formatter.py
@@ -22,7 +22,7 @@ def _make_record(**extra):
 
 
 def test_json_formatter_custom_fields_and_masking():
-    fmt = logger.JSONFormatter("%(asctime)sZ")
+    fmt = logger.JSONFormatter("%Y-%m-%dT%H:%M:%SZ")
     rec = _make_record(symbol="AAPL", api_key="abcdef1234", pathname="skip")
     out = fmt.format(rec)
     data = json.loads(out)
@@ -33,7 +33,7 @@ def test_json_formatter_custom_fields_and_masking():
 
 def test_json_formatter_extra_fields_and_mask_keys():
     fmt = logger.JSONFormatter(
-        "%(asctime)sZ",
+        "%Y-%m-%dT%H:%M:%SZ",
         extra_fields={"service": "trade", "secret": "top"},
         mask_keys=["secret", "symbol"],
     )
@@ -46,7 +46,7 @@ def test_json_formatter_extra_fields_and_mask_keys():
 
 
 def test_json_formatter_exc_info():
-    fmt = logger.JSONFormatter("%(asctime)sZ")
+    fmt = logger.JSONFormatter("%Y-%m-%dT%H:%M:%SZ")
     rec = _make_record()
     rec.exc_info = (ValueError, ValueError("boom"), None)
     out = fmt.format(rec)
@@ -56,7 +56,7 @@ def test_json_formatter_exc_info():
 
 
 def test_json_formatter_serializes_nonstandard_types():
-    fmt = logger.JSONFormatter("%(asctime)sZ")
+    fmt = logger.JSONFormatter("%Y-%m-%dT%H:%M:%SZ")
     from datetime import date, datetime
 
     import numpy as np


### PR DESCRIPTION
## Summary
- ensure JSON log formatters emit ISO 8601 timestamps
- align tests and helper script with the new timestamp format

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*
- `python - <<'PY'
from ai_trading.logging.json_formatter import JSONFormatter
import logging, json
from datetime import datetime, UTC
fmt = JSONFormatter('%Y-%m-%dT%H:%M:%SZ')
rec = logging.LogRecord(name='demo', level=logging.INFO, pathname=__file__, lineno=1, msg='hello', args=None, exc_info=None)
out = fmt.format(rec)
print(out)
print('parsed ts:', json.loads(out)['ts'])
print('current utc:', datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b0a48e9210833092c9c1de03331b7d