### PR TITLE
Log resolved Alpaca URL at startup

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -39,11 +39,14 @@ present before the service starts:
 | --- | --- |
 | `ALPACA_API_KEY` | Alpaca API authentication |
 | `ALPACA_SECRET_KEY` | Alpaca API authentication |
-| `ALPACA_API_URL` | Broker endpoint URL |
+| `ALPACA_API_URL` / `ALPACA_BASE_URL` | Broker endpoint URL (either variable is accepted and logged) |
 | `ALPACA_DATA_FEED` | Market data feed selection |
 | `WEBHOOK_SECRET` | Protects inbound webhooks |
 | `CAPITAL_CAP` | Maximum portfolio allocation |
 | `DOLLAR_RISK_LIMIT` | Maximum per-trade dollar risk |
+
+Either `ALPACA_API_URL` or `ALPACA_BASE_URL` may be set; the service resolves the
+alias and logs the effective URL during startup.
 
 If any are missing or empty the process exits with a `RuntimeError` listing the
 missing keys; values are masked in logs and exceptions. During health server

--- a/tests/unit/test_env_config_redaction.py
+++ b/tests/unit/test_env_config_redaction.py
@@ -38,3 +38,19 @@ def test_redact_env_drop_removes_keys():
     redacted = redact_env(payload, drop=True)
     for k in _SENSITIVE_ENV:
         assert k not in redacted
+
+
+def test_base_url_alias_logged(caplog, monkeypatch):
+    monkeypatch.setenv("ALPACA_API_KEY", "AK123456789")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "SK987654321")
+    monkeypatch.delenv("ALPACA_API_URL", raising=False)
+    monkeypatch.setenv("ALPACA_BASE_URL", "https://alias-api.alpaca.markets")
+    monkeypatch.setenv("ALPACA_DATA_FEED", "iex")
+    monkeypatch.setenv("WEBHOOK_SECRET", "HOOK-SECRET")
+    monkeypatch.setenv("CAPITAL_CAP", "0.5")
+    monkeypatch.setenv("DOLLAR_RISK_LIMIT", "1000")
+
+    caplog.set_level(logging.INFO)
+    main._fail_fast_env()
+    env_log = next(rec for rec in caplog.records if rec.getMessage() == "ENV_CONFIG_LOADED")
+    assert env_log.ALPACA_API_URL == "https://alias-api.alpaca.markets"


### PR DESCRIPTION
## Summary
- resolve Alpaca API URL from ALPACA_API_URL/ALPACA_BASE_URL during startup
- log the resolved URL and add regression test for ALPACA_BASE_URL alias
- document that either variable is accepted in deployment guide

## Testing
- `ruff check ai_trading/main.py tests/unit/test_env_config_redaction.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_env_config_redaction.py::test_base_url_alias_logged -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68b87ca608f08330ae2feb2380b617ff