### PR TITLE
Handle missing ML models with single warning fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1510,9 +1510,9 @@ pip install -r requirements-extras-train.txt
 python -m ai_trading.training.train_ml
 ```
 
-If `AI_TRADING_MODEL_PATH` is unset and the default file is missing, the bot
-quietly falls back to the baseline model (`USE_ML=False`). A warning is only
-emitted when `AI_TRADING_MODEL_PATH` points to a missing file.
+If neither variable is provided at runtime, the engine logs a single warning
+and falls back to a lightweight volume-spread-analysis heuristic. Repeated
+calls suppress further warnings to avoid log spam.
 
 ### Universe CSV
 - `AI_TRADING_TICKERS_CSV=/abs/path/to/tickers.csv` — explicit override, highest priority.

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5291,13 +5291,15 @@ class SignalManager:
         ):
             _path = os.getenv("AI_TRADING_MODEL_PATH")
             _mod = os.getenv("AI_TRADING_MODEL_MODULE")
-            logger.warning(
-                "ML predictions disabled; provide a model via AI_TRADING_MODEL_PATH or AI_TRADING_MODEL_MODULE "
-                f"(AI_TRADING_MODEL_PATH={_path!r}, AI_TRADING_MODEL_MODULE={_mod!r})",
-                extra={"model_path": _path, "model_module": _mod},
-            )
-            # AI-AGENT-REF: guard absent model
-            return None
+            if not getattr(self, "_ml_warned", False):
+                logger.warning(
+                    "ML predictions disabled; provide a model via AI_TRADING_MODEL_PATH or AI_TRADING_MODEL_MODULE "
+                    f"(AI_TRADING_MODEL_PATH={_path!r}, AI_TRADING_MODEL_MODULE={_mod!r})",
+                    extra={"model_path": _path, "model_module": _mod},
+                )
+                self._ml_warned = True
+            # AI-AGENT-REF: guard absent model with heuristic fallback
+            return self.signal_vsa(df)
         try:
             if hasattr(model, "feature_names_in_"):
                 feat = list(model.feature_names_in_)

--- a/tests/bot_engine/test_signal_ml.py
+++ b/tests/bot_engine/test_signal_ml.py
@@ -1,0 +1,55 @@
+import sys
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading.core.bot_engine import SignalManager
+
+
+def _minimal_df() -> pd.DataFrame:
+    """Return a DataFrame with required features for ML and VSA heuristics."""
+    data = {
+        "rsi": [30.0] * 20,
+        "macd": [0.1] * 20,
+        "atr": [1.0] * 20,
+        "vwap": [1.0] * 20,
+        "sma_50": [1.0] * 20,
+        "sma_200": [1.0] * 20,
+        "close": [1.0] * 20,
+        "open": [1.0] * 20,
+        "volume": [1.0] * 20,
+    }
+    return pd.DataFrame(data)
+
+
+def test_signal_ml_with_dummy_model(monkeypatch, caplog):
+    """Calling signal_ml with a dummy model should emit no warnings."""
+    monkeypatch.setenv("AI_TRADING_MODEL_MODULE", "dummy_model")
+
+    dummy_model = sys.modules["dummy_model"].get_model()
+    manager = SignalManager()
+    df = _minimal_df()
+
+    caplog.set_level("WARNING")
+    result = manager.signal_ml(df, model=dummy_model)
+
+    assert result is not None
+    assert "ML predictions disabled" not in caplog.text
+
+
+def test_signal_ml_warns_once(monkeypatch, caplog):
+    """Missing models trigger a single warning and fall back to VSA."""
+    monkeypatch.delenv("AI_TRADING_MODEL_MODULE", raising=False)
+    monkeypatch.delenv("AI_TRADING_MODEL_PATH", raising=False)
+    manager = SignalManager()
+    df = _minimal_df()
+
+    caplog.set_level("WARNING")
+    manager.signal_ml(df)
+    manager.signal_ml(df)
+
+    warnings = [
+        rec for rec in caplog.records if "ML predictions disabled" in rec.getMessage()
+    ]
+    assert len(warnings) == 1


### PR DESCRIPTION
## Summary
- fall back to volume-spread-analysis heuristic when ML model is missing and warn only once
- document single-warning fallback behaviour
- cover ML signal fallback with integration tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_signal_ml.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 98 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b89ac2cf4c8330933e16cd75402d10