### PR TITLE
Handle read-only cache dir fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ python ai_trading/scripts/self_check.py
 The script fetches a small sample of SPY bars using `alpaca-py` and exits with status **0** on success.
 
 
+## Runtime paths
+
+`ai_trading.paths` creates writable data, log, and cache directories on import.
+If a target directory is on a read-only filesystem, it falls back to
+`tempfile.gettempdir() / APP_NAME` and logs a warning so the application
+continues with a writable location.
+
+
 ## Config
 
 ```py


### PR DESCRIPTION
## Summary
- fall back to a temp directory when cache creation hits a read-only filesystem
- warn when using the fallback
- document runtime path fallback and test it

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_paths.py::test_cache_dir_falls_back -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError: cannot import name 'check_data_freshness' from partially initialized module 'ai_trading.data_validation')*


------
https://chatgpt.com/codex/tasks/task_e_68b0c40f98748330a1ff2b538fc98641