### PR TITLE
Configure persistent storage directories

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -53,6 +53,18 @@ startup the validation result is cached and `/healthz` reuses it, returning
 | --- | --- | --- |
 | `AI_TRADING_CONF_THRESHOLD` | Minimum model confidence required before acting | 0.75 |
 
+### Persistent directories
+
+The service writes state, cache, and logs to paths governed by the environment variables `AI_TRADING_DATA_DIR`, `AI_TRADING_CACHE_DIR`, and `AI_TRADING_LOG_DIR`.
+Each directory must exist and be writable by the service user with **0700** permissions.
+
+```bash
+sudo install -d -m 700 -o aiuser -g aiuser \
+  /var/lib/ai-trading-bot /var/cache/ai-trading-bot /var/log/ai-trading-bot
+```
+
+Mount these locations or set the variables above so data persists across restarts.
+
 ### Health endpoints & env
 
 Set `RUN_HEALTHCHECK=1` to expose `/healthz` and `/metrics` on the port defined by the `HEALTHCHECK_PORT` environment variable (default **9001**).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 FROM python:3.12-slim
 WORKDIR /app
+ENV AI_TRADING_DATA_DIR=/var/lib/ai-trading-bot \
+    AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot \
+    AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
 COPY . .
-RUN pip uninstall -y alpaca-trade-api || true \
+RUN mkdir -p $AI_TRADING_DATA_DIR $AI_TRADING_CACHE_DIR $AI_TRADING_LOG_DIR \
+    && chmod 700 $AI_TRADING_DATA_DIR $AI_TRADING_CACHE_DIR $AI_TRADING_LOG_DIR \
+    && (pip uninstall -y alpaca-trade-api || true) \
     && pip install -r requirements.txt \
     && pip install .[ml]
+VOLUME ["/var/lib/ai-trading-bot", "/var/cache/ai-trading-bot", "/var/log/ai-trading-bot"]
 CMD ["python", "-m", "ai_trading"]

--- a/ai_trading/paths.py
+++ b/ai_trading/paths.py
@@ -35,8 +35,11 @@ def _ensure_dir(path: Path) -> Path:
                     logger.debug("Skipping chmod for non-writable path %s", fallback)
             except OSError as perm_err:  # pragma: no cover - unlikely
                 logger.debug("chmod failed for %s: %s", fallback, perm_err)
-            logger.warning(
-                "Falling back to writable temp dir %s for %s: %s", fallback, path, e
+            logger.error(
+                "Persistent directory %s is not writable (%s); using temp dir %s. Set AI_TRADING_*_DIR env vars to a writable location.",
+                path,
+                e,
+                fallback,
             )
             return fallback
         logger.debug("Directory creation failed for %s: %s", path, e)

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -9,6 +9,9 @@ Group=aiuser
 WorkingDirectory=/home/aiuser/ai-trading-bot
 Environment=PATH=/home/aiuser/ai-trading-bot/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=AI_TRADING_MODEL_MODULE=ai_trading.models.baseline
+Environment=AI_TRADING_DATA_DIR=/var/lib/ai-trading-bot
+Environment=AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot
+Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
 EnvironmentFile=-/home/aiuser/ai-trading-bot/.env
 ExecStart=/home/aiuser/ai-trading-bot/venv/bin/python -m ai_trading.main
 Restart=always


### PR DESCRIPTION
## Summary
- Set `AI_TRADING_DATA_DIR`, `AI_TRADING_CACHE_DIR`, and `AI_TRADING_LOG_DIR` in container and systemd configs with writable 0700 directories
- Emit prominent error when falling back to temp storage for unwritable directories
- Document required persistent directory permissions and setup steps in deployment guide

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: pydantic_settings and many others)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_paths.py::test_runtime_paths_writable -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c84e3b40833091ead4928df566e2