### PR TITLE
Ensure third-party stubs take precedence in sys.path

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 try:
     repo_root = Path(__file__).resolve().parent
+    third_party_stubs = repo_root / "third_party_stubs"
+    if str(third_party_stubs) not in sys.path:
+        sys.path.insert(0, str(third_party_stubs))
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
 except Exception:


### PR DESCRIPTION
## Summary
- Insert `third_party_stubs` into `sys.path` before the repo root in `sitecustomize.py`
- Allows stub packages like `requests` to override installed libraries

## Testing
- `PYTHONPATH=. python - <<'PY'
import requests, inspect
print(inspect.getsource(requests.Session))
PY`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68b0d984fd74833087778e4a6a71a827