### PR TITLE
feat: centralize HTTP timeout handling

### DIFF
--- a/ai_trading/monitoring/alerting.py
+++ b/ai_trading/monitoring/alerting.py
@@ -17,6 +17,7 @@ from typing import Any
 from ai_trading.logging import logger
 from ai_trading.utils import http
 from ai_trading.utils.timing import HTTP_TIMEOUT
+from ai_trading.utils.http import clamp_request_timeout
 from ai_trading.exc import RequestException
 
 class AlertSeverity(Enum):
@@ -153,7 +154,9 @@ class SlackAlerter:
             if alert.metadata:
                 for key, value in alert.metadata.items():
                     payload['attachments'][0]['fields'].append({'title': key, 'value': str(value), 'short': True})
-            response = http.post(self.webhook_url, json=payload, timeout=HTTP_TIMEOUT)
+            response = http.post(
+                self.webhook_url, json=payload, timeout=clamp_request_timeout(HTTP_TIMEOUT)
+            )
             response.raise_for_status()
             logger.info(f'Slack alert sent: {alert.title}')
             return True

--- a/ai_trading/predict.py
+++ b/ai_trading/predict.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 from ai_trading.features import prepare as feature_prepare
 from ai_trading.net.http import HTTPSession
 from ai_trading.exc import RequestException
+from ai_trading.utils.http import clamp_request_timeout
 
 try:
     from cachetools import TTLCache
@@ -38,7 +39,9 @@ def fetch_sentiment(symbol: str) -> float:
         return _sentiment_cache[symbol]
     score = 0.0
     try:
-        resp = _HTTP.get(f"https://example.com/{symbol}", timeout=10)
+        resp = _HTTP.get(
+            f"https://example.com/{symbol}", timeout=clamp_request_timeout(10)
+        )
         resp.raise_for_status()
         data = resp.json()
         score = float(data.get("score", 0.0))

--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints
 
 from alpaca.common.exceptions import APIError
 from ai_trading.logging import get_logger
-from ai_trading.utils import clamp_timeout as _clamp_timeout
+from ai_trading.utils import clamp_timeout as _clamp_timeout, clamp_request_timeout
 from ai_trading.exc import RequestException
 logger = get_logger(__name__)
 _log = logger
@@ -109,7 +109,7 @@ def _fetch_api(url: str, retries: int=3, delay: float=1.0) -> dict:
     """Fetch JSON from an API with simple retry logic and backoff."""
     for attempt in range(1, retries + 1):
         try:
-            resp = http.get(url, timeout=_clamp_timeout(5))
+            resp = http.get(url, timeout=clamp_request_timeout(5))
             resp.raise_for_status()
             return resp.json()
         except RequestException as exc:

--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -32,6 +32,7 @@ _BASE_EXPORTS = {
 __all__ = tuple(sorted({
     "HTTP_TIMEOUT",
     "clamp_timeout",
+    "clamp_request_timeout",
     "sleep",
     "OptionalDependencyError",
     "module_ok",
@@ -48,6 +49,7 @@ __all__ = tuple(sorted({
 
 _LAZY_MAP = {
     "http": ("ai_trading.utils.http", None),
+    "clamp_request_timeout": ("ai_trading.utils.http", "clamp_request_timeout"),
     "retry": ("ai_trading.utils.retry", None),
     "timing": ("ai_trading.utils.timing", None),
     "device": ("ai_trading.utils.device", None),
@@ -74,6 +76,7 @@ _LAZY_MAP = {
 
 if TYPE_CHECKING:  # pragma: no cover - for static analyzers only
     from . import http as http  # type: ignore
+    from .http import clamp_request_timeout as clamp_request_timeout  # type: ignore
     from . import retry as retry  # type: ignore
     from . import timing as timing  # type: ignore
     from . import device as device  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,15 +87,22 @@ extend-exclude = ["**/.venv", "**/venv", "build", "dist", "notebooks", "artifact
 
 # Focus on safe mechanical families only.
 [tool.ruff.lint]
-select = ["E", "F", "UP", "DTZ", "T201"]  # AI-AGENT-REF: safe lint families
+select = ["E", "F", "UP", "DTZ", "T201", "TID"]  # AI-AGENT-REF: safe lint families
 ignore = ["E501"]
 
 # Allow prints in tests/tools; allow re-export F401 in package __init__ files.
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["T201"]
-"tools/**" = ["T201", "E402"]
-"scripts/**" = ["T201", "E402"]
+"tests/**" = ["T201", "TID251"]
+"tools/**" = ["T201", "E402", "TID251"]
+"scripts/**" = ["T201", "E402", "TID251"]
 "**/__init__.py" = ["F401"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"requests.get" = "use ai_trading.utils.http.get"
+"requests.post" = "use ai_trading.utils.http.post"
+"requests.put" = "use ai_trading.utils.http.put"
+"requests.delete" = "use ai_trading.utils.http.delete"
+"requests.request" = "use ai_trading.utils.http.request"
 
 [tool.pytest.ini_options]
 minversion = "7.0"


### PR DESCRIPTION
## Summary
- add reusable clamp_request_timeout helper and expose it across utils
- apply clamped timeouts in all network-facing modules
- ban direct requests.* calls via ruff

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b12cd1a6e88330aa774bf0cf6d2914