### PR TITLE
feat: list registered models

### DIFF
--- a/ai_trading/model_registry.py
+++ b/ai_trading/model_registry.py
@@ -128,6 +128,11 @@ class ModelRegistry:
             return None
         return sorted(candidates, key=lambda t: t[1])[-1][0]
 
+    def list_models(self) -> list[str]:
+        """Return a list of all registered model IDs."""
+
+        return list(self.model_index)
+
     @staticmethod
     def _json_safe(data: dict[str, Any]) -> dict[str, Any]:
         """Convert non-JSON-serializable objects to string paths."""

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -173,3 +173,17 @@ class TestModelRegistry:
             )
             _model, meta = registry.load_model(model_id)
             assert meta["cls"] == "unittest.mock.Mock"
+
+    def test_list_models_empty_registry(self):
+        """list_models returns an empty list when no models registered."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry = ModelRegistry(temp_dir)
+            assert registry.list_models() == []
+
+    def test_list_models_populated_registry(self):
+        """list_models returns all registered model IDs."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry = ModelRegistry(temp_dir)
+            m1 = registry.register_model({"a": 1}, "s1", "t1")
+            m2 = registry.register_model({"b": 2}, "s2", "t2")
+            assert sorted(registry.list_models()) == sorted([m1, m2])


### PR DESCRIPTION
## Summary
- add `ModelRegistry.list_models` for enumerating stored model IDs
- test listing behavior for empty and populated registries

## Testing
- `ruff check ai_trading/model_registry.py tests/test_model_registry.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_model_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8dbe7c26c8330b1a6361bd9c1125b