### PR TITLE
Remove root data_validation module references

### DIFF
--- a/CRITICAL_FIXES_IMPLEMENTATION_SUMMARY.md
+++ b/CRITICAL_FIXES_IMPLEMENTATION_SUMMARY.md
@@ -38,13 +38,13 @@ def alpaca_client(self):
 
 ### 4. ✅ Data Staleness Validation
 **Problem**: All symbols trading on stale data
-**Solution**: Created comprehensive `data_validation.py` module:
+**Solution**: Created comprehensive `ai_trading.data_validation` module:
 - `check_data_freshness()` - Validates data age (default: 15 minutes max)
 - `validate_trading_data()` - Batch validation for multiple symbols
 - `emergency_data_check()` - Fast validation for critical trades
 - `should_halt_trading()` - Automatic trading halt on data quality issues
 
-**File**: `data_validation.py` (complete new module)
+**File**: `ai_trading.data_validation` (complete new module)
 
 ### 5. ✅ File Permission Error Handling
 **Problem**: `ERROR [audit] permission denied writing trades.csv`
@@ -134,7 +134,7 @@ def alpaca_client(self):
 3. **ai_trading/process_manager.py**: Enhanced with locking and instance detection (73 lines)
 4. **main.py**: Integrated process management (29 lines)
 5. **audit.py**: Enhanced permission error handling (35 lines)
-6. **data_validation.py**: Complete new module for data validation (217 lines)
+6. **ai_trading.data_validation**: Complete new module for data validation (217 lines)
 
 ## Success Metrics
 

--- a/PRODUCTION_FIXES_SUMMARY.md
+++ b/PRODUCTION_FIXES_SUMMARY.md
@@ -59,7 +59,7 @@ This document summarizes the implementation of critical production fixes for the
 - **Weekends**: 4320 minutes / 72 hours (lenient)
 
 **Files Modified**:
-- `data_validation.py` - Complete staleness detection overhaul
+- `ai_trading.data_validation` - Complete staleness detection overhaul
 
 **Expected Outcome**: Data staleness alerts will be reduced to actionable items only, with appropriate thresholds based on market conditions.
 
@@ -150,7 +150,7 @@ If issues arise, the changes can be safely rolled back:
 | `bot_engine.py` | Updated sentiment logic | Better configuration handling |
 | `config.py` | Added new env vars | Extended configuration |
 | `performance_monitor.py` | Improved process detection | Reduced false alerts |
-| `data_validation.py` | Market-aware thresholds | Smarter staleness detection |
+| `ai_trading.data_validation` | Market-aware thresholds | Smarter staleness detection |
 | `ai_trading.tools.env_validate` | Enhanced debugging | Better troubleshooting |
 | `test_production_fixes.py` | Comprehensive test suite | Quality assurance |
 

--- a/tests/test_production_fixes.py
+++ b/tests/test_production_fixes.py
@@ -230,7 +230,7 @@ class TestIntegration(unittest.TestCase):
     def test_all_modules_importable(self):
         """Test that all modified modules can be imported without errors."""
         modules_to_test = [
-            'data_validation',
+            'ai_trading.data_validation',
             'validate_env',
         ]
 


### PR DESCRIPTION
## Summary
- replace legacy `data_validation` import with `ai_trading.data_validation` in tests
- clarify docs to reference `ai_trading.data_validation` module

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b2234f16d88330a395cd2d138236e4