### PR TITLE
refactor: lazily import strategy deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ sma = ta_lib.SMA(close_prices, timeperiod=20)
 rsi = ta_lib.RSI(close_prices, timeperiod=14)
 
 # Direct ta library interface for advanced usage
-from ai_trading.strategies.imports import ta
+from ai_trading.strategies.imports import get_ta
+ta = get_ta()
 sma_direct = ta.trend.sma_indicator(close_series, window=20)
 ```
 
@@ -376,7 +377,7 @@ docker logs ai-trading-bot
    python -c "import ta; print('ta library version:', ta.__version__ if hasattr(ta, '__version__') else 'installed')"
 
    # Check bot's technical analysis status
-   python -c "from ai_trading.strategies.imports import TA_AVAILABLE; print(f'TA available: {TA_AVAILABLE}')"
+   python -c "from ai_trading.strategies import imports; imports.get_ta(); print(f'TA available: {imports.TA_AVAILABLE}')"
 
    # Reinstall if needed
    pip install --upgrade ta==0.11.0

--- a/ai_trading/strategies/imports.py
+++ b/ai_trading/strategies/imports.py
@@ -1,19 +1,107 @@
-"""Centralized import management for ai_trading modules.
+"""Lazy loaded imports for strategy-related dependencies."""
 
-All dependencies are imported directly. Optional features are controlled
-via Settings flags rather than import guards.
-"""
+from __future__ import annotations
+
 from ai_trading.logging import get_logger
-import numpy as np
-import pandas as pd
-from sklearn import metrics
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.model_selection import train_test_split
+
 logger = get_logger(__name__)
-NUMPY_AVAILABLE = True
-PANDAS_AVAILABLE = True
-SKLEARN_AVAILABLE = True
-import ta
-TA_AVAILABLE = True
-logger.info('TA library loaded successfully for enhanced technical analysis')
-__all__ = ['np', 'pd', 'metrics', 'RandomForestClassifier', 'train_test_split', 'ta', 'NUMPY_AVAILABLE', 'PANDAS_AVAILABLE', 'SKLEARN_AVAILABLE', 'TA_AVAILABLE']
+
+_NP = None
+_PD = None
+_METRICS = None
+_RANDOM_FOREST_CLASSIFIER = None
+_TRAIN_TEST_SPLIT = None
+_TA = None
+
+NUMPY_AVAILABLE = False
+PANDAS_AVAILABLE = False
+SKLEARN_AVAILABLE = False
+TA_AVAILABLE = False
+
+
+def get_np():
+    """Return the :mod:`numpy` module on demand."""
+    global _NP, NUMPY_AVAILABLE
+    if _NP is None:
+        import numpy as np  # pragma: no cover - import side effect
+
+        _NP = np
+        NUMPY_AVAILABLE = True
+    return _NP
+
+
+def get_pd():
+    """Return the :mod:`pandas` module on demand."""
+    global _PD, PANDAS_AVAILABLE
+    if _PD is None:
+        import pandas as pd  # pragma: no cover - import side effect
+
+        _PD = pd
+        PANDAS_AVAILABLE = True
+    return _PD
+
+
+def get_metrics():
+    """Return :mod:`sklearn.metrics` lazily."""
+    global _METRICS, SKLEARN_AVAILABLE
+    if _METRICS is None:
+        from sklearn import metrics  # pragma: no cover - import side effect
+
+        _METRICS = metrics
+        SKLEARN_AVAILABLE = True
+    return _METRICS
+
+
+def get_random_forest_classifier():
+    """Return :class:`sklearn.ensemble.RandomForestClassifier` lazily."""
+    global _RANDOM_FOREST_CLASSIFIER, SKLEARN_AVAILABLE
+    if _RANDOM_FOREST_CLASSIFIER is None:
+        from sklearn.ensemble import (  # pragma: no cover - import side effect
+            RandomForestClassifier,
+        )
+
+        _RANDOM_FOREST_CLASSIFIER = RandomForestClassifier
+        SKLEARN_AVAILABLE = True
+    return _RANDOM_FOREST_CLASSIFIER
+
+
+def get_train_test_split():
+    """Return :func:`sklearn.model_selection.train_test_split` lazily."""
+    global _TRAIN_TEST_SPLIT, SKLEARN_AVAILABLE
+    if _TRAIN_TEST_SPLIT is None:
+        from sklearn.model_selection import (  # pragma: no cover - import side effect
+            train_test_split,
+        )
+
+        _TRAIN_TEST_SPLIT = train_test_split
+        SKLEARN_AVAILABLE = True
+    return _TRAIN_TEST_SPLIT
+
+
+def get_ta():
+    """Return the optional :mod:`ta` library when requested."""
+    global _TA, TA_AVAILABLE
+    if _TA is None:
+        import ta  # pragma: no cover - import side effect
+
+        logger.info(
+            "TA library loaded successfully for enhanced technical analysis"
+        )
+        _TA = ta
+        TA_AVAILABLE = True
+    return _TA
+
+
+__all__ = [
+    "get_np",
+    "get_pd",
+    "get_metrics",
+    "get_random_forest_classifier",
+    "get_train_test_split",
+    "get_ta",
+    "NUMPY_AVAILABLE",
+    "PANDAS_AVAILABLE",
+    "SKLEARN_AVAILABLE",
+    "TA_AVAILABLE",
+]
+

--- a/docs/TECHNICAL_ANALYSIS.md
+++ b/docs/TECHNICAL_ANALYSIS.md
@@ -73,8 +73,10 @@ bb_width = talib.BBANDWIDTH(close_prices, timeperiod=20)
 
 ### Direct TA Library Interface (Advanced)
 ```python
