### PR TITLE
Normalize timeframe input using Alpaca TimeFrame

### DIFF
--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -16,6 +16,7 @@ except Exception:  # pragma: no cover - inject stub
 
     class TimeFrameUnit:
         Day = type("Day", (), {"name": "Day"})()
+        Minute = type("Minute", (), {"name": "Minute"})()
 
     class TimeFrame:
         def __init__(self, amount, unit):
@@ -41,10 +42,11 @@ def test_day_timeframe_normalized(mock_rest_cls):
     )
     mock_rest_cls.return_value = mock_rest
 
-    df = get_bars_df("SPY", "Day", feed="iex", adjustment="all")
+    df = get_bars_df("SPY", "1Day", feed="iex", adjustment="all")
     mock_rest_cls.assert_called_once_with(bars=True)
     (req,), kwargs = mock_rest.get_stock_bars.call_args
-    assert req.timeframe in ("1Day", "1D")
+    assert getattr(req.timeframe, "amount", None) == 1
+    assert getattr(req.timeframe.unit, "name", "") == "Day"
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
 
 
@@ -59,7 +61,8 @@ def test_tf_object_normalized(mock_rest_cls):
     df = get_bars_df("SPY", TimeFrame(1, TimeFrameUnit.Day), feed="iex", adjustment="all")
     mock_rest_cls.assert_called_once_with(bars=True)
     (req,), kwargs = mock_rest.get_stock_bars.call_args
-    assert req.timeframe in ("1Day", "1D")
+    assert getattr(req.timeframe, "amount", None) == 1
+    assert getattr(req.timeframe.unit, "name", "") == "Day"
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
 
 
@@ -74,5 +77,6 @@ def test_minute_normalized(mock_rest_cls):
     df = get_bars_df("SPY", "Minute", feed="iex", adjustment="all")
     mock_rest_cls.assert_called_once_with(bars=True)
     (req,), kwargs = mock_rest.get_stock_bars.call_args
-    assert req.timeframe in ("1Min", "1Minute")
+    assert getattr(req.timeframe, "amount", None) == 1
+    assert getattr(req.timeframe.unit, "name", "") in {"Minute", "Min"}
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode


### PR DESCRIPTION
## Summary
- Convert `get_bars_df` timeframe strings to `alpaca-py` `TimeFrame` objects and feed to `StockBarsRequest`
- Map normalized timeframe suffixes to `TimeFrameUnit`
- Expand tests to verify `get_bars_df("SPY", "1Day", ...)` builds valid requests

## Testing
- `ruff check ai_trading/alpaca_api.py tests/test_alpaca_timeframe_mapping.py tests/test_alpaca_time_params.py`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 106 errors during collection)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_timeframe_mapping.py tests/test_alpaca_time_params.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1bff774e083309fc6028bf2f8d5e2