### PR TITLE
Handle empty watchlist fallback

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -11401,6 +11401,9 @@ def _validate_market_data_quality(df: pd.DataFrame, symbol: str) -> dict:
 _screen_lock = Lock()
 _screening_in_progress = False
 
+# Hard-coded fallback symbols when no watchlist is provided
+FALLBACK_SYMBOLS = ["AAPL", "MSFT", "GOOGL", "AMZN", "TSLA"]
+
 
 def screen_universe(
     candidates: Sequence[str],
@@ -11572,10 +11575,14 @@ def screen_universe(
 
 def screen_candidates(runtime, candidates, *, fallback_symbols=None) -> list[str]:
     """Run screening on provided candidate tickers using runtime."""
-    del fallback_symbols
     try:
         if not candidates:
-            return []
+            symbols = list(fallback_symbols or FALLBACK_SYMBOLS)
+            logger.info(
+                "SCREEN_FALLBACK_USED",
+                extra={"tickers": symbols},
+            )
+            return symbols
         return screen_universe(candidates, runtime)
     except (KeyError, ValueError, TypeError) as e:
         logger.error(
@@ -12626,6 +12633,8 @@ def _prepare_run(runtime, state: BotState, tickers: list[str]) -> tuple[float, b
         logger.warning(
             "No candidates found after filtering, using top 5 tickers fallback."
         )
+        if not full_watchlist:
+            full_watchlist = load_universe() or FALLBACK_SYMBOLS
         symbols = full_watchlist[:5]
     logger.info("CANDIDATES_SCREENED", extra={"tickers": symbols})
     runtime.tickers = symbols  # AI-AGENT-REF: store screened tickers on runtime

--- a/tests/unit/test_universe_loader.py
+++ b/tests/unit/test_universe_loader.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import types
 
 from ai_trading.data import universe
+from ai_trading.core import bot_engine
 
 
 def test_env_override_path_preferred(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
@@ -81,4 +83,10 @@ def test_brk_dot_b_normalized(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     finally:
         monkeypatch.delenv("AI_TRADING_TICKERS_CSV", raising=False)
     assert symbols == ["BRK-B"]
+
+
+def test_screen_candidates_empty_watchlist_returns_fallback():
+    """screen_candidates returns fallback symbols when watchlist is empty."""
+    runtime = types.SimpleNamespace()
+    assert bot_engine.screen_candidates(runtime, []) == bot_engine.FALLBACK_SYMBOLS
 


### PR DESCRIPTION
## Summary
- Return a predefined list of symbols when `screen_candidates` receives an empty watchlist
- Ensure bot engine reloads fallback tickers before slicing top-five candidates
- Test that an empty watchlist uses the hard-coded fallback symbols

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68b1f206b4508330a335fcd388ada2a4