### PR TITLE
fix: expose portfolio weights on lazy context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - **Import Blocker**: Replaced corrupted `ai_trading/model_registry.py` with clean, minimal, typed model registry implementation
 - Removed hard `data_client` dependency in risk engine with optional Alpaca client.
 - Added `RLTrader` alias and completed config defaults for stable runtime.
+- **BotContext**: expose portfolio weighting and rebalance attributes on `LazyBotContext` to avoid `AttributeError` during trades.
 - Replaced test mock imports in sentiment module with local stub to avoid leakage.
   - Supports `register_model`, `load_model`, and `latest_for` operations
   - Maintains JSON index for model metadata

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -6158,6 +6158,11 @@ class LazyBotContext:
         return self._context.execution_engine
 
     @property
+    def trade_logger(self):
+        self._ensure_initialized()
+        return self._context.trade_logger
+
+    @property
     def stop_targets(self):
         self._ensure_initialized()
         return self._context.stop_targets
@@ -6171,6 +6176,26 @@ class LazyBotContext:
     def confirmation_count(self):
         self._ensure_initialized()
         return self._context.confirmation_count
+
+    @property
+    def portfolio_weights(self):
+        self._ensure_initialized()
+        return self._context.portfolio_weights
+
+    @property
+    def rebalance_buys(self):
+        self._ensure_initialized()
+        return self._context.rebalance_buys
+
+    @property
+    def rebalance_ids(self):
+        self._ensure_initialized()
+        return self._context.rebalance_ids
+
+    @property
+    def rebalance_attempts(self):
+        self._ensure_initialized()
+        return self._context.rebalance_attempts
 
     @property
     def symbols(self):
@@ -6201,6 +6226,31 @@ class LazyBotContext:
     def trailing_extremes(self):
         self._ensure_initialized()
         return self._context.trailing_extremes
+
+    @property
+    def allocator(self):
+        self._ensure_initialized()
+        return self._context.allocator
+
+    @property
+    def strategies(self):
+        self._ensure_initialized()
+        return self._context.strategies
+
+    @property
+    def drawdown_circuit_breaker(self):
+        self._ensure_initialized()
+        return self._context.drawdown_circuit_breaker
+
+    @property
+    def logger(self):
+        self._ensure_initialized()
+        return self._context.logger
+
+    @property
+    def tickers(self):
+        self._ensure_initialized()
+        return self._context.tickers
 
     @property
     def params(self):

--- a/tests/test_lazy_context_attributes.py
+++ b/tests/test_lazy_context_attributes.py
@@ -1,0 +1,35 @@
+import importlib
+import types
+
+
+def test_lazy_context_portfolio_and_rebalance_attrs(monkeypatch):
+    be = importlib.reload(__import__('ai_trading.core.bot_engine', fromlist=['dummy']))
+
+    def fake_ensure(self):
+        self._context = types.SimpleNamespace(
+            portfolio_weights={},
+            rebalance_buys={},
+            rebalance_ids={},
+            rebalance_attempts={},
+            trade_logger=None,
+            allocator=None,
+            strategies=[],
+            drawdown_circuit_breaker=None,
+            logger=None,
+            tickers=[]
+        )
+        self._initialized = True
+
+    monkeypatch.setattr(be.LazyBotContext, '_ensure_initialized', fake_ensure)
+    lbc = be.LazyBotContext()
+
+    assert lbc.portfolio_weights == {}
+    assert lbc.rebalance_buys == {}
+    assert lbc.rebalance_ids == {}
+    assert lbc.rebalance_attempts == {}
+    assert lbc.trade_logger is None
+    assert lbc.allocator is None
+    assert lbc.strategies == []
+    assert lbc.drawdown_circuit_breaker is None
+    assert lbc.logger is None
+    assert lbc.tickers == []


### PR DESCRIPTION
## Summary
- prevent AttributeError in trading by exposing portfolio weights and rebalance fields on `LazyBotContext`
- add regression test for `LazyBotContext` portfolio and rebalance attributes

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_lazy_context_attributes.py tests/test_context_singleton.py::test_lazy_context_model_loaded_once -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ad6bbcfc83309e94e7c5cc75709a