### PR TITLE
feat: lazily load sklearn modules

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1231,30 +1231,12 @@ else:
         return args[0] if args else {}  # Mock column ensurer
 
 
-try:
-    from sklearn.exceptions import InconsistentVersionWarning
-except (
-    FileNotFoundError,
-    PermissionError,
-    IsADirectoryError,
-    JSONDecodeError,
-    ValueError,
-    KeyError,
-    TypeError,
-    OSError,
-    ImportError,
-):  # pragma: no cover - sklearn optional  # AI-AGENT-REF: narrow exception
-
-    class InconsistentVersionWarning(UserWarning):
-        pass
-
-
 warnings.filterwarnings(
     "ignore",
     message="pkg_resources is deprecated as an API.*",
     category=UserWarning,
 )
-warnings.filterwarnings("ignore", category=InconsistentVersionWarning)
+warnings.filterwarnings("ignore", message=".*InconsistentVersionWarning.*")
 warnings.filterwarnings(
     "ignore",
     message="Converting to PeriodArray/Index representation will drop timezone information.*",

--- a/ai_trading/data/splits.py
+++ b/ai_trading/data/splits.py
@@ -4,18 +4,19 @@ Time series cross-validation splits with purging and embargo.
 Provides leak-proof data splitting for financial time series,
 including purged group time series splits and walk-forward analysis.
 """
+from __future__ import annotations
+
 from collections.abc import Iterator
 from datetime import datetime, timedelta
 import numpy as np
 from typing import TYPE_CHECKING
-from sklearn.model_selection import BaseCrossValidator
 from ai_trading.logging import logger
 from ai_trading.utils.lazy_imports import load_pandas
 
 if TYPE_CHECKING:
     import pandas as pd
 
-class PurgedGroupTimeSeriesSplit(BaseCrossValidator):
+class PurgedGroupTimeSeriesSplit:
     """
     Time series cross-validation with purging and embargo.
     

--- a/ai_trading/pipeline.py
+++ b/ai_trading/pipeline.py
@@ -1,32 +1,100 @@
-from ai_trading.logging import get_logger
-import numpy as np
-logger = get_logger(__name__)
-from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.linear_model import SGDRegressor
-from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import StandardScaler
+"""Machine learning model pipeline with lazy sklearn imports."""
 
-class FeatureBuilder(BaseEstimator, TransformerMixin):
+from __future__ import annotations
+
+import numpy as np
+
+from ai_trading.logging import get_logger
+from ai_trading.utils.lazy_imports import (
+    load_sklearn_linear_model,
+    load_sklearn_pipeline,
+    load_sklearn_preprocessing,
+)
+
+logger = get_logger(__name__)
+
+
+class FeatureBuilder:
+    """Simple feature transformer for price-based data."""
 
     def fit(self, X, y=None):
         return self
 
     def transform(self, X):
         df = X.copy()
-        if hasattr(df, 'columns'):
-            close = df['close'].astype(float)
+        if hasattr(df, "columns"):
+            close = df["close"].astype(float)
             returns = close.pct_change().fillna(0)
-            features = {'returns': returns, 'ma10': close.rolling(10).mean().bfill(), 'ma30': close.rolling(30).mean().bfill(), 'vol': returns.rolling(10).std().fillna(0), 'sma_50': close.rolling(50).mean().bfill(), 'sma_200': close.rolling(200).mean().bfill(), 'price_change': (close.diff() > 0).astype(int), 'rsi': self._calculate_rsi(close)}
-            arr = np.column_stack([features['returns'], features['ma10'], features['ma30'], features['vol'], features['sma_50'], features['sma_200'], features['price_change'], features['rsi']])
+            features = {
+                "returns": returns,
+                "ma10": close.rolling(10).mean().bfill(),
+                "ma30": close.rolling(30).mean().bfill(),
+                "vol": returns.rolling(10).std().fillna(0),
+                "sma_50": close.rolling(50).mean().bfill(),
+                "sma_200": close.rolling(200).mean().bfill(),
+                "price_change": (close.diff() > 0).astype(int),
+                "rsi": self._calculate_rsi(close),
+            }
+            arr = np.column_stack(
+                [
+                    features["returns"],
+                    features["ma10"],
+                    features["ma30"],
+                    features["vol"],
+                    features["sma_50"],
+                    features["sma_200"],
+                    features["price_change"],
+                    features["rsi"],
+                ]
+            )
             return arr
         return np.asarray(df, dtype=float)
 
-    def _calculate_rsi(self, close, period=14):
+    def _calculate_rsi(self, close, period: int = 14):
         """Calculate RSI indicator."""
         delta = close.diff()
         gain = delta.where(delta > 0, 0).rolling(window=period).mean()
         loss = (-delta.where(delta < 0, 0)).rolling(window=period).mean()
         rs = gain / loss
         return 100 - 100 / (1 + rs)
-SGD_PARAMS = {'learning_rate': 'adaptive', 'eta0': 0.01, 'alpha': 0.0001, 'max_iter': 1000, 'tol': 0.001, 'random_state': 42}
-model_pipeline = Pipeline([('features', FeatureBuilder()), ('scaler', StandardScaler()), ('regressor', SGDRegressor(warm_start=True, **SGD_PARAMS))])
+
+
+SGD_PARAMS = {
+    "learning_rate": "adaptive",
+    "eta0": 0.01,
+    "alpha": 0.0001,
+    "max_iter": 1000,
+    "tol": 0.001,
+    "random_state": 42,
+}
+
+
+class _LazyPipeline:
+    _pipeline = None
+
+    def _load(self):
+        if self._pipeline is None:
+            skl_pipeline = load_sklearn_pipeline()
+            skl_pre = load_sklearn_preprocessing()
+            skl_linear = load_sklearn_linear_model()
+            if not all([skl_pipeline, skl_pre, skl_linear]):  # pragma: no cover - runtime guard
+                raise RuntimeError("sklearn not available")
+            Pipeline = skl_pipeline.Pipeline
+            StandardScaler = skl_pre.StandardScaler
+            SGDRegressor = skl_linear.SGDRegressor
+            self._pipeline = Pipeline(
+                [
+                    ("features", FeatureBuilder()),
+                    ("scaler", StandardScaler()),
+                    ("regressor", SGDRegressor(warm_start=True, **SGD_PARAMS)),
+                ]
+            )
+        return self._pipeline
+
+    def __getattr__(self, item):  # pragma: no cover - passthrough
+        return getattr(self._load(), item)
+
+
+model_pipeline = _LazyPipeline()
+
+__all__ = ["FeatureBuilder", "model_pipeline"]

--- a/ai_trading/strategies/signals.py
+++ b/ai_trading/strategies/signals.py
@@ -9,10 +9,11 @@ import statistics
 from datetime import UTC, datetime
 from typing import Any
 import numpy as np
-from sklearn.linear_model import Ridge
+from importlib.util import find_spec
 from ai_trading.exc import COMMON_EXC
 from ai_trading.logging import logger
-sklearn_available = True
+from ai_trading.utils.lazy_imports import load_sklearn_linear_model
+sklearn_available = bool(find_spec("sklearn"))
 from .base import StrategySignal
 
 class SignalAggregator:
@@ -299,6 +300,9 @@ class SignalAggregator:
                 return
             X, y = self._prepare_training_data()
             if len(X) < 5:
+                return
+            Ridge = load_sklearn_linear_model().Ridge if sklearn_available else None
+            if Ridge is None:
                 return
             self.meta_model = Ridge(alpha=1.0, random_state=42)
             self.meta_model.fit(X, y)

--- a/ai_trading/utils/lazy_imports.py
+++ b/ai_trading/utils/lazy_imports.py
@@ -50,3 +50,41 @@ def load_pandas_ta() -> ModuleType | None:
         return None
 
 
+@lru_cache(maxsize=None)
+def _load_sklearn_submodule(name: str) -> ModuleType | None:
+    """Return a proxy for a :mod:`sklearn` submodule if available."""
+    if find_spec(f"sklearn.{name}") is None:
+        return None
+    return _LazyModule(f"sklearn.{name}")
+
+
+def load_sklearn_linear_model() -> ModuleType | None:
+    """Return :mod:`sklearn.linear_model` lazily."""
+    return _load_sklearn_submodule("linear_model")
+
+
+def load_sklearn_pipeline() -> ModuleType | None:
+    """Return :mod:`sklearn.pipeline` lazily."""
+    return _load_sklearn_submodule("pipeline")
+
+
+def load_sklearn_preprocessing() -> ModuleType | None:
+    """Return :mod:`sklearn.preprocessing` lazily."""
+    return _load_sklearn_submodule("preprocessing")
+
+
+def load_sklearn_model_selection() -> ModuleType | None:
+    """Return :mod:`sklearn.model_selection` lazily."""
+    return _load_sklearn_submodule("model_selection")
+
+
+def load_sklearn_ensemble() -> ModuleType | None:
+    """Return :mod:`sklearn.ensemble` lazily."""
+    return _load_sklearn_submodule("ensemble")
+
+
+def load_sklearn_metrics() -> ModuleType | None:
+    """Return :mod:`sklearn.metrics` lazily."""
+    return _load_sklearn_submodule("metrics")
+
+


### PR DESCRIPTION
## Summary
- Add helpers to lazily load scikit-learn submodules
- Refactor pipelines and strategies to defer sklearn imports until used
- Simplify warning filters to avoid importing sklearn at startup

## Testing
- `ruff check ai_trading/pipeline.py ai_trading/features/pipeline.py ai_trading/data/splits.py ai_trading/strategies/signals.py ai_trading/strategies/metalearning.py ai_trading/utils/lazy_imports.py ai_trading/core/bot_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: alpaca)*
- `python - <<'PY'
import time, importlib
mods = [
    'ai_trading.pipeline',
    'ai_trading.features.pipeline',
    'ai_trading.data.splits',
    'ai_trading.strategies.signals',
    'ai_trading.strategies.metalearning',
]
for m in mods:
    t0 = time.perf_counter()
    importlib.import_module(m)
    dt = time.perf_counter() - t0
    print(m, 'imported in', round(dt, 4), 'sec')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b23fa46f7083308ab583ef820641e4