### PR TITLE
Fail fast when ML model configuration is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1481,6 +1481,12 @@ Set exactly one of:
 - AI_TRADING_MODEL_PATH=/abs/path/to/model.joblib
 - AI_TRADING_MODEL_MODULE=your.module.with.get_model
 
+The default systemd unit expects the model at
+`/var/lib/ai-trading-bot/models/trained_model.pkl`. On startup the bot
+validates these settings and **fails fast** if the path is missing or the
+module import fails, logging `MODEL_PATH_INVALID` or
+`MODEL_MODULE_IMPORT_FAILED`.
+
 At startup the engine verifies that model files exist in
 ``paths.MODELS_DIR``. If none are found, a lightweight fallback model is
 trained automatically. Supplying your own model via the variables above

--- a/tests/test_prediction_execution.py
+++ b/tests/test_prediction_execution.py
@@ -1,0 +1,41 @@
+import importlib
+
+import pandas as pd
+
+
+def reload_bot_engine():
+    return importlib.reload(__import__('ai_trading.core.bot_engine', fromlist=['dummy']))
+
+
+def test_signal_ml_executes_prediction(monkeypatch):
+    be = reload_bot_engine()
+
+    class DummyModel:
+        def __init__(self):
+            self.called = False
+
+        def predict(self, X):  # noqa: D401
+            """Record prediction call."""
+            self.called = True
+            return [1]
+
+        def predict_proba(self, X):  # noqa: D401
+            """Return constant probability."""
+            return [[0.2, 0.8]]
+
+    dummy = DummyModel()
+    monkeypatch.setattr(be, "_load_ml_model", lambda symbol: dummy)
+    sm = be.SignalManager()
+    df = pd.DataFrame(
+        {
+            "rsi": [50],
+            "macd": [0],
+            "atr": [1],
+            "vwap": [100],
+            "sma_50": [100],
+            "sma_200": [100],
+        }
+    )
+    result = sm.signal_ml(df, symbol="SPY")
+    assert dummy.called
+    assert result == (1, 0.8, "ml")


### PR DESCRIPTION
## Summary
- validate AI_TRADING_MODEL_PATH/AI_TRADING_MODEL_MODULE during startup and log explicit errors
- document model configuration and failure behavior in README
- add tests for missing model file and for ML prediction execution

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/test_model_loading.py tests/test_prediction_execution.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_model_loading.py tests/test_prediction_execution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b88c6ba01083309fdd390cd74557e7