### PR TITLE
feat: default to model_loader module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,4 +97,4 @@ API_PORT=9001
 
 # === MODEL CONFIGURATION ===
 # Module path providing get_model() or Model
-AI_TRADING_MODEL_MODULE=ai_trading.model_stub
+AI_TRADING_MODEL_MODULE=ai_trading.model_loader


### PR DESCRIPTION
## Summary
- Default AI_TRADING_MODEL_MODULE to ai_trading.model_loader in env example

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib', No module named 'cachetools', NameError: pd is not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b330f8c5948330ab70583d2b926e36