### PR TITLE
refactor: centralize alpaca imports behind adapters

### DIFF
--- a/tests/test_lazy_alpaca_imports.py
+++ b/tests/test_lazy_alpaca_imports.py
@@ -1,0 +1,37 @@
+import json
+import subprocess
+import sys
+import os
+
+
+def _imported_alpaca_modules(mod: str) -> list[str]:
+    code = (
+        "import sys, json, importlib.abc\n"
+        "class Blocker(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, fullname, path, target=None):\n"
+        "        if fullname.startswith('alpaca'):\n"
+        "            raise ImportError('blocked')\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, Blocker())\n"
+        f"try:\n    import {mod}\nexcept Exception:\n    pass\n"
+        "print(json.dumps([m for m in sys.modules if m.startswith('alpaca')]))\n"
+    )
+    env = {
+        **os.environ,
+        "ALPACA_API_KEY": "dummy",
+        "ALPACA_SECRET_KEY": "dummy",
+        "ALPACA_BASE_URL": "https://paper-api.alpaca.markets",
+    }
+    out = subprocess.check_output([sys.executable, "-c", code], env=env)
+    last = out.decode().strip().splitlines()[-1]
+    return json.loads(last)
+
+
+def test_bot_engine_lazy_alpaca_import():
+    mods = _imported_alpaca_modules("ai_trading.core.bot_engine")
+    assert mods == []
+
+
+def test_self_check_lazy_alpaca_import():
+    mods = _imported_alpaca_modules("ai_trading.scripts.self_check")
+    assert mods == []


### PR DESCRIPTION
## Summary
- add adapter helpers to lazily import Alpaca SDK components
- use dependency injection in bot engine and self-check scripts
- test that importing runtime modules doesn't pull in alpaca

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_lazy_alpaca_imports.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing optional deps, 37 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68b0dd7267b4833097dcf2fc275791da