### PR TITLE
tests: import ai_trading.pipeline module

### DIFF
--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -65,8 +65,7 @@ def test_pipeline_basic(monkeypatch):
     monkeypatch.setitem(sys.modules, "sklearn.linear_model", skl_lin)
 
     monkeypatch.syspath_prepend(".")
-    sys.modules.pop("pipeline", None)
-    pipeline = importlib.import_module("pipeline")
+    pipeline = importlib.import_module("ai_trading.pipeline")
 
     df = pd.DataFrame({"close": np.arange(10, dtype=float)})
     arr = pipeline.FeatureBuilder().transform(df)


### PR DESCRIPTION
## Summary
- switch pipeline smoke test to import from `ai_trading.pipeline`
- drop `sys.modules` cleanup for removed standalone module

## Testing
- `ruff check tests/test_pipeline_smoke.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_pipeline_smoke.py -q` *(fails: Skipped: alpaca-py is required for tests)*

## Rollback
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68b34577da1c8330a5c46bf5028fce46