### PR TITLE
Guard optional execution imports and add import test

### DIFF
--- a/ai_trading/execution/__init__.py
+++ b/ai_trading/execution/__init__.py
@@ -1,33 +1,137 @@
-"""
-Execution Module - Institutional Grade Order Management with Enhanced Debugging
+"""Execution Module - Institutional Grade Order Management with Enhanced Debugging."""
 
-This module provides comprehensive order execution capabilities for
-institutional trading operations including:
+from __future__ import annotations
 
-- Advanced order lifecycle management and execution algorithms
-- Production-ready execution coordination with safety controls
-- Liquidity analysis and volume screening
-- Slippage monitoring and market impact analysis
-- Order routing optimization and execution quality tracking
-
-ENHANCED FEATURES:
-- Complete execution debugging and correlation tracking
-- Position reconciliation between bot and broker
-- Detailed PnL attribution and explanation system
-- Signal-to-execution pipeline visibility
-
-The module is designed for institutional-scale operations with proper
-execution controls, monitoring, and compliance capabilities.
-"""
-from .debug_tracker import ExecutionPhase, OrderStatus, enable_debug_mode, get_debug_tracker, get_execution_statistics, log_execution_phase, log_order_outcome, log_position_change, log_signal_to_execution
-from .engine import ExecutionAlgorithm, ExecutionEngine, Order
-from .liquidity import LiquidityAnalyzer, LiquidityLevel, LiquidityManager, MarketHours
-from .pnl_attributor import PnLEvent, PnLSource, explain_recent_pnl_changes, get_pnl_attribution_stats, get_pnl_attributor, get_portfolio_pnl_summary, get_symbol_pnl_breakdown, record_dividend_income, record_trade_pnl, update_position_for_pnl
-from .position_reconciler import PositionDiscrepancy, adjust_bot_position, force_position_reconciliation, get_position_discrepancies, get_position_reconciler, get_reconciliation_statistics, start_position_monitoring, stop_position_monitoring, update_bot_position
-from .transaction_costs import estimate_cost
+# Core exports that should always be available
 from .classes import ExecutionResult, OrderRequest
-try:
+from .engine import ExecutionAlgorithm, ExecutionEngine, Order
+
+# Optional submodule: algorithms
+try:  # pragma: no cover - optional dependency
+    from . import algorithms
+except Exception:  # noqa: BLE001 - broad to guard optional deps
+    algorithms = None
+
+# Optional utilities guarded against missing dependencies
+try:  # pragma: no cover - optional dependency
+    from .debug_tracker import (
+        ExecutionPhase,
+        OrderStatus,
+        enable_debug_mode,
+        get_debug_tracker,
+        get_execution_statistics,
+        log_execution_phase,
+        log_order_outcome,
+        log_position_change,
+        log_signal_to_execution,
+    )
+except Exception:  # noqa: BLE001 - broad to guard optional deps
+    ExecutionPhase = OrderStatus = None
+    enable_debug_mode = get_debug_tracker = None
+    get_execution_statistics = None
+    log_execution_phase = log_order_outcome = None
+    log_position_change = log_signal_to_execution = None
+
+try:  # pragma: no cover - optional dependency
+    from .liquidity import (
+        LiquidityAnalyzer,
+        LiquidityLevel,
+        LiquidityManager,
+        MarketHours,
+    )
+except Exception:  # noqa: BLE001 - broad to guard optional deps
+    LiquidityAnalyzer = LiquidityLevel = None
+    LiquidityManager = MarketHours = None
+
+try:  # pragma: no cover - optional dependency
+    from .pnl_attributor import (
+        PnLEvent,
+        PnLSource,
+        explain_recent_pnl_changes,
+        get_pnl_attribution_stats,
+        get_pnl_attributor,
+        get_portfolio_pnl_summary,
+        get_symbol_pnl_breakdown,
+        record_dividend_income,
+        record_trade_pnl,
+        update_position_for_pnl,
+    )
+except Exception:  # noqa: BLE001 - broad to guard optional deps
+    PnLEvent = PnLSource = None
+    explain_recent_pnl_changes = get_pnl_attribution_stats = None
+    get_pnl_attributor = get_portfolio_pnl_summary = None
+    get_symbol_pnl_breakdown = record_dividend_income = None
+    record_trade_pnl = update_position_for_pnl = None
+
+try:  # pragma: no cover - optional dependency
+    from .position_reconciler import (
+        PositionDiscrepancy,
+        adjust_bot_position,
+        force_position_reconciliation,
+        get_position_discrepancies,
+        get_position_reconciler,
+        get_reconciliation_statistics,
+        start_position_monitoring,
+        stop_position_monitoring,
+        update_bot_position,
+    )
+except Exception:  # noqa: BLE001 - broad to guard optional deps
+    PositionDiscrepancy = None
+    adjust_bot_position = force_position_reconciliation = None
+    get_position_discrepancies = get_position_reconciler = None
+    get_reconciliation_statistics = start_position_monitoring = None
+    stop_position_monitoring = update_bot_position = None
+
+try:  # pragma: no cover - optional dependency
+    from .transaction_costs import estimate_cost
+except Exception:  # noqa: BLE001 - broad to guard optional deps
+    estimate_cost = None
+
+try:  # pragma: no cover - optional dependency
     from .production_engine import ProductionExecutionCoordinator
