### PR TITLE
fix: harmonize max position size config

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -246,7 +246,7 @@ class TradingConfig:
     disable_daily_retrain: bool = False
     capital_cap: Optional[float] = 0.04
     dollar_risk_limit: Optional[float] = 0.05
-    max_position_size: Optional[float] = 1.0
+    max_position_size: Optional[float] = None
     max_position_equity_fallback: float = 200000.0
     sector_exposure_cap: Optional[float] = None
     max_drawdown_threshold: Optional[float] = None
@@ -361,7 +361,7 @@ class TradingConfig:
         app_env = _get("APP_ENV", str, default="test") or "test"
         paper_default = "paper" in str(base_url).lower() or app_env.lower() != "prod"
 
-        mps = _get("MAX_POSITION_SIZE", float, default=1.0)
+        mps = _get("MAX_POSITION_SIZE", float)
         if mps is not None and mps <= 0:
             raise ValueError("MAX_POSITION_SIZE must be positive")
 

--- a/tests/test_runtime_max_position_size.py
+++ b/tests/test_runtime_max_position_size.py
@@ -1,10 +1,11 @@
 from ai_trading.core.runtime import build_runtime
 from ai_trading.config.management import TradingConfig
+from ai_trading.position_sizing import get_max_position_size
 
 
 def test_runtime_uses_env_max_position_size(monkeypatch):
     monkeypatch.setenv("MAX_POSITION_SIZE", "2500")
-    cfg = TradingConfig()
+    cfg = TradingConfig.from_env()
     runtime = build_runtime(cfg)
     assert runtime.params["MAX_POSITION_SIZE"] == 2500.0
 
@@ -15,4 +16,12 @@ def test_runtime_derives_max_position_size(monkeypatch):
     cfg = TradingConfig(capital_cap=0.04)
     runtime = build_runtime(cfg)
     assert runtime.params["MAX_POSITION_SIZE"] == 8000.0
+
+
+def test_runtime_matches_position_sizing(monkeypatch):
+    monkeypatch.delenv("MAX_POSITION_SIZE", raising=False)
+    monkeypatch.delenv("AI_TRADING_MAX_POSITION_SIZE", raising=False)
+    cfg = TradingConfig(capital_cap=0.04)
+    runtime = build_runtime(cfg)
+    assert runtime.params["MAX_POSITION_SIZE"] == get_max_position_size(cfg, cfg)
 


### PR DESCRIPTION
## Summary
- ensure TradingConfig leaves `max_position_size` unset by default and reads env without forcing 1
- derive runtime `MAX_POSITION_SIZE` via position_sizing helper for consistent env overrides
- test env override and default derivation of `MAX_POSITION_SIZE`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_max_position_size.py tests/test_runtime_params_hydration.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings'; 103 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b249dc0d008330b75a432756147049