### PR TITLE
test: cover script wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ The bot automatically uses optimized parameters when available:
 cat best_hyperparams.json
 
 # Manual optimization
-python algorithm_optimizer.py --symbols SPY --iterations 100
+python -m ai_trading.algorithm_optimizer --symbols SPY --iterations 100
 ```
 
 ### 🎛️ Trading Modes

--- a/tests/test_script_wrappers.py
+++ b/tests/test_script_wrappers.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script(name: str):
+    spec = spec_from_file_location(name, PROJECT_ROOT / "scripts" / f"{name}.py")
+    module = module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_algorithm_optimizer_wrapper():
+    script_mod = _load_script("algorithm_optimizer")
+    from ai_trading import algorithm_optimizer as pkg_mod
+
+    assert script_mod.AlgorithmOptimizer is pkg_mod.AlgorithmOptimizer
+    assert script_mod.get_algorithm_optimizer is pkg_mod.get_algorithm_optimizer
+
+
+def test_ml_model_wrapper():
+    script_mod = _load_script("ml_model")
+    from ai_trading import ml_model as pkg_mod
+
+    assert script_mod.MLModel is pkg_mod.MLModel
+    assert script_mod.train_model is pkg_mod.train_model


### PR DESCRIPTION
## Summary
- add tests verifying `scripts/algorithm_optimizer.py` and `scripts/ml_model.py` re-export their package counterparts
- document running algorithm optimizer via module entrypoint

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_script_wrappers.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68b335c11ea88330b850f081793ce989