### PR TITLE
Use lazy pandas imports

### DIFF
--- a/ai_trading/data/labels.py
+++ b/ai_trading/data/labels.py
@@ -5,10 +5,15 @@ Provides explicit labelers for future returns, triple barrier labels,
 and other trading-specific target variables.
 """
 import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
 from ai_trading.logging import logger
+from ai_trading.utils.lazy_imports import load_pandas
 
-def fixed_horizon_return(prices: pd.Series | pd.DataFrame, horizon_bars: int, fee_bps: float=0.0) -> pd.Series:
+if TYPE_CHECKING:
+    import pandas as pd
+
+def fixed_horizon_return(prices: "pd.Series" | "pd.DataFrame", horizon_bars: int, fee_bps: float = 0.0) -> "pd.Series":
+    pd = load_pandas()
     """
     Calculate fixed horizon future returns net of fees.
     
@@ -39,7 +44,16 @@ def fixed_horizon_return(prices: pd.Series | pd.DataFrame, horizon_bars: int, fe
         logger.error(f'Error calculating fixed horizon returns: {e}')
         return pd.Series(dtype=float)
 
-def triple_barrier_labels(prices: pd.Series | pd.DataFrame, events: pd.DataFrame | None=None, pt_sl: tuple | None=None, t1: pd.Series | None=None, min_ret: float=0.0, num_threads: int=1, vertical_barrier_times: pd.Series | None=None) -> pd.DataFrame:
+def triple_barrier_labels(
+    prices: "pd.Series" | "pd.DataFrame",
+    events: "pd.DataFrame" | None = None,
+    pt_sl: tuple | None = None,
+    t1: "pd.Series" | None = None,
+    min_ret: float = 0.0,
+    num_threads: int = 1,
+    vertical_barrier_times: "pd.Series" | None = None,
+) -> "pd.DataFrame":
+    pd = load_pandas()
     """
     Triple barrier labeling method.
     
@@ -131,7 +145,8 @@ def triple_barrier_labels(prices: pd.Series | pd.DataFrame, events: pd.DataFrame
         logger.error(f'Error in triple barrier labeling: {e}')
         return pd.DataFrame(columns=['t1', 'ret', 'bin'])
 
-def get_daily_vol(prices: pd.Series, span0: int=100) -> pd.Series:
+def get_daily_vol(prices: "pd.Series", span0: int = 100) -> "pd.Series":
+    pd = load_pandas()
     """
     Calculate daily volatility for barrier calibration.
     

--- a/ai_trading/data/sanitize.py
+++ b/ai_trading/data/sanitize.py
@@ -9,7 +9,9 @@ from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from typing import Any
 import numpy as np
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
+
+pd = load_pandas()
 logger = get_logger(__name__)
 
 @dataclass

--- a/ai_trading/features/prepare.py
+++ b/ai_trading/features/prepare.py
@@ -1,13 +1,18 @@
 import logging
 import importlib
 import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
 from ai_trading.utils.base import safe_to_datetime
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 logger = logging.getLogger(__name__)
 MFI_PERIOD = 14
 
-def prepare_indicators(df: pd.DataFrame, freq: str='daily') -> pd.DataFrame:
+def prepare_indicators(df: "pd.DataFrame", freq: str = 'daily') -> "pd.DataFrame":
+    pd = load_pandas()
     try:
         ta = importlib.import_module('pandas_ta')
     except ImportError as exc:  # pragma: no cover - optional dependency

--- a/ai_trading/position/correlation_analyzer.py
+++ b/ai_trading/position/correlation_analyzer.py
@@ -14,10 +14,13 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import numpy as np
-import pandas as pd
 from ai_trading.exc import COMMON_EXC
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 logger = get_logger(__name__)
 
 class ConcentrationLevel(Enum):
@@ -238,6 +241,7 @@ class PortfolioCorrelationAnalyzer:
                 return None
             corr_matrix = np.corrcoef(returns1, returns2)
             correlation = corr_matrix[0, 1] if len(corr_matrix) == 2 else 0.0
+            pd = load_pandas()
             if pd.isna(correlation):
                 correlation = 0.0
             strength = self._classify_correlation_strength(abs(correlation))

--- a/scripts/algorithm_optimizer.py
+++ b/scripts/algorithm_optimizer.py
@@ -19,9 +19,12 @@ from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import Enum
-from typing import Any
+from typing import Any, TYPE_CHECKING
 import numpy as np
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 class MarketRegime(Enum):
     """Market regime classification."""
@@ -101,11 +104,17 @@ class AlgorithmOptimizer:
         self.optimization_frequency = timedelta(hours=24)
         self.logger.info('Algorithm optimizer initialized')
 
-    def detect_market_regime(self, price_data: pd.DataFrame, volume_data: pd.DataFrame | None=None, market_data: pd.DataFrame | None=None) -> MarketConditions:
+    def detect_market_regime(
+        self,
+        price_data: "pd.DataFrame",
+        volume_data: "pd.DataFrame" | None = None,
+        market_data: "pd.DataFrame" | None = None,
+    ) -> MarketConditions:
         """Detect current market regime and conditions."""
         try:
             if len(price_data) < 20:
                 return MarketConditions(regime=MarketRegime.SIDEWAYS, volatility=0.02, trend_strength=0.0, volume_profile=1.0, correlation_to_market=0.5, sector_rotation=0.0, vix_level=20.0, time_of_day=self._get_trading_phase())
+            pd = load_pandas()
             returns = price_data['close'].pct_change().dropna()
             volatility = returns.std() * np.sqrt(252)
             high_low = price_data['high'] - price_data['low']
@@ -136,7 +145,7 @@ class AlgorithmOptimizer:
             self.logger.error(f'Error detecting market regime: {e}')
             return MarketConditions(regime=MarketRegime.SIDEWAYS, volatility=0.02, trend_strength=0.0, volume_profile=1.0, correlation_to_market=0.5, sector_rotation=0.0, vix_level=20.0, time_of_day=self._get_trading_phase())
 
-    def _classify_regime(self, volatility: float, trend_strength: float, returns: pd.Series) -> MarketRegime:
+    def _classify_regime(self, volatility: float, trend_strength: float, returns: "pd.Series") -> MarketRegime:
         """Classify market regime based on indicators."""
         if volatility > 0.3:
             return MarketRegime.VOLATILE

--- a/scripts/backtest_framework.py
+++ b/scripts/backtest_framework.py
@@ -5,8 +5,12 @@ import gc
 import weakref
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import pytest
+from typing import TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 class TradingBotValidator:
 
@@ -33,6 +37,7 @@ class TradingBotValidator:
         if cache_key in self._test_data_cache:
             data = self._test_data_cache[cache_key]
         else:
+            pd = load_pandas()
             data = pd.read_csv(historical_data_path)
             self._test_data_cache[cache_key] = data
         total_pnl = 0
@@ -87,6 +92,6 @@ class TradingBotValidator:
         """Ensure cleanup on garbage collection."""
         try:
             self.cleanup()
-        except (pd.errors.EmptyDataError, KeyError, ValueError, TypeError, ZeroDivisionError, OverflowError):
+        except (load_pandas().errors.EmptyDataError, KeyError, ValueError, TypeError, ZeroDivisionError, OverflowError):
             pass
 __all__ = ['TradingBotValidator']

--- a/scripts/check_feed.py
+++ b/scripts/check_feed.py
@@ -1,12 +1,21 @@
 """Small diagnostic to verify market data fetch."""
 from types import SimpleNamespace
-import pandas as pd
 from zoneinfo import ZoneInfo  # AI-AGENT-REF: use stdlib zoneinfo
 from ai_trading.core.runtime import build_runtime
 from ai_trading.data.bars import safe_get_stock_bars
+from ai_trading.utils.lazy_imports import load_pandas
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
 if __name__ == '__main__':
+    pd = load_pandas()
     rt = build_runtime(SimpleNamespace())
     now = pd.Timestamp.now(tz=ZoneInfo("UTC"))
     start = now - pd.Timedelta(days=120)
-    client = getattr(rt, 'data_client', SimpleNamespace(get_stock_bars=lambda req: SimpleNamespace(df=pd.DataFrame())))
+    client = getattr(
+        rt,
+        'data_client',
+        SimpleNamespace(get_stock_bars=lambda req: SimpleNamespace(df=pd.DataFrame())),
+    )
     df = safe_get_stock_bars(client, None, 'SPY', '1Day')

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -9,12 +9,16 @@ from pathlib import Path
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-import pandas as pd
+from typing import TYPE_CHECKING
+from ai_trading.utils.lazy_imports import load_pandas
 from alpaca.data.historical import StockHistoricalDataClient
 from alpaca.data.requests import StockBarsRequest
 from alpaca.data.timeframe import TimeFrame
 from ai_trading.env import ensure_dotenv_loaded
 from ai_trading.config.management import get_env
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def main() -> None:
@@ -43,6 +47,7 @@ def main() -> None:
             end=end,
             adjustment="raw",
         )
