### PR TITLE
refactor: improve RL portfolio import and testing

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -54,7 +54,7 @@ logger = get_logger(__name__)
 
 try:
     from ai_trading.portfolio_rl import PortfolioReinforcementLearner
-except Exception:  # pragma: no cover - optional dependency
+except (ImportError, OSError):  # pragma: no cover - optional dependency
     PortfolioReinforcementLearner = None  # type: ignore[assignment]
 
 

--- a/ai_trading/portfolio_rl.py
+++ b/ai_trading/portfolio_rl.py
@@ -8,24 +8,25 @@ clear :class:`ImportError` is raised when functionality requires PyTorch.
 from __future__ import annotations
 
 import numpy as np
+from functools import lru_cache
 
-torch = nn = optim = None  # type: ignore[assignment]
 
-
+@lru_cache(maxsize=1)
 def _lazy_import_torch():
-    """Import torch and related modules on demand."""
+    """Import :mod:`torch` and return its submodules.
 
-    global torch, nn, optim
-    if torch is None:
-        try:  # pragma: no cover - heavy optional dependency
-            import torch as t
-            from torch import nn as _nn, optim as _optim
-        except (ImportError, OSError) as exc:  # pragma: no cover - import guard
-            raise ImportError(
-                "PyTorch is required for ai_trading.portfolio_rl"
-            ) from exc
-        torch, nn, optim = t, _nn, _optim
-    return torch, nn, optim
+    Lazily imports the heavy dependency to keep module import light. The
+    result is cached so subsequent calls are inexpensive.
+    """
+
+    try:  # pragma: no cover - heavy optional dependency
+        import torch as t
+        from torch import nn as _nn, optim as _optim
+    except (ImportError, OSError) as exc:  # pragma: no cover - import guard
+        raise ImportError(
+            "PyTorch is required for ai_trading.portfolio_rl"
+        ) from exc
+    return t, _nn, _optim
 
 
 class Actor:

--- a/tests/test_portfolio_rl.py
+++ b/tests/test_portfolio_rl.py
@@ -14,3 +14,24 @@ def test_rebalance_portfolio_normalizes_weights():
     assert isinstance(learner.actor.net[0], torch.nn.Linear)
     assert np.isclose(weights.sum(), 1.0, atol=1e-6)
 
+
+def test_import_error_when_torch_missing(monkeypatch):
+    import builtins
+    import sys
+    import ai_trading.portfolio_rl as prl
+
+    prl._lazy_import_torch.cache_clear()
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("torch"):
+            raise ImportError("no torch")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match="PyTorch is required for ai_trading.portfolio_rl"):
+        prl.PortfolioReinforcementLearner()
+


### PR DESCRIPTION
## Summary
- lazy-load torch for RL portfolio management and cache imports
- narrow exception handling for RL optional dependency
- test RL portfolio behavior and missing-torch errors

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_portfolio_rl.py::test_rebalance_portfolio_normalizes_weights tests/test_portfolio_rl.py::test_import_error_when_torch_missing tests/test_meta_learning.py::test_portfolio_rl_trigger -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib', 'cachetools', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b3337338808330a548f320f3e6f73b