### PR TITLE
Skip chmod when directory not writable

### DIFF
--- a/ai_trading/paths.py
+++ b/ai_trading/paths.py
@@ -17,7 +17,10 @@ def _ensure_dir(path: Path) -> Path:
     try:
         path.mkdir(parents=True, exist_ok=True)
         try:
-            path.chmod(0o700)
+            if os.access(path, os.W_OK):
+                path.chmod(0o700)
+            else:
+                logger.debug("Skipping chmod for non-writable path %s", path)
         except OSError as perm_err:  # best effort permission fix
             logger.debug("chmod failed for %s: %s", path, perm_err)
         return path
@@ -26,7 +29,10 @@ def _ensure_dir(path: Path) -> Path:
             fallback = Path(tempfile.gettempdir()) / APP_NAME
             fallback.mkdir(parents=True, exist_ok=True)
             try:
-                fallback.chmod(0o700)
+                if os.access(fallback, os.W_OK):
+                    fallback.chmod(0o700)
+                else:
+                    logger.debug("Skipping chmod for non-writable path %s", fallback)
             except OSError as perm_err:  # pragma: no cover - unlikely
                 logger.debug("chmod failed for %s: %s", fallback, perm_err)
             logger.warning(


### PR DESCRIPTION
## Summary
- Check directory writability with `os.access` before calling `chmod`.
- Skip `chmod` and log a single debug message if the directory isn't writable; fallback logic to `/tmp/ai-trading-bot` remains intact.

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

## Rollback
- Revert the commit with `git revert <commit>`.

------
https://chatgpt.com/codex/tasks/task_e_68b1c4b068ac8330b2d863f95fba5587