### PR TITLE
gate startup to market hours

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -17,6 +17,10 @@ sudo systemctl status ai-trading.service
 
 The timer schedules the bot to start at market open and the service exits automatically after 6.5 hours (16:00 US/Eastern).
 
+If the bot is started manually outside regular hours, it waits until the next
+NYSE session before trading. Set `ALLOW_AFTER_HOURS=1` to disable this wait
+when running tests or after-hours experiments.
+
 Check logs and health:
 
 ```bash

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -539,6 +539,9 @@ PROMETHEUS_PORT=8000
 HEALTH_CHECK_INTERVAL=30
 ```
 
+The service waits for the next NYSE session if it starts outside regular market
+hours. Set `ALLOW_AFTER_HOURS=1` to bypass this check during testing.
+
 ### Configuration Validation
 
 ```python

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ The global HTTP session used for data/broker calls can be tuned via env to balan
 
 These map to `ai_trading.settings.Settings` and are applied at startup by `main._init_http_session`.
 
+### Market hours
+
+The bot checks NYSE trading hours at startup. If launched while the market is
+closed, it sleeps until the next session begins. Set `ALLOW_AFTER_HOURS=1` to
+skip this guard for testing or after-hours experimentation.
+
 ## Timezones
 
 Uses Python stdlib **zoneinfo**.


### PR DESCRIPTION
## Summary
- add `next_market_open` helper and guard startup to wait for the next NYSE session
- allow bypassing the wait with `ALLOW_AFTER_HOURS=1`
- document market-hours gate in README and deployment guides

## Testing
- `ruff check ai_trading/main.py ai_trading/utils/base.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*


------
https://chatgpt.com/codex/tasks/task_e_68b8c76aab6083309a698f81e042e5ba