### PR TITLE
Ensure TradingClient sets paper flag in position sizing

### DIFF
--- a/ai_trading/position_sizing.py
+++ b/ai_trading/position_sizing.py
@@ -130,7 +130,13 @@ def _get_equity_from_alpaca(cfg, *, force_refresh: bool = False) -> float:
     try:  # Prefer alpaca-py when available
         from alpaca.trading.client import TradingClient  # type: ignore
 
-        client = TradingClient(api_key=key, secret_key=secret, url_override=base)
+        is_paper = "paper" in base.lower()
+        client = TradingClient(
+            api_key=key,
+            secret_key=secret,
+            paper=is_paper,
+            url_override=base,
+        )
         acct = client.get_account()
         eq = _coerce_float(getattr(acct, "equity", None), 0.0)
         _CACHE.equity = eq

--- a/tests/test_position_sizing_equity.py
+++ b/tests/test_position_sizing_equity.py
@@ -5,6 +5,30 @@ import ai_trading.core.runtime as rt
 from ai_trading.logging import logger_once
 
 
+def test_get_equity_from_alpaca_sets_paper(monkeypatch):
+    ps._CACHE.value, ps._CACHE.ts, ps._CACHE.equity = (None, None, None)
+
+    calls: dict[str, bool] = {}
+
+    class Dummy:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+        def get_account(self):  # pragma: no cover - simple stub
+            return SimpleNamespace(equity=0.0)
+
+    monkeypatch.setattr("alpaca.trading.client.TradingClient", Dummy)
+
+    cfg = SimpleNamespace(
+        alpaca_api_key="k",
+        alpaca_secret_key_plain="s",
+        alpaca_base_url="https://paper-api.alpaca.markets",
+    )
+
+    ps._get_equity_from_alpaca(cfg, force_refresh=True)
+
+    assert calls.get("paper") is True
+
 def test_get_max_position_size_uses_cached_equity(monkeypatch, caplog):
     # Ensure cache is clear
     ps._CACHE.value, ps._CACHE.ts, ps._CACHE.equity = (None, None, None)


### PR DESCRIPTION
## Summary
- Ensure position sizing's TradingClient uses the paper flag based on the configured base URL
- Add unit test verifying `_get_equity_from_alpaca` passes `paper=True`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68b3541482688330a0f968edb8d28f47