### PR TITLE
feat: expose sentiment api config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ NEWS_API_KEY=your_news_api_key_here
 # Optional: Get from https://finnhub.io/
 FINNHUB_API_KEY=your_finnhub_api_key_here
 
+# Optional: Sentiment analysis service
+SENTIMENT_API_KEY=your_sentiment_api_key_here
+SENTIMENT_API_URL=https://api.sentiment.example.com
+
 # === LOGGING AND MONITORING ===
 BOT_LOG_FILE=logs/trading.log
 RUN_HEALTHCHECK=1

--- a/ai_trading/config/__init__.py
+++ b/ai_trading/config/__init__.py
@@ -21,6 +21,8 @@ ORDER_STALE_CLEANUP_INTERVAL = 60
 ORDER_FILL_RATE_TARGET = 0.8
 MAX_DRAWDOWN_THRESHOLD = 0.08
 MODE_PARAMETERS = {'conservative': 0.85, 'balanced': 0.75, 'aggressive': 0.65}
+SENTIMENT_API_KEY = os.getenv('SENTIMENT_API_KEY')
+SENTIMENT_API_URL = os.getenv('SENTIMENT_API_URL')
 SENTIMENT_ENHANCED_CACHING = True
 SENTIMENT_RECOVERY_TIMEOUT_SECS = 3600
 SENTIMENT_FALLBACK_SOURCES = []
@@ -116,4 +118,4 @@ def log_config(masked_keys: list[str] | None=None, secrets_to_redact: list[str] 
             if key in conf:
                 conf[key] = '***'
     return conf
-__all__ = ['Settings', 'get_settings', 'broker_keys', 'get_alpaca_config', 'AlpacaConfig', 'TradingConfig', 'derive_cap_from_settings', 'get_env', '_require_env_vars', 'require_env_vars', 'reload_env', 'validate_environment', 'validate_alpaca_credentials', 'validate_env_vars', 'log_config', 'ORDER_FILL_RATE_TARGET', 'MAX_DRAWDOWN_THRESHOLD', 'MODE_PARAMETERS', 'SENTIMENT_ENHANCED_CACHING', 'SENTIMENT_RECOVERY_TIMEOUT_SECS', 'SENTIMENT_FALLBACK_SOURCES', 'META_LEARNING_BOOTSTRAP_ENABLED', 'META_LEARNING_MIN_TRADES_REDUCED', 'SENTIMENT_SUCCESS_RATE_TARGET', 'META_LEARNING_BOOTSTRAP_WIN_RATE']
+__all__ = ['Settings', 'get_settings', 'broker_keys', 'get_alpaca_config', 'AlpacaConfig', 'TradingConfig', 'derive_cap_from_settings', 'get_env', '_require_env_vars', 'require_env_vars', 'reload_env', 'validate_environment', 'validate_alpaca_credentials', 'validate_env_vars', 'log_config', 'ORDER_FILL_RATE_TARGET', 'MAX_DRAWDOWN_THRESHOLD', 'MODE_PARAMETERS', 'SENTIMENT_API_KEY', 'SENTIMENT_API_URL', 'SENTIMENT_ENHANCED_CACHING', 'SENTIMENT_RECOVERY_TIMEOUT_SECS', 'SENTIMENT_FALLBACK_SOURCES', 'META_LEARNING_BOOTSTRAP_ENABLED', 'META_LEARNING_MIN_TRADES_REDUCED', 'SENTIMENT_SUCCESS_RATE_TARGET', 'META_LEARNING_BOOTSTRAP_WIN_RATE']

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -146,6 +146,12 @@ class Settings(BaseSettings):
     health_tick_seconds: int = Field(default=300, env='AI_TRADING_HEALTH_TICK_SECONDS')
     cpu_only: bool = Field(default=False, validation_alias='CPU_ONLY')
     news_api_key: str | None = None
+    sentiment_api_key: str | None = Field(
+        default=None,
+        alias='SENTIMENT_API_KEY',
+        validation_alias=AliasChoices('SENTIMENT_API_KEY', 'NEWS_API_KEY'),
+    )
+    sentiment_api_url: str | None = Field(default=None, alias='SENTIMENT_API_URL')
     rebalance_interval_min: int = Field(60, ge=1, description='Minutes between portfolio rebalances', alias='REBALANCE_INTERVAL_MIN')
 
     @field_validator('model_path', 'halt_flag_path', 'rl_model_path', mode='before')

--- a/docs/API_KEY_SETUP.md
+++ b/docs/API_KEY_SETUP.md
@@ -24,6 +24,7 @@ This trading bot requires API keys from Alpaca Markets to function. This guide e
 ### Optional
 - `FINNHUB_API_KEY`: For additional market data
 - `NEWS_API_KEY`: For news sentiment analysis
+- `SENTIMENT_API_KEY`/`SENTIMENT_API_URL`: For external sentiment service
 - `FUNDAMENTAL_API_KEY`: For fundamental analysis data
 
 ## 🚀 Quick Setup
@@ -60,6 +61,8 @@ ALPACA_BASE_URL=https://paper-api.alpaca.markets
 # Optional API keys - replace with your real keys or leave commented out
 FINNHUB_API_KEY=YOUR_FINNHUB_API_KEY
 NEWS_API_KEY=YOUR_NEWS_API_KEY
+SENTIMENT_API_KEY=YOUR_SENTIMENT_API_KEY
+SENTIMENT_API_URL=https://api.sentiment.example.com
 WEBHOOK_SECRET=YOUR_STRONG_WEBHOOK_SECRET
 ```
 

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -9,3 +9,10 @@ def test_api_host_port_defaults_present():
     assert hasattr(s, "api_port")
     assert s.api_host == "0.0.0.0"
     assert s.api_port == 9001
+
+
+def test_sentiment_fields_present():
+    get_settings.cache_clear()
+    s = get_settings()
+    assert hasattr(s, "sentiment_api_key")
+    assert hasattr(s, "sentiment_api_url")


### PR DESCRIPTION
## Summary
- map SENTIMENT_API_KEY and SENTIMENT_API_URL into runtime settings
- surface sentiment API env vars through config and sample env files
- document and test new sentiment API configuration

## Testing
- `ruff check ai_trading/settings.py ai_trading/config/__init__.py tests/test_api_settings.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_api_settings.py tests/test_production_fixes.py -q` *(fails: `ModuleNotFoundError: No module named 'alpaca'`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f447a7488330ab574b972972ee14