### PR TITLE
Support hour-based rebalance interval alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ config.reload_env()
 ```
 
 `.env` at the repo root is loaded at startup with `override=True`.
+Rebalance frequency defaults to 60 minutes; override with `AI_TRADING_REBALANCE_INTERVAL_MIN`
+(minutes) or `AI_TRADING_REBALANCE_INTERVAL_HOURS` (hours). The smallest positive value
+is used when multiple sources are set.
 Production code paths must avoid shim helpers like `optional_import(...)`; use direct `try`/`except ImportError` blocks or `importlib.util.find_spec` to guard optional dependencies and gate heavy imports inside function scope when possible.
 
 ## Timezones

--- a/tests/test_env_aliases.py
+++ b/tests/test_env_aliases.py
@@ -30,6 +30,20 @@ def test_rebalance_interval_env(monkeypatch):
     assert settings.get_rebalance_interval_min() == 7
 
 
+def test_rebalance_interval_env_hours(monkeypatch):
+    monkeypatch.delenv("AI_TRADING_REBALANCE_INTERVAL_MIN", raising=False)
+    monkeypatch.setenv("AI_TRADING_REBALANCE_INTERVAL_HOURS", "2")
+    importlib.reload(settings)
+    assert settings.get_rebalance_interval_min() == 120
+
+
+def test_rebalance_interval_env_smallest(monkeypatch):
+    monkeypatch.setenv("AI_TRADING_REBALANCE_INTERVAL_MIN", "45")
+    monkeypatch.setenv("AI_TRADING_REBALANCE_INTERVAL_HOURS", "2")
+    importlib.reload(settings)
+    assert settings.get_rebalance_interval_min() == 45
+
+
 def test_risk_engine_trade_slots(monkeypatch):
     monkeypatch.setenv("PYTEST_RUNNING", "1")
     eng = RiskEngine()


### PR DESCRIPTION
## Summary
- extend `get_rebalance_interval_min` to use `AI_TRADING_REBALANCE_INTERVAL_MIN` and `AI_TRADING_REBALANCE_INTERVAL_HOURS`, normalizing hours and selecting the smallest positive value
- document rebalance interval env vars in README
- add tests for minute/hour aliases and precedence

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_env_aliases.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'sklearn', 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68b123fac1148330935b453d721e5911