### PR TITLE
Ensure Session exported in requests stub

### DIFF
--- a/third_party_stubs/requests/__init__.py
+++ b/third_party_stubs/requests/__init__.py
@@ -36,7 +36,7 @@ exceptions = type(
 )
 
 
-from .sessions import Session, Response
+from .sessions import Response as Response, Session as Session
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- explicitly re-export Session from requests.sessions to make it available on the requests module

## Testing
- `python - <<'PY'
import requests
print('Session' in dir(requests))
print([name for name in dir(requests) if name == 'Session'])
PY`
- `ruff check third_party_stubs/requests/__init__.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing dependencies and circular imports)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dd7362948330803a2d1148cdd985