### PR TITLE
Ensure execution engine stop checks and warn when absent

### DIFF
--- a/tests/test_bot_engine_check_stops.py
+++ b/tests/test_bot_engine_check_stops.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+from ai_trading.core.bot_engine import _check_runtime_stops
+
+
+class DummyEngine:
+    def __init__(self):
+        self.called = False
+
+    def check_stops(self):
+        self.called = True
+
+
+def test_check_stops_invoked_when_present():
+    runtime = SimpleNamespace(exec_engine=DummyEngine())
+    _check_runtime_stops(runtime)
+    assert runtime.exec_engine.called
+
+
+def test_warning_when_exec_engine_missing(caplog):
+    runtime = SimpleNamespace()
+    with caplog.at_level("WARNING"):
+        _check_runtime_stops(runtime)
+    assert "risk-stop checks skipped" in caplog.text


### PR DESCRIPTION
## Summary
- Initialize and attach execution engine before trading loop
- Warn and skip risk-stop checks when execution engine lacks `check_stops`
- Add regression tests for `check_stops` invocation and missing-engine warnings

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c84f1e2483309fc8caf5bab3e3c2