### PR TITLE
refactor alpaca minute fetch error handling

### DIFF
--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -1130,11 +1130,11 @@ def get_minute_df(symbol: str, start: Any, end: Any, feed: str | None = None) ->
                             extra={"symbol": symbol, "timeframe": "1Min", "feed": feed or _DEFAULT_FEED, "occurrences": cnt},
                         )
                         df = None
-            else:
-                logger.warning(
-                    "ALPACA_FETCH_FAILED", extra={"symbol": symbol, "err": str(e)}
-                )
-                df = None
+                else:
+                    logger.warning(
+                        "ALPACA_FETCH_FAILED", extra={"symbol": symbol, "err": str(e)}
+                    )
+                    df = None
         else:
             logger.warning("ALPACA_API_KEY_MISSING", extra={"symbol": symbol, "timeframe": "1Min"})
             df = None

--- a/tests/test_get_minute_df_fetch_logging.py
+++ b/tests/test_get_minute_df_fetch_logging.py
@@ -1,0 +1,73 @@
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import ai_trading.data.fetch as data_fetcher
+
+pd = pytest.importorskip("pandas")
+
+
+def _dt_range():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+    return start, end
+
+
+def _reset_state(monkeypatch):
+    monkeypatch.setattr(data_fetcher, "_MINUTE_CACHE", {})
+    monkeypatch.setattr(data_fetcher, "_EMPTY_BAR_COUNTS", {})
+    monkeypatch.setattr(data_fetcher, "_SKIPPED_SYMBOLS", set())
+
+
+def test_fetch_success_no_error_logged(monkeypatch, caplog):
+    start, end = _dt_range()
+    df = pd.DataFrame({"t": [start], "o": [1], "h": [1], "l": [1], "c": [1], "v": [1]})
+    _reset_state(monkeypatch)
+    monkeypatch.setenv("ENABLE_FINNHUB", "0")
+    monkeypatch.setattr(data_fetcher, "_has_alpaca_keys", lambda: True)
+    monkeypatch.setattr(data_fetcher, "_fetch_bars", lambda *a, **k: df)
+
+    called = {"yahoo": False}
+
+    def _yahoo(*a, **k):
+        called["yahoo"] = True
+        return pd.DataFrame()
+
+    monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", _yahoo)
+
+    with caplog.at_level(logging.WARNING):
+        out = data_fetcher.get_minute_df("AAPL", start, end)
+
+    assert out is df
+    assert not called["yahoo"]
+    assert all(r.message != "ALPACA_FETCH_FAILED" for r in caplog.records)
+
+
+@pytest.mark.parametrize("exc_type", [ValueError, RuntimeError])
+def test_fetch_error_logs_and_sets_none(monkeypatch, caplog, exc_type):
+    start, end = _dt_range()
+    _reset_state(monkeypatch)
+    monkeypatch.setenv("ENABLE_FINNHUB", "0")
+    monkeypatch.setattr(data_fetcher, "_has_alpaca_keys", lambda: True)
+
+    def _fail(*a, **k):
+        raise exc_type("boom")
+
+    monkeypatch.setattr(data_fetcher, "_fetch_bars", _fail)
+
+    fallback_df = pd.DataFrame({"t": [start], "o": [1], "h": [1], "l": [1], "c": [1], "v": [1]})
+    yahoo_called = {"called": False}
+
+    def _yahoo(*a, **k):
+        yahoo_called["called"] = True
+        return fallback_df
+
+    monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", _yahoo)
+
+    with caplog.at_level(logging.WARNING):
+        out = data_fetcher.get_minute_df("AAPL", start, end)
+
+    assert yahoo_called["called"]
+    assert out is fallback_df
+    assert any(r.message == "ALPACA_FETCH_FAILED" for r in caplog.records)


### PR DESCRIPTION
## Summary
- handle non-empty bar errors in `get_minute_df` and remove erroneous try-else
- add tests for successful and failed `_fetch_bars` calls

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_get_minute_df_fetch_logging.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_get_minute_df_fetch_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9d044282c8330a987ed72d083334b