### PR TITLE
Guard optional ML deps with sentinel

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -8,6 +8,8 @@ resolved and constrained before deserialization. Prefer :mod:`joblib` or
 from importlib.util import find_spec
 from ai_trading.config import get_settings
 
+from ai_trading.utils.device import TORCH_AVAILABLE
+
 config = None
 SKLEARN_AVAILABLE = bool(find_spec("sklearn"))
 import csv
@@ -43,7 +45,6 @@ class RequestException(Exception):
 
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)
 sys.modules.setdefault("meta_learning", sys.modules[__name__])
-TORCH_AVAILABLE = False
 
 if TYPE_CHECKING:  # pragma: no cover - typing helpers
     import numpy as _np  # noqa: F401
@@ -88,8 +89,10 @@ def _import_pandas(optional: bool = False):
 
 def _import_torch():
     """Import :mod:`torch` lazily."""
-    global torch, nn, DataLoader, TensorDataset, TORCH_AVAILABLE
+    global torch, nn, DataLoader, TensorDataset
     if torch is None:
+        if not TORCH_AVAILABLE:
+            raise ImportError("PyTorch is required for this operation")
         try:
             import torch as t
             from torch import nn as _nn
@@ -97,7 +100,6 @@ def _import_torch():
         except (ImportError, OSError) as exc:  # pragma: no cover - import guard
             raise ImportError("PyTorch is required for this operation") from exc
         torch, nn, DataLoader, TensorDataset = t, _nn, _DL, _TD
-        TORCH_AVAILABLE = True
     return torch
 
 def get_device() -> str:

--- a/ai_trading/portfolio_rl.py
+++ b/ai_trading/portfolio_rl.py
@@ -10,21 +10,20 @@ from __future__ import annotations
 import numpy as np
 from functools import lru_cache
 
+from ai_trading.utils.device import TORCH_AVAILABLE
+
 
 @lru_cache(maxsize=1)
 def _lazy_import_torch():
-    """Import :mod:`torch` and return its submodules.
-
-    Lazily imports the heavy dependency to keep module import light. The
-    result is cached so subsequent calls are inexpensive.
-    """
-
+    """Import :mod:`torch` and return its submodules."""
+    if not TORCH_AVAILABLE:
+        raise ImportError("PyTorch is required for ai_trading.portfolio_rl")
     try:  # pragma: no cover - heavy optional dependency
         import torch as t
         from torch import nn as _nn, optim as _optim
     except (ImportError, OSError) as exc:  # pragma: no cover - import guard
         raise ImportError(
-            "PyTorch is required for ai_trading.portfolio_rl"
+            "PyTorch is required for ai_trading.portfolio_rl",
         ) from exc
     return t, _nn, _optim
 

--- a/ai_trading/training/train_ml.py
+++ b/ai_trading/training/train_ml.py
@@ -16,6 +16,14 @@ import numpy as np
 from ai_trading.logging import logger
 from ai_trading.utils.pickle_safe import safe_pickle_load
 
+# Optional dependencies
+try:  # pragma: no cover - optional lightgbm dependency
+    import lightgbm  # type: ignore  # noqa: F401
+    LIGHTGBM_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    lightgbm = None  # type: ignore
+    LIGHTGBM_AVAILABLE = False
+
 BASE_DIR = Path(__file__).resolve().parents[2]
 ALLOWED_DIRS = [BASE_DIR, Path(gettempdir()).resolve()]
 
@@ -74,12 +82,10 @@ class MLTrainer:
     def _validate_dependencies(self) -> None:
         """Validate required dependencies are available."""
         if self.model_type == "lightgbm":
-            try:
-                import lightgbm  # noqa: F401
-            except ImportError as exc:
+            if not LIGHTGBM_AVAILABLE:
                 raise ImportError(
                     "lightgbm is required for model_type 'lightgbm'. Install via `pip install lightgbm`.",
-                ) from exc
+                )
         elif self.model_type == "xgboost":
             try:
                 import xgboost  # noqa: F401

--- a/ai_trading/utils/device.py
+++ b/ai_trading/utils/device.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from ai_trading.logging import get_logger
 
+import importlib.util
+
+# Sentinel indicating whether torch is available without importing it
+TORCH_AVAILABLE = importlib.util.find_spec("torch") is not None
+
 # torch is optional and heavy; import lazily inside functions
 # Cache references for repeated calls
 torch = None  # type: ignore[assignment]

