### PR TITLE
feat(logging): drop sensitive env keys from startup logs

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -36,7 +36,10 @@ Risk exposure update failures are demoted to DEBUG level when the trading contex
 #### Automatic Secret Redaction
 Any `extra` fields such as API keys, secrets, or URLs are sanitized before
 being emitted to handlers, ensuring sensitive values are replaced with
-`***REDACTED***`.
+`***REDACTED***`.  The :func:`ai_trading.logging.redact.redact_env` helper now
+accepts ``drop=True`` to **remove** known sensitive keys instead of masking
+them.  The early environment validation step uses this mode so that logs do
+not contain secret key names or placeholder values.
 
 #### Data Fetch Diagnostics
 Daily price requests now log their parameters and outcome:

--- a/ai_trading/logging/redact.py
+++ b/ai_trading/logging/redact.py
@@ -54,13 +54,26 @@ def redact(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     return _redact_inplace(dup)
 
 
-def redact_env(env: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Return copy of *env* with known sensitive keys masked."""
+def redact_env(env: Mapping[str, Any], *, drop: bool = False) -> Mapping[str, Any]:
+    """Return copy of *env* with known sensitive keys masked or dropped.
+
+    Parameters
+    ----------
+    env:
+        Mapping of environment variables to sanitize.
+    drop:
+        When ``True`` remove sensitive keys entirely instead of masking their
+        values.  Defaults to ``False`` which keeps the keys but masks the
+        values with :data:`_ENV_MASK`.
+    """
 
     dup: MutableMapping[str, Any] = dict(env)
-    for key in _SENSITIVE_ENV:
-        if key in dup and dup[key]:
-            dup[key] = _ENV_MASK
+    for key in list(dup):
+        if key in _SENSITIVE_ENV and dup[key]:
+            if drop:
+                dup.pop(key)
+            else:
+                dup[key] = _ENV_MASK
     return dup
 
 

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -188,7 +188,10 @@ def _fail_fast_env() -> None:
     except RuntimeError as e:
         logger.critical("ENV_VALIDATION_FAILED", extra={"error": str(e)})
         raise SystemExit(1) from e
-    logger.info("ENV_CONFIG_LOADED", extra={"dotenv_path": loaded, **redact_env(snapshot)})
+    logger.info(
+        "ENV_CONFIG_LOADED",
+        extra={"dotenv_path": loaded, **redact_env(snapshot, drop=True)},
+    )
 
 
 def _validate_runtime_config(cfg, tcfg) -> None:

--- a/tests/unit/test_env_config_redaction.py
+++ b/tests/unit/test_env_config_redaction.py
@@ -4,7 +4,7 @@ from ai_trading import main
 from ai_trading.logging.redact import _ENV_MASK, _SENSITIVE_ENV, redact_env
 
 
-def test_startup_logs_redact_secrets(caplog, monkeypatch):
+def test_startup_logs_drop_secrets(caplog, monkeypatch):
     monkeypatch.setenv("ALPACA_API_KEY", "AK123456789")
     monkeypatch.setenv("ALPACA_SECRET_KEY", "SK987654321")
     monkeypatch.setenv("ALPACA_API_URL", "https://paper-api.alpaca.markets")
@@ -15,18 +15,26 @@ def test_startup_logs_redact_secrets(caplog, monkeypatch):
 
     caplog.set_level(logging.INFO)
     main._fail_fast_env()
-    env_log = next(rec for rec in caplog.records if hasattr(rec, "ALPACA_API_KEY"))
+    env_log = next(rec for rec in caplog.records if rec.getMessage() == "ENV_CONFIG_LOADED")
     joined = str(env_log.__dict__)
-    assert env_log.ALPACA_API_KEY == _ENV_MASK
-    assert env_log.ALPACA_SECRET_KEY == _ENV_MASK
-    assert env_log.WEBHOOK_SECRET == _ENV_MASK
+    for key in ("ALPACA_API_KEY", "ALPACA_SECRET_KEY", "WEBHOOK_SECRET"):
+        assert key not in env_log.__dict__
+        assert key not in joined
+    assert _ENV_MASK not in joined
     assert "AK123456789" not in joined
     assert "SK987654321" not in joined
     assert "HOOK-SECRET" not in joined
 
 
-def test_redact_env_masks_all_keys():
+def test_redact_env_masks_all_keys_by_default():
     payload = {k: f"{k}_VALUE" for k in _SENSITIVE_ENV}
     redacted = redact_env(payload)
     assert all(redacted[k] == _ENV_MASK for k in payload)
+    assert set(redacted) == set(payload)
 
+
+def test_redact_env_drop_removes_keys():
+    payload = {k: f"{k}_VALUE" for k in _SENSITIVE_ENV}
+    redacted = redact_env(payload, drop=True)
+    for k in _SENSITIVE_ENV:
+        assert k not in redacted


### PR DESCRIPTION
## Summary
- allow `redact_env` to drop sensitive keys
- exclude secrets from `_fail_fast_env` logs
- document env redaction behavior and add tests

## Testing
- `ruff check ai_trading/logging/redact.py ai_trading/main.py tests/unit/test_env_config_redaction.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/unit/test_env_config_redaction.py` *(fails: ModuleNotFoundError: No module named 'alpaca', then skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b320b2cf488330a29f97ea785f7e1e