### PR TITLE
Improve Alpaca empty bar diagnostics and fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this project will be documented in this file.
 - Dev deps: align `packaging` version with `constraints.txt` (25.0) to
   resolve resolver conflicts during `ensure-runtime` install.
 - **Data Fetch**: raise error when configuration unavailable instead of repeated warnings.
+- **Data Fetch**: improve Alpaca empty-bar handling by logging timeframe/feed,
+  verifying API credentials and market hours, and attempting feed or window
+  fallbacks before resorting to alternate providers.
 - Normalize broker-unavailable contract; remove false PDT warnings; add regression tests.
 - Fix IndentationError in `bot_engine.py` (pybreaker stub); add static compile guard.
 - **Runtime safety**: improved Alpaca availability checks, stable logging shutdown,


### PR DESCRIPTION
## Summary
- log Alpaca empty bar warnings with timeframe and feed
- switch feeds or shorten window before giving up on repeated empty bar responses
- verify API keys and market-hours when fetching minute bars

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 105 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ad84ea1083309b2cdd54a46fc4f7