### PR TITLE
Validate positive close prices in emergency data check

### DIFF
--- a/CRITICAL_FIXES_IMPLEMENTATION_SUMMARY.md
+++ b/CRITICAL_FIXES_IMPLEMENTATION_SUMMARY.md
@@ -41,7 +41,7 @@ def alpaca_client(self):
 **Solution**: Created comprehensive `ai_trading.data_validation` module:
 - `check_data_freshness()` - Validates data age (default: 15 minutes max)
 - `validate_trading_data()` - Batch validation for multiple symbols
-- `emergency_data_check()` - Fast validation for critical trades
+- `emergency_data_check()` - Fast validation ensuring bars exist and all closes are positive
 - `should_halt_trading()` - Automatic trading halt on data quality issues
 
 **File**: `ai_trading.data_validation` (complete new module)

--- a/ai_trading/data_validation.py
+++ b/ai_trading/data_validation.py
@@ -79,7 +79,11 @@ def emergency_data_check(symbols_or_df: Sequence[str] | str | pd.DataFrame, symb
     Back-compat: ``emergency_data_check(df, "AAPL")`` returns ``not df.empty``.
     """
     if isinstance(symbols_or_df, pd.DataFrame) and isinstance(symbol, str):
-        return not symbols_or_df.empty
+        return (
+            not symbols_or_df.empty
+            and 'close' in symbols_or_df.columns
+            and (symbols_or_df['close'] > 0).all()
+        )
     if isinstance(symbols_or_df, str | bytes):
         to_check = [symbols_or_df]
     elif isinstance(symbols_or_df, Sequence):
@@ -95,7 +99,12 @@ def emergency_data_check(symbols_or_df: Sequence[str] | str | pd.DataFrame, symb
     for sym in to_check:
         try:
             df = fetch(sym, '1Min', start, end)
-            if df is not None and (not df.empty):
+            if (
+                df is not None
+                and not df.empty
+                and 'close' in df.columns
+                and (df['close'] > 0).all()
+            ):
                 return True
         except (ValueError, TypeError):
             continue

--- a/tests/test_critical_trading_fixes.py
+++ b/tests/test_critical_trading_fixes.py
@@ -693,10 +693,13 @@ def test_emergency_data_validation():
     from ai_trading.data_validation import emergency_data_check
 
     # Test with valid data
-    valid_data = pd.DataFrame({
-        'Close': [150.0, 151.0, 152.0],
-        'Volume': [1000, 1100, 1200]
-    }, index=pd.date_range('2024-01-01 09:30:00', periods=3, freq='1min', tz='UTC'))
+    valid_data = pd.DataFrame(
+        {
+            'close': [150.0, 151.0, 152.0],
+            'volume': [1000, 1100, 1200],
+        },
+        index=pd.date_range('2024-01-01 09:30:00', periods=3, freq='1min', tz='UTC'),
+    )
 
     # Should pass emergency validation
     assert emergency_data_check(valid_data, "AAPL") is True
@@ -706,10 +709,13 @@ def test_emergency_data_validation():
     assert emergency_data_check(empty_data, "AAPL") is False
 
     # Test with invalid price data
-    invalid_data = pd.DataFrame({
-        'Close': [150.0, 151.0, -10.0],  # Invalid negative price
-        'Volume': [1000, 1100, 1200]
-    }, index=pd.date_range('2024-01-01 09:30:00', periods=3, freq='1min', tz='UTC'))
+    invalid_data = pd.DataFrame(
+        {
+            'close': [150.0, 151.0, -10.0],  # Invalid negative price
+            'volume': [1000, 1100, 1200],
+        },
+        index=pd.date_range('2024-01-01 09:30:00', periods=3, freq='1min', tz='UTC'),
+    )
 
     assert emergency_data_check(invalid_data, "AAPL") is False
 


### PR DESCRIPTION
## Summary
- ensure `emergency_data_check` returns true only when bars exist and all closes are positive
- document emergency data check requirements
- update tests for positive close validation

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

------
https://chatgpt.com/codex/tasks/task_e_68b654fcc7888330932309fe3b6a5f34