### PR TITLE
Add optional verbose flags for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ test: smoke
 # Run full test suite; disables common auto-loaded plugins for determinism
 test-all:
 	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
-	PYTEST_ADDOPTS="-p no:faulthandler -p no:randomly -p no:cov -m 'not integration and not slow and not requires_credentials'" \
+	PYTEST_ADDOPTS="-p no:faulthandler -p no:randomly -p no:cov \
+	-m 'not integration and not slow and not requires_credentials' \
+	$(if $(VERBOSE),-vv --durations=10 -s,)" \
 	python tools/run_pytest.py tests
 
 # Run everything, including slow/integration/credentials-marked tests, still without plugin autoload.


### PR DESCRIPTION
## Summary
- allow `make test-all` to accept `VERBOSE=1` and show detailed pytest output

## Testing
- `pip install pytest-timeout pytest-asyncio alpaca-py`
- `make test-all VERBOSE=1` *(fails: 106 errors during collection)*

## Rollback
- Revert commit `573bb1ce`

------
https://chatgpt.com/codex/tasks/task_e_68b0d34f9cb4833083eeabef47273d85