### PR TITLE
Initialize trade log before symbol processing

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -91,6 +91,7 @@ def run_cycle() -> None:
         BotState,
         run_all_trades_worker,
         get_ctx,
+        get_trade_logger,
     )
     from ai_trading.core.runtime import (
         build_runtime,
@@ -102,6 +103,10 @@ def run_cycle() -> None:
 
     state = BotState()
     cfg = TradingConfig.from_env()
+
+    # Ensure trade log file exists before any symbol processing occurs.
+    # get_trade_logger lazily creates the log and writes the header on first use.
+    get_trade_logger()
 
     # Carry through a pre-resolved max position size if available on Settings.
     S = get_settings()


### PR DESCRIPTION
## Summary
- Initialize trade log at the start of each trading cycle so `trades.jsonl` exists before symbols are processed

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_trade_log_init.py::test_trade_logger_records_entry -q` *(fails: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68b856b96090833094a4ecb202914c22