### PR TITLE
feat(logging): respect LOG_LEVEL for handler level

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,8 +908,10 @@ The system uses a **centralized logging architecture** to prevent duplicate log 
 # Correct way - use centralized logging
 from ai_trading.logging import get_logger, setup_logging
 
-# Initialize logging (only needed once at application startup)
-setup_logging(debug=True, log_file="logs/bot.log")
+# Initialize logging (only needed once at application startup).
+# Control verbosity with the LOG_LEVEL environment variable, e.g.
+# `export LOG_LEVEL=DEBUG` for debug output.
+setup_logging(log_file="logs/bot.log")
 
 # Get named logger for your module
 logger = get_logger(__name__)

--- a/ai_trading/logging/setup.py
+++ b/ai_trading/logging/setup.py
@@ -17,9 +17,9 @@ def get_logger_paths() -> list[str]:
 def setup_logging(debug: bool = False, log_file: str | None = None) -> logging.Logger:
     """Configure logging and track any file handlers created.
 
-    This is a thin wrapper around :func:`ai_trading.logging.setup_logging` that
-    records the ``log_file`` argument whenever a ``RotatingFileHandler`` is
-    requested.  Paths are tracked in ``_logger_paths`` which can be retrieved via
+    The ``debug`` flag is kept for compatibility but the effective log level is
+    now driven by configuration or the ``LOG_LEVEL`` environment variable.
+    Paths are tracked in ``_logger_paths`` which can be retrieved via
     :func:`get_logger_paths`.
     """
     from . import setup_logging as _setup_logging
@@ -31,4 +31,5 @@ def setup_logging(debug: bool = False, log_file: str | None = None) -> logging.L
     if log_file and log_file not in _logger_paths:
         _logger_paths.append(log_file)
 
-    return _setup_logging(debug=debug, log_file=log_file)
+    # ``debug`` is intentionally ignored; callers should set ``LOG_LEVEL``.
+    return _setup_logging(log_file=log_file)

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -14,10 +14,8 @@ ensure_dotenv_loaded()
 
 import ai_trading.logging as _logging
 
-# Determine log file and level from environment
+# Determine log file from environment
 LOG_FILE = os.getenv("BOT_LOG_FILE", "logs/bot.log")
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
-_numeric_level = getattr(logging, LOG_LEVEL, logging.INFO)
 
 # Reset any prior logging configuration to apply new settings
 if getattr(_logging, "_listener", None):
@@ -30,14 +28,8 @@ _logging._configured = False
 _logging._LOGGING_CONFIGURED = False
 logging.getLogger().handlers.clear()
 
-# Configure logging with the desired file and level
-root_logger = _logging.setup_logging(debug=_numeric_level <= logging.DEBUG, log_file=LOG_FILE)
-root_logger.setLevel(_numeric_level)
-for handler in root_logger.handlers:
-    handler.setLevel(_numeric_level)
-if _logging._listener is not None:
-    for _h in _logging._listener.handlers:
-        _h.setLevel(_numeric_level)
+# Configure logging with the desired file
+_logging.setup_logging(log_file=LOG_FILE)
 
 # Module logger
 logger = _logging.get_logger(__name__)

--- a/tests/test_centralized_logging_no_duplicates.py
+++ b/tests/test_centralized_logging_no_duplicates.py
@@ -33,7 +33,8 @@ def test_centralized_logging_prevents_duplicates():
         with patch.dict(os.environ, {
             'ALPACA_API_KEY': 'test',
             'ALPACA_SECRET_KEY': 'test',
-            'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets'
+            'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets',
+            'LOG_LEVEL': 'DEBUG',
         }):
             # Reset global state
             import ai_trading.logging as logging_module
@@ -42,15 +43,15 @@ def test_centralized_logging_prevents_duplicates():
                 logging_module._configured = False
 
             # First setup
-            logger1 = setup_logging(debug=True)
+            logger1 = setup_logging()
             handlers_after_first = len(root_logger.handlers)
 
             # Second setup (should not add more handlers)
-            logger2 = setup_logging(debug=True)
+            logger2 = setup_logging()
             handlers_after_second = len(root_logger.handlers)
 
             # Third setup with different params (should still not add handlers)
-            logger3 = setup_logging(debug=False)
+            logger3 = setup_logging()
             handlers_after_third = len(root_logger.handlers)
 
             # Validate results
@@ -86,9 +87,10 @@ def test_centralized_logging_thread_safety():
             with patch.dict(os.environ, {
                 'ALPACA_API_KEY': 'test',
                 'ALPACA_SECRET_KEY': 'test',
-                'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets'
+                'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets',
+                'LOG_LEVEL': 'DEBUG',
             }):
-                setup_logging(debug=True)
+                setup_logging()
                 results.append(len(logging.getLogger().handlers))
         except (RuntimeError, OSError, ValueError) as e:
             exceptions.append(e)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -31,18 +31,21 @@ def test_setup_logging_idempotent(monkeypatch, tmp_path):
         return logging.StreamHandler()
 
     monkeypatch.setattr(mod, "get_rotating_handler", fake_get_rotating)
-    lg = mod.setup_logging(debug=True, log_file=str(tmp_path / "f.log"))
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    lg = mod.setup_logging(log_file=str(tmp_path / "f.log"))
     assert lg.level in (logging.DEBUG, logging.INFO)
     assert created, f"No rotating handler paths created. Captured: {created}"
     created.clear()
-    lg2 = mod.setup_logging(debug=False)
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+    lg2 = mod.setup_logging()
     assert lg2 is lg
     assert created == []
 
 
-def test_get_logger():
+def test_get_logger(monkeypatch):
     mod = reload_module(logger)
-    root = mod.setup_logging(debug=True)
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    root = mod.setup_logging()
     lg = mod.get_logger("test")
     assert lg is mod._loggers["test"]
     assert len(lg.handlers) == len(root.handlers)


### PR DESCRIPTION
## Summary
- derive logging level from settings or LOG_LEVEL env var
- apply computed level to stream and queue handlers
- adjust entry points, tests, and docs to rely on LOG_LEVEL

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'pydantic_settings', plus 127 collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aebaab18833080d0f640b7d28c35