### PR TITLE
Normalize BRK-B ticker for Alpaca requests

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from ai_trading.net.http import HTTPSession, get_http_session
 from ai_trading.exc import RequestException
 from ai_trading.utils.http import clamp_request_timeout
+from ai_trading.market.symbol_map import to_alpaca_symbol
 import importlib.util
 from ai_trading.logging import get_logger
 from ai_trading.config.management import is_shadow_mode
@@ -233,6 +234,7 @@ def get_bars_df(
     rest = _get_rest(bars=True)
     feed = feed or os.getenv('ALPACA_DATA_FEED', 'iex')
     adjustment = adjustment or os.getenv('ALPACA_ADJUSTMENT', 'all')
+    symbol = to_alpaca_symbol(symbol)
     tf_raw = timeframe
     tf_norm = _normalize_timeframe_for_tradeapi(tf_raw)
     unit_name, suffix = _unit_from_norm(tf_norm)

--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -19,6 +19,7 @@ from ai_trading.alpaca_api import (
     get_timeframe_cls,
     get_stock_bars_request_cls,
 )
+from ai_trading.market.symbol_map import to_alpaca_symbol
 
 # Export dynamic Alpaca request classes at module import time
 TimeFrame = get_timeframe_cls()
@@ -113,6 +114,12 @@ def safe_get_stock_bars(client: Any, request: "StockBarsRequest", symbol: str, c
     """
     TimeFrame = get_timeframe_cls()
     StockBarsRequest = get_stock_bars_request_cls()
+    symbol = to_alpaca_symbol(symbol)
+    sym_field = getattr(request, 'symbol_or_symbols', None)
+    if isinstance(sym_field, str):
+        request.symbol_or_symbols = to_alpaca_symbol(sym_field)
+    elif isinstance(sym_field, (list, tuple, set)):
+        request.symbol_or_symbols = [to_alpaca_symbol(s) for s in sym_field]
     now = now_utc()
     prev_open, _ = rth_session_utc(previous_trading_session(now.date()))
     end_dt = ensure_utc_datetime(getattr(request, 'end', None) or now, default=now, clamp_to='eod', allow_callables=False)

--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -23,6 +23,7 @@ from ai_trading.logging.empty_policy import should_emit as _empty_should_emit
 from ai_trading.logging.normalize import canon_feed as _canon_feed
 from ai_trading.logging.normalize import canon_timeframe as _canon_tf
 from ai_trading.logging.normalize import normalize_extra as _norm_extra
+from ai_trading.market.symbol_map import to_alpaca_symbol
 from ai_trading.logging import logger
 from ai_trading.data.metrics import metrics
 from ai_trading.net.http import HTTPSession, get_http_session
@@ -502,6 +503,7 @@ def _fetch_bars(
     symbol: str, start: Any, end: Any, timeframe: str, *, feed: str = _DEFAULT_FEED, adjustment: str = "raw"
 ) -> pd.DataFrame:
     """Fetch bars from Alpaca v2 with alt-feed fallback."""
+    symbol = to_alpaca_symbol(symbol)
     pd = _ensure_pandas()
     _ensure_requests()
     if pd is None:

--- a/ai_trading/market/__init__.py
+++ b/ai_trading/market/__init__.py
@@ -1,3 +1,5 @@
-"""
-Market data and specifications module.
-"""
+"""Market data and specifications module."""
+
+from .symbol_map import to_alpaca_symbol
+
+__all__ = ["to_alpaca_symbol"]

--- a/ai_trading/market/symbol_map.py
+++ b/ai_trading/market/symbol_map.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+"""Utility for broker-specific symbol normalization."""
+
+_ALPACA_OVERRIDES = {"BRK-B": "BRK.B"}
+
+
+def to_alpaca_symbol(symbol: str) -> str:
+    """Return symbol normalized for Alpaca REST calls."""
+    s = symbol.strip().upper()
+    return _ALPACA_OVERRIDES.get(s, s)

--- a/tests/test_brkb_symbol_normalization.py
+++ b/tests/test_brkb_symbol_normalization.py
@@ -1,0 +1,23 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading.market.symbol_map import to_alpaca_symbol
+
+
+class DummyAPIError(Exception):
+    pass
+
+
+def _fake_get_stock_bars(symbol: str):
+    if symbol == "BRK-B":
+        raise DummyAPIError("invalid symbol")
+    return pd.DataFrame({"open": [1.0], "close": [1.1]})
+
+
+def test_brkb_conversion_avoids_api_error():
+    with pytest.raises(DummyAPIError):
+        _fake_get_stock_bars("BRK-B")
+    symbol = to_alpaca_symbol("BRK-B")
+    df = _fake_get_stock_bars(symbol)
+    assert not df.empty


### PR DESCRIPTION
## Summary
- map `BRK-B` to `BRK.B` for Alpaca-compatible requests
- normalize ticker in bars fetch and API request builders
- add test confirming conversion avoids APIError

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 100 errors during collection)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_brkb_symbol_normalization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1d9859b28833094dce78bc144ecbb