### PR TITLE
feat: allow loading ML models from external directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ the default `~/.cache/ai-trading-bot` is unavailable (for example, if the home
 directory is mounted read-only). The directory is created with `0700`
 permissions during startup.
 
+To load ML models from a custom location, set `AI_TRADING_MODELS_DIR` before
+startup. The path may reside outside the repository; each model file is
+validated to stay within this directory to guard against path traversal.
+
 
 ## Config
 

--- a/ai_trading/model_loader.py
+++ b/ai_trading/model_loader.py
@@ -7,14 +7,13 @@ avoids ``pickle.load`` where possible.
 """
 
 from ai_trading.logging import get_logger
+from ai_trading.paths import MODELS_DIR
 from datetime import UTC
 from pathlib import Path
 
 import joblib
 
 logger = get_logger(__name__)
-BASE_DIR = Path(__file__).resolve().parents[1]
-ALLOWED_MODELS_DIR = (BASE_DIR / "models").resolve()
 ML_MODELS: dict[str, object | None] = {}
 
 
@@ -61,17 +60,14 @@ def train_and_save_model(symbol: str, models_dir: Path) -> object:
 def load_model(symbol: str) -> object:
     """Load or train an ML model for ``symbol``.
 
-    The models directory is resolved via ``config.get_env('MODELS_DIR')`` if set,
-    otherwise defaults to ``<project>/models``. Paths are validated to reside
-    within the allowed models directory. Any deserialization error results in a
-    ``RuntimeError`` that includes the absolute path and ``symbol`` for
-    context.
+    The models directory defaults to :data:`ai_trading.paths.MODELS_DIR` and can
+    be overridden via the ``AI_TRADING_MODELS_DIR`` environment variable.
+    Resolved paths are validated to remain within ``models_dir``. Any
+    deserialization error results in a ``RuntimeError`` that includes the
+    absolute path and ``symbol`` for context.
     """
-    from ai_trading.config import management as config
 
-    models_dir = Path(config.get_env("MODELS_DIR") or ALLOWED_MODELS_DIR).resolve()
-    if not models_dir.is_relative_to(ALLOWED_MODELS_DIR):
-        raise RuntimeError(f"Disallowed models directory: {models_dir}")
+    models_dir = MODELS_DIR
     path = (models_dir / f"{symbol}.pkl").resolve()
     if not path.is_relative_to(models_dir):
         raise RuntimeError(f"Model path escapes models directory: {path}")

--- a/tests/test_ml_model_loading.py
+++ b/tests/test_ml_model_loading.py
@@ -1,22 +1,27 @@
 from __future__ import annotations
 
+import importlib
+import os
+from pathlib import Path
+
 import pytest
+
+# Ensure a deterministic models directory for most tests
+DEFAULT_MODELS_DIR = Path(__file__).resolve().parents[1] / "models"
+os.environ.setdefault("AI_TRADING_MODELS_DIR", str(DEFAULT_MODELS_DIR))
 
 np = pytest.importorskip("numpy")
 pytest.importorskip("sklearn")
 
-from ai_trading.core import bot_engine as bot
-from ai_trading.core.bot_engine import _ML_MODEL_CACHE, _load_ml_model
-from ai_trading.model_loader import ML_MODELS
+import ai_trading.core.bot_engine as bot_engine
+import ai_trading.model_loader as model_loader
 from sklearn.dummy import DummyClassifier
 
 
 def setup_function(function):
-    ML_MODELS.clear()
-    _ML_MODEL_CACHE.clear()
-    from pathlib import Path
-
-    models_dir = Path(__file__).resolve().parents[1] / "models"
+    model_loader.ML_MODELS.clear()
+    bot_engine._ML_MODEL_CACHE.clear()
+    models_dir = Path(os.environ["AI_TRADING_MODELS_DIR"])
     for p in models_dir.rglob("*.pkl"):
         try:
             p.unlink()
@@ -32,24 +37,28 @@ def setup_function(function):
 
 def test_load_missing_trains_model(caplog):
     caplog.set_level("WARNING")
-    result = _load_ml_model("FAKE")
+    result = bot_engine._load_ml_model("FAKE")
     assert result is not None
     assert hasattr(result, "predict_proba")
-    from pathlib import Path
-
-    assert (Path("models") / "FAKE.pkl").exists()
+    models_dir = Path(os.environ["AI_TRADING_MODELS_DIR"])
+    assert (models_dir / "FAKE.pkl").exists()
     assert any(r.message.startswith("MODEL_FILE_MISSING") for r in caplog.records)
 
 
 def test_load_corrupt_logs_error(tmp_path, monkeypatch, caplog):
-    from pathlib import Path
+    monkeypatch.setenv("AI_TRADING_MODELS_DIR", str(tmp_path))
+    import ai_trading.paths as paths
 
-    monkeypatch.setenv("MODELS_DIR", str(Path("models") / "tmp"))
-    bad = Path("models") / "tmp" / "BAD.pkl"
-    bad.parent.mkdir(parents=True, exist_ok=True)
+    importlib.reload(paths)
+    ml = importlib.reload(model_loader)
+    be = importlib.reload(bot_engine)
+    ml.ML_MODELS.clear()
+    be._ML_MODEL_CACHE.clear()
+
+    bad = tmp_path / "BAD.pkl"
     bad.write_text("not a model")
     caplog.set_level("ERROR")
-    result = _load_ml_model("BAD")
+    result = be._load_ml_model("BAD")
     assert result is None
     assert any(r.message.startswith("MODEL_LOAD_ERROR") for r in caplog.records)
 
@@ -59,8 +68,8 @@ def test_load_real_model():
     X = np.array([[0], [1]])
     y = np.array([0, 1])
     model.fit(X, y)
-    ML_MODELS["TESTSYM"] = model
-    loaded = _load_ml_model("TESTSYM")
+    model_loader.ML_MODELS["TESTSYM"] = model
+    loaded = bot_engine._load_ml_model("TESTSYM")
     assert loaded is not None
     pred = loaded.predict([[0]])[0]
     assert pred in [0, 1]
@@ -82,11 +91,26 @@ def test_signal_ml_returns_prediction_and_probability():
             "sma_200": [1.0],
         }
     )
-    sm = bot.SignalManager()
+    sm = bot_engine.SignalManager()
     result = sm.signal_ml(df, model=model)
     assert result is not None
     signal, proba, label = result
     assert label == "ml"
     assert signal in (-1, 1)
     assert 0.0 <= proba <= 1.0
+
+
+def test_external_models_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("AI_TRADING_MODELS_DIR", str(tmp_path))
+    import ai_trading.paths as paths
+
+    importlib.reload(paths)
+    ml = importlib.reload(model_loader)
+    be = importlib.reload(bot_engine)
+    ml.ML_MODELS.clear()
+    be._ML_MODEL_CACHE.clear()
+
+    result = be._load_ml_model("EXTSYM")
+    assert result is not None
+    assert (tmp_path / "EXTSYM.pkl").exists()
 


### PR DESCRIPTION
## Summary
- use `ai_trading.paths.MODELS_DIR` for ML model storage
- validate model paths stay within `MODELS_DIR`
- support external models directory via `AI_TRADING_MODELS_DIR`
- document models path configuration

## Testing
- `ruff check ai_trading/model_loader.py tests/test_ml_model_loading.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_ml_model_loading.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87ca4e47c83309bf312c7d35d4eba