### PR TITLE
feat: handle feed entitlement and throttle empty bars

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -44,8 +44,11 @@ Daily price requests now log their parameters and outcome:
 - `DAILY_FETCH_REQUEST` records the symbol, timeframe, and date range
 - `DAILY_FETCH_RESULT` reports the number of rows returned and whether the
   response came from cache
-- Empty bar responses log a warning only when the market is open; otherwise,
-  fallback attempts proceed without additional noise
+- Unauthorized feed responses trigger a quick entitlement check and switch to a
+  permitted feed when available. If no alternative exists, operators are
+  notified once.
+- Empty bar responses are retried with a short backoff and warnings are
+  throttled to once per minute to reduce log noise.
 
 ### Example Usage
 

--- a/ai_trading/logging/emit_once.py
+++ b/ai_trading/logging/emit_once.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 import threading
 from logging import Logger
+
 _emitted: set[str] = set()
 _lock = threading.Lock()
 
 def emit_once(logger: Logger, key: str, level: str, msg: str, **extra) -> bool:
     """Emit ``msg`` at ``level`` only once per process keyed by ``key``."""
-    token = f'{logger.name}:{key}'
+    token = f"{logger.name}:{key}"
     with _lock:
         if token in _emitted:
             return False
@@ -15,4 +16,5 @@ def emit_once(logger: Logger, key: str, level: str, msg: str, **extra) -> bool:
     fn = getattr(logger, level.lower(), logger.info)
     fn(msg, extra=extra or None)
     return True
-__all__ = ['emit_once']
+
+__all__ = ["emit_once"]

--- a/tests/test_feed_entitlement.py
+++ b/tests/test_feed_entitlement.py
@@ -1,0 +1,26 @@
+from ai_trading.data import bars
+
+
+class _Account:
+    def __init__(self, feeds):
+        self.market_data_subscription = feeds
+
+
+class _Client:
+    def __init__(self, feeds):
+        self._feeds = feeds
+
+    def get_account(self):
+        return _Account(self._feeds)
+
+
+def test_ensure_entitled_feed_switches():
+    bars._ENTITLE_CACHE.clear()
+    client = _Client(['iex'])
+    assert bars._ensure_entitled_feed(client, 'sip') == 'iex'
+
+
+def test_ensure_entitled_feed_keeps():
+    bars._ENTITLE_CACHE.clear()
+    client = _Client(['sip'])
+    assert bars._ensure_entitled_feed(client, 'sip') == 'sip'


### PR DESCRIPTION
## Summary
- verify Alpaca feed entitlement and switch to an allowed feed when unauthorized
- retry empty bar fetches with backoff and throttle repeated EMPTY_DATA logs
- document new entitlement checks and logging behavior

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68b1d98961e8833096bc38068efd29a4