### PR TITLE
Remove deprecated bot_engine warning flag

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -130,15 +130,6 @@ def _parse_timeframe(tf: Any) -> bars.TimeFrame:
     if key in tf_map:
         return tf_map[key]
     raise ValueError(f"Unsupported timeframe: {tf}")
-
-if os.getenv("BOT_SHOW_DEPRECATIONS", "").lower() in {"1", "true", "yes"}:
-    warnings.filterwarnings("default", category=DeprecationWarning)
-    warnings.warn(
-        "bot_engine.py is deprecated",
-        DeprecationWarning,
-    )  # AI-AGENT-REF: deprecation notice
-
-
 # One place to define the common exception family (module-scoped)
 COMMON_EXC = (
     TypeError,


### PR DESCRIPTION
## Summary
- remove BOT_SHOW_DEPRECATIONS flag and associated deprecation warning in `bot_engine`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b344b59be08330bbb78d4cb32ab462