### PR TITLE
Refine daily fetch cache logging

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -45,7 +45,8 @@ not contain secret key names or placeholder values.
 #### Data Fetch Diagnostics
 Daily price requests now log their parameters and outcome:
 
-- `DAILY_FETCH_REQUEST` records the symbol, timeframe, and date range
+- `DAILY_FETCH_REQUEST` records the symbol, timeframe, and date range only when a cache miss triggers a fetch
+- `DAILY_FETCH_CACHE_HIT` emits once on first cache use; subsequent hits appear only when debug logging is enabled
 - `DAILY_FETCH_RESULT` reports the number of rows returned and whether the
   response came from cache
 - Unauthorized feed responses trigger a quick entitlement check and switch to a


### PR DESCRIPTION
## Summary
- Log daily fetch requests only when an actual fetch occurs after a cache miss
- Emit a single info-level notice on the first daily cache hit; subsequent hits are debug-only
- Document daily fetch cache logging behavior

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_daily_cache.py::test_daily_fetcher_uses_cache -q` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68b9bf7fa0408330860ee32758ae5528