### PR TITLE
Allow tickers CSV to be configured via paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1461,10 +1461,20 @@ quietly falls back to the baseline model (`USE_ML=False`). A warning is only
 emitted when `AI_TRADING_MODEL_PATH` points to a missing file.
 
 ### Universe CSV
-- Optional: `AI_TRADING_TICKERS_CSV=/abs/path/to/tickers.csv`
-- Default: packaged `ai_trading/data/tickers.csv` (S&P-100)
+- `AI_TRADING_TICKERS_CSV=/abs/path/to/tickers.csv` — explicit override, highest priority.
+- `TICKERS_FILE_PATH=/abs/path/to/tickers.csv` — used when the above is unset; defaults to `$AI_TRADING_DATA_DIR/tickers.csv`.
+- Default: packaged `ai_trading/data/tickers.csv` (S&P-100).
 - Symbols are uppercased and mapped for provider quirks (e.g., `BRK.B` → `BRK-B` for Yahoo Finance).
 - Missing file: logs an error and falls back to `['SPY', 'AAPL', 'MSFT', 'AMZN', 'GOOGL']`.
+
+Example systemd unit override:
+
+```ini
+[Service]
+Environment="TICKERS_FILE_PATH=/var/lib/ai-trading-bot/tickers.csv"
+# or
+Environment="AI_TRADING_TICKERS_CSV=/etc/ai-trading-bot/tickers.csv"
+```
 
 ## Agent & Dev Quickstart
 

--- a/ai_trading/data/universe.py
+++ b/ai_trading/data/universe.py
@@ -3,6 +3,7 @@ from importlib.resources import files as pkg_files
 from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.logging import logger
 from ai_trading.utils.universe import normalize_symbol
+from ai_trading.paths import TICKERS_FILE_PATH
 
 # Lazy pandas proxy
 pd = load_pandas()
@@ -16,6 +17,10 @@ def locate_tickers_csv() -> str | None:
     env = os.getenv('AI_TRADING_TICKERS_CSV')
     if env and os.path.isfile(env):
         return os.path.abspath(env)
+    # Check ai_trading.paths.TICKERS_FILE_PATH
+    path = os.path.abspath(os.path.expanduser(os.path.normpath(str(TICKERS_FILE_PATH))))
+    if os.path.isfile(path):
+        return path
     try:
         p = pkg_files('ai_trading.data').joinpath('tickers.csv')
         if p.is_file():

--- a/tests/test_universe_csv.py
+++ b/tests/test_universe_csv.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 pd = pytest.importorskip("pandas")
 from ai_trading.data.universe import load_universe, locate_tickers_csv
@@ -11,6 +12,17 @@ def test_env_overrides_packaged(monkeypatch, tmp_path):
     assert path == str(csv)
     uni = load_universe()
     assert set(uni) == {"MSFT", "NVDA", "META"}
+
+
+def test_tickers_file_path(monkeypatch, tmp_path):
+    csv = tmp_path / "tick.csv"
+    pd.DataFrame({"symbol": ["TSLA", "IBM"]}).to_csv(csv, index=False)
+    monkeypatch.delenv("AI_TRADING_TICKERS_CSV", raising=False)
+    monkeypatch.setattr("ai_trading.data.universe.TICKERS_FILE_PATH", csv)
+    path = locate_tickers_csv()
+    assert path == os.path.abspath(str(csv))
+    uni = load_universe()
+    assert set(uni) == {"TSLA", "IBM"}
 
 
 def test_packaged_exists_without_env(monkeypatch):


### PR DESCRIPTION
## Summary
- check `ai_trading.paths.TICKERS_FILE_PATH` in `locate_tickers_csv`
- document `AI_TRADING_TICKERS_CSV` and `TICKERS_FILE_PATH` deployment options in README
- test that `TICKERS_FILE_PATH` locates custom CSV

## Testing
- `ruff check ai_trading/data/universe.py tests/test_universe_csv.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_universe_csv.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f4ed82108330a82dc9bf8e8f2bc9