### PR TITLE
Normalize BRK.B ticker for Yahoo Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1462,6 +1462,7 @@ emitted when `AI_TRADING_MODEL_PATH` points to a missing file.
 ### Universe CSV
 - Optional: `AI_TRADING_TICKERS_CSV=/abs/path/to/tickers.csv`
 - Default: packaged `ai_trading/data/tickers.csv` (S&P-100)
+- Symbols are uppercased and mapped for provider quirks (e.g., `BRK.B` → `BRK-B` for Yahoo Finance).
 
 ## Agent & Dev Quickstart
 

--- a/ai_trading/data/universe.py
+++ b/ai_trading/data/universe.py
@@ -2,6 +2,7 @@ import os
 from importlib.resources import files as pkg_files
 from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.logging import logger
+from ai_trading.utils.universe import normalize_symbol
 
 # Lazy pandas proxy
 pd = load_pandas()
@@ -28,6 +29,7 @@ def load_universe() -> list[str]:
     except (OSError, pd.errors.EmptyDataError, ValueError) as e:
         logger.error('TICKERS_FILE_READ_FAILED', extra={'path': path, 'error': str(e)})
         return []
-    symbols = [str(s).strip().upper() for s in df.iloc[:, 0].tolist() if str(s).strip()]
+    # Normalize symbols so downstream modules see provider-ready tickers
+    symbols = [normalize_symbol(str(s)) for s in df.iloc[:, 0].tolist() if str(s).strip()]
     logger.info('TICKERS_SOURCE', extra={'path': path, 'count': len(symbols)})
     return symbols

--- a/ai_trading/utils/universe.py
+++ b/ai_trading/utils/universe.py
@@ -1,22 +1,38 @@
+"""Utility helpers for symbol/universe loading."""
+
 from __future__ import annotations
+
 from pathlib import Path
 
-def load_universe(path_or_csv: str | None, limit: int | None=None) -> list[str]:
+# Mapping for data providers that expect alternate share-class separators.
+# Yahoo Finance uses dashes instead of dots for class shares (e.g., ``BRK-B``).
+_SYMBOL_FIXES: dict[str, str] = {"BRK.B": "BRK-B"}
+
+
+def normalize_symbol(symbol: str) -> str:
+    """Return uppercase symbol with provider-specific fixes applied."""
+    up = symbol.strip().upper()
+    return _SYMBOL_FIXES.get(up, up)
+
+
+def load_universe(path_or_csv: str | None, limit: int | None = None) -> list[str]:
     """Load symbols from file path or CSV string and return sanitized list."""
     raw: list[str] = []
     if path_or_csv:
         p = Path(path_or_csv)
         if p.exists() and p.is_file():
-            s = p.read_text(encoding='utf-8', errors='ignore')
+            s = p.read_text(encoding="utf-8", errors="ignore")
             raw = _split_symbols(s)
         else:
             raw = _split_symbols(path_or_csv)
     if not raw:
-        raise RuntimeError(f"No tickers found at '{path_or_csv}'. Provide a tickers.csv or CSV env list.")
+        raise RuntimeError(
+            f"No tickers found at '{path_or_csv}'. Provide a tickers.csv or CSV env list."
+        )
     seen: set[str] = set()
     out: list[str] = []
     for sym in raw:
-        up = sym.strip().upper()
+        up = normalize_symbol(sym)
         if up and up not in seen:
             seen.add(up)
             out.append(up)
@@ -25,12 +41,17 @@ def load_universe(path_or_csv: str | None, limit: int | None=None) -> list[str]:
         out = out[:limit]
     return out
 
+
 def _split_symbols(s: str) -> list[str]:
-    s = s.replace('\r', '')
+    s = s.replace("\r", "")
     parts: list[str] = []
-    for line in s.split('\n'):
-        if ',' in line:
-            parts.extend((x.strip() for x in line.split(',')))
+    for line in s.split("\n"):
+        if "," in line:
+            parts.extend((x.strip() for x in line.split(",")))
         else:
             parts.append(line.strip())
     return [p for p in parts if p]
+
+
+__all__ = ["load_universe", "normalize_symbol"]
+

--- a/tests/unit/test_universe_loader.py
+++ b/tests/unit/test_universe_loader.py
@@ -69,3 +69,16 @@ def test_malformed_empty_csv_logs_and_returns_empty(tmp_path: Path, monkeypatch:
     assert syms == []
     assert called and called[0][0] == "TICKERS_FILE_READ_FAILED"
 
+
+def test_brk_dot_b_normalized(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """BRK.B should be normalized to BRK-B for Yahoo Finance."""
+
+    csv_path = tmp_path / "tickers.csv"
+    csv_path.write_text("symbol\nBRK.B\n", encoding="utf-8")
+    monkeypatch.setenv("AI_TRADING_TICKERS_CSV", str(csv_path))
+    try:
+        symbols = universe.load_universe()
+    finally:
+        monkeypatch.delenv("AI_TRADING_TICKERS_CSV", raising=False)
+    assert symbols == ["BRK-B"]
+


### PR DESCRIPTION
## Summary
- normalize BRK.B to BRK-B when loading tickers for Yahoo Finance
- document provider-specific ticker mapping
- test and ensure universe loader returns normalized symbol

## Testing
- `ruff check ai_trading/data/universe.py ai_trading/utils/universe.py tests/unit/test_universe_loader.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e598d32883308ba08f476c953aec