### PR TITLE
Initialize trade logger before reads and add startup tests

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -4972,6 +4972,9 @@ def _read_trade_log(
         )
         return None
     if df.empty:
+        # Startup may legitimately run before any trades have executed; use INFO
+        # instead of WARNING to reduce noise when the log exists but has no
+        # rows yet.
         logger.info(
             "Trade log %s parsed but contains no rows | hint=call get_trade_logger() to initialize",
             path,

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -106,12 +106,13 @@ def run_cycle() -> None:
     from ai_trading.config.management import TradingConfig
     from ai_trading.config import get_settings
 
+    # Ensure trade log file exists before any trade-log reads occur. The
+    # ``get_trade_logger`` helper lazily creates the log and writes the header on
+    # first use so downstream components can safely read from it during startup.
+    get_trade_logger()
+
     state = BotState()
     cfg = TradingConfig.from_env()
-
-    # Ensure trade log file exists before any symbol processing occurs.
-    # get_trade_logger lazily creates the log and writes the header on first use.
-    get_trade_logger()
 
     # Carry through a pre-resolved max position size if available on Settings.
     S = get_settings()

--- a/tests/bot_engine/test_trade_log_init.py
+++ b/tests/bot_engine/test_trade_log_init.py
@@ -37,6 +37,20 @@ def test_trade_logger_records_entry(tmp_path, monkeypatch):
     assert "AAPL" in lines[1]
 
 
+def test_get_trade_logger_creates_header_when_missing(tmp_path, monkeypatch):
+    """get_trade_logger should create the file with a header if absent."""
+
+    log_path = tmp_path / "trades.jsonl"
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+
+    bot_engine.get_trade_logger()
+
+    assert log_path.exists()
+    lines = log_path.read_text().splitlines()
+    assert lines[0].startswith("symbol,entry_time")
+
+
 def test_read_trade_log_initializes_file_with_header(tmp_path, monkeypatch):
     """_read_trade_log initializes missing file and writes header."""
 

--- a/tests/test_empty_dataframe_logging.py
+++ b/tests/test_empty_dataframe_logging.py
@@ -12,17 +12,17 @@ def _write_empty_csv(path: Path, header: list[str]) -> None:
     path.write_text(",".join(header) + "\n")
 
 
-def test_parse_local_positions_warns_on_empty(caplog, tmp_path, monkeypatch):
-    """_parse_local_positions should warn when the log is empty."""
+def test_parse_local_positions_logs_info_on_empty(caplog, tmp_path, monkeypatch):
+    """_parse_local_positions should log info when the log is empty."""
 
     trade_log = tmp_path / "trades.csv"
     _write_empty_csv(trade_log, ["symbol", "qty", "side", "exit_time"])
     monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(trade_log))
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         bot_engine._parse_local_positions()
 
-    assert any(r.levelno == logging.WARNING and str(trade_log) in r.getMessage() for r in caplog.records)
+    assert any(r.levelno == logging.INFO and str(trade_log) in r.getMessage() for r in caplog.records)
 
 
 def test_parse_local_positions_warns_when_missing(caplog, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure trade logger initializes before any trade-log reads
- log empty trade log at INFO and cover with tests
- test that get_trade_logger creates file headers when missing

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b898da5408833091bebfdb6dc9c022