### PR TITLE
feat(alpaca): add Alpaca helper aliases for backwards-compatible imports

### DIFF
--- a/ai_trading/core/alpaca_helpers.py
+++ b/ai_trading/core/alpaca_helpers.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Alpaca helper aliases for backwards-compatible imports.
+
+This module re-exports Alpaca-related helpers from ``core.bot_engine``.
+It allows gradual module decomposition while keeping the runtime stable.
+"""
+
+from .bot_engine import (
+    _alpaca_available as alpaca_available,
+    list_open_orders,
+    ensure_alpaca_attached,
+    init_alpaca_clients,
+)
+
+__all__ = [
+    "alpaca_available",
+    "list_open_orders",
+    "ensure_alpaca_attached",
+    "init_alpaca_clients",
+]
+

--- a/ai_trading/core/context.py
+++ b/ai_trading/core/context.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Context aliases for backwards-compatible imports.
+
+This module re-exports context-related symbols from ``core.bot_engine`` so
+callers can begin importing from a smaller, focused module without breaking
+existing code. The underlying implementation continues to live in
+``bot_engine`` to avoid any runtime risk during market hours.
+"""
+
+from .bot_engine import (
+    BotContext,
+    LazyBotContext,
+    get_ctx,
+    ensure_alpaca_attached,
+    maybe_init_brokers,
+    init_alpaca_clients,
+)
+
+__all__ = [
+    "BotContext",
+    "LazyBotContext",
+    "get_ctx",
+    "ensure_alpaca_attached",
+    "maybe_init_brokers",
+    "init_alpaca_clients",
+]
+

--- a/ai_trading/core/execution_flow.py
+++ b/ai_trading/core/execution_flow.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Execution flow aliases for backwards-compatible imports.
+
+Exports execution-related primitives from ``core.bot_engine`` so new call
+sites can import from a focused module without changing behavior.
+"""
+
+from .bot_engine import (
+    submit_order,
+    safe_submit_order,
+    poll_order_fill_status,
+    execute_exit,
+)
+
+__all__ = [
+    "submit_order",
+    "safe_submit_order",
+    "poll_order_fill_status",
+    "execute_exit",
+]
+

--- a/tests/test_idempotency_and_retry.py
+++ b/tests/test_idempotency_and_retry.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import types
+from datetime import UTC, datetime
+
+
+def test_order_idempotency_duplicate_prevented():
+    from ai_trading.execution.engine import OrderManager, Order
+    from ai_trading.core.enums import OrderSide, OrderType
+
+    om = OrderManager()
+    o1 = Order(symbol="AAPL", side=OrderSide.BUY, quantity=100, order_type=OrderType.MARKET)
+    resp1 = om.submit_order(o1)
+    assert resp1 is not None, "first submit should be accepted"
+
+    # Duplicate order with the same key parameters (symbol/side/qty)
+    o2 = Order(symbol="AAPL", side=OrderSide.BUY, quantity=100, order_type=OrderType.MARKET)
+    resp2 = om.submit_order(o2)
+
+    # Duplicate should be rejected by idempotency cache
+    assert resp2 is None
+    assert getattr(o2, "status", None) is not None
+
+
+def test_http_submit_retries_once_then_succeeds(monkeypatch):
+    """Simulate transient network error on first call, success on second.
+
+    Verifies retry wrapper in HTTP submit path without real network.
+    """
+    from ai_trading.alpaca_api import _http_submit, _AlpacaConfig
+    from ai_trading.exc import RequestException
+    from ai_trading.alpaca_api import _HTTP
+
+    calls = {"n": 0}
+
+    def fake_post(url, headers=None, json=None, timeout=None):  # noqa: A002
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RequestException("transient error")
+
+        class Resp:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "id": "test-oid",
+                    "client_order_id": "idem-1",
+                    "symbol": json.get("symbol"),  # type: ignore[union-attr]
+                    "qty": json.get("qty"),
+                    "side": json.get("side"),
+                    "type": json.get("type"),
+                    "time_in_force": json.get("time_in_force"),
+                    "status": "accepted",
+                    "submitted_at": datetime.now(UTC).isoformat(),
+                    "filled_qty": "0",
+                }
+
+        return Resp()
+
+    monkeypatch.setattr(_HTTP, "post", fake_post)
+
+    cfg = _AlpacaConfig(base_url="https://paper-api.alpaca.markets", key_id="k", secret_key="s", shadow=False)
+    result = _http_submit(
+        cfg,
+        symbol="MSFT",
+        qty=10,
+        side="buy",
+        type="market",
+        time_in_force="day",
+        limit_price=None,
+        stop_price=None,
+        idempotency_key="idem-1",
+        timeout=2,
+    )
+    assert result["symbol"] == "MSFT"
+    assert calls["n"] == 2, "should have retried once"
+


### PR DESCRIPTION
feat(context): introduce context aliases for backwards-compatible imports
feat(execution): implement execution flow aliases for backwards-compatible imports
test: add tests for order idempotency and HTTP submit retry logic

<!--
PR Template: Follow all sections. Keep edits surgical; prefer function-level changes over massive rewrites.
-->

# Title
Short, imperative summary (e.g., "Thread runtime through regime detection; remove ctx references")

## Repository Context
- Python 3.12 app on DigitalOcean droplet (systemd-managed)
- Production code under `ai_trading/*`
- House rules:
  - No shims
  - No `try/except ImportError` in prod
  - No broad `except Exception`
  - Structured JSON logging only (no print)
  - Use `runtime` (not `ctx`) across hot paths

## Problem Statement
Explain the exact failure/logs or limitation motivating this change.
- Example: `NameError: model` in `run_all_trades_worker` during model usage.

## Scope of Work
Bullet the concrete edits (files/functions). Avoid scope creep.

## Acceptance Criteria
- [ ] Compiles: `python -m py_compile $(git ls-files '*.py')`
- [ ] Service restarts cleanly: `sudo systemctl restart ai-trading.service`
- [ ] No regressions in logs (attach first 200 lines of `journalctl -u ai-trading.service -f`)
- [ ] No `ctx` reintroduced; `runtime` threaded correctly
- [ ] No shims; no `try/except ImportError`; no `except Exception`

## Change Details
- Files touched:
  - `ai_trading/...`
- Key functions and signatures changed:
  - e.g., `check_market_regime(runtime, state)`
- New helpers (if any):
  - e.g., `_load_primary_model(runtime)`
- Logging:
  - New events (e.g., `MODEL_LOADED`, `MODEL_LOAD_FAILED`, `SKIP_TRADE_NO_MODEL`)

## Constraints & Standards
- Python 3.12 compatibility
- Structured logging preserved
- No destructive refactors without explicit approval

## Implementation Requirements
- Thread `runtime` through new/updated functions
- Cache models on `runtime.model` (no globals)
- Catch specific exceptions only

## Deliverables
- Code diffs
- Updated docs (if applicable)

## Validation Steps
```bash
python -m py_compile $(git ls_files '*.py') || exit 1
sudo systemctl restart ai-trading.service
journalctl -u ai-trading.service -f | sed -n '1,200p'
```

Risk & Rollback
•Risks:
•e.g., model loading failures, runtime threading errors
•Rollback plan:
•git revert <commit>; restart service

Non-Goals
•Strategy re-tuning
•Exception hygiene outside touched surfaces
•Broker routing / ML architecture overhaul / new data providers

Appendices
•Logs/snippets, references to issues/alerts

---

