### PR TITLE
feat: add force trades setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ connectivity.
 | `MAX_POSITION_PCT` | `0.05` | Maximum position size (% of equity) | `0.01-0.20` |
 | `MAX_PORTFOLIO_HEAT` | `0.15` | Maximum total portfolio risk | `0.05-0.30` |
 | `SIGNAL_THRESHOLD` | `0.7` | Minimum signal strength for trades | `0.1-1.0` |
+| `FORCE_TRADES` | `false` | Skip pre-trade halts (debug override) | `true`, `false` |
 
 #### Data and Market Configuration
 

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -9016,7 +9016,7 @@ def signal_and_confirm(
 def pre_trade_checks(
     ctx: BotContext, state: BotState, symbol: str, balance: float, regime_ok: bool
 ) -> bool:
-    if CFG.force_trades:
+    if getattr(CFG, "force_trades", False):
         logger.warning("FORCE_TRADES override active: ignoring all pre-trade halts.")
         return True
     # Streak kill-switch check

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -87,6 +87,7 @@ class Settings(BaseSettings):
     )
     testing: bool = Field(False, alias='TESTING')
     shadow_mode: bool = Field(False, alias='SHADOW_MODE')
+    force_trades: bool = Field(False, alias='FORCE_TRADES')
     disable_daily_retrain: bool = Field(False, alias='DISABLE_DAILY_RETRAIN')
     log_market_fetch: bool = Field(True, alias='LOG_MARKET_FETCH')
     healthcheck_port: int = Field(9001, alias='HEALTHCHECK_PORT')
@@ -198,6 +199,11 @@ class Settings(BaseSettings):
         if v is not None and float(v) <= 0.0:
             raise ValueError('max_position_size must be positive')
         return v
+
+    @field_validator('force_trades', mode='before')
+    @classmethod
+    def _force_trades_cast(cls, v):
+        return _to_bool(v, False)
 
     @computed_field
     @property


### PR DESCRIPTION
## Summary
- expose `FORCE_TRADES` env via Settings model
- guard pre-trade checks with optional `force_trades` flag
- document debug override in README

## Testing
- `ruff check ai_trading/settings.py ai_trading/core/bot_engine.py ai_trading/validation/validate_env.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e46f4a4083308b776824dd5f5f76