--- a/tests/slow/test_meta_learning_heavy.py
+++ b/tests/slow/test_meta_learning_heavy.py
@@ -6,7 +6,10 @@ import pytest
 pd = pytest.importorskip("pandas")
 sklearn = pytest.importorskip("sklearn")
 import sklearn.linear_model
-torch = pytest.importorskip("torch")
+from ai_trading.utils.device import TORCH_AVAILABLE
+if not TORCH_AVAILABLE:
+    pytest.skip("torch not installed", allow_module_level=True)
+import torch
 try:
     import pydantic_settings  # noqa: F401
     from ai_trading import meta_learning

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -5,7 +5,9 @@ import pytest
 
 pd = pytest.importorskip("pandas")
 pytest.importorskip("requests")
-pytest.importorskip("torch")
+from ai_trading.utils.device import TORCH_AVAILABLE
+if not TORCH_AVAILABLE:
+    pytest.skip("torch not installed", allow_module_level=True)
 # Minimal stubs so importing bot_engine succeeds without optional deps
 mods = [
     "sklearn",

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -7,7 +7,9 @@ from ai_trading.config import management as config
 
 pd = pytest.importorskip("pandas")
 pytest.importorskip("requests")
-pytest.importorskip("torch")
+from ai_trading.utils.device import TORCH_AVAILABLE
+if not TORCH_AVAILABLE:
+    pytest.skip("torch not installed", allow_module_level=True)
 
 """Minimal import-time stubs so strategy_allocator and other modules load."""
 try:

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -2,7 +2,10 @@ import types
 
 import pytest
 np = pytest.importorskip("numpy")
-torch = pytest.importorskip("torch")
+from ai_trading.utils.device import TORCH_AVAILABLE
+if not TORCH_AVAILABLE:
+    pytest.skip("torch not installed", allow_module_level=True)
+import torch
 from torch import nn
 
 np.random.seed(0)

--- a/tests/test_peak_performance.py
+++ b/tests/test_peak_performance.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 
 import numpy as np
 import pytest
+from ai_trading.training.train_ml import LIGHTGBM_AVAILABLE
 
 
 # Test idempotency
@@ -196,7 +197,8 @@ def test_adaptive_risk_controls():
 def test_determinism():
     """Test deterministic training setup."""
     pd = pytest.importorskip("pandas")
-    pytest.importorskip("lightgbm")
+    if not LIGHTGBM_AVAILABLE:
+        pytest.skip("lightgbm not installed")
     from ai_trading.utils.determinism import hash_data, set_random_seeds
 
     # Test seed setting

--- a/tests/test_portfolio_rl.py
+++ b/tests/test_portfolio_rl.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-torch = pytest.importorskip("torch")
+from ai_trading.utils.device import TORCH_AVAILABLE
+if not TORCH_AVAILABLE:
+    pytest.skip("torch not installed", allow_module_level=True)
+import torch
 
 
 def test_rebalance_portfolio_normalizes_weights():

--- a/tests/test_retrain_smoke.py
+++ b/tests/test_retrain_smoke.py
@@ -4,9 +4,11 @@ import types
 from pathlib import Path
 
 import pytest
+from ai_trading.training.train_ml import LIGHTGBM_AVAILABLE
 
 pd = pytest.importorskip("pandas")
-pytest.importorskip("lightgbm")
+if not LIGHTGBM_AVAILABLE:
+    pytest.skip("lightgbm not installed", allow_module_level=True)
 
 
 def _import_retrain(monkeypatch):

--- a/tests/test_rl_import_performance.py
+++ b/tests/test_rl_import_performance.py
@@ -5,9 +5,10 @@ import time
 import pytest
 
 pytest.importorskip("gymnasium")
-pytest.importorskip("torch")
-pytest.importorskip("torch.optim")
 pytest.importorskip("stable_baselines3")
+from ai_trading.utils.device import TORCH_AVAILABLE
+if not TORCH_AVAILABLE:
+    pytest.skip("torch not installed", allow_module_level=True)
 
 MODULES = [
     "ai_trading.rl_trading",


### PR DESCRIPTION
## Summary
- Add optional import guards for LightGBM and torch with sentinel flags
- Skip ML and RL tests when optional dependencies are missing

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3467a719483308ef635fb8e600366