### PR TITLE
feat(logging): honor LOG_LEVEL for handler levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,10 +906,13 @@ The system uses a **centralized logging architecture** to prevent duplicate log 
 ### Usage
 ```python
 # Correct way - use centralized logging
+import os
 from ai_trading.logging import get_logger, setup_logging
 
 # Initialize logging (only needed once at application startup)
-setup_logging(debug=True, log_file="logs/bot.log")
+# Set LOG_LEVEL before calling to control verbosity
+os.environ["LOG_LEVEL"] = "DEBUG"
+setup_logging(log_file="logs/bot.log")
 
 # Get named logger for your module
 logger = get_logger(__name__)

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -221,7 +221,7 @@ def run_bot(*_a, **_k) -> int:
     global config
     from ai_trading.logging import setup_logging, validate_logging_setup
 
-    logger = setup_logging(log_file="logs/bot.log", debug=False)
+    logger = setup_logging(log_file="logs/bot.log")
     validation_result = validate_logging_setup()
     if not validation_result["validation_passed"]:
         logger.error("Logging validation failed: %s", validation_result["issues"])

--- a/tests/test_centralized_logging_no_duplicates.py
+++ b/tests/test_centralized_logging_no_duplicates.py
@@ -33,7 +33,8 @@ def test_centralized_logging_prevents_duplicates():
         with patch.dict(os.environ, {
             'ALPACA_API_KEY': 'test',
             'ALPACA_SECRET_KEY': 'test',
-            'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets'
+            'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets',
+            'LOG_LEVEL': 'DEBUG',
         }):
             # Reset global state
             import ai_trading.logging as logging_module
@@ -42,15 +43,15 @@ def test_centralized_logging_prevents_duplicates():
                 logging_module._configured = False
 
             # First setup
-            logger1 = setup_logging(debug=True)
+            logger1 = setup_logging()
             handlers_after_first = len(root_logger.handlers)
 
             # Second setup (should not add more handlers)
-            logger2 = setup_logging(debug=True)
+            logger2 = setup_logging()
             handlers_after_second = len(root_logger.handlers)
 
             # Third setup with different params (should still not add handlers)
-            logger3 = setup_logging(debug=False)
+            logger3 = setup_logging()
             handlers_after_third = len(root_logger.handlers)
 
             # Validate results
@@ -86,9 +87,10 @@ def test_centralized_logging_thread_safety():
             with patch.dict(os.environ, {
                 'ALPACA_API_KEY': 'test',
                 'ALPACA_SECRET_KEY': 'test',
-                'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets'
+                'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets',
+                'LOG_LEVEL': 'DEBUG'
             }):
-                setup_logging(debug=True)
+                setup_logging()
                 results.append(len(logging.getLogger().handlers))
         except (RuntimeError, OSError, ValueError) as e:
             exceptions.append(e)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -31,18 +31,21 @@ def test_setup_logging_idempotent(monkeypatch, tmp_path):
         return logging.StreamHandler()
 
     monkeypatch.setattr(mod, "get_rotating_handler", fake_get_rotating)
-    lg = mod.setup_logging(debug=True, log_file=str(tmp_path / "f.log"))
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    lg = mod.setup_logging(log_file=str(tmp_path / "f.log"))
     assert lg.level in (logging.DEBUG, logging.INFO)
     assert created, f"No rotating handler paths created. Captured: {created}"
     created.clear()
-    lg2 = mod.setup_logging(debug=False)
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    lg2 = mod.setup_logging()
     assert lg2 is lg
     assert created == []
 
 
-def test_get_logger():
+def test_get_logger(monkeypatch):
     mod = reload_module(logger)
-    root = mod.setup_logging(debug=True)
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    root = mod.setup_logging()
     lg = mod.get_logger("test")
     assert lg is mod._loggers["test"]
     assert len(lg.handlers) == len(root.handlers)


### PR DESCRIPTION
## Summary
- derive handler level from settings.LOG_LEVEL or $LOG_LEVEL
- apply computed level to stream and queue handlers
- use LOG_LEVEL env var in docs and tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError cannot import name 'compute_atr' from 'ai_trading.indicators' and other missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a609c6fc8330ac8d30e1cc82fc3d