### PR TITLE
Remove CSV fallback for universe loading

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -11664,16 +11664,21 @@ def load_tickers(path: str = TICKERS_FILE) -> list[str]:
 
 
 def load_candidate_universe(runtime, tickers: list[str] | None = None) -> list[str]:
-    """Load tickers for screening from cached runtime list."""  # AI-AGENT-REF: use packaged universe loader
+    """Load tickers for screening from cached runtime list.
+
+    Raises
+    ------
+    RuntimeError
+        If no tickers are available after loading.
+    """  # AI-AGENT-REF: use packaged universe loader
     if tickers is not None:
         setattr(runtime, "tickers", tickers)
     tickers = getattr(runtime, "tickers", None)
     if tickers is None:
-        tickers = load_universe()
+        tickers = load_tickers()
         setattr(runtime, "tickers", tickers)
     if not tickers:
-        logger.error("UNIVERSE_EMPTY_ABORT", extra={"reason": "no_tickers_csv"})
-        return []
+        raise RuntimeError("No tickers available")
     logger.debug(
         "CANDIDATE_UNIVERSE_LOADED",
         extra={"count": len(tickers)},

--- a/ai_trading/data/universe.py
+++ b/ai_trading/data/universe.py
@@ -7,17 +7,12 @@ from ai_trading.utils.universe import normalize_symbol
 # Lazy pandas proxy
 pd = load_pandas()
 
-# Last-resort tickers if no CSV can be located
-FALLBACK_TICKERS = [
-    normalize_symbol(s) for s in ["SPY", "AAPL", "MSFT", "AMZN", "GOOGL"]
-]
-
 def locate_tickers_csv() -> str | None:
-    env = os.getenv('AI_TRADING_TICKERS_CSV')
+    env = os.getenv("AI_TRADING_TICKERS_CSV")
     if env and os.path.isfile(env):
         return os.path.abspath(env)
     try:
-        p = pkg_files('ai_trading.data').joinpath('tickers.csv')
+        p = pkg_files("ai_trading.data").joinpath("tickers.csv")
         if p.is_file():
             return str(p)
     except ModuleNotFoundError:
@@ -28,19 +23,27 @@ def locate_tickers_csv() -> str | None:
     return None
 
 def load_universe() -> list[str]:
+    """Load and return normalized tickers from a required CSV file.
+
+    The lookup path is resolved by :func:`locate_tickers_csv`. If no file can be
+    located a :class:`RuntimeError` is raised. If the CSV cannot be read a log
+    entry is emitted and an empty list is returned.
+    """
+
     path = locate_tickers_csv()
-    if not path:
-        logger.error(
-            'TICKERS_FILE_MISSING',
-            extra={'path': 'tickers.csv', 'fallback': 'default_list'},
-        )
-        return FALLBACK_TICKERS.copy()
+    if path is None:
+        logger.error("TICKERS_FILE_MISSING", extra={"path": "tickers.csv"})
+        raise RuntimeError("tickers.csv not found")
     try:
         df = pd.read_csv(path)
     except (OSError, pd.errors.EmptyDataError, ValueError) as e:
-        logger.error('TICKERS_FILE_READ_FAILED', extra={'path': path, 'error': str(e)})
+        logger.error(
+            "TICKERS_FILE_READ_FAILED", extra={"path": path, "error": str(e)}
+        )
         return []
     # Normalize symbols so downstream modules see provider-ready tickers
-    symbols = [normalize_symbol(str(s)) for s in df.iloc[:, 0].tolist() if str(s).strip()]
-    logger.info('TICKERS_SOURCE', extra={'path': path, 'count': len(symbols)})
+    symbols = [
+        normalize_symbol(str(s)) for s in df.iloc[:, 0].tolist() if str(s).strip()
+    ]
+    logger.info("TICKERS_SOURCE", extra={"path": path, "count": len(symbols)})
     return symbols

--- a/tests/test_universe_csv.py
+++ b/tests/test_universe_csv.py
@@ -21,12 +21,13 @@ def test_packaged_exists_without_env(monkeypatch):
     assert len(uni) > 3  # S&P-100 default
 
 
-def test_missing_returns_fallback(monkeypatch):
+def test_missing_raises_runtime_error(monkeypatch):
     monkeypatch.setenv("AI_TRADING_TICKERS_CSV", "/nonexistent.csv")
     import ai_trading.data.universe as U
     orig = U.locate_tickers_csv
     U.locate_tickers_csv = lambda: None
     try:
-        assert load_universe() == ["SPY", "AAPL", "MSFT", "AMZN", "GOOGL"]
+        with pytest.raises(RuntimeError):
+            load_universe()
     finally:
         U.locate_tickers_csv = orig


### PR DESCRIPTION
## Summary
- require tickers.csv and raise an error when missing
- use `load_tickers` in bot engine and surface empty-universe errors
- update tests for mandatory CSV and add coverage for missing file

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ERROR tests/execution/test_fetch_minute_df_safe_empty.py ... )*


------
https://chatgpt.com/codex/tasks/task_e_68b1f4eb6ca883308a328e68820e036a