### PR TITLE
Skip cycles when market closed

### DIFF
--- a/tests/unit/test_market_closed_cycle.py
+++ b/tests/unit/test_market_closed_cycle.py
@@ -1,0 +1,22 @@
+"""Ensure trading cycle is skipped when market is closed."""
+
+import types
+
+from ai_trading.core import bot_engine
+
+
+def test_cycle_skipped_when_market_closed(monkeypatch):
+    """schedule_run_all_trades should short-circuit when market closed."""
+
+    runtime = types.SimpleNamespace(api=object())
+    calls: list[tuple] = []
+
+    monkeypatch.setattr(bot_engine, "run_all_trades_worker", lambda *a, **k: calls.append(a))
+    monkeypatch.setattr(bot_engine, "ensure_alpaca_attached", lambda *_: None)
+    monkeypatch.setattr(bot_engine, "_validate_trading_api", lambda *_: True)
+    monkeypatch.setattr(bot_engine, "_is_market_open_base", lambda: False)
+
+    bot_engine.schedule_run_all_trades(runtime)
+
+    assert calls == []
+


### PR DESCRIPTION
## Summary
- Short-circuit trading cycle when the market is closed
- Throttle repeated market-closed logs
- Add test to ensure cycles do not run when market closed

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/unit/test_market_closed_cycle.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_market_closed_cycle.py -q` *(fails: Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b309806d10833092c29a77f69ebf32