### PR TITLE
Handle peak equity file permission errors

### DIFF
--- a/tests/test_peak_equity_permission.py
+++ b/tests/test_peak_equity_permission.py
@@ -1,0 +1,21 @@
+import ai_trading.core.bot_engine as bot
+from pathlib import Path
+import pytest
+
+def test_peak_equity_permission(monkeypatch, tmp_path, caplog):
+    peak = tmp_path / "peak.txt"
+    peak.touch()
+    peak.chmod(0)
+    equity = tmp_path / "equity.txt"
+    equity.write_text("0")
+    monkeypatch.setattr(bot, "PEAK_EQUITY_FILE", str(peak))
+    monkeypatch.setattr(bot, "EQUITY_FILE", str(equity))
+    monkeypatch.setattr(bot, "_PEAK_EQUITY_PERMISSION_LOGGED", False)
+    caplog.set_level("WARNING")
+
+    assert bot._current_drawdown() == 0.0
+    assert "permission denied" in caplog.text.lower()
+
+    caplog.clear()
+    assert bot._current_drawdown() == 0.0
+    assert caplog.text == ""


### PR DESCRIPTION
## Summary
- Default writable state dir even when standard paths are restricted
- Skip peak equity file I/O when permissions fail, logging a warning once
- Test peak equity permission fallback

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b749a4da3083309407ccfa30ccdfff