### PR TITLE
Use ordered container for runtime validation targets

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -204,7 +204,7 @@ def _validate_runtime_config(cfg, tcfg) -> None:
     if not 0.0 < risk <= 1.0:
         errors.append(f"DOLLAR_RISK_LIMIT out of range: {risk}")
     eq = _get_equity_from_alpaca(cfg)
-    targets = {cfg, tcfg}
+    targets = (cfg,) if cfg is tcfg else (cfg, tcfg)
     if eq > 0:
         for obj in targets:
             try:


### PR DESCRIPTION
## Summary
- avoid set hashing in `_validate_runtime_config` by using an ordered tuple and identity-based dedupe

## Testing
- `ruff check ai_trading/main.py tests/test_missing_max_position_size.py tests/test_config_validation_max_position_size.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_missing_max_position_size.py tests/test_config_validation_max_position_size.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b30cd5991483308774d8c38c000155