### PR TITLE
feat: defer market calendar import

### DIFF
--- a/ai_trading/scheduler/aligned_clock.py
+++ b/ai_trading/scheduler/aligned_clock.py
@@ -4,29 +4,39 @@ Exchange-aligned clock and scheduling module.
 Provides timing synchronization with exchange schedules and validates
 bar finality before signal generation.
 """
+
 from ai_trading.logging import get_logger
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-try:
-    import pandas_market_calendars as mcal
-except (ValueError, TypeError):
-    mcal = None
-MARKET_CALENDAR_AVAILABLE = mcal is not None
+from types import ModuleType
+import importlib
+
+mcal: ModuleType | None = None
+MARKET_CALENDAR_AVAILABLE = False
 logger = get_logger(__name__)
 
+
 def _get_calendar(cal_name: str):
+    global mcal, MARKET_CALENDAR_AVAILABLE
     if mcal is None:
-        return None
+        try:
+            mcal = importlib.import_module("pandas_market_calendars")
+            MARKET_CALENDAR_AVAILABLE = True
+        except (ModuleNotFoundError, ValueError, TypeError) as exc:
+            logger.warning(f"pandas_market_calendars not available: {exc}")
+            return None
     try:
-        return mcal.get_calendar(cal_name)
+        return mcal.get_calendar(cal_name)  # type: ignore[union-attr]
     except (ValueError, TypeError) as exc:
-        logger.warning(f'Failed to load {cal_name} calendar: {exc}')
+        logger.warning(f"Failed to load {cal_name} calendar: {exc}")
         return None
+
 
 @dataclass
 class BarValidation:
     """Result of bar finality validation."""
+
     symbol: str
     timeframe: str
     is_final: bool
@@ -34,6 +44,7 @@ class BarValidation:
     bar_close_time: datetime
     skew_ms: float
     reason: str | None = None
+
 
 class AlignedClock:
     """
@@ -43,7 +54,7 @@ class AlignedClock:
     validates that bars are final before generating signals.
     """
 
-    def __init__(self, max_skew_ms: float=250.0, exchange: str='NYSE'):
+    def __init__(self, max_skew_ms: float = 250.0, exchange: str = "NYSE"):
         """
         Initialize aligned clock.
 
@@ -53,7 +64,7 @@ class AlignedClock:
         """
         self.max_skew_ms = max_skew_ms
         self.exchange = exchange
-        self.logger = get_logger(f'{__name__}.{self.__class__.__name__}')
+        self.logger = get_logger(f"{__name__}.{self.__class__.__name__}")
         self.calendar = _get_calendar(exchange)
         self._bar_close_cache: dict[str, datetime] = {}
 
@@ -70,10 +81,10 @@ class AlignedClock:
                 exchange_tz = self.calendar.tz
                 return utc_now.astimezone(exchange_tz)
             except (ValueError, TypeError) as e:
-                self.logger.warning(f'Failed to get exchange time: {e.__class__.__name__}: {e}')
+                self.logger.warning(f"Failed to get exchange time: {e.__class__.__name__}: {e}")
         return utc_now
 
-    def next_bar_close(self, symbol: str, timeframe: str='1m') -> datetime:
+    def next_bar_close(self, symbol: str, timeframe: str = "1m") -> datetime:
         """
         Calculate next bar close time for symbol and timeframe.
 
