### PR TITLE
Remove lightgbm shim and gate dependency

### DIFF
--- a/ai_trading/utils/determinism.py
+++ b/ai_trading/utils/determinism.py
@@ -24,15 +24,6 @@ except ImportError:  # pragma: no cover
     HAS_NUMPY = False
     np = None  # type: ignore
 
-try:
-    import lightgbm as lgb  # type: ignore
-
-    HAS_LIGHTGBM = True
-except ImportError as exc:  # pragma: no cover - optional dep
-    lgb = None  # type: ignore[assignment]
-    HAS_LIGHTGBM = False
-    _lgb_import_error = exc
-
 
 def set_random_seeds(seed: int = 42) -> None:
     """
@@ -44,10 +35,12 @@ def set_random_seeds(seed: int = 42) -> None:
     random.seed(seed)
     if HAS_NUMPY:
         np.random.seed(seed)
-    if not HAS_LIGHTGBM:
+    try:
+        import lightgbm as lgb  # type: ignore
+    except ImportError as exc:  # pragma: no cover - optional dep
         raise ImportError(
-            "lightgbm is required for deterministic training. Install via `pip install lightgbm`."
-        ) from _lgb_import_error
+            "lightgbm is required for deterministic training. Install via `pip install lightgbm`.",
+        ) from exc
     try:
         lgb.reset_parameter({"seed": seed})  # type: ignore[attr-defined]
     except Exception:  # pragma: no cover - best effort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@
 
 # Ensure Alpaca SDK available for tests
 alpaca-py==0.42.0
-lightgbm==4.6.0
 
 # Lint & format
 ruff==0.5.6

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,4 +11,3 @@ hypothesis>=6.92
 coverage>=7.6
 requests>=2.31,<3
 alpaca-py==0.42.0
-lightgbm==4.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,5 +45,4 @@ statsmodels==0.14.5
 cryptography>=41
 torch==2.3.1
 transformers==4.55.4
-lightgbm==4.6.0
 hmmlearn==0.3.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,6 @@ pandas>=2.2
 pandas-market-calendars>=5.1
 tzdata>=2024.1  # AI-AGENT-REF: ensure timezone data
 alpaca-py==0.42.0
-lightgbm==4.6.0
 pytest>=7.4
 pytest-xdist>=3.6
 psutil>=5.9

--- a/tests/test_peak_performance.py
+++ b/tests/test_peak_performance.py
@@ -195,10 +195,9 @@ def test_adaptive_risk_controls():
 
 def test_determinism():
     """Test deterministic training setup."""
-    from ai_trading.utils.determinism import hash_data, set_random_seeds
-
     pd = pytest.importorskip("pandas")
     pytest.importorskip("lightgbm")
+    from ai_trading.utils.determinism import hash_data, set_random_seeds
 
     # Test seed setting
     set_random_seeds(42)


### PR DESCRIPTION
## Summary
- remove legacy lightgbm shim in training and determinism utilities
- make lightgbm an optional dependency and adjust tests accordingly

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b337c135088330b5b9502d061869ae