### PR TITLE
refactor: defer portfolio features init

### DIFF
--- a/tests/test_portfolio_integration.py
+++ b/tests/test_portfolio_integration.py
@@ -148,6 +148,7 @@ class TestPortfolioRebalancingIntegration:
         """Test that portfolio optimization integrates with rebalancing logic."""
         from ai_trading.rebalancer import (
             _get_current_positions_for_rebalancing,
+            init_rebalancer,
             portfolio_first_rebalance,
         )
 
@@ -157,6 +158,7 @@ class TestPortfolioRebalancingIntegration:
 
         # Test portfolio-first rebalancing (should not crash)
         try:
+            init_rebalancer()
             portfolio_first_rebalance(self.ctx)
             # If it doesn't crash, that's a success in this test environment
             assert True


### PR DESCRIPTION
## Summary
- add explicit `init_rebalancer` to control portfolio-first initialization
- lazily build optimizer and regime detector within `TaxAwareRebalancer`
- require callers to invoke initialization before portfolio-first rebalancing

## Testing
- `python -m ruff check ai_trading/rebalancer.py tests/test_portfolio_integration.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68b247c4b5c48330b1397140a6496154