### PR TITLE
Handle missing raise_for_status in Alpaca equity fetch

### DIFF
--- a/ai_trading/position_sizing.py
+++ b/ai_trading/position_sizing.py
@@ -119,7 +119,14 @@ def _get_equity_from_alpaca(cfg) -> float:
             return 0.0
         s = get_global_session()
         resp = s.get(url, headers={'APCA-API-KEY-ID': key, 'APCA-API-SECRET-KEY': secret})
-        resp.raise_for_status()
+        if hasattr(resp, "raise_for_status"):
+            resp.raise_for_status()
+        else:
+            status = getattr(resp, "status_code", None)
+            if status != 200:
+                err = HTTPError(f"HTTP {status}")
+                setattr(err, "response", resp)
+                raise err
         data = resp.json()
         eq = _coerce_float(data.get('equity'), 0.0)
         return eq


### PR DESCRIPTION
## Summary
- Avoid AttributeError when mock responses lack `raise_for_status` in `_get_equity_from_alpaca`
- Fall back to failure when response status isn't 200

## Testing
- `ruff check ai_trading/position_sizing.py tests/test_dynamic_position_sizing.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_dynamic_position_sizing.py` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b2277e0270833086d4148afba53288