### PR TITLE
refactor: lazy load pandas

### DIFF
--- a/ai_trading/data/labels.py
+++ b/ai_trading/data/labels.py
@@ -5,8 +5,12 @@ Provides explicit labelers for future returns, triple barrier labels,
 and other trading-specific target variables.
 """
 import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.logging import logger
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 def fixed_horizon_return(prices: pd.Series | pd.DataFrame, horizon_bars: int, fee_bps: float=0.0) -> pd.Series:
     """
@@ -20,6 +24,7 @@ def fixed_horizon_return(prices: pd.Series | pd.DataFrame, horizon_bars: int, fe
     Returns:
         Series of future log returns net of fees
     """
+    pd = load_pandas()
     try:
         if isinstance(prices, pd.DataFrame):
             if 'close' in prices.columns:
@@ -58,6 +63,7 @@ def triple_barrier_labels(prices: pd.Series | pd.DataFrame, events: pd.DataFrame
     Returns:
         DataFrame with labels: t1 (end time), ret (return), bin (label)
     """
+    pd = load_pandas()
     try:
         if isinstance(prices, pd.DataFrame):
             if 'close' in prices.columns:
@@ -142,6 +148,7 @@ def get_daily_vol(prices: pd.Series, span0: int=100) -> pd.Series:
     Returns:
         Daily volatility series
     """
+    pd = load_pandas()
     try:
         daily_ret = prices.resample('1D').last().pct_change().dropna()
         vol = daily_ret.ewm(span=span0).std()

--- a/ai_trading/data/splits.py
+++ b/ai_trading/data/splits.py
@@ -7,9 +7,13 @@ including purged group time series splits and walk-forward analysis.
 from collections.abc import Iterator
 from datetime import datetime, timedelta
 import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
 from sklearn.model_selection import BaseCrossValidator
 from ai_trading.logging import logger
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 class PurgedGroupTimeSeriesSplit(BaseCrossValidator):
     """
@@ -47,6 +51,7 @@ class PurgedGroupTimeSeriesSplit(BaseCrossValidator):
         Yields:
             Tuple of (train_indices, test_indices)
         """
+        pd = load_pandas()
         try:
             if hasattr(X, 'index'):
                 indices = X.index
@@ -104,6 +109,7 @@ class PurgedGroupTimeSeriesSplit(BaseCrossValidator):
         Returns:
             Purged training indices
         """
+        pd = load_pandas()
         try:
             if len(test_indices) == 0:
                 return train_indices
@@ -148,6 +154,7 @@ def walkforward_splits(dates: pd.DatetimeIndex | list[datetime], mode: str='roll
     Returns:
         List of split dictionaries with train/test periods
     """
+    pd = load_pandas()
     try:
         if not isinstance(dates, pd.DatetimeIndex):
             dates = pd.DatetimeIndex(dates)
@@ -194,6 +201,7 @@ def validate_no_leakage(train_indices: np.ndarray, test_indices: np.ndarray, tim
     Returns:
         True if no leakage detected, False otherwise
     """
+    pd = load_pandas()
     try:
         overlap = np.intersect1d(train_indices, test_indices)
         if len(overlap) > 0:

--- a/ai_trading/features/prepare.py
+++ b/ai_trading/features/prepare.py
@@ -1,13 +1,18 @@
 import logging
 import importlib
 import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.utils.base import safe_to_datetime
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 logger = logging.getLogger(__name__)
 MFI_PERIOD = 14
 
 def prepare_indicators(df: pd.DataFrame, freq: str='daily') -> pd.DataFrame:
+    pd = load_pandas()
     try:
         ta = importlib.import_module('pandas_ta')
     except ImportError as exc:  # pragma: no cover - optional dependency

--- a/ai_trading/position/correlation_analyzer.py
+++ b/ai_trading/position/correlation_analyzer.py
@@ -14,10 +14,13 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import numpy as np
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.exc import COMMON_EXC
+
+if TYPE_CHECKING:
+    import pandas as pd
 logger = get_logger(__name__)
 
 class ConcentrationLevel(Enum):
@@ -223,6 +226,7 @@ class PortfolioCorrelationAnalyzer:
 
     def _calculate_pair_correlation(self, symbol1: str, symbol2: str) -> PositionCorrelation | None:
         """Calculate correlation between two symbols."""
+        pd = load_pandas()
         try:
             data1 = self._get_price_data(symbol1)
             data2 = self._get_price_data(symbol2)

--- a/ai_trading/position/profit_taking.py
+++ b/ai_trading/position/profit_taking.py
@@ -13,9 +13,12 @@ from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
-import pandas as pd
+from typing import Any, TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.exc import COMMON_EXC
+
+if TYPE_CHECKING:
+    import pandas as pd
 logger = get_logger(__name__)
 
 class ProfitTakingStrategy(Enum):
@@ -285,6 +288,7 @@ class ProfitTakingEngine:
 
     def _create_rsi_overbought_target(self, symbol: str, data: pd.DataFrame, position_size: int) -> ProfitTarget | None:
         """Create RSI overbought profit target."""
+        pd = load_pandas()
         try:
             if 'close' not in data.columns or len(data) < 20:
                 return None
@@ -328,6 +332,7 @@ class ProfitTakingEngine:
 
     def _calculate_rsi(self, prices: pd.Series, period: int=14) -> float:
         """Calculate RSI indicator."""
+        pd = load_pandas()
         try:
             if len(prices) < period + 1:
                 return 50.0

--- a/ai_trading/position/trailing_stops.py
+++ b/ai_trading/position/trailing_stops.py
@@ -13,8 +13,12 @@ from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
-import pandas as pd
+from typing import Any, TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
+
 logger = get_logger(__name__)
 
 class TrailingStopType(Enum):
@@ -179,6 +183,7 @@ class TrailingStopManager:
 
     def _calculate_atr_stop_distance(self, data: pd.DataFrame) -> float:
         """Calculate ATR-based stop distance."""
+        pd = load_pandas()
         try:
             if 'high' not in data.columns or 'low' not in data.columns or 'close' not in data.columns or (len(data) < self.atr_period):
                 return self.base_trail_percent
@@ -202,6 +207,7 @@ class TrailingStopManager:
 
     def _calculate_momentum_multiplier(self, symbol: str, data: pd.DataFrame | None) -> float:
         """Calculate momentum-based multiplier for stop distance."""
+        pd = load_pandas()
         try:
             if data is None or 'close' not in data.columns or len(data) < self.momentum_period:
                 return 1.0
@@ -304,6 +310,7 @@ class TrailingStopManager:
 
     def _calculate_rsi(self, prices: pd.Series, period: int=14) -> float:
         """Calculate RSI indicator."""
+        pd = load_pandas()
         try:
             if len(prices) < period + 1:
                 return 50.0

--- a/ai_trading/strategies/imports.py
+++ b/ai_trading/strategies/imports.py
@@ -5,11 +5,16 @@ via Settings flags rather than import guards.
 """
 from ai_trading.logging import get_logger
 import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
 from sklearn import metrics
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
+if TYPE_CHECKING:
+    import pandas as pd
+
 logger = get_logger(__name__)
+pd = load_pandas()
 NUMPY_AVAILABLE = True
 PANDAS_AVAILABLE = True
 SKLEARN_AVAILABLE = True

--- a/scripts/algorithm_optimizer.py
+++ b/scripts/algorithm_optimizer.py
@@ -19,9 +19,12 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import Enum
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import numpy as np
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 class MarketRegime(Enum):
     """Market regime classification."""
@@ -103,6 +106,7 @@ class AlgorithmOptimizer:
 
     def detect_market_regime(self, price_data: pd.DataFrame, volume_data: pd.DataFrame | None=None, market_data: pd.DataFrame | None=None) -> MarketConditions:
         """Detect current market regime and conditions."""
+        pd = load_pandas()
         try:
             if len(price_data) < 20:
                 return MarketConditions(regime=MarketRegime.SIDEWAYS, volatility=0.02, trend_strength=0.0, volume_profile=1.0, correlation_to_market=0.5, sector_rotation=0.0, vix_level=20.0, time_of_day=self._get_trading_phase())

--- a/scripts/backtest_framework.py
+++ b/scripts/backtest_framework.py
@@ -5,8 +5,14 @@ import gc
 import weakref
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import pytest
+
+from typing import TYPE_CHECKING
+
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 class TradingBotValidator:
 
@@ -33,6 +39,7 @@ class TradingBotValidator:
         if cache_key in self._test_data_cache:
             data = self._test_data_cache[cache_key]
         else:
+            pd = load_pandas()
             data = pd.read_csv(historical_data_path)
             self._test_data_cache[cache_key] = data
         total_pnl = 0
@@ -86,6 +93,7 @@ class TradingBotValidator:
     def __del__(self):
         """Ensure cleanup on garbage collection."""
         try:
+            pd = load_pandas()
             self.cleanup()
         except (pd.errors.EmptyDataError, KeyError, ValueError, TypeError, ZeroDivisionError, OverflowError):
             pass

--- a/scripts/check_feed.py
+++ b/scripts/check_feed.py
@@ -1,10 +1,16 @@
 """Small diagnostic to verify market data fetch."""
 from types import SimpleNamespace
-import pandas as pd
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo  # AI-AGENT-REF: use stdlib zoneinfo
 from ai_trading.core.runtime import build_runtime
 from ai_trading.data.bars import safe_get_stock_bars
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
+
 if __name__ == '__main__':
+    pd = load_pandas()
     rt = build_runtime(SimpleNamespace())
     now = pd.Timestamp.now(tz=ZoneInfo("UTC"))
     start = now - pd.Timedelta(days=120)

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -9,7 +9,12 @@ from pathlib import Path
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-import pandas as pd
+from typing import TYPE_CHECKING
+
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.requests import StockBarsRequest
 from alpaca.data.timeframe import TimeFrame
@@ -19,6 +24,7 @@ from ai_trading.config.management import get_env
 
 def main() -> None:
     """Fetch bars for each symbol and save to ``data`` directory."""
+    pd = load_pandas()
     ensure_dotenv_loaded()
     api_key = get_env("ALPACA_API_KEY")
     secret_key = get_env("ALPACA_SECRET_KEY")

--- a/scripts/features.py
+++ b/scripts/features.py
@@ -1,9 +1,14 @@
 import logging
-import pandas as pd
+from typing import TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.indicators import atr, ema
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    import pandas as pd
+
 def compute_macd(df: pd.DataFrame) -> pd.DataFrame:
+    pd = load_pandas()
     try:
         if 'close' not in df.columns:
             logger.error("Missing 'close' column for MACD calculation")
@@ -17,14 +22,17 @@ def compute_macd(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 def compute_macds(df: pd.DataFrame) -> pd.DataFrame:
+    pd = load_pandas()
     df['macds'] = ema(tuple(df['macd'].astype(float)), 9)
     return df
 
 def compute_atr(df: pd.DataFrame, period: int=14) -> pd.DataFrame:
+    pd = load_pandas()
     df['atr'] = atr(df['high'], df['low'], df['close'], period)
     return df
 
 def compute_vwap(df: pd.DataFrame) -> pd.DataFrame:
+    pd = load_pandas()
     q = df['volume']
     p = (df['high'] + df['low'] + df['close']) / 3
     df['cum_vol'] = q.cumsum()
@@ -44,6 +52,7 @@ def ensure_columns(df: pd.DataFrame, columns: list[str], symbol: str | None=None
     return df
 
 def build_features_pipeline(df: pd.DataFrame, symbol: str) -> pd.DataFrame:
+    pd = load_pandas()
     try:
         logger.debug(f'Starting feature pipeline for {symbol}. Initial shape: {df.shape}')
         df = compute_macd(df)

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -7,10 +7,16 @@ import os
 from threading import Lock
 import time
 import joblib
-import pandas as pd
 from ai_trading.config.management import TradingConfig, reload_env
 from ai_trading.utils.http import http, HTTP_TIMEOUT
 from ai_trading.features.prepare import prepare_indicators
+
+from typing import TYPE_CHECKING
+
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 config = TradingConfig.from_env()
 _sentiment_lock = Lock()
@@ -92,6 +98,7 @@ def fetch_sentiment(symbol: str) -> float:
 
 def detect_regime(df: pd.DataFrame) -> str:
     """Classify a market regime based on moving average crossovers."""
+    pd = load_pandas()
     if df is None or df.empty or 'close' not in df:
         return 'chop'
     close = df['close'].astype(float)
@@ -113,6 +120,7 @@ def load_model(regime: str):
 
 def predict(csv_path: str, freq: str='intraday') -> tuple[int | None, float | None]:
     """Return the predicted class and probability for the data in ``csv_path``."""
+    pd = load_pandas()
     df = pd.read_csv(csv_path)
     symbol = os.path.splitext(os.path.basename(csv_path))[0]
     try:

--- a/scripts/profile_indicators.py
+++ b/scripts/profile_indicators.py
@@ -3,12 +3,17 @@ logger = logging.getLogger(__name__)
 import inspect
 import time
 import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading import indicators, signals
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 def profile(func, *args, **kwargs):
     start = time.perf_counter()
     try:
+        pd = load_pandas()
         result = func(*args, **kwargs)
     except (pd.errors.EmptyDataError, KeyError, ValueError, TypeError, ZeroDivisionError, OverflowError) as e:
         logger.error('%s failed: %s', func.__name__, e)
@@ -19,6 +24,7 @@ def profile(func, *args, **kwargs):
 
 def run_profiles():
     timings = []
+    pd = load_pandas()
     df = pd.DataFrame({'open': np.random.random(100000) * 100, 'high': np.random.random(100000) * 100, 'low': np.random.random(100000) * 100, 'close': np.random.random(100000) * 100, 'volume': np.random.randint(1000, 10000, size=100000)})
     modules = [signals, indicators]
     for module in modules:

--- a/scripts/risk_engine_cli.py
+++ b/scripts/risk_engine_cli.py
@@ -2,9 +2,11 @@ import logging
 import random
 from collections.abc import Sequence
 from datetime import UTC
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import numpy as np
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
+if TYPE_CHECKING:
+    import pandas as pd
 from ai_trading.config.management import (
     SEED,
     TradingConfig,
@@ -830,6 +832,7 @@ def check_exposure_caps(portfolio, exposure, cap):
 
 def apply_trailing_atr_stop(df: pd.DataFrame, entry_price: float, *, ctx: Any | None=None, symbol: str='SYMBOL', qty: int | None=None) -> None:
     """Exit ``qty`` at market if the trailing stop is triggered."""
+    pd = load_pandas()
     try:
         if entry_price <= 0:
             logger.warning('apply_trailing_atr_stop invalid entry price: %.2f', entry_price)
@@ -906,6 +909,7 @@ def compute_stop_levels(entry_price: float, atr: float, take_mult: float=2.0) ->
 
 def correlation_position_weights(corr: pd.DataFrame, base: dict[str, float]) -> dict[str, float]:
     """Scale weights inversely proportional to asset correlations."""
+    pd = load_pandas()
     weights = {}
     for sym, w in base.items():
         if sym in corr.columns:

--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -1,15 +1,21 @@
-import pandas as pd
+from typing import TYPE_CHECKING
 import pytest
 
 from ai_trading.core import bot_engine
 from ai_trading.guards import staleness
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def _sample_df():
+    pd = load_pandas()
     return pd.DataFrame({"close": [1.0]}, index=[pd.Timestamp("2024-01-01", tz="UTC")])
 
 
 def test_fetch_minute_df_safe_returns_dataframe(monkeypatch):
+    pd = load_pandas()
     monkeypatch.setattr(bot_engine, "get_minute_df", lambda s, start, end: _sample_df())
     monkeypatch.setattr(staleness, "_ensure_data_fresh", lambda df, max_age_seconds, *, symbol=None, now=None, tz=None: None)
     result = bot_engine.fetch_minute_df_safe("AAPL")
@@ -18,6 +24,7 @@ def test_fetch_minute_df_safe_returns_dataframe(monkeypatch):
 
 
 def test_fetch_minute_df_safe_raises_on_empty(monkeypatch):
+    pd = load_pandas()
     monkeypatch.setattr(bot_engine, "get_minute_df", lambda s, start, end: pd.DataFrame())
     monkeypatch.setattr(staleness, "_ensure_data_fresh", lambda df, max_age_seconds, *, symbol=None, now=None, tz=None: None)
     with pytest.raises(bot_engine.DataFetchError):

--- a/tests/test_empty_bars_guard.py
+++ b/tests/test_empty_bars_guard.py
@@ -1,6 +1,11 @@
-import pandas as pd
+from typing import TYPE_CHECKING
 import pytest
 from types import SimpleNamespace
+
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 from ai_trading.core import bot_engine
 
@@ -23,6 +28,7 @@ def test_get_daily_df_empty_bars_raises(monkeypatch):
     fetcher = bot_engine.DataFetcher()
     ctx = SimpleNamespace()
     monkeypatch.setattr(bot_engine, "get_alpaca_secret_key_plain", lambda: "secret")
+    pd = load_pandas()
     monkeypatch.setattr(bot_engine, "safe_get_stock_bars", lambda *a, **k: pd.DataFrame())
     with pytest.raises(bot_engine.DataFetchError):
         fetcher.get_daily_df(ctx, "AAPL")
@@ -46,6 +52,7 @@ def test_compute_spy_vol_stats_handles_failure(monkeypatch):
 
 def test_fetch_feature_data_halts_on_empty(monkeypatch):
     calls: list[str] = []
+    pd = load_pandas()
     ctx = SimpleNamespace(
         data_fetcher=SimpleNamespace(get_daily_df=lambda *a, **k: pd.DataFrame()),
         halt_manager=SimpleNamespace(manual_halt_trading=lambda r: calls.append(r)),

--- a/tests/test_get_bars_env_reload.py
+++ b/tests/test_get_bars_env_reload.py
@@ -1,10 +1,13 @@
 from datetime import datetime, timedelta, UTC
+from typing import TYPE_CHECKING
 
-import pandas as pd
-
+from ai_trading.utils.lazy_imports import load_pandas
 import ai_trading.config.settings as settings_mod
 from ai_trading.data import fetch
 from ai_trading.config import management
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def test_get_bars_recovers_after_env_reload(monkeypatch, tmp_path):
@@ -42,6 +45,7 @@ DOLLAR_RISK_LIMIT=0.05
         return real_get_settings()
 
     monkeypatch.setattr(settings_mod, "get_settings", fake_get_settings)
+    pd = load_pandas()
     monkeypatch.setattr(fetch, "_fetch_bars", lambda *a, **k: pd.DataFrame())
 
     start = datetime.now(UTC) - timedelta(minutes=1)

--- a/tests/test_sip_unauthorized.py
+++ b/tests/test_sip_unauthorized.py
@@ -1,6 +1,11 @@
 from datetime import datetime, UTC
 
-import pandas as pd
+from typing import TYPE_CHECKING
+
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 import ai_trading.data.fetch as data_fetcher
 from ai_trading.core import bot_engine
@@ -25,6 +30,7 @@ def test_get_bars_unauthorized_sip_returns_empty(monkeypatch):
     monkeypatch.setattr(data_fetcher.requests, "get", fake_get)
     start = datetime(2024, 1, 1, tzinfo=UTC)
     end = datetime(2024, 1, 2, tzinfo=UTC)
+    pd = load_pandas()
     df = data_fetcher.get_bars("AAPL", "1Min", start, end, feed="sip")
     assert isinstance(df, pd.DataFrame)
     assert df.empty


### PR DESCRIPTION
## Summary
- lazy load pandas across library, scripts, and tests to reduce startup overhead
- add `TYPE_CHECKING` hints so pandas types remain available for static analysis

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; tests require alpaca-py)*

------
https://chatgpt.com/codex/tasks/task_e_68b230ce15c8833091d7a93f2cadf6c9