### PR TITLE
Add model env configuration and log activation test

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,3 +16,8 @@ MIN_CONFIDENCE=0.6
 # Trading mode (use this; BOT_MODE is deprecated)
 TRADING_MODE=balanced
 
+# Model configuration
+# Provide a module exposing `get_model()` or `Model` factory, or point to a pickled model file.
+AI_TRADING_MODEL_MODULE=ai_trading.model_loader
+# AI_TRADING_MODEL_PATH=/absolute/path/to/trained_model.pkl
+


### PR DESCRIPTION
## Summary
- add model configuration variables to `.env.sample`
- verify bot engine logs model activation when loading

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_model_loading.py::test_load_model_logs_activation -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85804c62483308c8a193c48d8e95a