### PR TITLE
refactor: use HTTPSession wrapper

### DIFF
--- a/ai_trading/__main__.py
+++ b/ai_trading/__main__.py
@@ -5,7 +5,7 @@ import sys
 from collections.abc import Callable
 from typing import Any, Literal
 
-import requests
+from ai_trading.exc import HTTPError
 from pydantic import BaseModel, ValidationError, field_validator
 
 from ai_trading.logging import get_logger
@@ -43,7 +43,7 @@ def _run_loop(fn: Callable[[], None], args: argparse.Namespace, label: str) -> N
         while True:
             try:
                 fn()
-            except (ValueError, requests.HTTPError) as e:
+            except (ValueError, HTTPError) as e:
                 logger.warning("%s recoverable error: %s", label, e, exc_info=True)
             except Exception as e:
                 logger.error("%s failed: %s", label, e, exc_info=True)
@@ -220,7 +220,7 @@ if __name__ == "__main__":
         main()
     except SystemExit:
         raise
-    except (ValueError, requests.HTTPError) as e:
+    except (ValueError, HTTPError) as e:
         logger.error("startup error: %s", e, exc_info=True)
         if "--dry-run" in sys.argv:
             logger.warning("dry-run: ignoring startup exception: %s", e)

--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -8,7 +8,8 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Optional, TYPE_CHECKING
 
-import requests
+from ai_trading.net.http import HTTPSession
+from ai_trading.exc import RequestException
 import importlib.util
 from ai_trading.logging import get_logger
 from ai_trading.config.management import is_shadow_mode
@@ -20,6 +21,7 @@ _log = get_logger(__name__)
 RETRY_HTTP_CODES = {429, 500, 502, 503, 504}
 RETRYABLE_HTTP_STATUSES = tuple(RETRY_HTTP_CODES)
 _UTC = timezone.utc  # AI-AGENT-REF: prefer stdlib UTC
+_HTTP = HTTPSession()
 
 
 from zoneinfo import ZoneInfo
@@ -374,8 +376,8 @@ def _http_submit(
         payload["stop_price"] = str(stop_price)
 
     try:
-        resp = requests.post(url, headers=headers, json=payload, timeout=timeout or 10)
-    except requests.RequestException as e:  # pragma: no cover - network error path
+        resp = _HTTP.post(url, headers=headers, json=payload, timeout=timeout or 10)
+    except RequestException as e:  # pragma: no cover - network error path
         raise AlpacaOrderNetworkError(f"Network error calling {url}: {e}") from e
 
     try:

--- a/ai_trading/execution/liquidity.py
+++ b/ai_trading/execution/liquidity.py
@@ -9,13 +9,8 @@ from datetime import UTC, datetime
 from enum import Enum
 from json import JSONDecodeError
 from typing import Any
-try:
-    import requests
-    RequestException = requests.exceptions.RequestException
-except ImportError:
+from ai_trading.exc import RequestException
 
-    class RequestException(Exception):
-        pass
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)
 from ai_trading.logging import logger
 from ..core.enums import OrderType

--- a/ai_trading/monitoring/alerting.py
+++ b/ai_trading/monitoring/alerting.py
@@ -14,10 +14,10 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from enum import Enum
 from typing import Any
-import requests
 from ai_trading.logging import logger
 from ai_trading.utils import http
 from ai_trading.utils.timing import HTTP_TIMEOUT
+from ai_trading.exc import RequestException
 
 class AlertSeverity(Enum):
     """Alert severity levels."""
@@ -157,7 +157,7 @@ class SlackAlerter:
             response.raise_for_status()
             logger.info(f'Slack alert sent: {alert.title}')
             return True
-        except (requests.exceptions.RequestException, ValueError, KeyError, TimeoutError, OSError) as e:
+        except (RequestException, ValueError, KeyError, TimeoutError, OSError) as e:
             logger.error(f'Error sending Slack alert: {e}')
             return False
 
