### PR TITLE
Ensure trade log path is initialized and writable

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -19,6 +19,7 @@ Set `RUN_HEALTHCHECK=1` in the environment to enable the Flask endpoints.
 ### Paths & default files
 - Trade log file defaults to `/var/log/ai-trading-bot/trades.jsonl` when `TRADE_LOG_PATH` is not set. The directory is auto-created.
 - The application initializes this trade log on startup via `ai_trading.core.bot_engine.get_trade_logger()` and trade execution lazily creates it if missing. Custom deployments should call it once if they bypass the standard entrypoint.
+- Startup verifies this trade log path is writable and exits if it cannot be created.
 - Empty model path disables ML quietly. Set `MODEL_PATH` to enable.
 - Override cache location with `AI_TRADING_CACHE_DIR` when the default `~/.cache/ai-trading-bot`
   path is not writable (for example, on read-only home directories). The application

--- a/tests/test_main_trade_log_path.py
+++ b/tests/test_main_trade_log_path.py
@@ -1,0 +1,34 @@
+import pytest
+
+import ai_trading.main as main
+import ai_trading.core.bot_engine as bot_engine
+
+
+def test_ensure_trade_log_path_creates_file(tmp_path, monkeypatch):
+    """ensure_trade_log_path creates the trade log header if missing."""
+
+    log_path = tmp_path / "trades.csv"
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+
+    main.ensure_trade_log_path()
+
+    assert log_path.exists()
+    assert log_path.read_text().splitlines()[0].startswith("symbol,entry_time")
+
+
+def test_ensure_trade_log_path_unwritable(tmp_path, monkeypatch):
+    """ensure_trade_log_path exits when the path is not writable."""
+
+    log_path = tmp_path / "subdir" / "trades.csv"
+    parent = log_path.parent
+    parent.mkdir()
+    parent.chmod(0o400)
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+
+    with pytest.raises(SystemExit):
+        main.ensure_trade_log_path()
+
+    parent.chmod(0o700)
+


### PR DESCRIPTION
## Summary
- Verify trade log path is writable during startup via `ensure_trade_log_path`
- Fail fast in preflight, `run_bot`, and `main` if trade log cannot be created
- Document trade log path verification and add tests for it

## Testing
- `ruff check ai_trading/main.py tests/test_main_trade_log_path.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_main_trade_log_path.py tests/bot_engine/test_trade_log_init.py -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ad85ddb48330ae3ddfdb3c41ea1a