### PR TITLE
Skip symbols after repeated empty bars

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -50,8 +50,9 @@ Daily price requests now log their parameters and outcome:
 - Unauthorized feed responses trigger a quick entitlement check and switch to a
   permitted feed when available. If no alternative exists, operators are
   notified once.
-- Empty bar responses are retried with a short backoff and warnings are
-  throttled to once per minute to reduce log noise.
+- Empty bar responses are retried with a short backoff. Symbols that
+  repeatedly return empty bars are skipped and summarized once to reduce
+  log noise.
 
 ### Example Usage
 


### PR DESCRIPTION
## Summary
- Track consecutive empty-bar responses and skip symbols after three failures
- Emit a single warning summarizing skipped symbols instead of per-fetch spam
- Document empty-bar skip behavior in logging guide

## Testing
- `ruff check ai_trading/data/fetch.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_and_screen.py::test_minute_df_missing -q` *(fails: ModuleNotFoundError: No module named 'alpaca'); skipped alpaca-py required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7151a41d883309784e7e301dd72e8