### PR TITLE
feat: make ticker list optional

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -11627,9 +11627,10 @@ def load_tickers(path: str = TICKERS_FILE) -> list[str]:
     return load_universe_from_path(path)
 
 
-def load_candidate_universe(runtime, *, fallback_symbols=None) -> list[str]:
+def load_candidate_universe(runtime, tickers: list[str] | None = None) -> list[str]:
     """Load tickers for screening from cached runtime list."""  # AI-AGENT-REF: use packaged universe loader
-    del fallback_symbols
+    if tickers is not None:
+        setattr(runtime, "tickers", tickers)
     tickers = getattr(runtime, "tickers", None)
     if tickers is None:
         tickers = load_universe()
@@ -12611,7 +12612,7 @@ def _prepare_run(runtime, state: BotState, tickers: list[str]) -> tuple[float, b
     params["get_capital_cap()"] = _param(runtime, "get_capital_cap()", 0.04)
     compute_spy_vol_stats(runtime)
 
-    full_watchlist = load_candidate_universe(runtime, tickers=tickers)
+    full_watchlist = load_candidate_universe(runtime, tickers)
     try:
         pretrade_data_health(runtime, full_watchlist)
     except DataFetchError:

--- a/tests/unit/test_prepare_run_accepts_tickers.py
+++ b/tests/unit/test_prepare_run_accepts_tickers.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import types
+
+import ai_trading.core.bot_engine as eng
+
+
+# ensure _prepare_run uses provided tickers without raising TypeError
+
+def test_prepare_run_accepts_ticker_list(monkeypatch):
+    runtime = types.SimpleNamespace(params={}, cfg=None)
+    state = eng.BotState()
+    tickers = ["AAPL", "MSFT"]
+
+    # Stub functions called within _prepare_run
+    monkeypatch.setattr(eng, "ensure_data_fetcher", lambda rt: None)
+    monkeypatch.setattr(eng, "cancel_all_open_orders", lambda rt: None)
+    monkeypatch.setattr(eng, "audit_positions", lambda rt: None)
+    mock_acct = types.SimpleNamespace(equity="1000", buying_power="1000", cash="1000")
+    monkeypatch.setattr(eng, "safe_alpaca_get_account", lambda rt: mock_acct)
+    monkeypatch.setattr(eng, "compute_spy_vol_stats", lambda rt: None)
+    monkeypatch.setattr(eng, "pretrade_data_health", lambda rt, syms: None)
+    monkeypatch.setattr(eng, "screen_candidates", lambda rt, syms: syms)
+    monkeypatch.setattr(eng, "pre_trade_health_check", lambda rt, syms: {})
+    monkeypatch.setattr(eng, "check_market_regime", lambda rt, st: True)
+    monkeypatch.setattr(eng, "_param", lambda rt, key, default: default)
+    monkeypatch.setattr(eng.portfolio, "compute_portfolio_weights", lambda rt, syms: {})
+
+    class DummyLock:
+        def __enter__(self):  # pragma: no cover - simple stub
+            return None
+
+        def __exit__(self, exc_type, exc, tb):  # pragma: no cover - simple stub
+            return False
+
+    monkeypatch.setattr(eng, "portfolio_lock", DummyLock())
+
+    current_cash, regime_ok, symbols = eng._prepare_run(runtime, state, tickers)
+
+    assert current_cash == 1000.0
+    assert regime_ok is True
+    assert symbols == tickers


### PR DESCRIPTION
## Summary
- accept optional ticker list in `load_candidate_universe`
- invoke updated API from `_prepare_run`
- add unit test for supplying tickers to `_prepare_run`

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/unit/test_prepare_run_accepts_tickers.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_prepare_run_accepts_tickers.py -q` *(fails: No module named 'alpaca'; subsequent skip: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ef7d67d48330abe9fc3e072e2c51