### PR TITLE
Ensure trade log file initializes with headers

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -4865,6 +4865,13 @@ def _read_trade_log(
     Emits a warning when the log file is missing or empty with guidance on
     initializing the trade log via :func:`get_trade_logger`.
     """
+    # Ensure the trade log exists with headers before attempting to read. The
+    # :func:`get_trade_logger` helper will create the file and write the header
+    # row on first use. Calling it here prevents downstream consumers from
+    # failing when the trade log is missing or empty during startup or in fresh
+    # deployments.
+    get_trade_logger()
+
     if not os.path.exists(path) or os.path.getsize(path) == 0:
         logger.warning(
             "TRADE_LOG_MISSING_OR_EMPTY | path=%s | hint=call get_trade_logger() to initialize",

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -18,6 +18,7 @@ Set `RUN_HEALTHCHECK=1` in the environment to enable the Flask endpoints.
 
 ### Paths & default files
 - Trade log file defaults to `<repo>/logs/trades.jsonl` when `TRADE_LOG_PATH` is not set. The directory is auto-created.
+- New deployments should call `ai_trading.core.bot_engine.get_trade_logger()` once during startup to create the file and write CSV headers before any trades are recorded.
 - Empty model path disables ML quietly. Set `MODEL_PATH` to enable.
 - Override cache location with `AI_TRADING_CACHE_DIR` when the default `~/.cache/ai-trading-bot`
   path is not writable (for example, on read-only home directories). The application

--- a/tests/bot_engine/test_trade_log_init.py
+++ b/tests/bot_engine/test_trade_log_init.py
@@ -19,3 +19,19 @@ def test_parse_local_positions_creates_trade_log(tmp_path, monkeypatch):
     assert log_path.exists()
     assert log_path.stat().st_size > 0
 
+
+def test_trade_logger_records_entry(tmp_path, monkeypatch):
+    """Trade logger writes header then appends entries on first use."""
+
+    log_path = tmp_path / "trades.jsonl"
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+
+    logger = bot_engine.get_trade_logger()
+    logger.log_entry("AAPL", 100.0, 1, "buy", "test")
+
+    lines = log_path.read_text().splitlines()
+    assert lines[0].startswith("symbol,entry_time")
+    assert len(lines) == 2
+    assert "AAPL" in lines[1]
+


### PR DESCRIPTION
## Summary
- ensure trade log file is created with CSV headers before reads
- document trade log initialization for new deployments
- test trade log initialization and entry recording

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/bot_engine/test_trade_log_init.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_trade_log_init.py::test_parse_local_positions_creates_trade_log tests/bot_engine/test_trade_log_init.py::test_trade_logger_records_entry -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7436eae7083308b4117c6cf30f356