### PR TITLE
feat: centralize HTTP session usage

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -8,7 +8,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Optional, TYPE_CHECKING
 
-from ai_trading.net.http import HTTPSession
+from ai_trading.net.http import HTTPSession, get_http_session
 from ai_trading.exc import RequestException
 from ai_trading.utils.http import clamp_request_timeout
 import importlib.util
@@ -22,7 +22,7 @@ _log = get_logger(__name__)
 RETRY_HTTP_CODES = {429, 500, 502, 503, 504}
 RETRYABLE_HTTP_STATUSES = tuple(RETRY_HTTP_CODES)
 _UTC = timezone.utc  # AI-AGENT-REF: prefer stdlib UTC
-_HTTP = HTTPSession()
+_HTTP: HTTPSession = get_http_session()
 
 
 from zoneinfo import ZoneInfo

--- a/ai_trading/analysis/sentiment.py
+++ b/ai_trading/analysis/sentiment.py
@@ -7,7 +7,7 @@ extracted from bot_engine.py to enable standalone imports and testing.
 import time as pytime
 from datetime import datetime
 from threading import Lock
-from ai_trading.net.http import HTTPSession
+from ai_trading.net.http import HTTPSession, get_http_session
 from ai_trading.utils.http import clamp_request_timeout
 from ai_trading.utils.retry import (
     retry,
@@ -25,7 +25,7 @@ from ai_trading.utils.device import get_device, tensors_to_device  # AI-AGENT-RE
 from ai_trading.exc import RequestException, HTTPError
 
 SENTIMENT_API_KEY = get_env("SENTIMENT_API_KEY", "")
-_HTTP = HTTPSession()
+_HTTP: HTTPSession = get_http_session()
 DEVICE = None
 _SENTIMENT_INITIALIZED = False
 

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -35,9 +35,9 @@ except ImportError:  # pragma: no cover  # AI-AGENT-REF: narrow import handling
 
 # Reusable HTTP session
 try:  # pragma: no cover
-    from ai_trading.net.http import HTTPSession
+    from ai_trading.net.http import HTTPSession, get_http_session
 
-    _HTTP_SESSION = HTTPSession()
+    _HTTP_SESSION: HTTPSession = get_http_session()
 except Exception:  # pragma: no cover - fallback when requests missing
     class _HTTPStub:
         def get(self, *a, **k):  # type: ignore[no-untyped-def]

--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -25,11 +25,11 @@ from ai_trading.logging.normalize import canon_timeframe as _canon_tf
 from ai_trading.logging.normalize import normalize_extra as _norm_extra
 from ai_trading.logging import logger
 from ai_trading.data.metrics import metrics
-from ai_trading.net.http import HTTPSession
+from ai_trading.net.http import HTTPSession, get_http_session
 from ai_trading.utils.http import clamp_request_timeout
 
 # Module-level session reused across requests
-_HTTP_SESSION = HTTPSession()
+_HTTP_SESSION: HTTPSession = get_http_session()
 
 
 # Optional dependency placeholders

--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -76,11 +76,18 @@ def get_global_session() -> TimeoutSession:
     return _GLOBAL_SESSION
 
 
+def get_http_session() -> HTTPSession:
+    """Return process-wide HTTP session singleton."""
+
+    return get_global_session()
+
+
 __all__ = [
     "HTTPSession",
     "TimeoutSession",
     "build_retrying_session",
     "set_global_session",
     "get_global_session",
+    "get_http_session",
 ]
 

--- a/ai_trading/predict.py
+++ b/ai_trading/predict.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from functools import lru_cache
 from ai_trading.features import prepare as feature_prepare
-from ai_trading.net.http import HTTPSession
+from ai_trading.net.http import HTTPSession, get_http_session
 from ai_trading.exc import RequestException
 from ai_trading.utils.http import clamp_request_timeout
 
@@ -14,7 +14,7 @@ except Exception:
     _CACHETOOLS_AVAILABLE = False
     _sentiment_cache: dict[str, float] = {}
 
-_HTTP = HTTPSession()
+_HTTP: HTTPSession = get_http_session()
 
 @lru_cache(maxsize=1024)
 def predict(path: str):


### PR DESCRIPTION
## Summary
- add get_http_session returning global HTTPSession
- reuse get_http_session in prediction, Alpaca API, sentiment, data fetch, and bot engine modules

## Testing
- `python -m pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; skipped: alpaca-py is required for tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b1bdfd53e08330b4aa230888ca95d6