### PR TITLE
Add mixed trade log format detection helper

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -322,6 +322,12 @@ def validate_trade_data_quality(trade_log_path: str) -> dict:
         quality_report['issues'].append(f'Error accessing file: {e}')
     return quality_report
 
+
+def has_mixed_format(trade_log_path: str | os.PathLike) -> bool:
+    """Return ``True`` if trade log contains both audit and meta-learning rows."""
+    report = validate_trade_data_quality(trade_log_path)
+    return bool(report.get('audit_format_rows')) and bool(report.get('meta_format_rows'))
+
 def normalize_score(score: float, cap: float=1.2) -> float:
     """Clip ``score`` to ``cap`` preserving sign."""
     try:

--- a/tests/test_critical_trading_issues.py
+++ b/tests/test_critical_trading_issues.py
@@ -179,7 +179,7 @@ class TestMetaLearningLogFormat(unittest.TestCase):
             quality_report = meta_learning.validate_trade_data_quality(self.trade_log_path)
 
             # Should detect mixed format
-            self.assertTrue(quality_report.get('mixed_format_detected', False))
+            self.assertTrue(meta_learning.has_mixed_format(self.trade_log_path))
             self.assertGreater(quality_report.get('audit_format_rows', 0), 0)
             self.assertGreater(quality_report.get('meta_format_rows', 0), 0)
 

--- a/tests/test_performance_fixes.py
+++ b/tests/test_performance_fixes.py
@@ -16,14 +16,14 @@ from unittest.mock import Mock
 os.environ["TESTING"] = "1"
 os.environ["PYTEST_CURRENT_TEST"] = "test_performance_fixes"
 
+from ai_trading.meta_learning import (
+    retrain_meta_learner,
+    validate_trade_data_quality,
+    has_mixed_format,
+)
 
 def test_meta_learning_mixed_format():
     """Test that meta-learning can handle mixed audit/meta-learning log formats."""
-
-    from ai_trading.meta_learning import (
-        retrain_meta_learner,
-        validate_trade_data_quality,
-    )
 
     # Test with the actual trades.csv file
     quality_report = validate_trade_data_quality("trades.csv")
@@ -31,7 +31,7 @@ def test_meta_learning_mixed_format():
     # Verify mixed format detection
     assert quality_report["file_exists"], "Trade log file should exist"
     assert quality_report["has_valid_format"], "Should have valid format"
-    assert quality_report["mixed_format_detected"], "Should detect mixed formats"
+    assert has_mixed_format("trades.csv"), "Should detect mixed formats"
     assert quality_report["audit_format_rows"] > 0, "Should find audit format rows"
     assert quality_report["meta_format_rows"] > 0, "Should find meta-learning format rows"
     assert quality_report["valid_price_rows"] > 0, "Should find valid price rows"
@@ -40,7 +40,6 @@ def test_meta_learning_mixed_format():
     # Test that retrain_meta_learner works
     result = retrain_meta_learner("trades.csv", min_samples=10)
     assert result, "Meta-learning retraining should succeed"
-
 
 def test_position_size_reporting():
     """Test that position size reporting is consistent."""

--- a/tests/test_trigger_meta_learning_conversion.py
+++ b/tests/test_trigger_meta_learning_conversion.py
@@ -74,7 +74,7 @@ def test_trigger_meta_learning_conversion_pure_meta_format():
 
         # Verify quality report shows pure meta format
         quality_report = meta_learning.validate_trade_data_quality(test_file)
-        assert quality_report['mixed_format_detected'] is False
+        assert meta_learning.has_mixed_format(test_file) is False
         assert quality_report['audit_format_rows'] == 0
         assert quality_report['meta_format_rows'] > 0
 
@@ -114,7 +114,7 @@ def test_trigger_meta_learning_conversion_pure_audit_format():
 
         # Verify quality report shows pure audit format
         quality_report = meta_learning.validate_trade_data_quality(test_file)
-        assert quality_report['mixed_format_detected'] is False
+        assert meta_learning.has_mixed_format(test_file) is False
         assert quality_report['audit_format_rows'] > 0
         assert quality_report['meta_format_rows'] == 0
 
@@ -153,7 +153,7 @@ def test_trigger_meta_learning_conversion_mixed_format():
 
         # Verify quality report shows mixed format
         quality_report = meta_learning.validate_trade_data_quality(test_file)
-        assert quality_report['mixed_format_detected'] is True
+        assert meta_learning.has_mixed_format(test_file) is True
 
         # Test the trigger function - should attempt conversion and return True if successful
         result = meta_learning.trigger_meta_learning_conversion(test_trade)
@@ -187,7 +187,7 @@ def test_trigger_meta_learning_conversion_missing_file():
 def test_trigger_meta_learning_conversion_problem_statement_exact():
     """Test the exact scenario from the problem statement."""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:
-        # Create exactly the scenario: mixed_format_detected=False, audit_format_rows=0, meta_format_rows=4
+        # Create exactly the scenario: no mixed formats (audit_format_rows=0, meta_format_rows=4)
         f.write("symbol,entry_time,entry_price,exit_time,exit_price,qty,side,strategy,classification,signal_tags,confidence,reward\n")
         f.write("TEST,2025-08-05T23:17:35Z,100.0,2025-08-05T23:18:35Z,105.0,10,buy,test_strategy,test,signal1+signal2,0.8,5.0\n")
         f.write("AAPL,2025-08-05T23:19:35Z,150.0,2025-08-05T23:20:35Z,155.0,5,buy,test_strategy,test,signal3,0.7,25.0\n")
@@ -210,7 +210,7 @@ def test_trigger_meta_learning_conversion_problem_statement_exact():
 
         # Verify we have the exact scenario from problem statement
         quality_report = meta_learning.validate_trade_data_quality(test_file)
-        assert quality_report['mixed_format_detected'] is False
+        assert meta_learning.has_mixed_format(test_file) is False
         assert quality_report['audit_format_rows'] == 0
         assert quality_report['meta_format_rows'] > 0  # Should be 5 (4 data + 1 header)
 


### PR DESCRIPTION
## Summary
- add `has_mixed_format` helper to `meta_learning` for boolean mixed-format detection
- adjust tests to rely on new helper

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b34bacc7608330916209620b527e13