### PR TITLE
Reload env and validate config on startup

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -39,8 +39,11 @@ present before the service starts:
 | --- | --- |
 | `ALPACA_API_KEY` | Alpaca API authentication |
 | `ALPACA_SECRET_KEY` | Alpaca API authentication |
-| `ALPACA_BASE_URL` | Broker endpoint URL |
+| `ALPACA_API_URL` | Broker endpoint URL |
+| `ALPACA_DATA_FEED` | Market data feed selection |
 | `WEBHOOK_SECRET` | Protects inbound webhooks |
+| `CAPITAL_CAP` | Maximum portfolio allocation |
+| `DOLLAR_RISK_LIMIT` | Maximum per-trade dollar risk |
 
 If any are missing or empty the process exits with a `RuntimeError` listing the
 missing keys; values are masked in logs and exceptions. During health server

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Set `RUN_HEALTHCHECK=1` to launch the lightweight Flask app that serves:
 
 Use **one** Alpaca SDK in production (recommended: `alpaca-py`).
 Remove legacy `alpaca-trade-api` if present (`pip uninstall -y alpaca-trade-api`).
-Startup validates required environment variables at launch and exits early with
-clear remediation hints if configuration is missing.
+Startup validates required environment variables (API keys, feed selection, risk
+parameters) at launch and exits early with clear remediation hints if
+configuration is missing.
 ### Self-check
 
 Verify Alpaca connectivity and data access:


### PR DESCRIPTION
## Summary
- Reload `.env` and validate required environment variables (including `ALPACA_DATA_FEED`) before startup
- Log a one-time `ENV_CONFIG_LOADED` message after successful validation
- Document required Alpaca feed setting in deployment docs and README

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; tests skipped: alpaca-py is required for tests)*

## Rollback Plan
- Revert this PR to restore previous startup behavior without early env reload and validation


------
https://chatgpt.com/codex/tasks/task_e_68b1d9871da0833098ecf5cd9be636ec