### PR TITLE
chore: remove duplicate screening start log

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -11599,10 +11599,9 @@ def load_candidate_universe(runtime, *, fallback_symbols=None) -> list[str]:
     if not candidates:
         logger.error("UNIVERSE_EMPTY_ABORT", extra={"reason": "no_tickers_csv"})
         return []
-    logger.info(
-        "[SCREEN_UNIVERSE] Starting screening of %d candidates: %s",
-        len(candidates),
-        candidates[:10],
+    logger.debug(
+        "CANDIDATE_UNIVERSE_LOADED",
+        extra={"count": len(candidates)},
     )
     return candidates
 


### PR DESCRIPTION
## Summary
- avoid duplicate `[SCREEN_UNIVERSE]` start messages by downgrading the log in `load_candidate_universe`

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/test_fixes.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_fixes.py::test_screen_universe_logging`


------
https://chatgpt.com/codex/tasks/task_e_68b1c2f224008330bed727f857f4f17a