### PR TITLE
Handle missing universe CSV with fallback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,7 +33,7 @@
 - No `try/except ImportError` in prod—dependencies are explicit.
 
 ## Data & Models
-- Candidate tickers: `tickers.csv` if present, else defaults.
+- Candidate tickers: `tickers.csv` if present, else built-in fallback `[SPY, AAPL, MSFT, AMZN, GOOGL]`.
 - Model loader tries: `cfg.ml_model_path` / `cfg.model_path` (joblib/pickle), or `cfg.ml_model_module` / `cfg.model_module` (import module, `get_model(cfg)` or `Model(cfg)`).
 - Cache on `runtime.model`.
 

--- a/README.md
+++ b/README.md
@@ -1464,6 +1464,7 @@ emitted when `AI_TRADING_MODEL_PATH` points to a missing file.
 - Optional: `AI_TRADING_TICKERS_CSV=/abs/path/to/tickers.csv`
 - Default: packaged `ai_trading/data/tickers.csv` (S&P-100)
 - Symbols are uppercased and mapped for provider quirks (e.g., `BRK.B` → `BRK-B` for Yahoo Finance).
+- Missing file: logs an error and falls back to `['SPY', 'AAPL', 'MSFT', 'AMZN', 'GOOGL']`.
 
 ## Agent & Dev Quickstart
 
@@ -1485,7 +1486,7 @@ Conventions (must follow)
 • Models: configure via AI_TRADING_MODEL_PATH or AI_TRADING_MODEL_MODULE; cached at runtime.model.
 
 Common Pitfalls
-• tickers.csv missing → a single warning per process (defaults are used).
+• tickers.csv missing → a single warning per process (fallback list is used: SPY, AAPL, MSFT, AMZN, GOOGL).
 • Off-hours data empties are expected; don’t escalate severity.
 
 *(If `README.md` is long, add this as a new section without removing existing content.)*

--- a/tests/test_universe_csv.py
+++ b/tests/test_universe_csv.py
@@ -21,12 +21,12 @@ def test_packaged_exists_without_env(monkeypatch):
     assert len(uni) > 3  # S&P-100 default
 
 
-def test_missing_returns_empty(monkeypatch):
+def test_missing_returns_fallback(monkeypatch):
     monkeypatch.setenv("AI_TRADING_TICKERS_CSV", "/nonexistent.csv")
     import ai_trading.data.universe as U
     orig = U.locate_tickers_csv
     U.locate_tickers_csv = lambda: None
     try:
-        assert load_universe() == []
+        assert load_universe() == ["SPY", "AAPL", "MSFT", "AMZN", "GOOGL"]
     finally:
         U.locate_tickers_csv = orig

--- a/tests/unit/test_universe_loader.py
+++ b/tests/unit/test_universe_loader.py
@@ -31,14 +31,15 @@ def test_package_fallback_loads_packaged_csv():
     assert isinstance(symbols, list) and len(symbols) > 0
 
 
-def test_missing_package_returns_empty_and_logs(monkeypatch: pytest.MonkeyPatch):
-    """Missing package should log and return []"""  # AI-AGENT-REF: test missing pkg case
+def test_missing_package_returns_fallback_and_logs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Missing package should log and return fallback list"""  # AI-AGENT-REF: test missing pkg case
 
     def boom(_name: str):
         raise ModuleNotFoundError("ai_trading.data not importable")
 
     monkeypatch.setattr(universe, "pkg_files", boom, raising=True)
     monkeypatch.delenv("AI_TRADING_TICKERS_CSV", raising=False)
+    monkeypatch.chdir(tmp_path)
 
     called: list[tuple[str, dict]] = []
 
@@ -47,7 +48,7 @@ def test_missing_package_returns_empty_and_logs(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setattr(universe.logger, "error", fake_error)
     syms = universe.load_universe()
-    assert syms == []
+    assert syms == ["SPY", "AAPL", "MSFT", "AMZN", "GOOGL"]
     assert called and called[0][0] == "TICKERS_FILE_MISSING"
 
 


### PR DESCRIPTION
## Summary
- search current working directory for `tickers.csv` and use a hard-coded fallback list when none found
- test the fallback list behavior
- document the new fallback list

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_universe_csv.py tests/unit/test_universe_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f207d6488330a79ca569fc431ff6