### PR TITLE
Ensure config loaded log emitted only once

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1059,6 +1059,9 @@ from ai_trading.settings import (
     get_seed_int,
 )  # AI-AGENT-REF: runtime env settings
 
+# Refresh environment variables on startup for reliability
+_reload_env()
+
 # Initialize settings once for global use
 CFG = get_settings()
 # Backward-compat constants for risk thresholds used throughout this module
@@ -1245,10 +1248,6 @@ warnings.filterwarnings(
 )
 
 import os
-
-
-# Refresh environment variables on startup for reliability
-_reload_env()
 
 
 # TRADING_MODE must be defined before any classes that reference it

--- a/tests/test_config_logging.py
+++ b/tests/test_config_logging.py
@@ -12,6 +12,7 @@ def test_config_loaded_logs_once_and_on_reload(caplog):
 
     caplog.clear()
     with caplog.at_level(logging.INFO):
+        _ = bot_engine.state.mode_obj  # access lazy state
         bot_engine.BotMode()
         bot_engine.BotMode()
     assert "Config settings loaded, validation deferred to runtime" not in caplog.text


### PR DESCRIPTION
## Summary
- Call `_reload_env()` before fetching settings so the "Config settings loaded" info message only appears once during startup
- Extend logging test to access the lazy state and ensure the config message doesn't repeat

## Testing
- `ruff check .`
- `pytest tests/test_config_logging.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'cachetools'; NameError: name 'pd' is not defined; ImportError: cannot import name 'ExecutionResult'; and other missing dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b30e254670833081051ee527cb9261