### PR TITLE
Add daily bars wrapper and refresh fetch tests

### DIFF
--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -702,6 +702,29 @@ def get_minute_df(symbol: str, start: Any, end: Any, feed: str | None=None) -> p
         pass
     return _post_process(df)
 
+
+def get_daily_df(
+    symbol: str,
+    start: Any | None = None,
+    end: Any | None = None,
+    *,
+    feed: str | None = None,
+    adjustment: str | None = None,
+) -> pd.DataFrame:
+    """Thin wrapper around :func:`bars.get_bars_df` for daily bars."""
+
+    from ai_trading.alpaca_api import get_bars_df as _get_bars_df
+
+    return _get_bars_df(
+        symbol,
+        timeframe="1Day",
+        start=start,
+        end=end,
+        feed=feed,
+        adjustment=adjustment,
+    )
+
+
 def get_bars(symbol: str, timeframe: str, start: Any, end: Any, *, feed: str | None=None, adjustment: str | None=None) -> pd.DataFrame:
     """Compatibility wrapper delegating to _fetch_bars."""
     S = get_settings()
@@ -748,6 +771,7 @@ __all__ = [
     'get_last_available_bar',
     'fh_fetcher',
     'get_minute_df',
+    'get_daily_df',
     'metrics',
     'build_fetcher',
     'DataFetchError',

--- a/tests/test_fetch_and_screen.py
+++ b/tests/test_fetch_and_screen.py
@@ -6,6 +6,7 @@ import pytest
 
 pd = pytest.importorskip("pandas")
 from ai_trading.data import fetch as data_fetcher
+from ai_trading import alpaca_api as bars
 from ai_trading.utils.base import health_check
 
 
@@ -23,7 +24,7 @@ def _stub_df():
 def test_fetch_fallback_to_daily(monkeypatch):
     df = _stub_df()
     monkeypatch.setattr(data_fetcher, "get_minute_df", lambda *a, **k: None)
-    monkeypatch.setattr(data_fetcher, "get_daily_df", lambda *a, **k: df)
+    monkeypatch.setattr(bars, "get_bars_df", lambda *a, **k: df)
 
     # Properly mocked module for pandas_ta
     mock_module = types.ModuleType("pandas_ta")


### PR DESCRIPTION
## Summary
- add `get_daily_df` wrapper around Alpaca `get_bars_df` for daily bar retrieval
- update fetch-and-screen test to stub modern API

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_and_screen.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn'; AttributeError: module 'ai_trading.data.bars' has no attribute 'StockBarsRequest')*

------
https://chatgpt.com/codex/tasks/task_e_68b0eff943888330ab47c5bd0adcf7e6