### PR TITLE
chore: bound supported python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   - Updated README/CHANGELOG to document package-only policy
 
 ### Changed
+- **Python**: restrict supported version to >=3.12,<3.13
 - **Package Structure**: Root modules previously moved into `ai_trading/` package
   - **Migration Required**: Use `from ai_trading.signals import ...` instead of `from signals import ...`
   - **Breaking**: Root imports are no longer supported as of this version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ai-trading-bot"
 version = "0.0.0"
 description = "AI trading bot (lightweight testable build)"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.13"
 dependencies = [
   "numpy==1.26.4",  # AI-AGENT-REF: pin NumPy to 1.x for pandas-ta compatibility
   "requests>=2.31,<3",


### PR DESCRIPTION
## Summary
- restrict package to Python 3.12.x
- note Python version constraint in changelog

## Testing
- `python -m pip install -U pip`
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*
- `python -m build`
- `RUN_HEALTHCHECK=1 python -m ai_trading.app` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68b0f189dd5483309c92dd7130c1d684