@@ -84,7 +95,7 @@ class AlignedClock:
         Returns:
             Next bar close time in exchange timezone
         """
-        cache_key = f'{symbol}_{timeframe}'
+        cache_key = f"{symbol}_{timeframe}"
         if cache_key in self._bar_close_cache:
             cached_close = self._bar_close_cache[cache_key]
             if cached_close > self.get_exchange_time():
@@ -98,36 +109,40 @@ class AlignedClock:
         else:
             minutes_since_midnight = current_time.hour * 60 + current_time.minute
             next_interval = (minutes_since_midnight // interval_minutes + 1) * interval_minutes
-            next_close = current_time.replace(hour=next_interval // 60, minute=next_interval % 60, second=0, microsecond=0)
+            next_close = current_time.replace(
+                hour=next_interval // 60, minute=next_interval % 60, second=0, microsecond=0
+            )
             if next_close.day != current_time.day:
                 next_close = current_time.replace(hour=0, minute=0, second=0, microsecond=0)
                 next_close += timedelta(days=1)
         if self.calendar:
             try:
-                trading_days = self.calendar.valid_days(start_date=next_close.date(), end_date=next_close.date() + timedelta(days=7))
+                trading_days = self.calendar.valid_days(
+                    start_date=next_close.date(), end_date=next_close.date() + timedelta(days=7)
+                )
                 if len(trading_days) > 0:
                     next_trading_day = trading_days[0].date()
                     if next_close.date() != next_trading_day:
                         next_close = datetime.combine(next_trading_day, next_close.time())
                         next_close = next_close.replace(tzinfo=next_close.tzinfo)
             except (ValueError, TypeError) as e:
-                self.logger.warning(f'Calendar check failed: {e.__class__.__name__}: {e}')
+                self.logger.warning(f"Calendar check failed: {e.__class__.__name__}: {e}")
         self._bar_close_cache[cache_key] = next_close
         return next_close
 
     def _parse_timeframe_minutes(self, timeframe: str) -> int:
         """Parse timeframe string into minutes."""
         timeframe = timeframe.lower()
-        if timeframe.endswith('m'):
+        if timeframe.endswith("m"):
             return int(timeframe[:-1])
-        elif timeframe.endswith('h'):
+        elif timeframe.endswith("h"):
             return int(timeframe[:-1]) * 60
-        elif timeframe.endswith('d'):
+        elif timeframe.endswith("d"):
             return int(timeframe[:-1]) * 1440
         else:
             return 1
 
-    def check_skew(self, reference_time: datetime | None=None) -> float:
+    def check_skew(self, reference_time: datetime | None = None) -> float:
         """
         Check time skew against reference time.
 
@@ -145,10 +160,10 @@ class AlignedClock:
         skew_seconds = (local_utc - exchange_utc).total_seconds()
         skew_ms = skew_seconds * 1000
         if abs(skew_ms) > self.max_skew_ms:
-            self.logger.warning(f'Time skew detected: {skew_ms:.1f}ms (max allowed: {self.max_skew_ms}ms)')
+            self.logger.warning(f"Time skew detected: {skew_ms:.1f}ms (max allowed: {self.max_skew_ms}ms)")
         return skew_ms
 
-    def ensure_final_bar(self, symbol: str, timeframe: str='1m') -> BarValidation:
+    def ensure_final_bar(self, symbol: str, timeframe: str = "1m") -> BarValidation:
         """
         Validate that the current bar is final before generating signals.
 
@@ -165,13 +180,22 @@ class AlignedClock:
         skew_ms = self.check_skew()
         buffer_seconds = (self.max_skew_ms + 100) / 1000
         is_final = time_to_close > buffer_seconds
-        validation = BarValidation(symbol=symbol, timeframe=timeframe, is_final=is_final, current_time=current_time, bar_close_time=next_close, skew_ms=skew_ms)
+        validation = BarValidation(
+            symbol=symbol,
+            timeframe=timeframe,
+            is_final=is_final,
+            current_time=current_time,
+            bar_close_time=next_close,
+            skew_ms=skew_ms,
+        )
         if not is_final:
-            validation.reason = f'Too close to bar close: {time_to_close:.1f}s remaining (need >{buffer_seconds:.1f}s buffer)'
-            self.logger.warning(f'Bar not final for {symbol} {timeframe}: {validation.reason}')
+            validation.reason = (
+                f"Too close to bar close: {time_to_close:.1f}s remaining (need >{buffer_seconds:.1f}s buffer)"
+            )
+            self.logger.warning(f"Bar not final for {symbol} {timeframe}: {validation.reason}")
         return validation
 
-    def is_market_open(self, symbol: str, timestamp: datetime | None=None) -> bool:
+    def is_market_open(self, symbol: str, timestamp: datetime | None = None) -> bool:
         """
         Check if market is open for trading.
 
