### PR TITLE
Add position enumeration fallback

### DIFF
--- a/tests/test_initial_rebalance.py
+++ b/tests/test_initial_rebalance.py
@@ -11,19 +11,34 @@ class DummyFetcher:
     def get_daily_df(self, ctx, symbol):
         return pd.DataFrame({"close": [100]})
 
-class DummyAPI:
+class DummyAPIList:
     def __init__(self):
         self.positions = {}
         self.orders = []
+
     def get_account(self):
         return types.SimpleNamespace(cash=1000.0, equity=1000.0, buying_power=1000.0)
+
+    def list_positions(self):
+        return [types.SimpleNamespace(symbol=s, qty=q) for s, q in self.positions.items()]
+
+
+class DummyAPIAll:
+    def __init__(self):
+        self.positions = {}
+        self.orders = []
+
+    def get_account(self):
+        return types.SimpleNamespace(cash=1000.0, equity=1000.0, buying_power=1000.0)
+
     def get_all_positions(self):
         return [types.SimpleNamespace(symbol=s, qty=q) for s, q in self.positions.items()]
 
 
-def test_partial_initial_rebalance_fill(monkeypatch):
+@pytest.mark.parametrize("api_cls", [DummyAPIList, DummyAPIAll])
+def test_partial_initial_rebalance_fill(monkeypatch, api_cls):
     ctx = types.SimpleNamespace(
-        api=DummyAPI(),
+        api=api_cls(),
         data_fetcher=DummyFetcher(),
         rebalance_ids={},
         rebalance_attempts={},


### PR DESCRIPTION
## Summary
- support legacy `get_all_positions` when `list_positions` is missing
- broaden initial rebalance test to cover both Alpaca position APIs

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_initial_rebalance.py -q` *(fails: ImportError: cannot import name 'check_data_freshness')*


------
https://chatgpt.com/codex/tasks/task_e_68b125e7c5f08330bcac8d023ab47d95