### PR TITLE
Default model module in deployment scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,5 +96,6 @@ API_HOST=0.0.0.0
 API_PORT=9001
 
 # === MODEL CONFIGURATION ===
-# Module path providing get_model() or Model
+# Module path providing get_model() or Model (defaults to ai_trading.model_loader)
 AI_TRADING_MODEL_MODULE=ai_trading.model_loader
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.12-slim
 WORKDIR /app
-ENV AI_TRADING_DATA_DIR=/var/lib/ai-trading-bot \
+ENV AI_TRADING_MODEL_MODULE=ai_trading.model_loader \
+    AI_TRADING_DATA_DIR=/var/lib/ai-trading-bot \
     AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot \
     AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
 COPY . .

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,6 +14,7 @@ if [ -z "${AI_TRADING_MAX_POSITION_SIZE:-}" ]; then
 fi
 
 ssh "$SERVER" << EOF
+  export AI_TRADING_MODEL_MODULE=ai_trading.model_loader
   cd "$APP_DIR"
   git fetch origin "$BRANCH"
   git reset --hard "origin/$BRANCH"

--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,7 @@ export OPENBLAS_NUM_THREADS=1
 export OMP_NUM_THREADS=1
 export MKL_NUM_THREADS=1
 export NUMEXPR_NUM_THREADS=1
+export AI_TRADING_MODEL_MODULE="${AI_TRADING_MODEL_MODULE:-ai_trading.model_loader}"
 
 # Ensure position sizing limit is defined before launching
 if [ -z "${AI_TRADING_MAX_POSITION_SIZE:-}" ]; then


### PR DESCRIPTION
## Summary
- default model module to `ai_trading.model_loader` in deploy and start scripts
- document model loader in env example and Docker builds

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b3457697f08330ad9f61f5ccf6ad4b