### PR TITLE
Avoid duplicate Prometheus metrics on repeated imports

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -15,7 +15,7 @@ import importlib.util
 from ai_trading.logging import get_logger
 from ai_trading.config.management import is_shadow_mode
 from ai_trading.logging.normalize import canon_symbol as _canon_symbol
-from ai_trading.metrics import Counter, Histogram
+from ai_trading.metrics import get_counter, get_histogram
 from time import monotonic as _mono
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -28,9 +28,9 @@ _UTC = timezone.utc  # AI-AGENT-REF: prefer stdlib UTC
 _HTTP: HTTPSession = get_http_session()
 
 # Lightweight Prometheus metrics (no-op when client unavailable)
-_alpaca_calls_total = Counter("alpaca_calls_total", "Total Alpaca calls")
-_alpaca_errors_total = Counter("alpaca_errors_total", "Total Alpaca call errors")
-_alpaca_call_latency = Histogram(
+_alpaca_calls_total = get_counter("alpaca_calls_total", "Total Alpaca calls")
+_alpaca_errors_total = get_counter("alpaca_errors_total", "Total Alpaca call errors")
+_alpaca_call_latency = get_histogram(
     "alpaca_call_latency_seconds",
     "Latency of Alpaca calls",
 )

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1893,9 +1893,9 @@ except ImportError:  # pragma: no cover - fallback  # AI-AGENT-REF: optional pyb
 from ai_trading.metrics import (
     PROMETHEUS_AVAILABLE,
     REGISTRY,
-    Counter,
-    Gauge,
-    Histogram,
+    get_counter,
+    get_gauge,
+    get_histogram,
     Summary,
     start_http_server,
 )
@@ -1907,63 +1907,41 @@ _METRICS_READY = False
 def _init_metrics() -> None:
     """Create/register metrics once; tolerate partial imports & re-imports."""
     global _METRICS_READY, orders_total, order_failures, daily_drawdown, signals_evaluated
-    global run_all_trades_duration, minute_cache_hit, minute_cache_miss, daily_cache_hit
-    global daily_cache_miss, event_cooldown_hits, slippage_total, slippage_count
-    global weekly_drawdown, skipped_duplicates, skipped_cooldown
+    global run_all_trades_duration, minute_cache_hit, minute_cache_miss, daily_cache_hit, daily_cache_miss
+    global event_cooldown_hits, slippage_total, slippage_count, weekly_drawdown, skipped_duplicates, skipped_cooldown
     if _METRICS_READY:
         return
-    try:
-        orders_total = Counter("bot_orders_total", "Total orders sent")
-        order_failures = Counter("bot_order_failures", "Order submission failures")
-        daily_drawdown = Gauge("bot_daily_drawdown", "Current daily drawdown fraction")
-        signals_evaluated = Counter(
-            "bot_signals_evaluated_total", "Total signals evaluated"
-        )
-        run_all_trades_duration = Histogram(
-            "run_all_trades_duration_seconds", "Time spent in run_all_trades"
-        )
-        minute_cache_hit = Counter("bot_minute_cache_hits", "Minute bar cache hits")
-        minute_cache_miss = Counter(
-            "bot_minute_cache_misses", "Minute bar cache misses"
-        )
-        daily_cache_hit = Counter("bot_daily_cache_hits", "Daily bar cache hits")
-        daily_cache_miss = Counter("bot_daily_cache_misses", "Daily bar cache misses")
-        event_cooldown_hits = Counter("bot_event_cooldown_hits", "Event cooldown hits")
-        slippage_total = Counter("bot_slippage_total", "Cumulative slippage in cents")
-        slippage_count = Counter(
-            "bot_slippage_count", "Number of orders with slippage logged"
-        )
-        weekly_drawdown = Gauge(
-            "bot_weekly_drawdown", "Current weekly drawdown fraction"
-        )
-        skipped_duplicates = Counter(
-            "bot_skipped_duplicates",
-            "Trades skipped due to open position",
-        )
-        skipped_cooldown = Counter(
-            "bot_skipped_cooldown",
-            "Trades skipped due to recent execution",
-        )
-    except ValueError:
-        # Already registered (e.g., prior partial import). Reuse existing.
-        # Accessing REGISTRY internals is stable in prometheus-client; safe fallback.
-        if REGISTRY is not None:
-            existing = getattr(REGISTRY, "_names_to_collectors", {})
-            orders_total = existing.get("bot_orders_total")
-            order_failures = existing.get("bot_order_failures")
-            daily_drawdown = existing.get("bot_daily_drawdown")
-            signals_evaluated = existing.get("bot_signals_evaluated_total")
-            run_all_trades_duration = existing.get("run_all_trades_duration_seconds")
-            minute_cache_hit = existing.get("bot_minute_cache_hits")
-            minute_cache_miss = existing.get("bot_minute_cache_misses")
-            daily_cache_hit = existing.get("bot_daily_cache_hits")
-            daily_cache_miss = existing.get("bot_daily_cache_misses")
-            event_cooldown_hits = existing.get("bot_event_cooldown_hits")
-            slippage_total = existing.get("bot_slippage_total")
-            slippage_count = existing.get("bot_slippage_count")
-            weekly_drawdown = existing.get("bot_weekly_drawdown")
-            skipped_duplicates = existing.get("bot_skipped_duplicates")
-            skipped_cooldown = existing.get("bot_skipped_cooldown")
+    orders_total = get_counter("bot_orders_total", "Total orders sent")
+    order_failures = get_counter("bot_order_failures", "Order submission failures")
+    daily_drawdown = get_gauge("bot_daily_drawdown", "Current daily drawdown fraction")
+    signals_evaluated = get_counter(
+        "bot_signals_evaluated_total", "Total signals evaluated"
+    )
+    run_all_trades_duration = get_histogram(
+        "run_all_trades_duration_seconds", "Time spent in run_all_trades"
+    )
+    minute_cache_hit = get_counter("bot_minute_cache_hits", "Minute bar cache hits")
+    minute_cache_miss = get_counter(
+        "bot_minute_cache_misses", "Minute bar cache misses"
+    )
+    daily_cache_hit = get_counter("bot_daily_cache_hits", "Daily bar cache hits")
+    daily_cache_miss = get_counter("bot_daily_cache_misses", "Daily bar cache misses")
+    event_cooldown_hits = get_counter("bot_event_cooldown_hits", "Event cooldown hits")
+    slippage_total = get_counter("bot_slippage_total", "Cumulative slippage in cents")
+    slippage_count = get_counter(
+        "bot_slippage_count", "Number of orders with slippage logged"
+    )
+    weekly_drawdown = get_gauge(
+        "bot_weekly_drawdown", "Current weekly drawdown fraction"
+    )
+    skipped_duplicates = get_counter(
+        "bot_skipped_duplicates",
+        "Trades skipped due to open position",
+    )
+    skipped_cooldown = get_counter(
+        "bot_skipped_cooldown",
+        "Trades skipped due to recent execution",
+    )
     _METRICS_READY = True
 
 

--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -17,15 +17,15 @@ from typing import Any
 from types import SimpleNamespace
 from alpaca.common.exceptions import APIError
 from ai_trading.logging.emit_once import emit_once
-from ai_trading.metrics import Counter
+from ai_trading.metrics import get_counter
 
 logger = get_logger(__name__)
 ORDER_STALE_AFTER_S = 8 * 60
 
 # Lightweight Prometheus counters (no-op if client unavailable)
-_orders_submitted_total = Counter("orders_submitted_total", "Orders submitted")
-_orders_rejected_total = Counter("orders_rejected_total", "Orders rejected")
-_orders_duplicate_total = Counter("orders_duplicate_total", "Duplicate orders prevented")
+_orders_submitted_total = get_counter("orders_submitted_total", "Orders submitted")
+_orders_rejected_total = get_counter("orders_rejected_total", "Orders rejected")
+_orders_duplicate_total = get_counter("orders_duplicate_total", "Duplicate orders prevented")
 
 from ai_trading.monitoring.order_health_monitor import (
     OrderInfo,

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -46,7 +46,7 @@ from ai_trading.utils.http import clamp_request_timeout
 from ai_trading.utils.base import is_market_open as _is_market_open_base
 from ai_trading.position_sizing import resolve_max_position_size, _get_equity_from_alpaca, _CACHE
 from ai_trading.config.management import get_env, validate_required_env, reload_env
-from ai_trading.metrics import Histogram, Counter
+from ai_trading.metrics import get_histogram, get_counter
 from time import monotonic as _mono
 
 
@@ -476,8 +476,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     # Metrics for cycle timing and budget overruns (labels are no-op when metrics unavailable)
     # Labeled stage timings: fetch/compute/execute
-    _cycle_stage_seconds = Histogram("cycle_stage_seconds", "Cycle stage duration seconds", ["stage"])  # type: ignore[arg-type]
-    _cycle_budget_over_total = Counter("cycle_budget_over_total", "Budget-over events", ["stage"])  # type: ignore[arg-type]
+    _cycle_stage_seconds = get_histogram("cycle_stage_seconds", "Cycle stage duration seconds", ["stage"])  # type: ignore[arg-type]
+    _cycle_budget_over_total = get_counter("cycle_budget_over_total", "Budget-over events", ["stage"])  # type: ignore[arg-type]
 
     try:
         _validate_runtime_config(config, S)

--- a/tests/test_metrics_registry.py
+++ b/tests/test_metrics_registry.py
@@ -1,0 +1,13 @@
+import importlib
+
+from ai_trading import metrics
+
+
+def test_metrics_reimport_does_not_duplicate():
+    metrics.reset_registry()
+    mod = importlib.import_module("ai_trading.execution.engine")
+    first = getattr(metrics.REGISTRY, "_names_to_collectors", {}).get("orders_submitted_total")
+    assert first is not None
+    mod = importlib.reload(mod)
+    second = getattr(metrics.REGISTRY, "_names_to_collectors", {}).get("orders_submitted_total")
+    assert second is first


### PR DESCRIPTION
## Summary
- add helper functions to reuse Prometheus collectors and reset registries for tests
- initialize counters and histograms through new helpers across modules
- verify metrics don't duplicate on repeated imports

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_metrics_registry.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68b65776d08c8330a9932e51fe9d5a9b