### PR TITLE
Handle empty Alpaca bars based on market state

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -42,6 +42,8 @@ Daily price requests now log their parameters and outcome:
 - `DAILY_FETCH_REQUEST` records the symbol, timeframe, and date range
 - `DAILY_FETCH_RESULT` reports the number of rows returned and whether the
   response came from cache
+- Empty bar responses log a warning only when the market is open; otherwise,
+  fallback attempts proceed without additional noise
 
 ### Example Usage
 

--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -672,22 +672,27 @@ def _fetch_bars(
                             return rdf
             _now = datetime.now(UTC)
             _key = (symbol, "AVAILABLE", _now.date().isoformat(), _feed, _interval)
-            if _empty_should_emit(_key, _now):
-                lvl = _empty_classify(is_market_open=False)
-                cnt = _empty_record(_key, _now)
-                logger.log(
-                    lvl,
-                    "EMPTY_DATA",
-                    extra=_norm_extra(
-                        {
-                            "provider": "alpaca",
-                            "status": "empty",
-                            "feed": _feed,
-                            "timeframe": _interval,
-                            "occurrences": cnt,
-                        }
-                    ),
-                )
+            try:
+                _open = is_market_open()
+            except Exception:  # pragma: no cover - defensive
+                _open = False
+            if _open:
+                if _empty_should_emit(_key, _now):
+                    lvl = _empty_classify(is_market_open=True)
+                    cnt = _empty_record(_key, _now)
+                    logger.log(
+                        lvl,
+                        "EMPTY_DATA",
+                        extra=_norm_extra(
+                            {
+                                "provider": "alpaca",
+                                "status": "empty",
+                                "feed": _feed,
+                                "timeframe": _interval,
+                                "occurrences": cnt,
+                            }
+                        ),
+                    )
             if fallback:
                 _interval, _feed, _start, _end = fallback
                 _incr("data.fetch.fallback_attempt", value=1.0, tags=_tags())

--- a/tests/test_fetch_empty_handling.py
+++ b/tests/test_fetch_empty_handling.py
@@ -1,0 +1,64 @@
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ai_trading.data import fetch
+
+
+class _Resp:
+    def __init__(self, payload):
+        self.status_code = 200
+        self.headers = {"Content-Type": "application/json"}
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, payloads):
+        self._payloads = list(payloads)
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        return _Resp(self._payloads.pop(0))
+
+
+def _dt_range():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+    return start, end
+
+
+def test_warn_on_empty_when_market_open(monkeypatch, caplog):
+    start, end = _dt_range()
+    sess = _Session([{"bars": []}])
+    monkeypatch.setattr(fetch, "_HTTP_SESSION", sess)
+    monkeypatch.setattr(fetch, "_SIP_UNAUTHORIZED", True)
+    monkeypatch.setattr(fetch, "is_market_open", lambda: True)
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError, match="empty_bars"):
+            fetch._fetch_bars("AAPL", start, end, "1Min")
+
+    assert any(r.message == "EMPTY_DATA" and r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_silent_fallback_when_market_closed(monkeypatch, caplog):
+    start, end = _dt_range()
+    payloads = [
+        {"bars": []},
+        {"bars": [{"t": "2024-01-01T00:00:00Z", "o": 1, "h": 1, "l": 1, "c": 1, "v": 1}]},
+    ]
+    sess = _Session(payloads)
+    monkeypatch.setattr(fetch, "_HTTP_SESSION", sess)
+    monkeypatch.setattr(fetch, "_SIP_UNAUTHORIZED", False)
+    monkeypatch.setattr(fetch, "is_market_open", lambda: False)
+
+    with caplog.at_level(logging.INFO):
+        df = fetch._fetch_bars("AAPL", start, end, "1Min")
+
+    assert not df.empty
+    assert all(r.message != "EMPTY_DATA" for r in caplog.records)


### PR DESCRIPTION
## Summary
- Skip noisy empty-bar warnings when markets are closed
- Warn only when empty data arrives during open market hours
- Document and test the fallback behavior

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_empty_handling.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68b1cfa2022c8330b79d382bcd96a94f