### PR TITLE
Ensure trade log file initialized before reading

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5010,6 +5010,12 @@ def _read_trade_log(
 
 def _parse_local_positions() -> dict[str, int]:
     """Return current local open positions from the trade logger."""
+    # Ensure the trade log file exists with headers before attempting to read
+    # from it.  ``get_trade_logger`` will create the file and write the header
+    # row on first use, which prevents later reads from failing due to a missing
+    # or empty file.
+    get_trade_logger()
+
     positions: dict[str, int] = {}
     df = _read_trade_log(
         TRADE_LOG_FILE, usecols=["symbol", "qty", "side", "exit_time"], dtype=str

--- a/tests/bot_engine/test_trade_log_init.py
+++ b/tests/bot_engine/test_trade_log_init.py
@@ -1,0 +1,21 @@
+from ai_trading.core import bot_engine
+
+
+def test_parse_local_positions_creates_trade_log(tmp_path, monkeypatch):
+    """Smoke test: reading positions initializes the trade log file."""
+
+    log_path = tmp_path / "trades.csv"
+    # Point the bot engine to our temporary log file and reset singleton
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+
+    # Ensure file does not yet exist
+    assert not log_path.exists()
+
+    # Parsing positions should trigger trade log initialization
+    positions = bot_engine._parse_local_positions()
+
+    assert positions == {}
+    assert log_path.exists()
+    assert log_path.stat().st_size > 0
+


### PR DESCRIPTION
## Summary
- Initialize trade log via `get_trade_logger()` before parsing local positions
- Add smoke test verifying trade log creation and content

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 101 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68b2014046988330aaaca7aed087e379