-from ai_trading.strategies.imports import ta
+from ai_trading.strategies.imports import get_ta
 import pandas as pd
+
+ta = get_ta()
 
 # Convert to pandas Series for optimal performance
 close_series = pd.Series(close_prices)
@@ -118,7 +120,9 @@ bullish = (rsi_short[-1] > 50 and
 ### Pandas Series Input (Recommended)
 ```python
 import pandas as pd
-from ai_trading.strategies.imports import ta
+from ai_trading.strategies.imports import get_ta
+
+ta = get_ta()
 
 # Convert once for multiple calculations
 df = pd.DataFrame({

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -50,34 +50,27 @@ def test_talib_imports():
         os.environ.setdefault('WEBHOOK_SECRET', 'dummy')
         os.environ.setdefault('FLASK_PORT', '5000')
 
-        from ai_trading.strategies.imports import TA_AVAILABLE, ta
+        from ai_trading.strategies import imports as strategy_imports
+
+        ta = strategy_imports.get_ta()
 
         # Test that ta object is always available (real or mock)
-        if hasattr(ta, 'trend'):
-            pass
-        else:
+        if not hasattr(ta, "trend"):
             return False
-
-        if hasattr(ta, 'momentum'):
-            pass
-        else:
+        if not hasattr(ta, "momentum"):
             return False
-
-        if hasattr(ta, 'volatility'):
-            pass
-        else:
+        if not hasattr(ta, "volatility"):
             return False
 
         # Test basic functionality with small dataset
         test_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 3  # 30 data points
         try:
             import pytest
+
             pd = pytest.importorskip("pandas")
             test_series = pd.Series(test_data)
             sma_result = ta.trend.sma_indicator(test_series, window=10)
             if sma_result is not None and len(sma_result) == len(test_data):
-                pass
-            else:
                 pass
         except (AttributeError, ValueError):
             pass


### PR DESCRIPTION
## Summary
- gate numpy, pandas, sklearn, and ta behind accessor functions in `ai_trading.strategies.imports`
- log TA library usage only when `get_ta()` is invoked
- update docs and tests to use the new accessor helpers

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*
- `time python -c "import ai_trading.strategies.imports"` before: 1.964s
- `time python -c "import ai_trading.strategies.imports"` after: 1.958s

------
https://chatgpt.com/codex/tasks/task_e_68b230bd0e4c8330a7e44bee85c26d71