### PR TITLE
Add explicit empty bar error handling

### DIFF
--- a/tests/test_empty_bar_backoff.py
+++ b/tests/test_empty_bar_backoff.py
@@ -22,7 +22,7 @@ def test_backoff_uses_alternate_provider(monkeypatch, caplog):
     fetch._EMPTY_BAR_COUNTS[key] = fetch._EMPTY_BAR_THRESHOLD - 1
 
     def _raise_empty(*_a, **_k):
-        raise ValueError("empty_bars")
+        raise fetch.EmptyBarsError("empty_bars")
 
     monkeypatch.setattr(fetch, "_fetch_bars", _raise_empty)
     monkeypatch.setattr(fetch, "fh_fetcher", None)
@@ -70,7 +70,7 @@ def test_backoff_skips_when_alternate_empty(monkeypatch, caplog):
     fetch._EMPTY_BAR_COUNTS[key] = fetch._EMPTY_BAR_THRESHOLD - 1
 
     def _raise_empty(*_a, **_k):
-        raise ValueError("empty_bars")
+        raise fetch.EmptyBarsError("empty_bars")
 
     monkeypatch.setattr(fetch, "_fetch_bars", _raise_empty)
     monkeypatch.setattr(fetch, "fh_fetcher", None)

--- a/tests/test_fetch_empty_handling.py
+++ b/tests/test_fetch_empty_handling.py
@@ -40,7 +40,7 @@ def test_warn_on_empty_when_market_open(monkeypatch, caplog):
     monkeypatch.setattr(fetch, "is_market_open", lambda: True)
 
     with caplog.at_level(logging.WARNING):
-        with pytest.raises(ValueError, match="empty_bars"):
+        with pytest.raises(fetch.EmptyBarsError, match="empty_bars"):
             fetch._fetch_bars("AAPL", start, end, "1Min")
 
     assert any(r.message == "EMPTY_DATA" and r.levelno == logging.WARNING for r in caplog.records)


### PR DESCRIPTION
## Summary
- raise new `EmptyBarsError` when data provider returns no bars
- handle `EmptyBarsError` during minute fetches and log fallback details
- update tests for new exception

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_fetch_empty_handling.py tests/test_empty_bar_backoff.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_empty_handling.py tests/test_empty_bar_backoff.py -q` *(fails: Missing optional dependency `alpaca-py`; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b856b7cb088330af7ceef09c683545