### PR TITLE
Cap Kelly fraction

### DIFF
--- a/tests/test_institutional_kelly.py
+++ b/tests/test_institutional_kelly.py
@@ -55,6 +55,13 @@ class TestKellyCriterion:
         assert kelly_fraction <= self.kelly.max_fraction
         assert kelly_fraction == self.kelly.max_fraction
 
+    def test_fractional_kelly_cap(self):
+        """Fractional Kelly should respect the maximum fraction."""
+        base_fraction = 0.2
+        # Use a multiplier that would exceed max_fraction if uncapped
+        capped_fraction = self.kelly.fractional_kelly(base_fraction, fraction=2.0)
+        assert capped_fraction == self.kelly.max_fraction
+
     def test_kelly_negative_expectancy(self):
         """Test Kelly returns zero for negative expectancy."""
         # Losing strategy: 30% win rate, small wins, large losses


### PR DESCRIPTION
## Summary
- enforce max_fraction cap in Kelly calculations
- add fractional Kelly unit test verifying capping

## Testing
- `ruff check ai_trading/risk/kelly.py tests/test_institutional_kelly.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_institutional_kelly.py::TestKellyCriterion::test_kelly_with_max_fraction_cap tests/test_institutional_kelly.py::TestKellyCriterion::test_fractional_kelly_cap -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34896d6b8833091cebb5bc8e6591c