### PR TITLE
Guard logging handlers in system context

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -612,9 +612,25 @@ def _get_system_context() -> dict[str, any]:
     except COMMON_EXC as e:
         return {'context_error': f'psutil missing: {e}'}
     try:
-        context = {'memory_usage_mb': round(psutil.virtual_memory().used / 1024 / 1024, 1), 'memory_percent': psutil.virtual_memory().percent, 'cpu_percent': psutil.cpu_percent(interval=None), 'disk_usage_percent': psutil.disk_usage('/').percent}
+        context = {
+            'memory_usage_mb': round(psutil.virtual_memory().used / 1024 / 1024, 1),
+            'memory_percent': psutil.virtual_memory().percent,
+            'cpu_percent': psutil.cpu_percent(interval=None),
+            'disk_usage_percent': psutil.disk_usage('/').percent,
+        }
         root = logging.getLogger()
-        context.update({'python_version': sys.version.split()[0], 'log_level': root.level, 'handlers_count': len(root.handlers)})
+        handlers = getattr(root, 'handlers', [])
+        try:
+            handler_count = len(handlers)
+        except TypeError:
+            handler_count = 0
+        context.update(
+            {
+                'python_version': sys.version.split()[0],
+                'log_level': root.level,
+                'handlers_count': handler_count,
+            }
+        )
         return context
     except COMMON_EXC as e:
         return {'context_error': str(e)}


### PR DESCRIPTION
## Summary
- Protect system context logging against missing or non-sized handler lists

## Testing
- `ruff check ai_trading/logging/__init__.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_ellipsis_fix.py::TestEllipsisFix.test_json_formatter_log_trading_event_unicode -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

------
https://chatgpt.com/codex/tasks/task_e_68b228600aa88330bbd21d2eef3942e2