### PR TITLE
Guard get_bars when config missing

### DIFF
--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -10,7 +10,7 @@ from ai_trading.utils.lazy_imports import load_pandas
 
 try:
     from ai_trading.config import get_settings
-except Exception:
+except ImportError:
 
     def get_settings():
         return None
@@ -817,6 +817,8 @@ def get_bars(
 ) -> pd.DataFrame:
     """Compatibility wrapper delegating to _fetch_bars."""
     S = get_settings()
+    if S is None:
+        raise RuntimeError("Configuration is unavailable; cannot fetch bars")
     feed = feed or S.alpaca_data_feed
     adjustment = adjustment or S.alpaca_adjustment
     return _fetch_bars(symbol, start, end, timeframe, feed=feed, adjustment=adjustment)

--- a/tests/test_fetch_contract.py
+++ b/tests/test_fetch_contract.py
@@ -45,3 +45,12 @@ def test_get_bars_never_none(monkeypatch):
         "volume",
     ]
     assert str(result["timestamp"].dt.tz) == "UTC"
+
+
+def test_get_bars_requires_settings(monkeypatch):
+    now = pd.Timestamp("2024-01-01", tz="UTC")
+    monkeypatch.setattr(data_fetcher, "get_settings", lambda: None)
+    with pytest.raises(RuntimeError, match="Configuration is unavailable"):
+        data_fetcher.get_bars(
+            "AAPL", "1Day", now - pd.Timedelta(days=1), now
+        )


### PR DESCRIPTION
## Summary
- narrow `get_settings` import handling to `ImportError`
- raise `RuntimeError` when configuration is unavailable in `get_bars`
- add test covering configuration missing case

## Testing
- `ruff check tests/test_fetch_contract.py ai_trading/data/fetch.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_contract.py::test_get_bars_requires_settings -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c2f131c88330aa0cc6848177a04d