### PR TITLE
Fetch and cache account equity for position sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to this project will be documented in this file.
 - **Alpaca API**: provide lightweight fallback for `StockLatestQuoteRequest` to avoid startup ImportError when class is absent
 - **CLI dry-run**: log indicator import confirmation and exit with code 0 before heavy imports.
 - **Settings**: centralize value normalization and eliminate `FieldInfo` leaks
+- **Position sizing**: fetch real account equity via Alpaca once and cache it to avoid repeated `EQUITY_MISSING` warnings.
 
 ### Added
 - **Parallel Predictions**: Replaced single-threaded prediction executor with auto-sized thread pool

--- a/tests/test_position_sizing_equity.py
+++ b/tests/test_position_sizing_equity.py
@@ -1,11 +1,14 @@
 import logging
+from types import SimpleNamespace
 import ai_trading.position_sizing as ps
 import ai_trading.core.runtime as rt
+from ai_trading.logging import logger_once
 
 
 def test_get_max_position_size_uses_cached_equity(monkeypatch, caplog):
     # Ensure cache is clear
-    ps._CACHE.value, ps._CACHE.ts = (None, None)
+    ps._CACHE.value, ps._CACHE.ts, ps._CACHE.equity = (None, None, None)
+    logger_once._emitted_keys.clear()
 
     # Stub equity fetcher to return a positive value
     monkeypatch.setattr(ps, "_get_equity_from_alpaca", lambda cfg: 1000.0)
@@ -24,10 +27,56 @@ def test_get_max_position_size_uses_cached_equity(monkeypatch, caplog):
     assert getattr(cfg, "equity", None) == 1000.0
 
     # Force recompute and ensure no EQUITY_MISSING is logged
-    cfg.max_position_size = 0.0
+    cfg.max_position_size = None
     caplog.set_level(logging.WARNING)
     caplog.clear()
     ps.get_max_position_size(cfg, cfg, force_refresh=True)
     assert not any(
         r.msg == "EQUITY_MISSING" for r in caplog.records if r.name == "ai_trading.position_sizing"
     )
+
+
+def test_resolve_max_position_size_uses_real_equity_and_caches(monkeypatch, caplog):
+    ps._CACHE.value, ps._CACHE.ts, ps._CACHE.equity = (None, None, None)
+    logger_once._emitted_keys.clear()
+    calls = {"n": 0}
+
+    def fake_fetch(cfg):
+        calls["n"] += 1
+        return 50000.0
+
+    monkeypatch.setattr(ps, "_get_equity_from_alpaca", fake_fetch)
+    cfg = SimpleNamespace(alpaca_api_key="k", alpaca_secret_key_plain="s", alpaca_base_url="https://paper-api.alpaca.markets")
+    tcfg = SimpleNamespace(capital_cap=0.02, max_position_mode="STATIC")
+
+    with caplog.at_level(logging.WARNING):
+        size1, _ = ps.resolve_max_position_size(cfg, tcfg, force_refresh=True)
+        size2, meta2 = ps.resolve_max_position_size(cfg, tcfg)
+
+    assert size1 == size2 == 1000.0
+    assert meta2["source"] == "cache"
+    assert calls["n"] == 1
+    assert not any(r.msg == "EQUITY_MISSING" for r in caplog.records)
+
+
+def test_failed_equity_fetch_warns_once_and_caches(monkeypatch, caplog):
+    ps._CACHE.value, ps._CACHE.ts, ps._CACHE.equity = (None, None, None)
+    logger_once._emitted_keys.clear()
+    calls = {"n": 0}
+
+    def fake_fetch(cfg):
+        calls["n"] += 1
+        return 0.0
+
+    monkeypatch.setattr(ps, "_get_equity_from_alpaca", fake_fetch)
+    cfg = SimpleNamespace(alpaca_api_key="k", alpaca_secret_key_plain="s", alpaca_base_url="https://paper-api.alpaca.markets")
+    tcfg = SimpleNamespace(capital_cap=0.02, max_position_mode="STATIC")
+
+    with caplog.at_level(logging.WARNING):
+        size1, _ = ps.resolve_max_position_size(cfg, tcfg, force_refresh=True)
+        size2, meta2 = ps.resolve_max_position_size(cfg, tcfg)
+
+    assert size1 == size2
+    assert meta2["source"] == "cache"
+    assert calls["n"] == 1
+    assert [r.msg for r in caplog.records].count("EQUITY_MISSING") == 1


### PR DESCRIPTION
## Summary
- fetch account equity with `TradingClient.get_account` and fall back to HTTP
- cache computed max position size and log missing equity only once
- test equity fetch caching and failure warning behavior

## Testing
- `ruff check ai_trading/position_sizing.py tests/test_position_sizing_equity.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_position_sizing_equity.py -q`
- `RUN_HEALTHCHECK=1 python -m ai_trading.app & sleep 2 && curl -sf http://127.0.0.1:${HEALTHCHECK_PORT:-9001}/healthz`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca' and 103 other import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b30e24467883309bfad60cc6aaee08