### PR TITLE
Defer data fetch imports in validation

### DIFF
--- a/ai_trading/data_validation.py
+++ b/ai_trading/data_validation.py
@@ -6,7 +6,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 from ai_trading.utils.lazy_imports import load_pandas
-from ai_trading.data.fetch import get_bars
 from ai_trading.validation.require_env import should_halt_trading
 
 # Lazy pandas proxy for on-demand import
@@ -87,7 +86,10 @@ def emergency_data_check(symbols_or_df: Sequence[str] | str | pd.DataFrame, symb
         to_check = list(symbols_or_df)
     else:
         to_check = [str(symbols_or_df)]
-    fetch = fetcher or get_bars
+    if fetcher is None:
+        from ai_trading.data.fetch import get_bars as fetch
+    else:
+        fetch = fetcher
     end = datetime.now(UTC)
     start = end - timedelta(minutes=1)
     for sym in to_check:

--- a/ai_trading/validation/__init__.py
+++ b/ai_trading/validation/__init__.py
@@ -1,11 +1,25 @@
 """Validation utilities and facades."""
-from ai_trading.data_validation import check_data_freshness
+
 from .require_env import (
     _require_env_vars,
     require_env_vars,
     should_halt_trading,
 )
 from .validate_env import debug_environment, validate_specific_env_var
+
+
+def check_data_freshness(*args, **kwargs):
+    """Lazy proxy to :func:`ai_trading.data_validation.check_data_freshness`.
+
+    Importing :mod:`ai_trading.data_validation` can pull in heavy dependencies
+    like pandas, so this function defers that import until it is actually
+    needed.
+    """
+
+    from ai_trading.data_validation import check_data_freshness as _check
+
+    return _check(*args, **kwargs)
+
 
 __all__ = [
     "check_data_freshness",


### PR DESCRIPTION
## Summary
- lazily import `get_bars` inside `emergency_data_check` to avoid heavy dependencies at import time
- expose `check_data_freshness` via a lazy proxy in `ai_trading.validation` to drop eager module import

## Testing
- `ruff check ai_trading/data_validation.py ai_trading/validation/__init__.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py` *(fails: No module named 'alpaca'; skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b21f766294833095f53414be491e3f