### PR TITLE
Silence yfinance debug logs

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -8,6 +8,8 @@
 
 - **`LOG_MARKET_FETCH`** (default: `false`): When enabled, logs periodic market fetch heartbeats at INFO level. When disabled, these messages are demoted to DEBUG level to reduce noise.
 
+- **`LOG_LEVEL_YFINANCE`** (default: `WARNING`): Controls the log level for the `yfinance` package. Set to `INFO` or another level to troubleshoot provider interactions.
+
 ### Features
 
 #### Emit-Once Logging

--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -329,18 +329,25 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
         _ensure_single_handler(logger)
         logger.handlers.clear()
         try:
-            from ai_trading.config import get_settings
+            from ai_trading.config import get_settings, management as config
             S = get_settings()
             level_name = getattr(S, 'log_level', 'INFO')
+            yf_level_name = getattr(
+                S, 'log_level_yfinance', config.get_env('LOG_LEVEL_YFINANCE', 'WARNING')
+            )
             if S.log_compact_json:
                 formatter = CompactJsonFormatter('%Y-%m-%dT%H:%M:%SZ')
             else:
                 formatter = JSONFormatter('%Y-%m-%dT%H:%M:%SZ')
         except COMMON_EXC:
+            from ai_trading.config import management as config
             level_name = os.getenv('LOG_LEVEL', 'INFO')
+            yf_level_name = config.get_env('LOG_LEVEL_YFINANCE', 'WARNING')
             formatter = JSONFormatter('%Y-%m-%dT%H:%M:%SZ')
         level = getattr(logging, str(level_name).upper(), logging.INFO)
         logger.setLevel(level)
+        yf_level = getattr(logging, str(yf_level_name).upper(), logging.WARNING)
+        logging.getLogger('yfinance').setLevel(yf_level)
 
         class _PhaseFilter(logging.Filter):
 


### PR DESCRIPTION
## Summary
- Set yfinance logger to WARNING by default during central logging setup
- Allow overriding yfinance log level via LOG_LEVEL_YFINANCE
- Document new LOG_LEVEL_YFINANCE env var

## Testing
- `python - <<'PY'
import logging
from ai_trading.logging import setup_logging
import yfinance as yf
setup_logging()
print('yfinance effective level', logging.getLogger('yfinance').getEffectiveLevel())
logging.getLogger().setLevel(logging.DEBUG)
logger = logging.getLogger('yfinance')
logger.debug('debug message should not appear')
logger.info('info message should not appear')
print('done before fetch')
yf.Ticker('AAPL').history(period='1d')
print('fetch complete')
PY`
- `LOG_LEVEL_YFINANCE=INFO python - <<'PY'
import logging
from ai_trading.logging import setup_logging
import yfinance as yf
setup_logging()
print('yfinance effective level', logging.getLogger('yfinance').getEffectiveLevel())
PY`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1cfa2fe50833095fd3af5a810210b