### PR TITLE
Ensure trade log initialization on import

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -605,7 +605,7 @@ def default_trade_log_path() -> str:
             os.makedirs(os.path.dirname(cand), exist_ok=True)
             return cand
 
-    fallback = os.path.join(BASE_DIR, "logs", "trades.jsonl")
+    fallback = "/var/log/ai-trading-bot/trades.jsonl"
     os.makedirs(os.path.dirname(fallback), exist_ok=True)
     return fallback
 
@@ -5591,7 +5591,7 @@ class BotContext:
 
 data_fetcher: DataFetcher | None = None
 signal_manager = SignalManager()
-# AI-AGENT-REF: Lazy initialization for trade logger to speed up imports in testing
+# AI-AGENT-REF: Singleton initialized at import to ensure trade log availability
 _TRADE_LOGGER_SINGLETON = None
 
 
@@ -5641,8 +5641,10 @@ from ai_trading.utils.imports import (
     resolve_risk_engine_cls,
     resolve_strategy_allocator_cls,
 )
-
 logger = get_logger(__name__)
+
+# Ensure trade log file exists when module is imported
+get_trade_logger()
 
 
 def get_risk_engine():

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -17,7 +17,7 @@ curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9001/metrics  # 200 if e
 Set `RUN_HEALTHCHECK=1` in the environment to enable the Flask endpoints.
 
 ### Paths & default files
-- Trade log file defaults to `<repo>/logs/trades.jsonl` when `TRADE_LOG_PATH` is not set. The directory is auto-created.
+- Trade log file defaults to `/var/log/ai-trading-bot/trades.jsonl` when `TRADE_LOG_PATH` is not set. The directory is auto-created.
 - The application initializes this trade log on startup via `ai_trading.core.bot_engine.get_trade_logger()`. Custom deployments should call it once if they bypass the standard entrypoint.
 - Empty model path disables ML quietly. Set `MODEL_PATH` to enable.
 - Override cache location with `AI_TRADING_CACHE_DIR` when the default `~/.cache/ai-trading-bot`

--- a/tests/bot_engine/test_trade_log_init.py
+++ b/tests/bot_engine/test_trade_log_init.py
@@ -51,3 +51,20 @@ def test_read_trade_log_initializes_file_with_header(tmp_path, monkeypatch):
     lines = log_path.read_text().splitlines()
     assert lines[0].startswith("symbol,entry_time")
 
+
+def test_existing_empty_log_gets_header_and_entry(tmp_path, monkeypatch):
+    """Existing empty log gets header and first entry on startup."""
+
+    log_path = tmp_path / "trades.jsonl"
+    log_path.touch()
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+
+    logger = bot_engine.get_trade_logger()
+    logger.log_entry("MSFT", 123.0, 1, "buy", "test")
+
+    lines = log_path.read_text().splitlines()
+    assert lines[0].startswith("symbol,entry_time")
+    assert len(lines) == 2
+    assert "MSFT" in lines[1]
+


### PR DESCRIPTION
## Summary
- default trade log path now `/var/log/ai-trading-bot/trades.jsonl`
- initialize trade logger when module imports to create file and header
- add test covering empty trade log initialization and first entry

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_trade_log_init.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b88940daf48330b2ca235f67ca75cd