### PR TITLE
Ensure environment reload before trading cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ seed = config.SEED  # defaults to 42
 config.reload_env()
 ```
 
-`.env` at the repo root is loaded at startup with `override=True`.
+`.env` at the repo root is reloaded at startup with `override=True`; if configuration
+cannot be loaded, the bot exits early with a critical log.
 Rebalance frequency defaults to 60 minutes; override with `AI_TRADING_REBALANCE_INTERVAL_MIN`
 (minutes) or `AI_TRADING_REBALANCE_INTERVAL_HOURS` (hours). The smallest positive value
 is used when multiple sources are set.

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -273,7 +273,15 @@ def run_bot(*_a, **_k) -> int:
         logger.error("Logging validation failed: %s", validation_result["issues"])
     logger.info("Application startup - logging configured once")
     try:
+        try:
+            reload_env()
+        except Exception as exc:  # noqa: BLE001
+            logger.critical("ENV_LOAD_FAILED", extra={"error": str(exc)})
+            return 1
         config = get_settings()
+        if config is None:
+            logger.critical("SETTINGS_UNAVAILABLE")
+            return 1
         validate_environment()
         memory_optimizer = get_memory_optimizer()
         if memory_optimizer:
@@ -283,7 +291,7 @@ def run_bot(*_a, **_k) -> int:
         preflight_import_health()
         run_cycle()
         return 0
-    except (ValueError, TypeError) as e:
+    except (ValueError, TypeError, RuntimeError) as e:
         logger.error("Bot startup failed: %s", e, exc_info=True)
         return 1
 


### PR DESCRIPTION
## Summary
- Reload environment configuration during bot startup before running trading cycles
- Exit early with a critical log if settings cannot be loaded
- Document startup reload and failure behaviour

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e991627c83309e4a4d3e622b20b3