### PR TITLE
Fix TypeError in MLTrainer annotations under Python 3.12

### DIFF
--- a/ai_trading/training/train_ml.py
+++ b/ai_trading/training/train_ml.py
@@ -5,6 +5,8 @@ deserialization. Consider safer formats like :mod:`joblib` or JSON for simpler
 objects.
 """
 
+from __future__ import annotations
+
 import json
 import pickle
 from datetime import UTC, datetime
@@ -104,7 +106,7 @@ class MLTrainer:
         optimize_hyperparams: bool = True,
         optimization_trials: int = 100,
         feature_pipeline: Any | None = None,
-        t1: "pd.Series" | None = None,
+        t1: pd.Series | None = None,
     ) -> dict[str, Any]:
         """
         Train model with optional hyperparameter optimization.


### PR DESCRIPTION
## Summary
- postpone annotation evaluation in `train_ml.py`
- annotate `t1` parameter with `pd.Series | None` to avoid runtime `TypeError`

## Testing
- `ruff check ai_trading/training/train_ml.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b35b51784c83309558c938959a386e