### PR TITLE
Ensure trade log ready at startup

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -4922,7 +4922,7 @@ def _read_trade_log(
         )
         return None
     if df.empty:
-        logger.warning(
+        logger.info(
             "Trade log %s parsed but contains no rows | hint=call get_trade_logger() to initialize",
             path,
         )

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -79,6 +79,10 @@ def preflight_import_health() -> None:
             )
             raise SystemExit(1)
     logger.info("IMPORT_PREFLIGHT_OK")
+    try:
+        importlib.import_module("ai_trading.core.bot_engine").get_trade_logger()
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.warning("TRADE_LOG_INIT_FAILED", extra={"error": repr(exc)})
 
 
 def run_cycle() -> None:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -18,7 +18,7 @@ Set `RUN_HEALTHCHECK=1` in the environment to enable the Flask endpoints.
 
 ### Paths & default files
 - Trade log file defaults to `<repo>/logs/trades.jsonl` when `TRADE_LOG_PATH` is not set. The directory is auto-created.
-- New deployments should call `ai_trading.core.bot_engine.get_trade_logger()` once during startup to create the file and write CSV headers before any trades are recorded.
+- The application initializes this trade log on startup via `ai_trading.core.bot_engine.get_trade_logger()`. Custom deployments should call it once if they bypass the standard entrypoint.
 - Empty model path disables ML quietly. Set `MODEL_PATH` to enable.
 - Override cache location with `AI_TRADING_CACHE_DIR` when the default `~/.cache/ai-trading-bot`
   path is not writable (for example, on read-only home directories). The application

--- a/tests/test_preflight_trade_logger.py
+++ b/tests/test_preflight_trade_logger.py
@@ -1,0 +1,24 @@
+import sys
+import types
+
+from ai_trading import main as main_module
+from ai_trading.core import bot_engine
+
+
+def test_preflight_initializes_trade_log(tmp_path, monkeypatch):
+    """preflight_import_health creates the trade log file on startup."""
+    # Stub alpaca client modules required by preflight_import_health
+    monkeypatch.setitem(sys.modules, "alpaca", types.ModuleType("alpaca"))
+    monkeypatch.setitem(sys.modules, "alpaca.trading", types.ModuleType("alpaca.trading"))
+    monkeypatch.setitem(
+        sys.modules, "alpaca.trading.client", types.ModuleType("alpaca.trading.client")
+    )
+
+    log_path = tmp_path / "trades.csv"
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path), raising=False)
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+
+    main_module.preflight_import_health()
+
+    assert log_path.exists()
+    assert log_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- tone down empty trade log warning to `logger.info`
- initialize trade log during `preflight_import_health`
- document automatic trade log creation and add regression test

## Testing
- `ruff check ai_trading/core/bot_engine.py ai_trading/main.py tests/test_preflight_trade_logger.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 18 errors during collection)*
- `RUN_HEALTHCHECK=1 python -m ai_trading.app & curl -sf http://127.0.0.1:9001/healthz`


------
https://chatgpt.com/codex/tasks/task_e_68b749a4a554833086388f998890949f