### PR TITLE
Ensure dry-run submit_order returns order info

### DIFF
--- a/tests/test_engine_submit_order_return.py
+++ b/tests/test_engine_submit_order_return.py
@@ -1,0 +1,14 @@
+from ai_trading.execution.engine import OrderManager, Order
+from ai_trading.core.enums import OrderSide, OrderType
+
+
+def test_submit_order_returns_object_with_filled_qty():
+    om = OrderManager()
+    order = Order(symbol="AAPL", side=OrderSide.BUY, quantity=10, order_type=OrderType.MARKET)
+    result = om.submit_order(order)
+    assert result is not None, "submit_order should return an object"
+    assert result.id == order.id
+    assert result.symbol == "AAPL"
+    assert result.side == OrderSide.BUY.value
+    assert str(getattr(result, "filled_qty")) == "0"
+


### PR DESCRIPTION
## Summary
- return broker-like SimpleNamespace from `OrderManager.submit_order`
- add unit test verifying `filled_qty` and metadata in returned object

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_engine_submit_order_return.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*

------
https://chatgpt.com/codex/tasks/task_e_68b350934acc8330833b534e1cfaad49