@@ -336,7 +336,7 @@ class AlertManager:
             else:
                 logger.warning(f'Unknown alert channel: {channel}')
                 return False
-        except (ValueError, RuntimeError, OSError, requests.exceptions.RequestException, smtplib.SMTPException) as e:
+        except (ValueError, RuntimeError, OSError, RequestException, smtplib.SMTPException) as e:
             logger.error(f'Error sending to channel {channel}: {e}')
             return False
 

--- a/ai_trading/monitoring/performance_dashboard.py
+++ b/ai_trading/monitoring/performance_dashboard.py
@@ -11,13 +11,8 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from ai_trading.logging import logger
 from json import JSONDecodeError
-try:
-    import requests
-    RequestException = requests.exceptions.RequestException
-except ImportError:
+from ai_trading.exc import RequestException
 
-    class RequestException(Exception):
-        pass
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)
 from ..core.constants import DATA_PARAMETERS, PERFORMANCE_THRESHOLDS
 from .alerting import AlertManager, AlertSeverity

--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -1,37 +1,80 @@
 from __future__ import annotations
+
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-class TimeoutSession(requests.Session):
-    """Requests Session that injects a default timeout if none is provided."""
 
-    def __init__(self, default_timeout: tuple[float, float]=(5.0, 10.0)) -> None:
+class TimeoutSession(requests.Session):
+    """Requests ``Session`` that injects a default timeout."""
+
+    def __init__(self, default_timeout: tuple[float, float] = (5.0, 10.0)) -> None:
         super().__init__()
         self._default_timeout = default_timeout
 
-    def request(self, method, url, **kwargs):
-        if 'timeout' not in kwargs or kwargs['timeout'] is None:
-            kwargs['timeout'] = self._default_timeout
+    def request(self, method, url, **kwargs):  # type: ignore[override]
+        if "timeout" not in kwargs or kwargs["timeout"] is None:
+            kwargs["timeout"] = self._default_timeout
         return super().request(method, url, **kwargs)
+
+
+# Public alias used throughout the codebase
+HTTPSession = TimeoutSession
+
 _GLOBAL_SESSION: TimeoutSession | None = None
 
-def build_retrying_session(*, pool_maxsize: int=32, total_retries: int=3, backoff_factor: float=0.3, status_forcelist: tuple[int, ...]=(429, 500, 502, 503, 504), connect_timeout: float=5.0, read_timeout: float=10.0) -> TimeoutSession:
-    """Create a session with urllib3 Retry and default timeout."""
+
+def build_retrying_session(
+    *,
+    pool_maxsize: int = 32,
+    total_retries: int = 3,
+    backoff_factor: float = 0.3,
+    status_forcelist: tuple[int, ...] = (429, 500, 502, 503, 504),
+    connect_timeout: float = 5.0,
+    read_timeout: float = 10.0,
+) -> TimeoutSession:
+    """Create a session with urllib3 ``Retry`` and default timeout."""
+
     s = TimeoutSession(default_timeout=(connect_timeout, read_timeout))
-    retry = Retry(total=total_retries, connect=total_retries, read=total_retries, backoff_factor=backoff_factor, status_forcelist=status_forcelist, allowed_methods=frozenset({'GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH'}), raise_on_status=False)
-    adapter = HTTPAdapter(max_retries=retry, pool_connections=pool_maxsize, pool_maxsize=pool_maxsize)
-    s.mount('http://', adapter)
-    s.mount('https://', adapter)
+    retry = Retry(
+        total=total_retries,
+        connect=total_retries,
+        read=total_retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        allowed_methods=frozenset({"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"}),
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(
+        max_retries=retry,
+        pool_connections=pool_maxsize,
+        pool_maxsize=pool_maxsize,
+    )
+    s.mount("http://", adapter)
+    s.mount("https://", adapter)
     return s
+
 
 def set_global_session(s: TimeoutSession) -> None:
     """Register global session singleton."""
+
     global _GLOBAL_SESSION
     _GLOBAL_SESSION = s
 
+
 def get_global_session() -> TimeoutSession:
     """Return the global session, building a default if missing."""
+
     if _GLOBAL_SESSION is None:
         set_global_session(build_retrying_session())
     return _GLOBAL_SESSION
+
+
+__all__ = [
+    "HTTPSession",
+    "TimeoutSession",
+    "build_retrying_session",
+    "set_global_session",
+    "get_global_session",
+]
+

--- a/ai_trading/portfolio/sizing.py
+++ b/ai_trading/portfolio/sizing.py
@@ -12,13 +12,8 @@ import numpy as np
 from json import JSONDecodeError
 from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.logging import logger
-try:
-    import requests
-    RequestException = requests.exceptions.RequestException
-except ImportError:
+from ai_trading.exc import RequestException
 
-    class RequestException(Exception):
-        pass
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)
 
 if TYPE_CHECKING:  # pragma: no cover - typing only

