### PR TITLE
Add optional test dependencies and skip missing-package tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,5 +9,9 @@ pytest-cov>=5
 pytest-benchmark>=4.0
 hypothesis>=6.92
 coverage>=7.6
+beautifulsoup4>=4.12
+gymnasium>=0.29
+portalocker>=2.7
+joblib>=1.3
 requests>=2.31,<3
 alpaca-py==0.42.0

--- a/tests/test_retrain_smoke.py
+++ b/tests/test_retrain_smoke.py
@@ -4,6 +4,9 @@ import types
 from pathlib import Path
 
 import pytest
+
+sys.modules.pop("lightgbm", None)
+pytest.importorskip("lightgbm")
 from ai_trading.training.train_ml import LIGHTGBM_AVAILABLE
 
 pd = pytest.importorskip("pandas")

--- a/tests/test_sentiment_interface.py
+++ b/tests/test_sentiment_interface.py
@@ -1,6 +1,9 @@
 import os
+import sys
 import pytest
 
+sys.modules.pop("tenacity", None)
+pytest.importorskip("tenacity")
 os.environ.setdefault("PYTEST_RUNNING", "1")
 from ai_trading.analysis import sentiment
 


### PR DESCRIPTION
## Summary
- include beautifulsoup4, gymnasium, portalocker, and joblib in test requirements
- skip sentiment and retrain smoke tests when tenacity or lightgbm are absent

## Testing
- `ruff check tests/test_sentiment_interface.py tests/test_retrain_smoke.py`
- `make test-all` *(fails: Timeout in tests/test_critical_trading_issues.py::test_order_slicing_quantity_mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b35b595ef08330951af31c06181878