### PR TITLE
Align Alpaca request stubs with current SDK

### DIFF
--- a/tests/test_vendor_stub_alpaca_requests.py
+++ b/tests/test_vendor_stub_alpaca_requests.py
@@ -1,0 +1,43 @@
+"""Unit tests for vendor Alpaca request stubs.
+
+These tests ensure the lightweight stub classes mimic the real SDK's
+behaviour when instantiated using positional or keyword arguments.
+"""
+
+from datetime import UTC, datetime
+
+from tests.vendor_stubs.alpaca.data.requests import StockBarsRequest
+from tests.vendor_stubs.alpaca.data.timeframe import TimeFrame, TimeFrameUnit
+
+
+def _tf_day():
+    return TimeFrame(1, TimeFrameUnit.Day)
+
+
+def test_stock_bars_request_positional_args():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    req = StockBarsRequest("SPY", _tf_day(), start=start, limit=10, feed="sip")
+
+    assert req.symbol_or_symbols == "SPY"
+    assert req.timeframe == _tf_day()
+    assert req.start == start.astimezone(UTC).replace(tzinfo=None)
+    assert req.limit == 10
+    assert req.feed == "sip"
+
+
+def test_stock_bars_request_keyword_args():
+    start = datetime(2024, 2, 1, tzinfo=UTC)
+    req = StockBarsRequest(
+        symbol_or_symbols="SPY",
+        timeframe=_tf_day(),
+        start=start,
+        adjustment="raw",
+        asof="2024-02-01",
+    )
+
+    assert req.symbol_or_symbols == "SPY"
+    assert req.timeframe == _tf_day()
+    assert req.start == start.astimezone(UTC).replace(tzinfo=None)
+    assert req.adjustment == "raw"
+    assert req.asof == "2024-02-01"
+

--- a/tests/vendor_stubs/alpaca/data/requests.py
+++ b/tests/vendor_stubs/alpaca/data/requests.py
@@ -1,11 +1,96 @@
-"""Stub request classes for tests."""
+"""Stub request classes for tests.
 
-class StockBarsRequest:
-    def __init__(self, *a, **k):
-        pass
+These classes mimic a tiny subset of the real ``alpaca-py`` request
+models.  Only the attributes and behaviour required by the tests are
+implemented here.  The goal is to provide a light‑weight stand‑in that
+resembles the public API of the SDK so higher level code can be exercised
+without importing the real package.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Iterable, Optional, Union
+
+
+class BaseTimeseriesDataRequest:
+    """Base request capturing common time series parameters."""
+
+    def __init__(
+        self,
+        symbol_or_symbols: Union[str, Iterable[str]],
+        *,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+        limit: Optional[int] = None,
+        currency: Optional[str] = None,
+        sort: Optional[str] = None,
+        **extra: Any,
+    ) -> None:
+        if start and start.tzinfo is not None:
+            start = start.astimezone(UTC).replace(tzinfo=None)
+        if end and end.tzinfo is not None:
+            end = end.astimezone(UTC).replace(tzinfo=None)
+
+        self.symbol_or_symbols = symbol_or_symbols
+        self.start = start
+        self.end = end
+        self.limit = limit
+        self.currency = currency
+        self.sort = sort
+        for k, v in extra.items():
+            setattr(self, k, v)
+
+
+class BaseBarsRequest(BaseTimeseriesDataRequest):
+    """Base request for bar data types."""
+
+    def __init__(self, symbol_or_symbols, timeframe, **kwargs):
+        super().__init__(symbol_or_symbols, **kwargs)
+        self.timeframe = timeframe
+
+
+class StockBarsRequest(BaseBarsRequest):
+    """Request model for retrieving equity bar data."""
+
+    def __init__(
+        self,
+        symbol_or_symbols,
+        timeframe,
+        *,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+        limit: Optional[int] = None,
+        adjustment: Optional[str] = None,
+        feed: Optional[str] = None,
+        sort: Optional[str] = None,
+        asof: Optional[str] = None,
+        currency: Optional[str] = None,
+        **extra: Any,
+    ) -> None:
+        super().__init__(
+            symbol_or_symbols,
+            timeframe,
+            start=start,
+            end=end,
+            limit=limit,
+            currency=currency,
+            sort=sort,
+            **extra,
+        )
+        self.adjustment = adjustment
+        self.feed = feed
+        self.asof = asof
+
 
 class StockLatestQuoteRequest:
-    def __init__(self, *a, **k):
+    def __init__(self, *a, **k):  # pragma: no cover - trivial stub
         pass
 
-__all__ = ["StockBarsRequest", "StockLatestQuoteRequest"]
+
+__all__ = [
+    "BaseTimeseriesDataRequest",
+    "BaseBarsRequest",
+    "StockBarsRequest",
+    "StockLatestQuoteRequest",
+]


### PR DESCRIPTION
## Summary
- flesh out Alpaca data request stubs to mirror current alpaca-py API
- support mapping `symbol_or_symbols` and store common parameters
- add unit tests for positional and keyword `StockBarsRequest` construction

## Testing
- `ruff check tests/vendor_stubs/alpaca/data/requests.py tests/test_vendor_stub_alpaca_requests.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_vendor_stub_alpaca_requests.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0e7c79db8833094c2ef642d272d3b