### PR TITLE
Raise error when configuration missing for data fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - **Utils**: remove legacy `pathlib_shim` re-export; use `ai_trading.utils.paths` instead
 
 ### Fixed
+- **Data Fetch**: raise error when configuration unavailable instead of repeated warnings.
 - Normalize broker-unavailable contract; remove false PDT warnings; add regression tests.
 - Fix IndentationError in `bot_engine.py` (pybreaker stub); add static compile guard.
 - **Runtime safety**: improved Alpaca availability checks, stable logging shutdown,

--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -823,19 +823,11 @@ def get_bars(
     """Compatibility wrapper delegating to _fetch_bars."""
     S = get_settings()
     if S is None:
-        feed = feed or os.getenv("ALPACA_DATA_FEED", _DEFAULT_FEED)
-        adjustment = adjustment or os.getenv("ALPACA_ADJUSTMENT", "raw")
-        logger.warning(
-            "SETTINGS_MISSING_DEFAULTS",  # AI-AGENT-REF: clearer remediation
-            extra={
-                "feed": feed,
-                "adjustment": adjustment,
-                "hint": "ensure configuration is loaded or run ai_trading.config.management.reload_env",
-            },
+        raise RuntimeError(
+            "SETTINGS_UNAVAILABLE: configuration not loaded; call ai_trading.config.management.reload_env()",
         )
-    else:
-        feed = feed or S.alpaca_data_feed
-        adjustment = adjustment or S.alpaca_adjustment
+    feed = feed or S.alpaca_data_feed
+    adjustment = adjustment or S.alpaca_adjustment
     return _fetch_bars(symbol, start, end, timeframe, feed=feed, adjustment=adjustment)
 
 

--- a/tests/test_configuration_absence.py
+++ b/tests/test_configuration_absence.py
@@ -1,29 +1,16 @@
-import pandas as pd
 import pytest
 from datetime import datetime, timedelta, UTC
 
 
-def test_get_bars_falls_back_when_settings_missing(monkeypatch, caplog):
+def test_get_bars_raises_when_settings_missing(monkeypatch):
     from ai_trading.data import fetch
 
     monkeypatch.setattr(fetch, "get_settings", lambda: None)
 
-    called = {}
-
-    def fake_fetch(symbol, start, end, timeframe, *, feed=None, adjustment=None):
-        called["feed"] = feed
-        called["adjustment"] = adjustment
-        return pd.DataFrame()
-
-    monkeypatch.setattr(fetch, "_fetch_bars", fake_fetch)
-
     start = datetime.now(UTC) - timedelta(minutes=1)
     end = datetime.now(UTC)
-    with caplog.at_level("WARNING"):
-        df = fetch.get_bars("AAPL", "1Min", start, end)
-    assert df.empty
-    assert called["feed"] == fetch._DEFAULT_FEED
-    assert called["adjustment"] == "raw"
+    with pytest.raises(RuntimeError):
+        fetch.get_bars("AAPL", "1Min", start, end)
 
 
 def test_main_exits_when_env_invalid(monkeypatch):


### PR DESCRIPTION
## Summary
- raise runtime error when market-data settings are unavailable
- update configuration absence test to expect failure
- document behavior in changelog

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_configuration_absence.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_configuration_absence.py::test_get_bars_raises_when_settings_missing -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*


------
https://chatgpt.com/codex/tasks/task_e_68b1e46d715083309e4cbe8a2c6f605c