@@ -196,16 +220,16 @@ class AlignedClock:
             schedule = self.calendar.schedule(start_date=timestamp.date(), end_date=timestamp.date())
             if schedule.empty:
                 return False
-            market_open = schedule.iloc[0]['market_open']
-            market_close = schedule.iloc[0]['market_close']
+            market_open = schedule.iloc[0]["market_open"]
+            market_close = schedule.iloc[0]["market_close"]
             market_open = market_open.tz_convert(timestamp.tzinfo)
             market_close = market_close.tz_convert(timestamp.tzinfo)
             return market_open <= timestamp <= market_close
         except (ValueError, TypeError) as e:
-            self.logger.warning(f'Market hours check failed: {e.__class__.__name__}: {e}')
+            self.logger.warning(f"Market hours check failed: {e.__class__.__name__}: {e}")
             return False
 
-    def wait_for_aligned_tick(self, symbol: str, timeframe: str='1m') -> BarValidation:
+    def wait_for_aligned_tick(self, symbol: str, timeframe: str = "1m") -> BarValidation:
         """
         Wait until we're properly aligned for the next trading tick.
 
@@ -223,9 +247,12 @@ class AlignedClock:
             if validation.is_final:
                 return validation
             time.sleep(0.1)
-        self.logger.warning(f'Timed out waiting for aligned tick for {symbol} {timeframe}')
+        self.logger.warning(f"Timed out waiting for aligned tick for {symbol} {timeframe}")
         return validation
+
+
 _global_clock: AlignedClock | None = None
+
 
 def get_aligned_clock() -> AlignedClock:
     """Get or create global aligned clock instance."""
@@ -234,7 +261,8 @@ def get_aligned_clock() -> AlignedClock:
         _global_clock = AlignedClock()
     return _global_clock
 
-def ensure_final_bar(symbol: str, timeframe: str='1m') -> BarValidation:
+
+def ensure_final_bar(symbol: str, timeframe: str = "1m") -> BarValidation:
     """
     Convenience function to validate bar finality.
 
@@ -248,7 +276,8 @@ def ensure_final_bar(symbol: str, timeframe: str='1m') -> BarValidation:
     clock = get_aligned_clock()
     return clock.ensure_final_bar(symbol, timeframe)
 
-def is_market_open(symbol: str, timestamp: datetime | None=None) -> bool:
+
+def is_market_open(symbol: str, timestamp: datetime | None = None) -> bool:
     """
     Convenience function to check if market is open.
 


### PR DESCRIPTION
## Summary
- defer `pandas_market_calendars` import until `_get_calendar` is invoked
- cache loaded calendar module to avoid repeated imports

## Testing
- `SKIP=repo-guard,check-no-legacy-symbols pre-commit run --files ai_trading/scheduler/aligned_clock.py`
- `ruff check ai_trading/scheduler/aligned_clock.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: `ModuleNotFoundError: No module named 'alpaca'`)*
- `python - <<'PY'
import importlib
from unittest.mock import patch
real_import = importlib.import_module

def fake_import(name, *args, **kwargs):
    if name == 'pandas_market_calendars':
        raise ModuleNotFoundError
    return real_import(name, *args, **kwargs)

with patch('importlib.import_module', side_effect=fake_import):
    import ai_trading.scheduler.aligned_clock as ac
    print('MARKET_CALENDAR_AVAILABLE:', ac.MARKET_CALENDAR_AVAILABLE)
    print('calendar:', ac._get_calendar('NYSE'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b23fa530e08330aac96b59e2d47e15