### PR TITLE
Narrow broad exception handlers

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -499,7 +499,7 @@ class BotEngine:
             from ai_trading.ml_model import ensure_default_models
 
             ensure_default_models(self._tickers)
-        except Exception as exc:  # noqa: BLE001 - best effort on startup
+        except (*COMMON_EXC, OSError, RuntimeError) as exc:  # pragma: no cover - best effort on startup
             self.logger.warning(
                 "MODEL_STARTUP_CHECK_FAILED", extra={"error": str(exc)}
             )
@@ -2351,7 +2351,7 @@ def fetch_minute_df_safe(symbol: str) -> pd.DataFrame:
             df = df[df.index < current_minute]
         if "volume" in df.columns:
             df = df[df["volume"] > 0]
-    except Exception as exc:  # pragma: no cover - defensive
+    except (*COMMON_EXC, AttributeError) as exc:  # pragma: no cover - defensive
         logger.debug("minute bar filtering failed: %s", exc)
 
     if df.empty:
@@ -3317,7 +3317,7 @@ _cfg = TradingConfig.from_env()
 if getattr(_cfg, "max_position_size", None):
     try:
         MAX_POSITION_SIZE = float(_cfg.max_position_size)
-    except Exception:  # pragma: no cover - defensive
+    except (ValueError, TypeError):  # pragma: no cover - defensive
         pass
 _settings_drl = get_dollar_risk_limit()
 DOLLAR_RISK_LIMIT = _settings_drl

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -398,7 +398,7 @@ def next_market_open(now: dt.datetime | None = None) -> dt.datetime:
         future = sched[sched["market_open"] > check_time]
         if not future.empty:
             return future.iloc[0]["market_open"].tz_convert(EASTERN_TZ).to_pydatetime()
-    except Exception as exc:  # pragma: no cover - best effort
+    except (ImportError, ValueError, TypeError) as exc:  # pragma: no cover - best effort
         logger.debug("next_market_open calendar lookup failed: %s", exc)
 
     candidate = check_time
@@ -855,9 +855,7 @@ def _get_alpaca_rest():
     try:
         from alpaca.trading.client import TradingClient  # pylint: disable=import-error
     except ImportError as exc:  # pragma: no cover - alpaca SDK missing
-        raise ImportError(
-            "alpaca-py is required for Alpaca access. Install with `pip install alpaca-py`."
-        ) from exc
+        raise ImportError("alpaca-py is required for Alpaca access. Install with `pip install alpaca-py`.") from exc
     return TradingClient
 
 


### PR DESCRIPTION
## Summary
- Restrict `next_market_open` to catch only `ImportError`, `ValueError`, and `TypeError`
- Narrow several broad `Exception` handlers in `bot_engine` to specific exception tuples

## Testing
- `python -m pre_commit run --hook-stage manual ruff --files ai_trading/utils/base.py ai_trading/core/bot_engine.py`
- `python -m pre_commit run --hook-stage manual black --files ai_trading/utils/base.py ai_trading/core/bot_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/runtime/test_no_broad_in_stage2.py tests/runtime/test_no_broad_except_stage2.py tests/runtime/test_no_broad_except_in_hotpaths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8da2da4c0833094bff762abf4cbc1