### PR TITLE
fix: append third-party stubs

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -6,8 +6,11 @@ from pathlib import Path
 try:
     repo_root = Path(__file__).resolve().parent
     third_party_stubs = repo_root / "third_party_stubs"
+    # Append stub paths so that bundled ``site-packages`` take precedence
+    # over our third-party type stubs. This avoids situations where the stubs
+    # overshadow the real packages that tests rely on (e.g. ``requests``).
     if str(third_party_stubs) not in sys.path:
-        sys.path.insert(0, str(third_party_stubs))
+        sys.path.append(str(third_party_stubs))
     if str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
 except Exception:


### PR DESCRIPTION
## Summary
- ensure third_party_stubs is appended so site-packages take precedence

## Testing
- `python -m pip install -r requirements-test.txt`
- `NO_XDIST=1 make test-all` *(fails: 106 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fb32a1f083309a1e25aa4ae262ab