### PR TITLE
feat: make meta-learning cfg optional

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -1045,7 +1045,13 @@ def _convert_audit_to_meta_format(df: 'pd.DataFrame') -> 'pd.DataFrame':
         logger.error(f'META_LEARNING_AUDIT_CONVERSION: Conversion failed: {e}')
         return pd.DataFrame()
 
-def optimize_signals(signal_data: Any, cfg: Any, model: Any | None=None, *, volatility: float=1.0) -> Any:
+def optimize_signals(
+    signal_data: Any,
+    cfg: Any | None = None,
+    model: Any | None = None,
+    *,
+    volatility: float = 1.0,
+) -> Any:
     """Optimize trading signals using ``model`` if provided."""
     if signal_data is None:
         logger.warning('optimize_signals received None signal_data, returning empty list')
@@ -1064,6 +1070,9 @@ def optimize_signals(signal_data: Any, cfg: Any, model: Any | None=None, *, vola
             logger.exception('optimize_signals model prediction failed: %s', exc)
             return signal_data if signal_data is not None else []
     if model is None:
+        if cfg is None:
+            logger.debug('No cfg provided for model loading')
+            return signal_data if signal_data is not None else []
         try:
             model = load_model_checkpoint(cfg.MODEL_PATH)
         except AttributeError:

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -67,6 +67,13 @@ def test_optimize_signals(monkeypatch):
     assert meta_learning.optimize_signals(data, cfg, model=None) == data
 
 
+def test_optimize_signals_no_cfg():
+    m = types.SimpleNamespace(predict=lambda X: [1] * len(X))
+    data = [3, 4]
+    assert meta_learning.optimize_signals(data, cfg=None, model=m) == [1, 1]
+    assert meta_learning.optimize_signals(data, cfg=None, model=None) == data
+
+
 def test_retrain_meta_missing(tmp_path):
     assert not meta_learning.retrain_meta_learner(str(tmp_path / "no.csv"))
 


### PR DESCRIPTION
## Summary
- allow `optimize_signals` to run without a config object
- handle missing cfg during model loading
- test `optimize_signals` with no cfg provided

## Testing
- `ruff check ai_trading/meta_learning.py tests/test_meta_learning.py tests/test_meta_learning_additional.py tests/test_meta_learning_optional.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

------
https://chatgpt.com/codex/tasks/task_e_68b8dbe7156083309074b7076c2bc65b