### PR TITLE
Expose StockBarsRequest alias from bars

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -20,8 +20,16 @@ from ai_trading.alpaca_api import (
     get_stock_bars_request_cls,
 )
 
+# Export dynamic Alpaca request classes at module import time
+TimeFrame = get_timeframe_cls()
+StockBarsRequest = get_stock_bars_request_cls()
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from alpaca.data import TimeFrame, StockBarsRequest
+    from alpaca.data import TimeFrame as _TimeFrame, StockBarsRequest as _StockBarsRequest
+    TimeFrame = _TimeFrame
+    StockBarsRequest = _StockBarsRequest
+
+__all__ = ["TimeFrame", "StockBarsRequest"]
 
 # Lazy pandas proxy; only imported on first use
 pd = load_pandas()


### PR DESCRIPTION
## Summary
- Export `TimeFrame` and `StockBarsRequest` in `ai_trading.data.bars` using Alpaca helper factories
- Provide `__all__` to make these request classes explicitly available

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails to collect tests: alpaca-py is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f6c94ecc833088431a13d0ba8ff0