### PR TITLE
Centralize logging initialization in main

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1017,14 +1017,8 @@ else:
 # AI-AGENT-REF: numpy is a hard dependency - import directly
 import numpy as np
 
-LOG_PATH = os.getenv("BOT_LOG_FILE", "logs/scheduler.log")
-# Set up logging only once
+# AI-AGENT-REF: logger configuration is handled upstream in ``ai_trading.main``
 logger = get_logger(__name__)  # AI-AGENT-REF: define logger before use
-# AI-AGENT-REF: lazy logger setup to avoid expensive imports during test
-if not logging.getLogger().handlers and not os.getenv("PYTEST_RUNNING"):
-    from ai_trading.logging import setup_logging  # AI-AGENT-REF: lazy logger import
-
-    setup_logging(log_file=LOG_PATH)
 
 # AI-AGENT-REF: import sanity signal for CI/ops
 info_kv(

--- a/ai_trading/env.py
+++ b/ai_trading/env.py
@@ -24,11 +24,13 @@ def ensure_dotenv_loaded() -> None:
         loaded_from = '<default>'
     _ENV_LOADED = True
     try:
-        from ai_trading.logging import get_logger, logger_once
-        get_logger(__name__)
-        if loaded_from == '<default>':
-            logger_once.info('ENV_LOADED_DEFAULT override=True', key='env_loaded:default')
-        else:
-            logger_once.info('ENV_LOADED_FROM override=True', key=f'env_loaded:{loaded_from}', extra={'dotenv_path': loaded_from})
+        import logging as _logging
+        if _logging.getLogger().handlers:
+            from ai_trading.logging import get_logger, logger_once
+            get_logger(__name__)
+            if loaded_from == '<default>':
+                logger_once.info('ENV_LOADED_DEFAULT override=True', key='env_loaded:default')
+            else:
+                logger_once.info('ENV_LOADED_FROM override=True', key=f'env_loaded:{loaded_from}', extra={'dotenv_path': loaded_from})
     except (KeyError, ValueError, TypeError):
         pass

--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -427,7 +427,7 @@ def get_logger(name: str) -> SanitizingLoggerAdapter:
         base.setLevel(logging.NOTSET)
         _loggers[name] = SanitizingLoggerAdapter(base, {})
     return _loggers[name]
-logger = get_logger(__name__)
+logger = SanitizingLoggerAdapter(logging.getLogger(__name__), {})
 logger_once = EmitOnceLogger(logger)
 
 def get_phase_logger(name: str, phase: str | None=None) -> logging.Logger:

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -29,6 +29,8 @@ _logging._LOGGING_CONFIGURED = False
 logging.getLogger().handlers.clear()
 
 # Configure logging with the desired file
+# Logging must be initialized once here before importing heavy modules like
+# ``ai_trading.core.bot_engine``.
 _logging.setup_logging(log_file=LOG_FILE)
 
 # Module logger


### PR DESCRIPTION
## Summary
- Remove redundant `setup_logging` call from `bot_engine`
- Configure logging exclusively in `main` and skip logging in `ensure_dotenv_loaded` when not yet configured
- Avoid auto-initialization of logging at import time

## Testing
- `ruff check ai_trading/main.py ai_trading/core/bot_engine.py ai_trading/env.py ai_trading/logging/__init__.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*
- `BOT_LOG_FILE=/tmp/logtest.log PYTEST_RUNNING=1 python - <<'PY'\nimport ai_trading.main\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68b0b177130c8330aa466a078a0ae99f