### PR TITLE
Preload trading model and expose configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,6 +1085,8 @@ User=ai-trading
 Group=ai-trading
 WorkingDirectory=/opt/ai-trading-bot
 Environment=PATH=/opt/ai-trading-bot/venv/bin
+Environment=AI_TRADING_MODEL_MODULE=ai_trading.model_loader
+Environment=AI_TRADING_MODEL_PATH=/var/lib/ai-trading-bot/models/trained_model.pkl
 Environment=AI_TRADING_DATA_DIR=/var/lib/ai-trading-bot
 Environment=AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot
 Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -504,6 +504,9 @@ class BotEngine:
                 "MODEL_STARTUP_CHECK_FAILED", extra={"error": str(exc)}
             )
 
+        # Eagerly load the configured model so misconfiguration fails fast
+        _load_required_model()
+
     @property
     def ctx(self):
         """Return the lazily-initialized bot context."""
@@ -5269,8 +5272,12 @@ class SignalManager:
         if model is None or not (
             hasattr(model, "predict") and hasattr(model, "predict_proba")
         ):
+            _path = os.getenv("AI_TRADING_MODEL_PATH")
+            _mod = os.getenv("AI_TRADING_MODEL_MODULE")
             logger.warning(
-                "ML predictions disabled; provide a model via AI_TRADING_MODEL_PATH or AI_TRADING_MODEL_MODULE"
+                "ML predictions disabled; provide a model via AI_TRADING_MODEL_PATH or AI_TRADING_MODEL_MODULE "
+                f"(AI_TRADING_MODEL_PATH={_path!r}, AI_TRADING_MODEL_MODULE={_mod!r})",
+                extra={"model_path": _path, "model_module": _mod},
             )
             # AI-AGENT-REF: guard absent model
             return None

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,27 @@
-import importlib.util
+import importlib
 import os
 import random
+import sys
+import types
 from pathlib import Path
 
 import pytest
+
+# Provide a lightweight default model so bot initialization can preload it
+_dummy_mod = types.ModuleType("dummy_model")
+
+
+class _DummyModel:
+    def predict(self, _x):
+        return [0]
+
+    def predict_proba(self, _x):
+        return [[0.5, 0.5]]
+
+
+_dummy_mod.get_model = lambda: _DummyModel()
+sys.modules["dummy_model"] = _dummy_mod
+os.environ.setdefault("AI_TRADING_MODEL_MODULE", "dummy_model")
 
 
 def _missing(mod: str) -> bool:

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -9,6 +9,7 @@ Group=aiuser
 WorkingDirectory=/home/aiuser/ai-trading-bot
 Environment=PATH=/home/aiuser/ai-trading-bot/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=AI_TRADING_MODEL_MODULE=ai_trading.model_loader
+Environment=AI_TRADING_MODEL_PATH=/var/lib/ai-trading-bot/models/trained_model.pkl
 Environment=AI_TRADING_DATA_DIR=/var/lib/ai-trading-bot
 Environment=AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot
 Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot


### PR DESCRIPTION
## Summary
- Set model path and module in `ai-trading.service`
- Preload the configured ML model during `BotEngine` initialization
- Warn with configured model path/module when predictions run without a model

## Testing
- `ruff check conftest.py ai_trading/core/bot_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'pydantic_settings')*
- `python -m pip install pydantic-settings`
- `python -m pip install joblib`
- `python -m pip install portalocker`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_model_loading.py -q` *(fails: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68b88192c6f48330ad65c469d22b76e5