### PR TITLE
Schedule trading service during US market hours

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -6,11 +6,16 @@ Use the canonical unit at `packaging/systemd/ai-trading.service`.
 
 ```bash
 sudo cp packaging/systemd/ai-trading.service /etc/systemd/system/ai-trading.service
+sudo cp packaging/systemd/ai-trading.timer /etc/systemd/system/ai-trading.timer
 sudo systemctl daemon-reload
-sudo systemctl enable --now ai-trading.service
-sudo systemctl restart ai-trading.service
+# Confirm host timezone (service timer uses America/New_York)
+timedatectl | grep 'Time zone'
+# Enable timer to run the bot 09:30-16:00 US/Eastern
+sudo systemctl enable --now ai-trading.timer
 sudo systemctl status ai-trading.service
 ```
+
+The timer schedules the bot to start at market open and the service exits automatically after 6.5 hours (16:00 US/Eastern).
 
 Check logs and health:
 

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -7,6 +7,7 @@ import logging
 from threading import Thread
 import signal
 from datetime import datetime, UTC
+from zoneinfo import ZoneInfo
 from ai_trading.env import ensure_dotenv_loaded
 
 # Ensure environment variables are loaded before any logging configuration
@@ -462,6 +463,15 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_cli(argv)
     global config
     config = S = get_settings()
+    try:
+        if not _is_market_open_base():
+            now = datetime.now(ZoneInfo("America/New_York"))
+            logger.warning(
+                "STARTUP_OUTSIDE_MARKET_HOURS",
+                extra={"now": now.isoformat()},
+            )
+    except Exception:
+        logger.debug("MARKET_OPEN_CHECK_FAILED", exc_info=True)
     # Align Settings.capital_cap with plain env when provided to avoid prefix alias gaps
     _cap_env = os.getenv("CAPITAL_CAP")
     if _cap_env:

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -23,8 +23,8 @@ ExecStartPre=/usr/bin/install -d -m 700 -o aiuser -g aiuser \
     /var/cache/ai-trading-bot \
     /var/log/ai-trading-bot
 ExecStart=/home/aiuser/ai-trading-bot/venv/bin/python -m ai_trading.main
-Restart=always
-RestartSec=10
+RuntimeMaxSec=23400
+Restart=no
 StandardOutput=journal
 StandardError=journal
 

--- a/packaging/systemd/ai-trading.timer
+++ b/packaging/systemd/ai-trading.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Start AI Trading Bot at US market open
+
+[Timer]
+OnCalendar=Mon..Fri 09:30
+Timezone=America/New_York
+Persistent=true
+Unit=ai-trading.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add systemd timer to start the bot at 09:30 America/New_York
- stop service after 6.5h and warn if startup happens outside market hours
- document timezone check and timer enablement

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*


------
https://chatgpt.com/codex/tasks/task_e_68b8baf5d6308330bf0bea508d27064c