### PR TITLE
Ensure trade log created before first trade

### DIFF
--- a/ai_trading/core/execution_flow.py
+++ b/ai_trading/core/execution_flow.py
@@ -460,12 +460,18 @@ def execute_entry(ctx: Any, symbol: str, qty: int, side: str) -> None:
         scaled_atr_stop,
         targets_lock,
         BotState,
+        get_trade_logger,  # AI-AGENT-REF: ensure trade log initialization
     )
     import numpy as np  # local import to avoid global cost
     from datetime import UTC, datetime
     from zoneinfo import ZoneInfo
 
     PACIFIC = ZoneInfo("America/Los_Angeles")
+
+    # Ensure trade log file exists before logging first entry
+    tl = get_trade_logger()
+    if getattr(ctx, "trade_logger", None) is None:
+        ctx.trade_logger = tl
 
     if getattr(ctx, "api", None) is None:
         logger.warning("ctx.api is None - cannot execute entry")

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -18,7 +18,7 @@ Set `RUN_HEALTHCHECK=1` in the environment to enable the Flask endpoints.
 
 ### Paths & default files
 - Trade log file defaults to `/var/log/ai-trading-bot/trades.jsonl` when `TRADE_LOG_PATH` is not set. The directory is auto-created.
-- The application initializes this trade log on startup via `ai_trading.core.bot_engine.get_trade_logger()`. Custom deployments should call it once if they bypass the standard entrypoint.
+- The application initializes this trade log on startup via `ai_trading.core.bot_engine.get_trade_logger()` and trade execution lazily creates it if missing. Custom deployments should call it once if they bypass the standard entrypoint.
 - Empty model path disables ML quietly. Set `MODEL_PATH` to enable.
 - Override cache location with `AI_TRADING_CACHE_DIR` when the default `~/.cache/ai-trading-bot`
   path is not writable (for example, on read-only home directories). The application

--- a/tests/execution/test_execute_entry_trade_log.py
+++ b/tests/execution/test_execute_entry_trade_log.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+from datetime import time
+import threading
+import pandas as pd
+
+from ai_trading.core import bot_engine, execution_flow
+
+
+def test_execute_entry_logs_trade(tmp_path, monkeypatch):
+    """execute_entry should create trade log and append entry."""
+
+    log_path = tmp_path / "trades.jsonl"
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+
+    # Stub out heavy dependencies
+    monkeypatch.setattr(bot_engine, "submit_order", lambda *a, **k: None)
+    monkeypatch.setattr(bot_engine, "vwap_pegged_submit", lambda *a, **k: None)
+    monkeypatch.setattr(bot_engine, "pov_submit", lambda *a, **k: None)
+    monkeypatch.setattr(bot_engine, "POV_SLICE_PCT", 0)
+    monkeypatch.setattr(bot_engine, "SLICE_THRESHOLD", 10)
+
+    df = pd.DataFrame({"close": [100.0], "atr": [1.0]})
+    monkeypatch.setattr(bot_engine, "fetch_minute_df_safe", lambda symbol: df)
+    monkeypatch.setattr(bot_engine, "prepare_indicators", lambda raw: raw)
+    monkeypatch.setattr(bot_engine, "get_latest_close", lambda df: float(df["close"].iloc[-1]))
+    monkeypatch.setattr(bot_engine, "TAKE_PROFIT_FACTOR", 1.0)
+    monkeypatch.setattr(bot_engine, "is_high_vol_regime", lambda: False)
+    monkeypatch.setattr(
+        bot_engine,
+        "scaled_atr_stop",
+        lambda entry, atr, now, mo, mc, max_factor, min_factor: (entry - 1, entry + 1),
+    )
+    monkeypatch.setattr(bot_engine, "targets_lock", threading.Lock())
+
+    ctx = SimpleNamespace(
+        api=SimpleNamespace(get_account=lambda: SimpleNamespace(buying_power="10000")),
+        trade_logger=None,
+        market_open=time(9, 30),
+        market_close=time(16, 0),
+        stop_targets={},
+        take_profit_targets={},
+    )
+
+    execution_flow.execute_entry(ctx, "AAPL", 1, "buy")
+
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 2
+    assert "AAPL" in lines[1]


### PR DESCRIPTION
## Summary
- call `get_trade_logger()` within `execute_entry` so the trades log file is created before logging
- document lazy trade log creation
- add integration test verifying a trade writes to `trades.jsonl`

## Testing
- `ruff check tests/execution/test_execute_entry_trade_log.py ai_trading/core/execution_flow.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_execute_entry_trade_log.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b766f9b08330b6c2837f6b2ff737