-except (ImportError, AttributeError):
+except Exception:  # noqa: BLE001 - broad to guard optional deps
     ProductionExecutionCoordinator = None
-__all__ = ['Order', 'ExecutionAlgorithm', 'ExecutionEngine', 'ProductionExecutionCoordinator', 'ExecutionResult', 'OrderRequest', 'LiquidityAnalyzer', 'LiquidityManager', 'LiquidityLevel', 'MarketHours', 'get_debug_tracker', 'log_signal_to_execution', 'log_execution_phase', 'log_order_outcome', 'log_position_change', 'enable_debug_mode', 'get_execution_statistics', 'ExecutionPhase', 'OrderStatus', 'get_position_reconciler', 'update_bot_position', 'adjust_bot_position', 'force_position_reconciliation', 'start_position_monitoring', 'stop_position_monitoring', 'get_position_discrepancies', 'get_reconciliation_statistics', 'PositionDiscrepancy', 'get_pnl_attributor', 'update_position_for_pnl', 'record_trade_pnl', 'record_dividend_income', 'get_symbol_pnl_breakdown', 'get_portfolio_pnl_summary', 'explain_recent_pnl_changes', 'get_pnl_attribution_stats', 'PnLSource', 'PnLEvent', 'estimate_cost']
+
+__all__ = [
+    "Order",
+    "ExecutionAlgorithm",
+    "ExecutionEngine",
+    "ProductionExecutionCoordinator",
+    "ExecutionResult",
+    "OrderRequest",
+    "algorithms",
+    "LiquidityAnalyzer",
+    "LiquidityManager",
+    "LiquidityLevel",
+    "MarketHours",
+    "get_debug_tracker",
+    "log_signal_to_execution",
+    "log_execution_phase",
+    "log_order_outcome",
+    "log_position_change",
+    "enable_debug_mode",
+    "get_execution_statistics",
+    "ExecutionPhase",
+    "OrderStatus",
+    "get_position_reconciler",
+    "update_bot_position",
+    "adjust_bot_position",
+    "force_position_reconciliation",
+    "start_position_monitoring",
+    "stop_position_monitoring",
+    "get_position_discrepancies",
+    "get_reconciliation_statistics",
+    "PositionDiscrepancy",
+    "get_pnl_attributor",
+    "update_position_for_pnl",
+    "record_trade_pnl",
+    "record_dividend_income",
+    "get_symbol_pnl_breakdown",
+    "get_portfolio_pnl_summary",
+    "explain_recent_pnl_changes",
+    "get_pnl_attribution_stats",
+    "PnLSource",
+    "PnLEvent",
+    "estimate_cost",
+]
+

--- a/tests/execution/test_execution_imports.py
+++ b/tests/execution/test_execution_imports.py
@@ -1,0 +1,11 @@
+from importlib import import_module
+
+
+def test_execution_algorithms_and_result_importable():
+    """Ensure algorithms submodule and ExecutionResult can be imported."""
+    algos = import_module("ai_trading.execution.algorithms")
+    from ai_trading.execution import ExecutionResult
+
+    assert algos is not None
+    assert ExecutionResult is not None
+


### PR DESCRIPTION
## Summary
- Guard optional `ai_trading.execution` imports so missing extras no longer break module load
- Expose `algorithms`, `ExecutionResult`, and related utilities via `__all__`
- Add regression test ensuring `ExecutionResult` and `execution.algorithms` import cleanly

## Testing
- `ruff check ai_trading/execution/__init__.py tests/execution/test_execution_imports.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_execution_imports.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b35b5cc7388330a41e9aa606cb7f2d