### PR TITLE
feat: make atr optional

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1166,9 +1166,9 @@ if not os.getenv("PYTEST_RUNNING"):
         compute_macd,
         compute_macds,
         compute_vwap,
+        compute_atr,
         ensure_columns,
     )
-    from ai_trading.indicators import compute_atr
 else:
     # AI-AGENT-REF: mock feature functions for test environments to avoid slow imports
     def compute_macd(*args, **kwargs):
@@ -8745,7 +8745,7 @@ def _fetch_feature_data(
 
     df = compute_macds(df)
     logger.debug(f"{symbol} dataframe columns after indicators: {df.columns.tolist()}")
-    df = ensure_columns(df, ["macd", "atr", "vwap", "macds"], symbol)
+    df = ensure_columns(df, ["macd", "vwap", "macds"], symbol)
     if df.empty and raw_df is not None:
         df = raw_df.copy()
 

--- a/ai_trading/features/__init__.py
+++ b/ai_trading/features/__init__.py
@@ -1,14 +1,13 @@
 """
 Feature engineering public API.
 """
-from ai_trading.indicators import compute_atr
-from .indicators import compute_macd, compute_macds, compute_vwap, ensure_columns
+from .indicators import compute_macd, compute_macds, compute_vwap, compute_atr, ensure_columns
 
 def build_features_pipeline(df, symbol: str):
     """
     Minimal pipeline expected by tests:
     - ensure expected columns
-    - compute MACD/MACD signal, ATR, VWAP
+    - compute MACD/MACD signal, ATR (if possible), VWAP
     """
     df = compute_macd(df)
     df = compute_macds(df)

--- a/ai_trading/features/indicators.py
+++ b/ai_trading/features/indicators.py
@@ -32,6 +32,26 @@ def compute_macd(df: pd.DataFrame) -> pd.DataFrame:
         logger.error('MACD computation failed', exc_info=True)
         return df
 
+def compute_atr(df: pd.DataFrame, period: int = 14) -> pd.DataFrame:
+    """Compute Average True Range (ATR)."""
+    try:
+        if not all((col in df.columns for col in ['high', 'low', 'close'])):
+            logger.warning('Missing required columns for ATR calculation; skipping')
+            return df
+        high = df['high'].astype(float)
+        low = df['low'].astype(float)
+        close = df['close'].astype(float)
+        tr = pd.concat([
+            high - low,
+            (high - close.shift()).abs(),
+            (low - close.shift()).abs(),
+        ], axis=1).max(axis=1)
+        df['atr'] = tr.rolling(window=period).mean()
+        return df
+    except (pd.errors.EmptyDataError, KeyError, ValueError, TypeError, ZeroDivisionError, OverflowError):
+        logger.error('ATR computation failed', exc_info=True)
+        return df
+
 def compute_vwap(df: pd.DataFrame) -> pd.DataFrame:
     """Compute Volume Weighted Average Price (VWAP)."""
     try:
@@ -75,4 +95,4 @@ def ensure_columns(df: pd.DataFrame, required: list[str] | None=None, symbol: st
         logger.error('Column validation failed', exc_info=True)
         return df
 
-__all__ = ['compute_macd', 'compute_vwap', 'compute_macds', 'ensure_columns']
+__all__ = ['compute_macd', 'compute_atr', 'compute_vwap', 'compute_macds', 'ensure_columns']

--- a/docs/TECHNICAL_ANALYSIS.md
+++ b/docs/TECHNICAL_ANALYSIS.md
@@ -21,6 +21,10 @@ The AI Trading Bot uses the `ta` library v0.11.0 as its primary technical analys
 - Complete coverage of trend, momentum, volatility, and volume indicators
 - Advanced indicators not available in basic TA-Lib implementations
 
+## Data Requirements & Missing Features
+
+Most indicators expect standard OHLCV columns (open, high, low, close, volume). The helper `ensure_columns` inserts any missing base columns with zeros to keep pipelines running. Optional features, such as ATR, are computed only when their prerequisite columns are present; if they cannot be derived, ATR-dependent logic is skipped without repeated warnings.
+
 ## Available Indicators
 
 ### Trend Indicators

--- a/tests/test_atr_optional.py
+++ b/tests/test_atr_optional.py
@@ -1,0 +1,25 @@
+import pytest
+pd = pytest.importorskip("pandas")
+
+from ai_trading.features.indicators import compute_atr, ensure_columns
+
+
+def test_compute_atr_skips_when_columns_missing():
+    df = pd.DataFrame({"close": [1, 2, 3, 4]})
+    out = compute_atr(df.copy())
+    assert "atr" not in out.columns
+    out = ensure_columns(out, ["macd"], symbol="TEST")
+    assert "atr" not in out.columns
+
+
+def test_compute_atr_when_available():
+    df = pd.DataFrame(
+        {
+            "high": [2, 3, 4, 5],
+            "low": [1, 1, 2, 2],
+            "close": [1.5, 2.5, 3.5, 4.5],
+        }
+    )
+    out = compute_atr(df.copy())
+    assert "atr" in out.columns
+    assert out["atr"].notna().any()


### PR DESCRIPTION
## Summary
- compute ATR within `features.indicators` and expose it via API
- treat ATR as optional when ensuring columns in the core bot engine
- document required columns and optional indicator behavior

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b744fd69048330bce5e5e3cde81c52