+        pd = load_pandas()
         try:
             bars = client.get_stock_bars(req).df
         except (pd.errors.EmptyDataError, KeyError, ValueError, TypeError):
@@ -73,3 +78,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/scripts/profile_indicators.py
+++ b/scripts/profile_indicators.py
@@ -3,10 +3,15 @@ logger = logging.getLogger(__name__)
 import inspect
 import time
 import numpy as np
-import pandas as pd
+from typing import TYPE_CHECKING
 from ai_trading import indicators, signals
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 def profile(func, *args, **kwargs):
+    pd = load_pandas()
     start = time.perf_counter()
     try:
         result = func(*args, **kwargs)
@@ -18,8 +23,17 @@ def profile(func, *args, **kwargs):
     return (result, elapsed)
 
 def run_profiles():
+    pd = load_pandas()
     timings = []
-    df = pd.DataFrame({'open': np.random.random(100000) * 100, 'high': np.random.random(100000) * 100, 'low': np.random.random(100000) * 100, 'close': np.random.random(100000) * 100, 'volume': np.random.randint(1000, 10000, size=100000)})
+    df = pd.DataFrame(
+        {
+            'open': np.random.random(100000) * 100,
+            'high': np.random.random(100000) * 100,
+            'low': np.random.random(100000) * 100,
+            'close': np.random.random(100000) * 100,
+            'volume': np.random.randint(1000, 10000, size=100000),
+        }
+    )
     modules = [signals, indicators]
     for module in modules:
         for name, func in inspect.getmembers(module, inspect.isfunction):

