### PR TITLE
Allow positional wait_random fallback

### DIFF
--- a/ai_trading/utils/retry.py
+++ b/ai_trading/utils/retry.py
@@ -61,7 +61,7 @@ except (ImportError, TypeError):  # pragma: no cover - fallback path when tenaci
             return delay
         return _Wait(fn)
 
-    def wait_random(*, min: float = 0.0, max: float = 1.0) -> _Wait:
+    def wait_random(min: float = 0.0, max: float = 1.0) -> _Wait:
         def fn(_attempt: int) -> float:
             return random.uniform(min, max)
         return _Wait(fn)

--- a/tests/utils/test_wait_random.py
+++ b/tests/utils/test_wait_random.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+
+def test_wait_random_positional_without_tenacity(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "tenacity":
+            raise ImportError("tenacity not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "tenacity", raising=False)
+    monkeypatch.delitem(sys.modules, "ai_trading.utils.retry", raising=False)
+
+    retry_mod = importlib.import_module("ai_trading.utils.retry")
+    assert retry_mod.HAS_TENACITY is False
+
+    wait = retry_mod.wait_random(0, 5)
+    value = wait(1)
+    assert 0 <= value <= 5


### PR DESCRIPTION
## Summary
- Allow `wait_random` fallback to accept positional `min` and `max` arguments when Tenacity isn't installed
- Add regression test ensuring `wait_random(0, 5)` works without Tenacity

## Testing
- `ruff check ai_trading/utils/retry.py tests/utils/test_wait_random.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/utils/test_wait_random.py`


------
https://chatgpt.com/codex/tasks/task_e_68b35b5380c88330beb9cd461546bb6c