### PR TITLE
refactor: avoid logging env details

### DIFF
--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -138,8 +138,8 @@ class RiskEngine:
         """Validate required environment variables unless running tests."""
         if get_env("PYTEST_RUNNING", "0", cast=bool):
             return
-        snapshot = validate_required_env()
-        logger.debug("ENV_VARS_MASKED", extra=snapshot)
+        env_count = len(validate_required_env())
+        logger.debug("Validated %d environment variables", env_count)
 
     def _dynamic_cap(self, asset_class: str, volatility: float | None=None, cash_ratio: float | None=None) -> float:
         """Return exposure cap for ``asset_class`` using adaptive rules."""

--- a/ai_trading/scripts/self_check.py
+++ b/ai_trading/scripts/self_check.py
@@ -60,6 +60,6 @@ def main() -> None:
 
 if __name__ == "__main__":
     if not get_env("PYTEST_RUNNING", "0", cast=bool):
-        snapshot = validate_required_env()
-        logger.debug("ENV_VARS_MASKED", extra=snapshot)
+        env_count = len(validate_required_env())
+        logger.debug("Validated %d environment variables", env_count)
     main()

--- a/scripts/risk_engine_cli.py
+++ b/scripts/risk_engine_cli.py
@@ -16,8 +16,8 @@ from ai_trading.logging import _get_metrics_logger
 from ai_trading.utils.base import get_phase_logger
 logger = get_phase_logger(__name__, 'RISK_CHECK')
 if not get_env('PYTEST_RUNNING', '0', cast=bool):
-    _ENV_SNAPSHOT = validate_required_env()
-    logger.debug('ENV_VARS_MASKED', extra=_ENV_SNAPSHOT)
+    env_count = len(validate_required_env())
+    logger.debug('Validated %d environment variables', env_count)
 
 random.seed(SEED)
 np.random.seed(SEED)


### PR DESCRIPTION
## Summary
- stop logging full env snapshots in `RiskEngine._validate_env`
- redact env logging in CLI utilities to only report counts

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn' and other missing deps)*

## Rollback Plan
- Revert this PR.

------
https://chatgpt.com/codex/tasks/task_e_68b0c4120dac83308948ad9a2f0ae238