### PR TITLE
refactor: lazy torch import for portfolio RL

### DIFF
--- a/ai_trading/portfolio_rl.py
+++ b/ai_trading/portfolio_rl.py
@@ -1,121 +1,79 @@
-import types
-import numpy as np
-try:
-    import torch
-    from torch import nn, optim
-    _TORCH_AVAILABLE = True
-    try:
-        _test_module = nn.Module()
-        _PYTORCH_WORKS = True
-    except (ValueError, TypeError, ZeroDivisionError, OverflowError, KeyError):
-        _PYTORCH_WORKS = False
-except (ValueError, TypeError, ZeroDivisionError, OverflowError, KeyError):
-    torch = types.ModuleType('torch')
-    torch.Tensor = object
-    torch.tensor = lambda *a, **k: [0.0] if np is None else np.array([0.0])
-    nn = types.ModuleType('torch.nn')
-    nn.Module = object
-    nn.Sequential = lambda *a, **k: None
-    nn.Linear = lambda *a, **k: None
-    nn.ReLU = lambda *a, **k: None
-    nn.Softmax = lambda *a, **k: None
-    optim = types.ModuleType('torch.optim')
-    optim.Adam = lambda *a, **k: None
-    _TORCH_AVAILABLE = False
-    _PYTORCH_WORKS = False
+"""Simple reinforcement-learning portfolio manager.
 
-class Actor(nn.Module if _TORCH_AVAILABLE and _PYTORCH_WORKS else object):
+This module defers importing :mod:`torch` until it's actually needed so that
+environments without the optional dependency can still import the package. A
+clear :class:`ImportError` is raised when functionality requires PyTorch.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+torch = nn = optim = None  # type: ignore[assignment]
+
+
+def _lazy_import_torch():
+    """Import torch and related modules on demand."""
+
+    global torch, nn, optim
+    if torch is None:
+        try:  # pragma: no cover - heavy optional dependency
+            import torch as t
+            from torch import nn as _nn, optim as _optim
+        except (ImportError, OSError) as exc:  # pragma: no cover - import guard
+            raise ImportError(
+                "PyTorch is required for ai_trading.portfolio_rl"
+            ) from exc
+        torch, nn, optim = t, _nn, _optim
+    return torch, nn, optim
+
+
+class Actor:
+    """Wrapper around a small neural network policy."""
 
     def __init__(self, state_dim: int, action_dim: int) -> None:
-        if not _TORCH_AVAILABLE or not _PYTORCH_WORKS:
-            self.state_dim = state_dim
-            self.action_dim = action_dim
-            self.net = None
-            return
-        try:
-            super().__init__()
-            self.net = nn.Sequential(nn.Linear(state_dim, 64), nn.ReLU(), nn.Linear(64, action_dim), nn.Softmax(dim=-1))
-        except (ValueError, TypeError, ZeroDivisionError, OverflowError, KeyError):
-            self.state_dim = state_dim
-            self.action_dim = action_dim
-            self.net = None
+        _, nn_mod, _ = _lazy_import_torch()
+        self.net = nn_mod.Sequential(
+            nn_mod.Linear(state_dim, 64),
+            nn_mod.ReLU(),
+            nn_mod.Linear(64, action_dim),
+            nn_mod.Softmax(dim=-1),
+        )
 
-    def forward(self, x) -> object:
-        if not _TORCH_AVAILABLE or not _PYTORCH_WORKS or self.net is None:
-            if np is not None:
-                weights = np.random.rand(self.action_dim)
-                return weights / weights.sum()
-            else:
-                return [1.0 / self.action_dim] * self.action_dim
-        try:
-            return self.net(x)
-        except (ValueError, TypeError, ZeroDivisionError, OverflowError, KeyError):
-            if np is not None:
-                weights = np.random.rand(self.action_dim)
-                return weights / weights.sum()
-            else:
-                return [1.0 / self.action_dim] * self.action_dim
+    def __call__(self, x):
+        return self.net(x)
+
+    def parameters(self):
+        return self.net.parameters()
+
 
 class PortfolioReinforcementLearner:
+    """Minimal RL-based portfolio balancer."""
 
-    def __init__(self, state_dim: int=10, action_dim: int=5) -> None:
+    def __init__(self, state_dim: int = 10, action_dim: int = 5) -> None:
+        _, _, optim_mod = _lazy_import_torch()
         self.state_dim = state_dim
         self.action_dim = action_dim
-        if not _TORCH_AVAILABLE or not _PYTORCH_WORKS:
-            self.actor = Actor(state_dim, action_dim)
-            self.optimizer = None
-            return
-        try:
-            self.actor = Actor(state_dim, action_dim)
-            self.optimizer = optim.Adam(self.actor.parameters(), lr=0.001)
-        except (ValueError, TypeError, ZeroDivisionError, OverflowError, KeyError):
-            self.actor = Actor(state_dim, action_dim)
-            self.optimizer = None
+        self.actor = Actor(state_dim, action_dim)
+        self.optimizer = optim_mod.Adam(self.actor.parameters(), lr=0.001)
 
-    def rebalance_portfolio(self, state) -> object:
-        if np is None:
-            weights = [1.0 / self.action_dim] * self.action_dim
-            return weights
-        if hasattr(state, 'tolist'):
+    def rebalance_portfolio(self, state) -> np.ndarray:
+        """Return normalized action weights for the given state."""
+
+        torch_mod, _, _ = _lazy_import_torch()
+        if hasattr(state, "tolist"):
             state = state.tolist()
-        if isinstance(state, list):
-            state = [0.0] * self.state_dim if np is None else np.array(state)
-        if len(state) != self.state_dim:
-            if np is not None:
-                state = np.pad(state, (0, self.state_dim - len(state)), 'constant')
-            else:
-                state = list(state) + [0.0] * (self.state_dim - len(state))
-        if not _TORCH_AVAILABLE or not _PYTORCH_WORKS:
-            weights = self.actor.forward(state)
-            if np is not None and hasattr(weights, 'sum'):
-                total = weights.sum()
-                if total == 0:
-                    total = 1.0
-                return weights / total
-            elif isinstance(weights, list):
-                total = sum(weights)
-                if total == 0:
-                    total = 1.0
-                return [w / total for w in weights]
-            return weights
+        arr = np.asarray(state, dtype=np.float32)
+        if arr.size < self.state_dim:
+            arr = np.pad(arr, (0, self.state_dim - arr.size))
+        elif arr.size > self.state_dim:
+            arr = arr[: self.state_dim]
+        state_tensor = torch_mod.tensor(arr, dtype=torch_mod.float32)
+        with torch_mod.no_grad():
+            weights = self.actor(state_tensor).numpy()
+        total = float(weights.sum())
+        return weights / total if total else weights
 
-        try:
-            state_tensor = torch.tensor(state, dtype=torch.float32)
-            weights = self.actor(state_tensor).detach().numpy()
-            total = weights.sum()
-            if total == 0:
-                total = 1.0
-            return weights / total
-        except (ValueError, TypeError, ZeroDivisionError, OverflowError, KeyError):
-            weights = self.actor.forward(state)
-            if np is not None and hasattr(weights, 'sum'):
-                total = weights.sum()
-                if total == 0:
-                    total = 1.0
-                return weights / total
-            elif isinstance(weights, list):
-                total = sum(weights)
-                if total == 0:
-                    total = 1.0
-                return [w / total for w in weights]
-            return weights
+
+__all__ = ["PortfolioReinforcementLearner", "Actor"]
+

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -156,22 +156,16 @@ def test_update_signal_weights_norm_zero(caplog):
 
 
 def test_portfolio_rl_trigger(monkeypatch):
-    # AI-AGENT-REF: ensure real torch is loaded during tests
-    # if not hasattr(torch, "nn") or not hasattr(torch.nn, "Parameter"):
-    #     pytest.skip("torch stubs active")
     class FakeLinear(nn.Module):
         def __init__(self, *a, **k):
             super().__init__()
             self.weight = nn.Parameter(torch.tensor([0.0]))
 
-        def forward(self, x):
+        def forward(self, x):  # pragma: no cover - trivial
             return x
 
     monkeypatch.setattr(nn, "Linear", lambda *a, **k: FakeLinear())
-    import ai_trading.portfolio_rl as portfolio_rl
-    monkeypatch.setattr(portfolio_rl, "_TORCH_AVAILABLE", True)
-    monkeypatch.setattr(portfolio_rl.optim, "Adam", lambda *a, **k: types.SimpleNamespace(step=lambda: None))
     learner = meta_learning.PortfolioReinforcementLearner()
     state = np.random.rand(10)
     weights = learner.rebalance_portfolio(state)
-    assert np.isclose(weights.sum(), 1, atol=0.1)
+    assert np.isclose(weights.sum(), 1.0, atol=0.1)

--- a/tests/test_portfolio_rl.py
+++ b/tests/test_portfolio_rl.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+def test_rebalance_portfolio_normalizes_weights():
+    from ai_trading.portfolio_rl import PortfolioReinforcementLearner
+
+    learner = PortfolioReinforcementLearner()
+    state = np.random.rand(learner.state_dim)
+    weights = learner.rebalance_portfolio(state)
+    assert weights.shape[0] == learner.action_dim
+    assert isinstance(learner.actor.net[0], torch.nn.Linear)
+    assert np.isclose(weights.sum(), 1.0, atol=1e-6)
+


### PR DESCRIPTION
## Summary
- simplify PortfolioReinforcementLearner to import torch lazily and raise ImportError when missing
- normalize RL test to use real torch modules
- add direct unit test ensuring PortfolioReinforcementLearner returns normalized weights with torch

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68b3263201248330839f7c47432c315c