### PR TITLE
Ensure unique signal components

### DIFF
--- a/tests/bot_engine/test_component_signals_unique.py
+++ b/tests/bot_engine/test_component_signals_unique.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from ai_trading.core.bot_engine import SignalManager, BotState, _evaluate_trade_signal
+
+
+def test_component_signals_unique(monkeypatch):
+    sm = SignalManager()
+    ctx = SimpleNamespace(signal_manager=sm)
+    state = BotState()
+    df = pd.DataFrame({"close": [1, 2, 3]})
+
+    def fake_evaluate(self, ctx, state, df, ticker, model):
+        self.last_components = [(1, 0.5, "vsa"), (1, 0.3, "vsa")]
+        return 1, 0.8, "vsa+vsa"
+
+    monkeypatch.setattr(SignalManager, "evaluate", fake_evaluate, raising=False)
+    _evaluate_trade_signal(ctx, state, df, "TEST", None)
+    labels = [lab for _, _, lab in ctx.signal_manager.last_components]
+    assert len(labels) == len(set(labels))


### PR DESCRIPTION
## Summary
- Deduplicate trade signal components by name before logging and scoring
- Aggregate confidence and strategy identifiers from the unique component set
- Add unit test ensuring signals for a symbol do not repeat identifiers

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_component_signals_unique.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b761a5b483309615c276534213c6