### PR TITLE
Add exponential backoff to Alpaca bar fetch retries

### DIFF
--- a/tests/test_fetch_empty_retry_once.py
+++ b/tests/test_fetch_empty_retry_once.py
@@ -59,7 +59,10 @@ def test_single_retry_and_warning(monkeypatch, caplog):
     monkeypatch.setattr(
         fetch,
         "time",
-        types.SimpleNamespace(sleep=lambda s: sleep_called.setdefault("delay", s)),
+        types.SimpleNamespace(
+            sleep=lambda s: sleep_called.setdefault("delay", s),
+            monotonic=lambda: 0.0,
+        ),
     )
 
     calls = []


### PR DESCRIPTION
## Summary
- increase `_fetch_bars` retry limit to three attempts and track elapsed time
- log each empty-bar retry with attempt count and add exponential backoff
- verify retry logging and timing in tests

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_fetch_empty_handling.py tests/test_fetch_empty_retry_once.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_fetch_empty_handling.py tests/test_fetch_empty_retry_once.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9d237da1883308739150368fd4b3b