### PR TITLE
Add configurable filters for noisy library logging

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -9,6 +9,7 @@
 - **`LOG_MARKET_FETCH`** (default: `false`): When enabled, logs periodic market fetch heartbeats at INFO level. When disabled, these messages are demoted to DEBUG level to reduce noise.
 
 - **`LOG_LEVEL_YFINANCE`** (default: `WARNING`): Controls the log level for the `yfinance` package. Set to `INFO` or another level to troubleshoot provider interactions.
+- **`LOG_QUIET_LIBRARIES`** (default: `charset_normalizer=INFO`): Comma-separated `logger=LEVEL` pairs used to suppress noisy third-party libraries.
 
 ### Features
 

--- a/tests/test_charset_normalizer_logging_filter.py
+++ b/tests/test_charset_normalizer_logging_filter.py
@@ -1,0 +1,33 @@
+"""Smoke test ensuring noisy libraries are quieted after setup."""
+
+import logging
+
+import ai_trading.logging as base_logger
+import ai_trading.logging.setup as log_setup
+
+
+def _reset_logging_state() -> None:
+    base_logger._configured = False
+    base_logger._LOGGING_CONFIGURED = False
+    base_logger._listener = None
+    base_logger._log_queue = None
+    logging.getLogger().handlers.clear()
+
+
+def test_charset_normalizer_debug_suppressed(monkeypatch) -> None:
+    """After setup, charset_normalizer should not emit debug logs."""
+
+    _reset_logging_state()
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.delenv("LOG_QUIET_LIBRARIES", raising=False)
+
+    log_setup.setup_logging()
+
+    regular = logging.getLogger("regular_logger")
+    noisy = logging.getLogger("charset_normalizer")
+
+    assert regular.getEffectiveLevel() == logging.DEBUG
+    assert noisy.getEffectiveLevel() >= logging.INFO
+
+    _reset_logging_state()
+


### PR DESCRIPTION
## Summary
- allow quieting verbose third-party loggers with new LOG_QUIET_LIBRARIES option (defaults to charset_normalizer)
- document quiet logger configuration
- add smoke test confirming charset_normalizer debug logs are suppressed

## Testing
- `ruff check ai_trading/logging/setup.py tests/test_charset_normalizer_logging_filter.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_charset_normalizer_logging_filter.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b89ac333748330a75969dcd8b1c6c5