### PR TITLE
Expose getattr alias for meta_learning tests

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing helpers
     import pandas as _pd  # noqa: F401
 
 open = open
+getattr = getattr
 logger = get_logger(__name__)
 
 try:


### PR DESCRIPTION
## Summary
- alias built-in `getattr` in `meta_learning` so tests can monkeypatch it

## Testing
- `ruff check ai_trading/meta_learning.py tests/test_meta_learning_module.py tests/test_meta_learning_additional.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_meta_learning_module.py tests/test_meta_learning_additional.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8da2e70188330adea94ea5599e2c9