### PR TITLE
Use info level for legacy order mapping

### DIFF
--- a/ai_trading/core/alpaca_client.py
+++ b/ai_trading/core/alpaca_client.py
@@ -40,7 +40,7 @@ def _validate_trading_api(api: Any) -> bool:
                 return api.get_orders(*args, **kwargs)  # type: ignore[attr-defined]
 
             setattr(api, "list_orders", _list_orders_wrapper)  # type: ignore[attr-defined]
-            logger_once.warning("API_GET_ORDERS_MAPPED", key="alpaca_get_orders_mapped")
+            logger_once.info("API_GET_ORDERS_MAPPED", key="alpaca_get_orders_mapped")
         else:
             logger_once.error("ALPACA_LIST_ORDERS_MISSING", key="alpaca_list_orders_missing")
             if not is_shadow_mode():

--- a/tests/unit/test_run_all_trades_warning.py
+++ b/tests/unit/test_run_all_trades_warning.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import types
 import sys
-from unittest.mock import Mock, call
+from unittest.mock import Mock
 
 sklearn_stub = types.ModuleType("sklearn")
 ensemble_stub = types.ModuleType("sklearn.ensemble")
@@ -99,16 +99,14 @@ def test_run_all_trades_no_warning_with_valid_api(monkeypatch):
     monkeypatch.setattr(eng, "run_lock", DummyLock())
 
     warn_mock = Mock()
+    info_mock = Mock()
     monkeypatch.setattr(eng.logger_once, "warning", warn_mock)
+    monkeypatch.setattr(eng.logger_once, "info", info_mock)
 
     eng.run_all_trades_worker(state, runtime)
 
-    warn_mock.assert_has_calls(
-        [
-            call("API_GET_ORDERS_MAPPED", key="alpaca_get_orders_mapped"),
-            call("ALPACA_API_ADAPTER", key="alpaca_api_adapter"),
-        ]
-    )
+    info_mock.assert_called_once_with("API_GET_ORDERS_MAPPED", key="alpaca_get_orders_mapped")
+    warn_mock.assert_called_once_with("ALPACA_API_ADAPTER", key="alpaca_api_adapter")
     assert api.called_with is not None
     assert "filter" in api.called_with
     assert api.called_with["filter"].statuses == [OrderStatus.OPEN]


### PR DESCRIPTION
## Summary
- use info instead of warning when mapping `get_orders` to `list_orders`
- adjust tests to expect info-level message

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b70f0e97a08330a16a90ea0a179f23