### PR TITLE
feat: backoff sentiment retries

### DIFF
--- a/CRITICAL_FIXES_IMPLEMENTATION_COMPLETE.md
+++ b/CRITICAL_FIXES_IMPLEMENTATION_COMPLETE.md
@@ -62,6 +62,8 @@ SENTIMENT_FAILURE_THRESHOLD = 15  # Increased from 5 to 15
 SENTIMENT_RECOVERY_TIMEOUT = 1800  # Extended from 600s to 1800s
 ```
 
+- Circuit breaker tracks consecutive failures and schedules progressive retry delays before opening.
+
 #### bot_engine.py
 ```python
 # Lines 3034-3035: Updated circuit breaker thresholds for consistency

--- a/ai_trading/analysis/sentiment.py
+++ b/ai_trading/analysis/sentiment.py
@@ -82,7 +82,13 @@ SENTIMENT_RECOVERY_TIMEOUT = 1800
 SENTIMENT_MAX_RETRIES = 5
 SENTIMENT_BASE_DELAY = 5
 _SENTIMENT_CACHE: dict[str, tuple[float, float]] = {}
-_SENTIMENT_CIRCUIT_BREAKER = {'failures': 0, 'last_failure': 0, 'state': 'closed'}
+# track failures and progressive retry scheduling
+_SENTIMENT_CIRCUIT_BREAKER = {
+    'failures': 0,
+    'last_failure': 0,
+    'state': 'closed',
+    'next_retry': 0,
+}
 sentiment_lock = Lock()
 __all__ = ['fetch_sentiment', 'analyze_text', 'sentiment_lock', '_SENTIMENT_CACHE', 'SENTIMENT_FAILURE_THRESHOLD', 'SENTIMENT_API_KEY']
 
@@ -97,12 +103,18 @@ def _check_sentiment_circuit_breaker() -> bool:
             logger.info('Sentiment circuit breaker moved to half-open state')
             return True
         return False
+    if now < cb.get('next_retry', 0):
+        logger.debug(
+            'Sentiment retry delayed %.1fs', cb['next_retry'] - now
+        )
+        return False
     return True
 
 def _record_sentiment_success():
     """Record successful sentiment API call."""
     global _SENTIMENT_CIRCUIT_BREAKER
     _SENTIMENT_CIRCUIT_BREAKER['failures'] = 0
+    _SENTIMENT_CIRCUIT_BREAKER['next_retry'] = 0
     if _SENTIMENT_CIRCUIT_BREAKER['state'] == 'half-open':
         _SENTIMENT_CIRCUIT_BREAKER['state'] = 'closed'
         logger.info('Sentiment circuit breaker closed - service recovered')
@@ -113,9 +125,20 @@ def _record_sentiment_failure():
     cb = _SENTIMENT_CIRCUIT_BREAKER
     cb['failures'] += 1
     cb['last_failure'] = pytime.time()
+    delay = min(
+        SENTIMENT_BASE_DELAY * (2 ** (cb['failures'] - 1)),
+        SENTIMENT_RECOVERY_TIMEOUT,
+    )
+    cb['next_retry'] = cb['last_failure'] + delay
     if cb['failures'] >= SENTIMENT_FAILURE_THRESHOLD:
         cb['state'] = 'open'
-        logger.warning(f"Sentiment circuit breaker opened after {cb['failures']} failures")
+        logger.warning(
+            f"Sentiment circuit breaker opened after {cb['failures']} failures"
+        )
+    else:
+        logger.debug(
+            'Sentiment failure %s; next retry in %.1fs', cb['failures'], delay
+        )
 
 @retry(stop=stop_after_attempt(SENTIMENT_MAX_RETRIES), wait=wait_exponential(multiplier=SENTIMENT_BASE_DELAY, min=SENTIMENT_BASE_DELAY, max=180) + wait_random(0, 5), retry=retry_if_exception_type((Exception,)))
 def fetch_sentiment(ctx, ticker: str) -> float:

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5149,11 +5149,13 @@ _SENTIMENT_CIRCUIT_BREAKER = {
     "failures": 0,
     "last_failure": 0,
     "state": "closed",
+    "next_retry": 0,
 }  # closed, open, half-open
 # AI-AGENT-REF: Enhanced sentiment circuit breaker thresholds for better resilience
 SENTIMENT_RECOVERY_TIMEOUT = (
     1800  # Extended to 30 minutes (1800s) for better recovery per problem statement
 )
+SENTIMENT_BASE_DELAY = 5
 
 
 class SignalManager:
@@ -6461,6 +6463,9 @@ def _check_sentiment_circuit_breaker() -> bool:
             logger.info("Sentiment circuit breaker moved to half-open state")
             return True
         return False
+    if now < cb.get("next_retry", 0):
+        logger.debug("Sentiment retry delayed %.1fs", cb["next_retry"] - now)
+        return False
     return True
 
 
@@ -6468,6 +6473,7 @@ def _record_sentiment_success():
     """Record successful sentiment API call."""
     global _SENTIMENT_CIRCUIT_BREAKER
     _SENTIMENT_CIRCUIT_BREAKER["failures"] = 0
