### PR TITLE
Configure model and output directories

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -58,12 +58,16 @@ startup the validation result is cached and `/healthz` reuses it, returning
 
 ### Persistent directories
 
-The service writes state, cache, and logs to paths governed by the environment variables `AI_TRADING_DATA_DIR`, `AI_TRADING_CACHE_DIR`, and `AI_TRADING_LOG_DIR`.
+The service writes state, cache, logs, models, and run outputs to paths governed by the environment variables `AI_TRADING_DATA_DIR`, `AI_TRADING_CACHE_DIR`, `AI_TRADING_LOG_DIR`, `AI_TRADING_MODELS_DIR`, and `AI_TRADING_OUTPUT_DIR`.
 Each directory must exist and be writable by the service user with **0700** permissions.
 
 ```bash
 sudo install -d -m 700 -o aiuser -g aiuser \
-  /var/lib/ai-trading-bot /var/cache/ai-trading-bot /var/log/ai-trading-bot
+  /var/lib/ai-trading-bot \
+  /var/lib/ai-trading-bot/models \
+  /var/lib/ai-trading-bot/output \
+  /var/cache/ai-trading-bot \
+  /var/log/ai-trading-bot
 ```
 
 Mount these locations or set the variables above so data persists across restarts.

--- a/README.md
+++ b/README.md
@@ -1049,6 +1049,11 @@ User=ai-trading
 Group=ai-trading
 WorkingDirectory=/opt/ai-trading-bot
 Environment=PATH=/opt/ai-trading-bot/venv/bin
+Environment=AI_TRADING_DATA_DIR=/var/lib/ai-trading-bot
+Environment=AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot
+Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
+Environment=AI_TRADING_MODELS_DIR=/var/lib/ai-trading-bot/models
+Environment=AI_TRADING_OUTPUT_DIR=/var/lib/ai-trading-bot/output
 ExecStart=/opt/ai-trading-bot/venv/bin/python -m ai_trading
 Restart=always
 RestartSec=10

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -12,7 +12,15 @@ Environment=AI_TRADING_MODEL_MODULE=ai_trading.models.baseline
 Environment=AI_TRADING_DATA_DIR=/var/lib/ai-trading-bot
 Environment=AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot
 Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
+Environment=AI_TRADING_MODELS_DIR=/var/lib/ai-trading-bot/models
+Environment=AI_TRADING_OUTPUT_DIR=/var/lib/ai-trading-bot/output
 EnvironmentFile=-/home/aiuser/ai-trading-bot/.env
+ExecStartPre=/usr/bin/install -d -m 700 -o aiuser -g aiuser \
+    /var/lib/ai-trading-bot \
+    /var/lib/ai-trading-bot/models \
+    /var/lib/ai-trading-bot/output \
+    /var/cache/ai-trading-bot \
+    /var/log/ai-trading-bot
 ExecStart=/home/aiuser/ai-trading-bot/venv/bin/python -m ai_trading.main
 Restart=always
 RestartSec=10

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -39,6 +39,24 @@ def test_runtime_paths_writable():
         pytest.fail(f"CACHE_DIR {paths.CACHE_DIR} is not writable")
     assert stat.S_IMODE(paths.CACHE_DIR.stat().st_mode) == 0o700
 
+    # Test MODELS_DIR is writable
+    test_file = paths.MODELS_DIR / "test_write.tmp"
+    try:
+        test_file.write_text("test")
+        assert test_file.exists()
+        test_file.unlink()
+    except PermissionError:
+        pytest.fail(f"MODELS_DIR {paths.MODELS_DIR} is not writable")
+
+    # Test OUTPUT_DIR is writable
+    test_file = paths.OUTPUT_DIR / "test_write.tmp"
+    try:
+        test_file.write_text("test")
+        assert test_file.exists()
+        test_file.unlink()
+    except PermissionError:
+        pytest.fail(f"OUTPUT_DIR {paths.OUTPUT_DIR} is not writable")
+
 
 def test_cache_dir_falls_back(monkeypatch, tmp_path):
     """Cache dir falls back to a temp path if configured location is read-only."""
@@ -76,11 +94,15 @@ def test_paths_module_imports():
     assert hasattr(paths, 'DATA_DIR')
     assert hasattr(paths, 'LOG_DIR')
     assert hasattr(paths, 'CACHE_DIR')
+    assert hasattr(paths, 'MODELS_DIR')
+    assert hasattr(paths, 'OUTPUT_DIR')
 
     # Ensure directories exist
     assert paths.DATA_DIR.exists()
     assert paths.LOG_DIR.exists()
     assert paths.CACHE_DIR.exists()
+    assert paths.MODELS_DIR.exists()
+    assert paths.OUTPUT_DIR.exists()
 
 
 def test_http_utilities_available():


### PR DESCRIPTION
## Summary
- export `AI_TRADING_MODELS_DIR` and `AI_TRADING_OUTPUT_DIR` in systemd unit and pre-create writable directories
- document model and output paths in deployment and README
- test that models and output directories are writable

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*
- `AI_TRADING_MODELS_DIR=/tmp/ai-models AI_TRADING_OUTPUT_DIR=/tmp/ai-output python -m ai_trading.main --iterations 1 --interval 0` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b1fea751b88330ba22e1b68c78127b