### PR TITLE
Guard RL imports and document dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,13 @@ pip install "ai-trading-bot[all]"
 | Trading Calendars    | `pandas-market-calendars` | `pandas-market-calendars` |
 | Plotting             | `plot`   | `matplotlib`                 |
 | Machine Learning     | `ml`     | `scikit-learn`, `torch`      |
+| Reinforcement Learning | `rl`*   | `stable-baselines3`, `gymnasium`, `torch` |
 | Technical Indicators | `ta`     | `ta`, `TA-Lib`               |
 
 > **Notes**
 > - **TA-Lib** may require system libraries/headers. See the TA-Lib docs for platform-specific instructions before installing `ai-trading-bot[ta]`.
 > - **PyTorch** wheels vary by CUDA/CPU and OS. If the default marker doesn’t suit your platform, follow the official instructions at [pytorch.org](https://pytorch.org) and/or install `torch` first, then `ai-trading-bot[ml]`.
+> - `rl` uses a separate extras file: `WITH_RL=1 pip install -r requirements-extras-rl.txt -c constraints-dev.txt`.
 
 When a feature is used without its optional dependency, the code raises a helpful error like:
 

--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -26,12 +26,15 @@ def _load_rl_stack() -> dict[str, Any] | None:
         sb3 = importlib.import_module("stable_baselines3")
         gym = importlib.import_module("gymnasium")
         importlib.import_module("torch")
-    except Exception as exc:  # noqa: BLE001 - best-effort import
+    except ImportError as exc:
         logger.debug("RL stack unavailable: %s", exc)
         return None
     global PPO, DummyVecEnv
-    PPO = sb3.PPO
-    DummyVecEnv = sb3.common.vec_env.DummyVecEnv
+    try:
+        PPO = sb3.PPO
+        DummyVecEnv = sb3.common.vec_env.DummyVecEnv
+    except AttributeError as exc:  # pragma: no cover - sanity guard
+        raise ImportError("stable-baselines3 missing PPO or DummyVecEnv") from exc
     return {"sb3": sb3, "gym": gym}
 
 


### PR DESCRIPTION
## Summary
- ensure `stable_baselines3` and `torch` imports raise clear `ImportError` when missing PPO or DummyVecEnv
- document reinforcement learning extras in README

## Testing
- `ruff check ai_trading/rl_trading/__init__.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rl_import_performance.py ai_trading/rl_trading/tests -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*


------
https://chatgpt.com/codex/tasks/task_e_68b127658f2483308e3e86e1a7329faa