### PR TITLE
feat: enable finnhub when key present

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,3 +21,7 @@ TRADING_MODE=balanced
 AI_TRADING_MODEL_MODULE=ai_trading.model_loader
 # AI_TRADING_MODEL_PATH=/absolute/path/to/trained_model.pkl
 
+# Finnhub data provider (optional)
+FINNHUB_API_KEY=your_finnhub_api_key_here
+# ENABLE_FINNHUB=1
+

--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -23,6 +23,10 @@ from ai_trading.exc import COMMON_EXC
 from .json_formatter import JSONFormatter
 from ai_trading.logging.redact import _ENV_MASK
 
+if os.getenv("FINNHUB_API_KEY") and os.getenv("ENABLE_FINNHUB") is None:
+    os.environ["ENABLE_FINNHUB"] = "1"
+    logging.getLogger(__name__).debug("ENABLE_FINNHUB_SET", extra={"enabled": True})
+
 def _ensure_single_handler(log: logging.Logger, level: int | None=None) -> None:
     """Ensure no duplicate handler types and attach default if none exist."""
 

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -70,6 +70,8 @@ class Settings(BaseSettings):
     alpaca_api_key: str | None = Field(default=None, alias='ALPACA_API_KEY')
     alpaca_secret_key: SecretStr | None = Field(default=None, alias='ALPACA_SECRET_KEY')
     redis_url: str | None = Field(default=None, alias='REDIS_URL')
+    enable_finnhub: bool = Field(True, alias='ENABLE_FINNHUB')
+    finnhub_api_key: str | None = Field(default=None, alias='FINNHUB_API_KEY')
     alpaca_base_url: str = Field(
         default='https://paper-api.alpaca.markets',
         alias='ALPACA_API_URL',

--- a/tests/test_finnhub_symbol_processing.py
+++ b/tests/test_finnhub_symbol_processing.py
@@ -1,0 +1,22 @@
+import os
+import importlib
+import pandas as pd
+
+def test_get_minute_df_uses_finnhub_when_key(monkeypatch):
+    monkeypatch.setenv("FINNHUB_API_KEY", "testkey")
+    monkeypatch.delenv("ENABLE_FINNHUB", raising=False)
+    import ai_trading.logging as logging_mod
+    importlib.reload(logging_mod)
+    assert os.getenv("ENABLE_FINNHUB") == "1"
+    from ai_trading.data import fetch
+
+    called = {}
+    class DummyFetcher:
+        is_stub = False
+        def fetch(self, symbol, start, end, resolution="1"):
+            called["called"] = True
+            return pd.DataFrame({"t": [1, 2], "c": [1.0, 2.0]})
+    monkeypatch.setattr(fetch, "fh_fetcher", DummyFetcher())
+    df = fetch.get_minute_df("AAPL", "2024-01-01", "2024-01-02")
+    assert called.get("called") is True
+    assert list(df["c"]) == [1.0, 2.0]


### PR DESCRIPTION
## Summary
- expose Finnhub credentials in settings and sample env
- auto-enable Finnhub via logging when API key present
- test Finnhub minute-bar consumption

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

------
https://chatgpt.com/codex/tasks/task_e_68b85d1893508330b79505a18946e0a6