### PR TITLE
Expire memory cache entries at TTL threshold

### DIFF
--- a/ai_trading/market/cache.py
+++ b/ai_trading/market/cache.py
@@ -30,7 +30,8 @@ def get_mem(symbol: str, tf: str, start: str, end: str, ttl: int) -> Any | None:
         if not v:
             return None
         ts, obj = v
-        if _now() - ts > ttl:
+        # Use `>=` so a TTL of 0 expires immediately
+        if _now() - ts >= ttl:
             _mem.pop(k, None)
             return None
         if pd is not None and hasattr(obj, 'copy'):


### PR DESCRIPTION
## Summary
- Use `>=` in memory cache TTL check so `ttl=0` expires immediately

## Testing
- `ruff check ai_trading/market/cache.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_data_cache.py::test_mem_cache_ttl_basic -q`

------
https://chatgpt.com/codex/tasks/task_e_68b225de38448330af4dae38d3974b43