### PR TITLE
Remove bars proxies and legacy logger alias

### DIFF
--- a/tests/test_empty_bars_guard.py
+++ b/tests/test_empty_bars_guard.py
@@ -3,6 +3,7 @@ from ai_trading.utils.lazy_imports import load_pandas
 from types import SimpleNamespace
 
 from ai_trading.core import bot_engine
+import ai_trading.data.bars as data_bars
 
 
 def _dummy_cfg():
@@ -24,7 +25,8 @@ def test_get_daily_df_empty_bars_raises(monkeypatch):
     fetcher = bot_engine.DataFetcher()
     ctx = SimpleNamespace()
     monkeypatch.setattr(bot_engine, "get_alpaca_secret_key_plain", lambda: "secret")
-    monkeypatch.setattr(bot_engine, "safe_get_stock_bars", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(data_bars, "safe_get_stock_bars", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(bot_engine, "safe_get_stock_bars", data_bars.safe_get_stock_bars)
     with pytest.raises(bot_engine.DataFetchError):
         fetcher.get_daily_df(ctx, "AAPL")
 


### PR DESCRIPTION
## Summary
- remove deprecated `StockBarsRequest`/`safe_get_stock_bars` proxies in bot_engine
- route `_current_position_qty` and risk engine diagnostics through main `logger`
- update tests to patch `ai_trading.data.bars.safe_get_stock_bars`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b3294780e883309e1db6759b008fa0