### PR TITLE
Reload env when get_bars lacks settings

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -133,6 +133,11 @@ class DataProvider:
         """Fetch data from provider."""
 ```
 
+`get_bars()` will automatically attempt to reload environment variables via
+`ai_trading.config.management.reload_env()` if configuration is unavailable and
+retry once before raising an error. This permits runtime `.env` edits during
+tests or scripts without restarting the process.
+
 ### Signal Generation API
 
 #### `signals.py` - Trading Signals

--- a/tests/test_configuration_absence.py
+++ b/tests/test_configuration_absence.py
@@ -3,9 +3,10 @@ from datetime import datetime, timedelta, UTC
 
 
 def test_get_bars_raises_when_settings_missing(monkeypatch):
+    import ai_trading.config.settings as settings_mod
     from ai_trading.data import fetch
 
-    monkeypatch.setattr(fetch, "get_settings", lambda: None)
+    monkeypatch.setattr(settings_mod, "get_settings", lambda: None)
 
     start = datetime.now(UTC) - timedelta(minutes=1)
     end = datetime.now(UTC)
@@ -19,7 +20,7 @@ def test_main_exits_when_env_invalid(monkeypatch):
     def bad_validate():
         raise RuntimeError("missing env")
 
-    monkeypatch.setattr(m, "validate_required_env", bad_validate)
+    monkeypatch.setattr(m, "validate_required_env", lambda *a, **k: bad_validate())
     with pytest.raises(SystemExit) as excinfo:
         m.main([])
     assert excinfo.value.code == 1

--- a/tests/test_get_bars_env_reload.py
+++ b/tests/test_get_bars_env_reload.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timedelta, UTC
+
+import pandas as pd
+
+import ai_trading.config.settings as settings_mod
+from ai_trading.data import fetch
+from ai_trading.config import management
+
+
+def test_get_bars_recovers_after_env_reload(monkeypatch, tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text(
+        """
+ALPACA_API_KEY=key
+ALPACA_SECRET_KEY=secret
+ALPACA_API_URL=https://paper-api.alpaca.markets
+WEBHOOK_SECRET=wh
+CAPITAL_CAP=0.04
+DOLLAR_RISK_LIMIT=0.05
+""".strip()
+    )
+
+    for key in [
+        "ALPACA_API_KEY",
+        "ALPACA_SECRET_KEY",
+        "ALPACA_API_URL",
+        "WEBHOOK_SECRET",
+        "CAPITAL_CAP",
+        "DOLLAR_RISK_LIMIT",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    management.reload_env(str(env_path))
+
+    real_get_settings = settings_mod.get_settings
+    calls = {"n": 0}
+
+    def fake_get_settings():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return real_get_settings()
+
+    monkeypatch.setattr(settings_mod, "get_settings", fake_get_settings)
+    monkeypatch.setattr(fetch, "_fetch_bars", lambda *a, **k: pd.DataFrame())
+
+    start = datetime.now(UTC) - timedelta(minutes=1)
+    end = datetime.now(UTC)
+
+    df = fetch.get_bars("AAPL", "1Min", start, end)
+    assert isinstance(df, pd.DataFrame)
+    assert calls["n"] == 2


### PR DESCRIPTION
## Summary
- ensure `get_bars` uses the real `get_settings` and reloads `.env` once if configuration is missing
- add regression test covering env reload path
- document auto `.env` reload behavior for `get_bars`

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_get_bars_env_reload.py tests/test_configuration_absence.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_get_bars_env_reload.py tests/test_configuration_absence.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn', 'joblib', 'cachetools', etc.; ImportError due to circular dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f4ec5a088330b65713431460cffc