### PR TITLE
cache account equity on trading config

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -204,17 +204,26 @@ def _validate_runtime_config(cfg, tcfg) -> None:
     if not 0.0 < risk <= 1.0:
         errors.append(f"DOLLAR_RISK_LIMIT out of range: {risk}")
     eq = _get_equity_from_alpaca(cfg)
+    targets = {cfg, tcfg}
     if eq > 0:
-        try:
-            setattr(tcfg, "equity", eq)
-        except Exception:
-            object.__setattr__(tcfg, "equity", eq)
+        for obj in targets:
+            try:
+                setattr(obj, "equity", eq)
+            except Exception:
+                try:
+                    object.__setattr__(obj, "equity", eq)
+                except Exception:  # pragma: no cover - defensive
+                    pass
     else:
         logger.warning("ACCOUNT_EQUITY_MISSING", extra={"equity": eq})
-        try:
-            setattr(tcfg, "equity", None)
-        except Exception:
-            object.__setattr__(tcfg, "equity", None)
+        for obj in targets:
+            try:
+                setattr(obj, "equity", None)
+            except Exception:
+                try:
+                    object.__setattr__(obj, "equity", None)
+                except Exception:  # pragma: no cover - defensive
+                    pass
     try:
         resolved, _meta = resolve_max_position_size(cfg, tcfg, force_refresh=True)
         if hasattr(tcfg, "max_position_size"):

--- a/ai_trading/position_sizing.py
+++ b/ai_trading/position_sizing.py
@@ -162,6 +162,20 @@ def resolve_max_position_size(cfg, tcfg, *, force_refresh: bool=False) -> tuple[
             if raw_val is not None:
                 raise ValueError('max_position_size must be positive')
             eq = getattr(tcfg, 'equity', getattr(cfg, 'equity', None))
+            if eq in (None, 0.0):
+                fetched = _get_equity_from_alpaca(cfg)
+                if fetched > 0:
+                    eq = fetched
+                    for obj in {cfg, tcfg}:
+                        try:
+                            setattr(obj, 'equity', eq)
+                        except Exception:
+                            try:
+                                object.__setattr__(obj, 'equity', eq)
+                            except Exception:  # pragma: no cover - defensive
+                                pass
+                else:
+                    eq = None
             cur, source = _resolve_max_position_size(cur, cap, eq, default_equity=default_eq)
         _CACHE.value, _CACHE.ts = (cur, _now_utc())
         return (

--- a/tests/test_position_sizing_equity.py
+++ b/tests/test_position_sizing_equity.py
@@ -1,0 +1,33 @@
+import logging
+import ai_trading.position_sizing as ps
+import ai_trading.core.runtime as rt
+
+
+def test_get_max_position_size_uses_cached_equity(monkeypatch, caplog):
+    # Ensure cache is clear
+    ps._CACHE.value, ps._CACHE.ts = (None, None)
+
+    # Stub equity fetcher to return a positive value
+    monkeypatch.setattr(ps, "_get_equity_from_alpaca", lambda cfg: 1000.0)
+    monkeypatch.setattr(rt, "_get_equity_from_alpaca", lambda cfg: 1000.0)
+
+    class Cfg:
+        capital_cap = 0.04
+        dollar_risk_limit = 0.05
+        max_position_size = None
+        max_position_mode = "STATIC"
+
+    cfg = Cfg()
+
+    # First call populates equity on the config
+    rt.build_runtime(cfg)
+    assert getattr(cfg, "equity", None) == 1000.0
+
+    # Force recompute and ensure no EQUITY_MISSING is logged
+    cfg.max_position_size = 0.0
+    caplog.set_level(logging.WARNING)
+    caplog.clear()
+    ps.get_max_position_size(cfg, cfg, force_refresh=True)
+    assert not any(
+        r.msg == "EQUITY_MISSING" for r in caplog.records if r.name == "ai_trading.position_sizing"
+    )


### PR DESCRIPTION
## Summary
- cache account equity on both runtime and trading config so later calls see it
- re-fetch equity in resolve_max_position_size when missing instead of logging
- add regression test to ensure EQUITY_MISSING isn't emitted once equity is cached

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py missing, tests skipped)*

## Rollback
- Revert the commit to restore prior position sizing behavior.

------
https://chatgpt.com/codex/tasks/task_e_68b3097b2c288330b16a5d511302749a