### PR TITLE
Handle missing positions API in bot engine

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -7051,7 +7051,7 @@ def check_halt_flag(runtime) -> bool:
 def too_many_positions(ctx: BotContext, symbol: str | None = None) -> bool:
     """Check if there are too many positions, with allowance for rebalancing."""
     try:
-        current_positions = ctx.api.list_positions()
+        current_positions = ctx.api.get_all_positions()
         position_count = len(current_positions)
 
         # If we're not at the limit, allow new positions
@@ -7076,6 +7076,9 @@ def too_many_positions(ctx: BotContext, symbol: str | None = None) -> bool:
 
         return position_count >= get_max_portfolio_positions()
 
+    except AttributeError as e:
+        logger.warning(f"[too_many_positions] Positions API unavailable: {e}")
+        return False
     except (
         FileNotFoundError,
         PermissionError,
@@ -7085,6 +7088,7 @@ def too_many_positions(ctx: BotContext, symbol: str | None = None) -> bool:
         KeyError,
         TypeError,
         OSError,
+        APIError,
     ) as e:  # AI-AGENT-REF: narrow exception
         logger.warning(f"[too_many_positions] Could not fetch positions: {e}")
         return False

--- a/tests/test_too_many_positions_api_unavailable.py
+++ b/tests/test_too_many_positions_api_unavailable.py
@@ -1,0 +1,11 @@
+import logging
+from types import SimpleNamespace
+from ai_trading.core import bot_engine
+
+
+def test_too_many_positions_api_unavailable(caplog):
+    ctx = SimpleNamespace(api=SimpleNamespace())
+    with caplog.at_level(logging.WARNING):
+        assert bot_engine.too_many_positions(ctx) is False
+    assert "Positions API unavailable" in caplog.text
+


### PR DESCRIPTION
## Summary
- replace deprecated `list_positions` with Alpaca `get_all_positions`
- log a clear warning when the positions API is unavailable
- add regression test for missing positions API

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_too_many_positions_api_unavailable.py -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b712ac86248330afb54856268fe905