--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -1,15 +1,17 @@
-import pandas as pd
 import pytest
+from ai_trading.utils.lazy_imports import load_pandas
 
 from ai_trading.core import bot_engine
 from ai_trading.guards import staleness
 
 
 def _sample_df():
+    pd = load_pandas()
     return pd.DataFrame({"close": [1.0]}, index=[pd.Timestamp("2024-01-01", tz="UTC")])
 
 
 def test_fetch_minute_df_safe_returns_dataframe(monkeypatch):
+    pd = load_pandas()
     monkeypatch.setattr(bot_engine, "get_minute_df", lambda s, start, end: _sample_df())
     monkeypatch.setattr(staleness, "_ensure_data_fresh", lambda df, max_age_seconds, *, symbol=None, now=None, tz=None: None)
     result = bot_engine.fetch_minute_df_safe("AAPL")
@@ -18,7 +20,9 @@ def test_fetch_minute_df_safe_returns_dataframe(monkeypatch):
 
 
 def test_fetch_minute_df_safe_raises_on_empty(monkeypatch):
+    pd = load_pandas()
     monkeypatch.setattr(bot_engine, "get_minute_df", lambda s, start, end: pd.DataFrame())
     monkeypatch.setattr(staleness, "_ensure_data_fresh", lambda df, max_age_seconds, *, symbol=None, now=None, tz=None: None)
     with pytest.raises(bot_engine.DataFetchError):
         bot_engine.fetch_minute_df_safe("AAPL")
+

--- a/tests/test_empty_bars_guard.py
+++ b/tests/test_empty_bars_guard.py
@@ -1,5 +1,5 @@
-import pandas as pd
 import pytest
+from ai_trading.utils.lazy_imports import load_pandas
 from types import SimpleNamespace
 
 from ai_trading.core import bot_engine
@@ -17,6 +17,7 @@ def _dummy_cfg():
 
 
 def test_get_daily_df_empty_bars_raises(monkeypatch):
+    pd = load_pandas()
     cfg = _dummy_cfg()
     monkeypatch.setattr(bot_engine, "CFG", cfg)
     monkeypatch.setattr(bot_engine, "get_settings", lambda: cfg)
@@ -45,6 +46,7 @@ def test_compute_spy_vol_stats_handles_failure(monkeypatch):
 
 
 def test_fetch_feature_data_halts_on_empty(monkeypatch):
+    pd = load_pandas()
     calls: list[str] = []
     ctx = SimpleNamespace(
         data_fetcher=SimpleNamespace(get_daily_df=lambda *a, **k: pd.DataFrame()),
@@ -59,3 +61,4 @@ def test_fetch_feature_data_halts_on_empty(monkeypatch):
     raw, feat, skip = bot_engine._fetch_feature_data(ctx, state, "AAPL")
     assert raw is None and feat is None and skip is False
     assert calls, "halt manager should be invoked on empty data"
+

--- a/tests/test_get_bars_env_reload.py
+++ b/tests/test_get_bars_env_reload.py
@@ -1,10 +1,12 @@
 from datetime import datetime, timedelta, UTC
 
-import pandas as pd
+from ai_trading.utils.lazy_imports import load_pandas
 
 import ai_trading.config.settings as settings_mod
 from ai_trading.data import fetch
 from ai_trading.config import management
+
+pd = load_pandas()
 
 
 def test_get_bars_recovers_after_env_reload(monkeypatch, tmp_path):
@@ -50,3 +52,4 @@ DOLLAR_RISK_LIMIT=0.05
     df = fetch.get_bars("AAPL", "1Min", start, end)
     assert isinstance(df, pd.DataFrame)
     assert calls["n"] == 2
+

--- a/tests/test_sip_unauthorized.py
+++ b/tests/test_sip_unauthorized.py
@@ -1,10 +1,11 @@
 from datetime import datetime, UTC
 
-import pandas as pd
-
 import ai_trading.data.fetch as data_fetcher
 from ai_trading.core import bot_engine
+from ai_trading.utils.lazy_imports import load_pandas
 
+
+pd = load_pandas()
 
 class _RespForbidden:
     status_code = 403
@@ -55,3 +56,4 @@ def test_data_check_skips_unauthorized_symbols(monkeypatch):
     result = bot_engine.data_check(symbols, feed="sip")
     assert "AAPL" in result
     assert "MSFT" not in result
+


### PR DESCRIPTION
## Summary
- gate pandas imports behind `load_pandas()` throughout codebase
- add `TYPE_CHECKING` blocks for pandas type hints
- verify no top-level `import pandas as pd` remains

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b2362e42808330806cb348c93c5170