### PR TITLE
feat: enforce max position size

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,7 @@ exits early with a clear error message when these values are invalid.
   CAPITAL_CAP=0.04                    # Fraction of equity usable per cycle
   DOLLAR_RISK_LIMIT=0.05              # Max fraction of equity at risk per position
   MAX_POSITION_SIZE=5000              # Absolute USD cap per position (1-10000; derived from CAPITAL_CAP if unset)
+  AI_TRADING_MAX_POSITION_SIZE=5000   # Explicit override; deployment scripts require this to be set
   ```
 
   Unauthorized SIP requests return an empty DataFrame and automatically
@@ -745,8 +746,10 @@ exits early with a clear error message when these values are invalid.
   Provide either ALPACA_API_KEY/ALPACA_SECRET_KEY or ALPACA_OAUTH. Do not set both.
 
   `MAX_POSITION_SIZE` must be a positive dollar value (>0). Values ≤0 are rejected.
-  If omitted, the bot derives a value from `CAPITAL_CAP` and available equity. Optionally
-  set `MAX_POSITION_SIZE_PCT` to cap positions as a percentage of the portfolio.
+  If omitted, the bot derives a value from `CAPITAL_CAP` and available equity. Set
+  `AI_TRADING_MAX_POSITION_SIZE` to explicitly enforce a limit—deployment scripts
+  expect this variable to be present. Optionally set `MAX_POSITION_SIZE_PCT` to cap
+  positions as a percentage of the portfolio.
 
 If any `ALPACA_*` credentials are missing or `alpaca-py` is not installed,
 the bot now aborts startup with a clear error instead of running without broker

--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -246,7 +246,7 @@ class TradingConfig:
     disable_daily_retrain: bool = False
     capital_cap: Optional[float] = 0.04
     dollar_risk_limit: Optional[float] = 0.05
-    max_position_size: Optional[float] = None
+    max_position_size: Optional[float] = 8000.0
     max_position_equity_fallback: float = 200000.0
     sector_exposure_cap: Optional[float] = None
     max_drawdown_threshold: Optional[float] = None
@@ -361,7 +361,12 @@ class TradingConfig:
         app_env = _get("APP_ENV", str, default="test") or "test"
         paper_default = "paper" in str(base_url).lower() or app_env.lower() != "prod"
 
-        mps = _get("MAX_POSITION_SIZE", float)
+        mps = _get(
+            "MAX_POSITION_SIZE",
+            float,
+            default=8000.0,
+            aliases=("AI_TRADING_MAX_POSITION_SIZE",),
+        )
         if mps is not None and mps <= 0:
             raise ValueError("MAX_POSITION_SIZE must be positive")
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,6 +8,11 @@ BRANCH="main"
 
 echo "Deploying branch '$BRANCH' to $SERVER:$APP_DIR …"
 
+if [ -z "${AI_TRADING_MAX_POSITION_SIZE:-}" ]; then
+  echo "AI_TRADING_MAX_POSITION_SIZE is required" >&2
+  exit 1
+fi
+
 ssh "$SERVER" << EOF
   cd "$APP_DIR"
   git fetch origin "$BRANCH"

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -29,4 +29,5 @@ Set the following to control position sizing:
 - `CAPITAL_CAP`: fraction of equity usable per cycle.
 - `DOLLAR_RISK_LIMIT`: fraction of equity at risk per position.
 - `MAX_POSITION_SIZE`: absolute USD cap per position. Must be >0 (typically 1-10000). Values ≤0 raise a configuration error. If unset, the bot derives a value from `CAPITAL_CAP` and equity.
+- `AI_TRADING_MAX_POSITION_SIZE`: explicit override for deployments; must be positive and is required by startup scripts.
 - `MAX_POSITION_EQUITY_FALLBACK`: equity assumed when deriving `MAX_POSITION_SIZE` but the real account equity cannot be fetched. Defaults to `200000`.

--- a/start.sh
+++ b/start.sh
@@ -9,6 +9,12 @@ export OMP_NUM_THREADS=1
 export MKL_NUM_THREADS=1
 export NUMEXPR_NUM_THREADS=1
 
+# Ensure position sizing limit is defined before launching
+if [ -z "${AI_TRADING_MAX_POSITION_SIZE:-}" ]; then
+  echo "AI_TRADING_MAX_POSITION_SIZE is required" >&2
+  exit 1
+fi
+
 VENV_PATH="${VENV_PATH:-venv}"
 # shellcheck disable=SC1090
 source "${VENV_PATH}/bin/activate"

--- a/tests/test_runtime_params_hydration.py
+++ b/tests/test_runtime_params_hydration.py
@@ -24,7 +24,7 @@ def test_trading_config_has_required_parameters():
     # Verify default values
     assert cfg.capital_cap == 0.04
     assert cfg.dollar_risk_limit == 0.05
-    assert cfg.max_position_size is None
+    assert cfg.max_position_size == 8000.0
 
 
 def test_trading_config_from_env_loads_parameters():


### PR DESCRIPTION
## Summary
- default TradingConfig max_position_size to 8000 and allow AI_TRADING_MAX_POSITION_SIZE env override
- require AI_TRADING_MAX_POSITION_SIZE in startup scripts
- document explicit max position sizing requirement

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_params_hydration.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings'; numerous missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b31ab5e37c83308c38cf67b1b0af79