--- a/ai_trading/position_sizing.py
+++ b/ai_trading/position_sizing.py
@@ -4,10 +4,10 @@ from datetime import UTC, datetime, timedelta
 from math import floor
 from typing import Any
 import os
-import requests
 from ai_trading.logging import get_logger
 from ai_trading.net.http import get_global_session
 from ai_trading.settings import get_alpaca_secret_key_plain
+from ai_trading.exc import HTTPError, RequestException
 _log = get_logger(__name__)
 
 @dataclass
@@ -123,10 +123,10 @@ def _get_equity_from_alpaca(cfg) -> float:
         data = resp.json()
         eq = _coerce_float(data.get('equity'), 0.0)
         return eq
-    except requests.HTTPError as e:
+    except HTTPError as e:
         _log.warning("ALPACA_HTTP_ERROR", extra={"url": url, "status": getattr(e.response, "status_code", None)})
         return 0.0
-    except requests.RequestException as e:
+    except RequestException as e:
         _log.warning("ALPACA_REQUEST_FAILED", extra={"url": url, "error": str(e)})
         return 0.0
     except ValueError as e:

--- a/ai_trading/risk/circuit_breakers.py
+++ b/ai_trading/risk/circuit_breakers.py
@@ -9,13 +9,8 @@ from typing import Any
 from ai_trading.logging import logger
 from ai_trading.logging.emit_once import emit_once
 from json import JSONDecodeError
-try:
-    import requests
-    RequestException = requests.exceptions.RequestException
-except ImportError:
+from ai_trading.exc import RequestException
 
-    class RequestException(Exception):
-        pass
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)
 from ..core.constants import PERFORMANCE_THRESHOLDS
 

--- a/tests/runtime/test_http_wrapped.py
+++ b/tests/runtime/test_http_wrapped.py
@@ -1,6 +1,6 @@
-import requests
 from ai_trading.utils import http
 from ai_trading.utils import HTTP_TIMEOUT, clamp_timeout
+from ai_trading.exc import RequestException
 
 
 class DummyResp:
@@ -14,17 +14,15 @@ class DummyResp:
 def test_wrapped_get_retries_and_parses(monkeypatch):
     calls = []
 
-    def fake_request(self, method, url, **kwargs):
-        calls.append(kwargs)
-        assert kwargs["timeout"] == clamp_timeout(None)
-        if len(calls) == 1:
-            raise requests.exceptions.RequestException("boom")
-        return DummyResp({"ok": True})
+    class _Session:
+        def request(self, method, url, **kwargs):
+            calls.append(kwargs)
+            assert kwargs["timeout"] == clamp_timeout(None)
+            if len(calls) == 1:
+                raise RequestException("boom")
+            return DummyResp({"ok": True})
 
-    # Patch session.request used by wrapper
-    monkeypatch.setattr(requests.Session, "request", fake_request)
-    # Patch requests.get per requirement, though wrapper uses session
-    monkeypatch.setattr(requests, "get", lambda url, **kw: fake_request(None, "GET", url, **kw))
+    monkeypatch.setattr(http, "_get_session", lambda: _Session())
 
     resp = http.get("https://example.com")
     assert resp.json() == {"ok": True}

