### PR TITLE
Use datetime timezone for UTC in timeutils

### DIFF
--- a/ai_trading/data/timeutils.py
+++ b/ai_trading/data/timeutils.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
-from datetime import date, datetime, time, timedelta
+import datetime
+from datetime import date, time, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
-NY = ZoneInfo('America/New_York')
-UTC = ZoneInfo('UTC')
 
-def ensure_utc_datetime(value: Any, *, default: datetime | None=None, clamp_to: str | None=None, allow_callables: bool=False) -> datetime:
+NY = ZoneInfo('America/New_York')
+UTC = datetime.timezone.utc
+
+def ensure_utc_datetime(
+    value: Any,
+    *,
+    default: datetime.datetime | None = None,
+    clamp_to: str | None = None,
+    allow_callables: bool = False,
+) -> datetime.datetime:
     """Normalize a variety of inputs to a timezone-aware UTC datetime.
 
     - If ``value`` is callable and ``allow_callables`` is ``True``, call it (no args) and
@@ -22,12 +30,12 @@ def ensure_utc_datetime(value: Any, *, default: datetime | None=None, clamp_to: 
         else:
             raise TypeError('datetime argument was callable')
     try:
-        if isinstance(value, datetime):
+        if isinstance(value, datetime.datetime):
             dt = value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
         elif isinstance(value, date):
-            dt = datetime(value.year, value.month, value.day, tzinfo=UTC)
+            dt = datetime.datetime(value.year, value.month, value.day, tzinfo=UTC)
         elif isinstance(value, str):
-            tmp = datetime.fromisoformat(str(value).replace('Z', '+00:00'))
+            tmp = datetime.datetime.fromisoformat(str(value).replace('Z', '+00:00'))
             dt = tmp.astimezone(UTC) if tmp.tzinfo else tmp.replace(tzinfo=UTC)
         else:
             raise TypeError(f'Unsupported datetime type: {type(value).__name__}')
@@ -43,8 +51,8 @@ def ensure_utc_datetime(value: Any, *, default: datetime | None=None, clamp_to: 
 
 def nyse_session_utc(for_day: date):
     """Return (start_utc, end_utc) for regular 09:30–16:00 NY session converted to UTC."""
-    start_ny = datetime.combine(for_day, time(9, 30), tzinfo=NY)
-    end_ny = datetime.combine(for_day, time(16, 0), tzinfo=NY)
+    start_ny = datetime.datetime.combine(for_day, time(9, 30), tzinfo=NY)
+    end_ny = datetime.datetime.combine(for_day, time(16, 0), tzinfo=NY)
     return (start_ny.astimezone(UTC), end_ny.astimezone(UTC))
 
 def previous_business_day(d: date) -> date:

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -1,5 +1,4 @@
-from datetime import date
-from zoneinfo import ZoneInfo
+from datetime import UTC, date
 
 from ai_trading.data.timeutils import nyse_session_utc
 
@@ -7,8 +6,8 @@ from ai_trading.data.timeutils import nyse_session_utc
 def test_nyse_session_dst():
     # July 15, 2024 (DST)
     s, e = nyse_session_utc(date(2024, 7, 15))
-    assert s.hour == 13 and s.tzinfo == ZoneInfo("UTC")
-    assert e.hour == 20 and e.tzinfo == ZoneInfo("UTC")
+    assert s.hour == 13 and s.tzinfo == UTC
+    assert e.hour == 20 and e.tzinfo == UTC
 
 
 def test_nyse_session_standard():


### PR DESCRIPTION
## Summary
- replace `ZoneInfo('UTC')` with `datetime.timezone.utc` in `timeutils`
- update NYSE session and normalization utilities to use `datetime.timezone.utc`
- align timeutils tests with the new UTC constant

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*
- `RUN_HEALTHCHECK=1 python -m ai_trading.app` *(fails: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b654fdaf7c8330bdeb2dc4098acb3e