### PR TITLE
Use module-based model stub for default config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,7 @@ ALPACA_ADJUSTMENT=all
 # Host/port for the Flask control/health API. Defaults are safe for Docker/VMs.
 API_HOST=0.0.0.0
 API_PORT=9001
+
+# === MODEL CONFIGURATION ===
+# Module path providing get_model() or Model
+AI_TRADING_MODEL_MODULE=ai_trading.model_stub

--- a/ai_trading/model_stub.py
+++ b/ai_trading/model_stub.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Example model module providing a lightweight linear model."""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass
+class Model:
+    """Simple linear model using predefined coefficients."""
+
+    coefficients: list[float]
+
+    def predict(self, features: Iterable[float]) -> float:
+        """Return a single prediction for ``features``."""
+        return float(sum(c * f for c, f in zip(self.coefficients, features)))
+
+
+def get_model() -> Model:
+    """Return a :class:`Model` instance with example coefficients."""
+    return Model(coefficients=[0.1, 0.2, 0.3])

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -8,7 +8,7 @@ User=aiuser
 Group=aiuser
 WorkingDirectory=/home/aiuser/ai-trading-bot
 Environment=PATH=/home/aiuser/ai-trading-bot/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-Environment=AI_TRADING_MODEL_MODULE=ai_trading.models.baseline
+Environment=AI_TRADING_MODEL_MODULE=ai_trading.model_stub
 Environment=AI_TRADING_DATA_DIR=/var/lib/ai-trading-bot
 Environment=AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot
 Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot


### PR DESCRIPTION
## Summary
- add `ai_trading.model_stub` providing a tiny linear model via `get_model`
- default to `AI_TRADING_MODEL_MODULE=ai_trading.model_stub` in `.env.example`
- point systemd unit to the stub module and drop path-based model

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b20904b4048330a8030bc3ecfc7458