--- a/tests/test_net_http_timeout.py
+++ b/tests/test_net_http_timeout.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import types
 
-import requests
-from ai_trading.net.http import TimeoutSession, build_retrying_session
+from ai_trading.net import http
+from ai_trading.net.http import HTTPSession, build_retrying_session
 
 
 def test_timeoutsession_injects_default_timeout(monkeypatch):
@@ -13,9 +13,9 @@ def test_timeoutsession_injects_default_timeout(monkeypatch):
         captured.update(kwargs)
         return types.SimpleNamespace(ok=True)
 
-    monkeypatch.setattr(requests.Session, "request", fake_request, raising=True)
+    monkeypatch.setattr(http.requests.Session, "request", fake_request, raising=True)
 
-    s = TimeoutSession(default_timeout=(5.0, 10.0))
+    s = HTTPSession(default_timeout=(5.0, 10.0))
     s.request("GET", "http://unit.test")
     assert captured["timeout"] == (5.0, 10.0)
 
@@ -31,7 +31,7 @@ def test_build_retrying_session_defaults(monkeypatch):
         captured.update(kwargs)
         return types.SimpleNamespace(ok=True)
 
-    monkeypatch.setattr(requests.Session, "request", fake_request, raising=True)
+    monkeypatch.setattr(http.requests.Session, "request", fake_request, raising=True)
 
     s = build_retrying_session(connect_timeout=2.0, read_timeout=3.0)
     s.request("GET", "http://unit.test")

--- a/tests/test_position_sizing_error_handling.py
+++ b/tests/test_position_sizing_error_handling.py
@@ -1,10 +1,8 @@
 import types
 from unittest.mock import Mock, patch
 
-from unittest.mock import Mock, patch
-
 import pytest
-import requests
+from ai_trading.exc import HTTPError, RequestException
 
 from ai_trading.position_sizing import _get_equity_from_alpaca
 
@@ -22,7 +20,7 @@ def _cfg():
 def test_get_equity_http_error_returns_zero():
     cfg = _cfg()
     resp = Mock()
-    resp.raise_for_status.side_effect = requests.HTTPError(response=Mock(status_code=500))
+    resp.raise_for_status.side_effect = HTTPError(response=Mock(status_code=500))
     session = Mock(get=Mock(return_value=resp))
     with patch("ai_trading.position_sizing.get_global_session", return_value=session):
         assert _get_equity_from_alpaca(cfg) == 0.0
@@ -31,7 +29,7 @@ def test_get_equity_http_error_returns_zero():
 def test_get_equity_request_exception_returns_zero():
     cfg = _cfg()
     session = Mock()
-    session.get.side_effect = requests.ConnectionError("boom")
+    session.get.side_effect = RequestException("boom")
     with patch("ai_trading.position_sizing.get_global_session", return_value=session):
         assert _get_equity_from_alpaca(cfg) == 0.0
 

--- a/tests/test_run_loop_error_handling.py
+++ b/tests/test_run_loop_error_handling.py
@@ -1,7 +1,7 @@
 from argparse import Namespace
 
 import pytest
-import requests
+from ai_trading.exc import HTTPError
 
 from ai_trading.__main__ import _run_loop
 
@@ -19,7 +19,7 @@ def test_run_loop_swallow_value_error():
 
 def test_run_loop_swallow_http_error():
     def fn():
-        raise requests.HTTPError("oops")
+        raise HTTPError("oops")
 
     _run_loop(fn, _args(), "Test")
 


### PR DESCRIPTION
## Summary
- replace direct `requests` usage with `ai_trading.net.http.HTTPSession`
- ensure HTTP calls share a session with explicit timeouts
- adjust tests to patch the HTTP wrapper instead of `requests`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

## Rollback Plan
- Revert this PR to restore previous `requests` usage.


------
https://chatgpt.com/codex/tasks/task_e_68b0d986694c83309fe1dd913fc2e58f