### PR TITLE
Use postponed annotations in trailing stop manager

### DIFF
--- a/ai_trading/position/trailing_stops.py
+++ b/ai_trading/position/trailing_stops.py
@@ -9,6 +9,7 @@ Implements sophisticated trailing stop strategies:
 
 AI-AGENT-REF: Advanced trailing stop management with multiple algorithms
 """
+from __future__ import annotations
 from ai_trading.logging import get_logger
 from dataclasses import dataclass
 from datetime import UTC, datetime


### PR DESCRIPTION
## Summary
- defer annotation evaluation in `trailing_stops` with `from __future__ import annotations`
- retain lazy `pandas` imports with `load_pandas`

## Testing
- `ruff check ai_trading/position/trailing_stops.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*


------
https://chatgpt.com/codex/tasks/task_e_68b34679fc0c833097ca5dd6914e9b73