### PR TITLE
refactor: improve settings validators

### DIFF
--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -195,9 +195,9 @@ class Settings(BaseSettings):
 
     @field_validator('max_position_size')
     @classmethod
-    def _max_pos_positive(cls, v):
+    def _max_pos_positive(cls, v, info):
         if v is not None and float(v) <= 0.0:
-            raise ValueError('max_position_size must be positive')
+            raise ValueError(f"{info.field_name} must be positive")
         return v
 
     @field_validator('force_trades', mode='before')

--- a/tests/config/test_settings_validation.py
+++ b/tests/config/test_settings_validation.py
@@ -1,23 +1,33 @@
 from datetime import timedelta
 
 import pytest
+from pydantic import ValidationError
 
 from ai_trading.settings import Settings
 
 
 def test_risk_parameters_validated():
     """Risk ratios must be within (0, 1]."""
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="capital_cap must be in \(0, 1], got 1.5"
+    ):
         Settings(capital_cap=1.5)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="dollar_risk_limit must be in \(0, 1], got 0"
+    ):
         Settings(dollar_risk_limit=0)
 
 
 def test_max_position_size_positive():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="max_position_size must be positive"):
         Settings(MAX_POSITION_SIZE=-10)
     s = Settings(MAX_POSITION_SIZE=1000)
     assert s.max_position_size == 1000
+
+
+def test_missing_risk_parameter():
+    with pytest.raises(ValidationError, match="Input should be a valid number"):
+        Settings(capital_cap=None)
 
 
 def test_computed_fields(monkeypatch):


### PR DESCRIPTION
## Summary
- refine `Settings._max_pos_positive` to include field name in validation errors
- expand settings validation tests for invalid and missing values

## Testing
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 18 errors during collection)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/config/test_settings_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34ed0b4b0833085fb0d6e75d9cf13