+    _SENTIMENT_CIRCUIT_BREAKER["next_retry"] = 0
     if _SENTIMENT_CIRCUIT_BREAKER["state"] == "half-open":
         _SENTIMENT_CIRCUIT_BREAKER["state"] = "closed"
         logger.info("Sentiment circuit breaker closed - service recovered")
@@ -6479,11 +6485,19 @@ def _record_sentiment_failure():
     cb = _SENTIMENT_CIRCUIT_BREAKER
     cb["failures"] += 1
     cb["last_failure"] = pytime.time()
-
+    delay = min(
+        SENTIMENT_BASE_DELAY * (2 ** (cb["failures"] - 1)),
+        SENTIMENT_RECOVERY_TIMEOUT,
+    )
+    cb["next_retry"] = cb["last_failure"] + delay
     if cb["failures"] >= SENTIMENT_FAILURE_THRESHOLD:
         cb["state"] = "open"
         logger.warning(
             f"Sentiment circuit breaker opened after {cb['failures']} failures"
+        )
+    else:
+        logger.debug(
+            "Sentiment failure %s; next retry in %.1fs", cb["failures"], delay
         )
 
 

--- a/scripts/integration_test.py
+++ b/scripts/integration_test.py
@@ -146,9 +146,9 @@ def test_http_timeouts():
         if bot_engine_path.exists():
             content = bot_engine_path.read_text()
             import re
-            timeout_pattern = 'requests\\.get\\([^)]*timeout\\s*=\\s*\\d+'
+            timeout_pattern = r'_HTTP[_A-Z]*\\.get\\([^)]*timeout\\s*=\\s*\\d+'
             matches = re.findall(timeout_pattern, content)
-            assert len(matches) >= 1, 'Should find at least one requests.get call with timeout'
+            assert len(matches) >= 1, 'Should find at least one HTTP session get call with timeout'
             assert 'timeout=2' in content, 'Should have health probe timeout=2'
             assert 'timeout=10' in content, 'Should have API timeout=10'
         return True

--- a/scripts/problem_statement_validation.py
+++ b/scripts/problem_statement_validation.py
@@ -75,10 +75,10 @@ def check_timeouts():
     bot_engine_path = Path('ai_trading/core/bot_engine.py')
     if bot_engine_path.exists():
         content = bot_engine_path.read_text()
-        timeout_pattern = r'requests\.get\([^)]*timeout\s*=\s*'
+        timeout_pattern = r'_HTTP[_A-Z]*\.get\([^)]*timeout\s*=\s*'
         matches = re.findall(timeout_pattern, content)
-        assert len(matches) >= 1, 'Should find requests.get calls with timeout'
-        logging.info('  - Added explicit timeouts to blocking requests.get calls ✓')
+        assert len(matches) >= 1, 'Should find HTTP session calls with timeout'
+        logging.info('  - Added explicit timeouts to HTTP session calls ✓')
 
 def check_minute_cache():
     """Check minute-cache freshness helpers and validation."""

--- a/scripts/retrain_model.py
+++ b/scripts/retrain_model.py
@@ -10,9 +10,11 @@ from ai_trading.config import management as config
 from ai_trading.config.management import TradingConfig
 from ai_trading.features.prepare import prepare_indicators
 CONFIG = TradingConfig()
+from ai_trading.net.http import HTTPSession
 from ai_trading.utils.base import safe_to_datetime
 logger = logging.getLogger(__name__)
 config.reload_env()
+_HTTP = HTTPSession()
 SEED = config.SEED
 random.seed(SEED)
 np.random.seed(SEED)
@@ -22,7 +24,6 @@ try:
 except ImportError:
     pass
 from datetime import UTC, date, datetime, time, timedelta
-import requests
 from lightgbm import LGBMClassifier
 from sklearn.model_selection import ParameterSampler, cross_val_score
 from sklearn.pipeline import make_pipeline
@@ -94,7 +95,7 @@ def fetch_sentiment(symbol: str) -> float:
     try:
         url = 'https://newsapi.org/v2/everything'
         params = {'q': symbol, 'apiKey': NEWS_API_KEY, 'pageSize': 10, 'sortBy': 'publishedAt', 'language': 'en'}
-        response = requests.get(url, params=params, timeout=30)
+        response = _HTTP.get(url, params=params, timeout=30)
         response.raise_for_status()
         data = response.json()
         articles = data.get('articles', [])

--- a/tests/test_critical_fixes_implementation.py
+++ b/tests/test_critical_fixes_implementation.py
@@ -109,7 +109,7 @@ def test_sentiment_cache_memory_leak_prevention():
         with patch.object(predict, '_sentiment_cache', {}):
             # Simulate filling cache beyond limit
             for i in range(1500):
-                with patch('predict.requests.get') as mock_get:
+                with patch('predict._HTTP.get') as mock_get:
                     mock_response = Mock()
                     mock_response.json.return_value = {"articles": []}
                     mock_response.raise_for_status.return_value = None


### PR DESCRIPTION
## Summary
- use shared HTTPSession instead of direct requests.get
- add consecutive failure tracking with exponential retry delays
- update tests and validation scripts for new HTTP session

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b12cd1a3e8833097c6d541a501f87d