### PR TITLE
Normalize BRK-B ticker for Alpaca requests

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -14,6 +14,7 @@ from ai_trading.utils.http import clamp_request_timeout
 import importlib.util
 from ai_trading.logging import get_logger
 from ai_trading.config.management import is_shadow_mode
+from ai_trading.logging.normalize import canon_symbol as _canon_symbol
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd
@@ -224,6 +225,7 @@ def get_bars_df(
     feed: str | None = None,
 ) -> "pd.DataFrame":
     """Fetch bars for ``symbol`` and return a normalized DataFrame."""
+    symbol = _canon_symbol(symbol)
     APIError = get_api_error_cls()
     StockBarsRequest = get_stock_bars_request_cls()
     TimeFrame = get_timeframe_cls()

--- a/ai_trading/logging/normalize.py
+++ b/ai_trading/logging/normalize.py
@@ -34,6 +34,24 @@ def canon_feed(value: Any) -> str:
         return 'sip'
     return 'sip'
 
+def canon_symbol(value: Any) -> str:
+    """Return canonical stock symbol for Alpaca REST calls.
+
+    Alpaca expects class share separators to use dots rather than dashes
+    (e.g., ``BRK.B``).  This helper normalizes incoming symbols by
+    uppercasing and replacing a single dash with a dot when present.  Any
+    non-string input results in an empty string.
+    """
+    try:
+        sym = str(value).strip().upper()
+    except (KeyError, ValueError, TypeError):
+        return ''
+    if '-' in sym:
+        parts = sym.split('-')
+        if len(parts) == 2 and all(parts):
+            sym = '.'.join(parts)
+    return sym
+
 def normalize_extra(extra: Mapping[str, Any] | None) -> dict:
     """Return a copy of `extra` with canonical feed/timeframe if present."""
     if extra is None:

--- a/tests/test_bars_timeframe_feed_canonicalization.py
+++ b/tests/test_bars_timeframe_feed_canonicalization.py
@@ -11,6 +11,9 @@ from ai_trading.logging.normalize import (
     canon_feed as _canon_feed,
 )
 from ai_trading.logging.normalize import (
+    canon_symbol as _canon_symbol,
+)
+from ai_trading.logging.normalize import (
     canon_timeframe as _canon_tf,
 )
 
@@ -28,6 +31,9 @@ def test_canonicalizers_map_weird_values_to_safe_defaults():
     assert _canon_feed(_dummy_callable) == "sip"
     assert _canon_feed("IEX") == "iex"
     assert _canon_feed("sip") == "sip"
+
+    assert _canon_symbol("brk-b") == "BRK.B"
+    assert _canon_symbol("AAPL") == "AAPL"
 
 
 def test_safe_get_stock_bars_uses_canonicalized_values(monkeypatch):
@@ -57,3 +63,28 @@ def test_safe_get_stock_bars_uses_canonicalized_values(monkeypatch):
 
     assert captured["timeframe"] in {"1Day", "1Min"}
     assert captured["feed"] in {"iex", "sip"}
+
+
+def test_safe_get_stock_bars_normalizes_symbol(monkeypatch):
+    class APIError(Exception):
+        pass
+
+    called: dict[str, str] = {}
+
+    class Client:
+        class _Resp:
+            df = pd.DataFrame()
+
+        def get_stock_bars(self, request):
+            sym = request.symbol_or_symbols
+            if isinstance(sym, list):
+                sym = sym[0]
+            if sym == "BRK-B":
+                raise APIError("bad symbol")
+            called["symbol"] = sym
+            return self._Resp()
+
+    req = bars_mod.StockBarsRequest(symbol_or_symbols="BRK-B", timeframe=bars_mod.TimeFrame.Day)
+    bars_mod.safe_get_stock_bars(Client(), req, symbol="BRK-B", context="TEST")
+
+    assert called["symbol"] == "BRK.B"


### PR DESCRIPTION
## Summary
- add `canon_symbol` helper to convert share-class tickers like BRK-B to Alpaca's BRK.B format
- normalize symbols in Alpaca bar fetchers so REST requests use canonical tickers
- test that BRK-B is converted and avoids API errors

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bars_timeframe_feed_canonicalization.py::test_safe_get_stock_bars_normalizes_symbol -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn', joblib, cachetools, hypothesis; TypeError wait_random)*

## Rollback Plan
- Revert this PR.

------
https://chatgpt.com/codex/tasks/task_e_68b1e06ee03483308b076d985cd70fa6