### PR TITLE
feat: redact secrets from startup logs

### DIFF
--- a/ai_trading/logging/redact.py
+++ b/ai_trading/logging/redact.py
@@ -1,13 +1,21 @@
+"""Utilities for redacting sensitive information from log payloads."""
+
 from __future__ import annotations
-import re
+
 from collections.abc import Mapping, MutableMapping
 from copy import deepcopy
+import re
 from typing import Any
-_RE_KEYS = re.compile('(key|secret|token|password)', re.IGNORECASE)
-_MASK = '***REDACTED***'
+
+_RE_KEYS = re.compile("(key|secret|token|password)", re.IGNORECASE)
+_MASK = "***REDACTED***"
+
+_SENSITIVE_ENV = {"ALPACA_API_KEY", "ALPACA_SECRET_KEY", "WEBHOOK_SECRET"}
+
 
 def _redact_inplace(obj: Any) -> Any:
     """Recursively redact matching keys."""
+
     if isinstance(obj, Mapping):
         for k, v in list(obj.items()):
             if isinstance(k, str) and _RE_KEYS.search(k):
@@ -21,7 +29,23 @@ def _redact_inplace(obj: Any) -> Any:
         return obj
     return obj
 
+
 def redact(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     """Return a redacted copy of *payload*."""
+
     dup: MutableMapping[str, Any] = deepcopy(payload)
     return _redact_inplace(dup)
+
+
+def redact_env(env: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return copy of *env* with known sensitive keys masked."""
+
+    dup: MutableMapping[str, Any] = dict(env)
+    for key in _SENSITIVE_ENV:
+        if key in dup and dup[key]:
+            dup[key] = _MASK
+    return dup
+
+
+__all__ = ["redact", "redact_env"]
+

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -40,7 +40,7 @@ from ai_trading.settings import get_seed_int
 from ai_trading.config import get_settings
 from ai_trading.utils import get_free_port, get_pid_on_port
 from ai_trading.utils.prof import StageTimer, SoftBudget
-from ai_trading.logging.redact import redact as _redact
+from ai_trading.logging.redact import redact as _redact, redact_env
 from ai_trading.net.http import build_retrying_session, set_global_session
 from ai_trading.utils.http import clamp_request_timeout
 from ai_trading.position_sizing import resolve_max_position_size, _get_equity_from_alpaca
@@ -186,7 +186,7 @@ def _fail_fast_env() -> None:
     except RuntimeError as e:
         logger.critical("ENV_VALIDATION_FAILED", extra={"error": str(e)})
         raise SystemExit(1) from e
-    logger.info("ENV_CONFIG_LOADED", extra={"dotenv_path": loaded, **snapshot})
+    logger.info("ENV_CONFIG_LOADED", extra={"dotenv_path": loaded, **redact_env(snapshot)})
 
 
 def _validate_runtime_config(cfg, tcfg) -> None:

--- a/ai_trading/validation/validate_env.py
+++ b/ai_trading/validation/validate_env.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os
 from pydantic import BaseModel, Field, field_validator
+from ai_trading.logging.redact import redact_env
 
 class Settings(BaseModel):
     ALPACA_API_KEY: str = Field(...)
@@ -46,7 +47,7 @@ class Settings(BaseModel):
 
 def debug_environment() -> dict:
     """Return a tiny dump used by tests without side effects."""
-    return {'pythonpath': os.environ.get('PYTHONPATH', ''), 'env': dict(os.environ)}
+    return {'pythonpath': os.environ.get('PYTHONPATH', ''), 'env': redact_env(os.environ)}
 
 def validate_specific_env_var(name: str, required: bool=False) -> str | None:
     val = os.environ.get(name)

--- a/tests/test_startup_secret_redaction.py
+++ b/tests/test_startup_secret_redaction.py
@@ -1,0 +1,21 @@
+import logging
+
+from ai_trading import main
+
+
+def test_startup_logs_redact_secrets(caplog, monkeypatch):
+    monkeypatch.setenv("ALPACA_API_KEY", "AK123456789")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "SK987654321")
+    monkeypatch.setenv("ALPACA_API_URL", "https://paper-api.alpaca.markets")
+    monkeypatch.setenv("ALPACA_DATA_FEED", "iex")
+    monkeypatch.setenv("WEBHOOK_SECRET", "HOOK-SECRET")
+    monkeypatch.setenv("CAPITAL_CAP", "0.5")
+    monkeypatch.setenv("DOLLAR_RISK_LIMIT", "1000")
+
+    caplog.set_level(logging.INFO)
+    main._fail_fast_env()
+    joined = "\n".join(str(rec.__dict__) for rec in caplog.records)
+    assert "AK123456789" not in joined
+    assert "SK987654321" not in joined
+    assert "HOOK-SECRET" not in joined
+


### PR DESCRIPTION
## Summary
- add `redact_env` utility to mask sensitive environment variables
- use `redact_env` when validating startup config
- return redacted environment data for debug helpers
- test that startup logs never expose secret values

## Testing
- `python -m ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; skipped: alpaca-py is required for tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b2135ca4308330a349760f93c14d4e