### PR TITLE
Ensure trade log initialized at startup

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -332,6 +332,8 @@ def run_bot(*_a, **_k) -> int:
             logger.info("Memory optimization enabled")
         logger.info("Bot startup complete - entering main loop")
         preflight_import_health()
+        from ai_trading.core.bot_engine import get_trade_logger
+        get_trade_logger()
         run_cycle()
         return 0
     except (ValueError, TypeError, RuntimeError) as e:
@@ -521,6 +523,8 @@ def main(argv: list[str] | None = None) -> None:
     }
     logger.info("STARTUP_BANNER", extra=_redact(banner))
     _install_signal_handlers()
+    from ai_trading.core.bot_engine import get_trade_logger
+    get_trade_logger()
     try:
         run_cycle()
     except (TypeError, ValueError) as e:


### PR DESCRIPTION
## Summary
- Initialize trade logger during bot startup in `run_bot`
- Invoke trade logger before warm-up cycle in `main`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68b85b5ded2c8330aeb257921de9bbe5