### PR TITLE
Add backoff and fallback provider for empty minute bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,16 @@ connectivity.
 | `CACHE_MARKET_DATA` | `true` | Enable data caching |
 | `TRADING_HOURS_ONLY` | `true` | Trade only during market hours |
 
+After several empty bar responses from the primary provider, the bot backs off
+and queries the backup source. Configure additional fallbacks with:
+
+- `ENABLE_FINNHUB=1` and `FINNHUB_API_KEY` to allow an intermediate Finnhub
+  retry before using the backup provider.
+- `BACKUP_DATA_PROVIDER` to override the default Yahoo Finance fallback.
+
+When this backoff triggers, the system logs the affected symbol, timeframe and
+provider status to aid debugging.
+
 #### Machine Learning Configuration
 
 | Parameter | Default | Description |

--- a/tests/test_empty_bar_backoff.py
+++ b/tests/test_empty_bar_backoff.py
@@ -1,0 +1,85 @@
+import logging
+import types
+from datetime import UTC, datetime, timedelta
+
+import pandas as pd
+
+from ai_trading.data import fetch
+
+
+def _dt_range():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+    return start, end
+
+
+def test_backoff_uses_alternate_provider(monkeypatch, caplog):
+    start, end = _dt_range()
+    symbol = "AAPL"
+    fetch._EMPTY_BAR_COUNTS.clear()
+    fetch._SKIPPED_SYMBOLS.clear()
+    fetch._EMPTY_BAR_COUNTS[symbol] = fetch._EMPTY_BAR_THRESHOLD - 1
+
+    def _raise_empty(*_a, **_k):
+        raise ValueError("empty_bars")
+
+    monkeypatch.setattr(fetch, "_fetch_bars", _raise_empty)
+    monkeypatch.setattr(fetch, "fh_fetcher", None)
+    monkeypatch.setenv("ENABLE_FINNHUB", "0")
+
+    called: dict[str, object] = {}
+
+    def _sleep(sec):
+        called["sleep"] = sec
+
+    monkeypatch.setattr(fetch, "time", types.SimpleNamespace(sleep=_sleep))
+
+    df = pd.DataFrame(
+        {
+            "timestamp": [start],
+            "open": [1],
+            "high": [1],
+            "low": [1],
+            "close": [1],
+        }
+    )
+
+    def _alt_fetch(sym, s, e, interval="1m"):
+        called["alt"] = True
+        return df
+
+    monkeypatch.setattr(fetch, "_yahoo_get_bars", _alt_fetch)
+
+    with caplog.at_level(logging.WARNING):
+        out = fetch.get_minute_df(symbol, start, end)
+
+    assert not out.empty
+    assert called.get("alt")
+    assert called.get("sleep")
+    assert symbol not in fetch._SKIPPED_SYMBOLS
+    assert any(r.message == "ALPACA_EMPTY_BAR_BACKOFF" for r in caplog.records)
+
+
+def test_backoff_skips_when_alternate_empty(monkeypatch, caplog):
+    start, end = _dt_range()
+    symbol = "MSFT"
+    fetch._EMPTY_BAR_COUNTS.clear()
+    fetch._SKIPPED_SYMBOLS.clear()
+    fetch._EMPTY_BAR_COUNTS[symbol] = fetch._EMPTY_BAR_THRESHOLD - 1
+
+    def _raise_empty(*_a, **_k):
+        raise ValueError("empty_bars")
+
+    monkeypatch.setattr(fetch, "_fetch_bars", _raise_empty)
+    monkeypatch.setattr(fetch, "fh_fetcher", None)
+    monkeypatch.setenv("ENABLE_FINNHUB", "0")
+    monkeypatch.setattr(fetch, "time", types.SimpleNamespace(sleep=lambda _s: None))
+
+    monkeypatch.setattr(fetch, "_yahoo_get_bars", lambda *a, **k: pd.DataFrame())
+
+    with caplog.at_level(logging.WARNING):
+        out = fetch.get_minute_df(symbol, start, end)
+
+    assert out.empty
+    assert symbol in fetch._SKIPPED_SYMBOLS
+    assert any(r.message == "ALPACA_EMPTY_BAR_BACKOFF" for r in caplog.records)


### PR DESCRIPTION
## Summary
- add backoff with alternate Yahoo fallback when Alpaca minute bars return empty repeatedly
- log detailed context (symbol, timeframe, provider status) for empty bar backoff events
- document configuring backup data sources and write tests covering backoff and skip paths

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*
- `RUN_HEALTHCHECK=1 python -m ai_trading.app` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b744fd2af483308baed2486e8f5cf7