### PR TITLE
Warn when Alpaca data empty and Finnhub disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,7 +820,7 @@ connectivity.
 After several empty bar responses from the primary provider, the bot backs off
 and queries the backup source. Configure additional fallbacks with:
 
-- `ENABLE_FINNHUB=1` and `FINNHUB_API_KEY` to allow an intermediate Finnhub
+- Set `ENABLE_FINNHUB=1` and supply `FINNHUB_API_KEY` to enable a Finnhub
   retry before using the backup provider.
 - `BACKUP_DATA_PROVIDER` to override the default Yahoo Finance fallback.
 
@@ -931,9 +931,9 @@ SECONDARY_DATA_PROVIDER=finnhub
 FALLBACK_DATA_PROVIDER=yahoo
 
 # Finnhub API (optional, for enhanced data)
+# Set ENABLE_FINNHUB=1 and provide FINNHUB_API_KEY to enable Finnhub fallback
 FINNHUB_API_KEY=your_finnhub_api_key
-# Disable Finnhub integration if credentials missing
-ENABLE_FINNHUB=false
+ENABLE_FINNHUB=1
 
 # Data quality settings
 ENABLE_DATA_VALIDATION=true

--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -1139,6 +1139,14 @@ def get_minute_df(symbol: str, start: Any, end: Any, feed: str | None = None) ->
             logger.warning("ALPACA_API_KEY_MISSING", extra={"symbol": symbol, "timeframe": "1Min"})
             df = None
     if df is None or getattr(df, "empty", True):
+        if not use_finnhub:
+            logger.warning(
+                "FINNHUB_DISABLED_NO_DATA",
+                extra={
+                    "symbol": symbol,
+                    "recommendation": "set ENABLE_FINNHUB=1 and provide FINNHUB_API_KEY",
+                },
+            )
         max_span = _dt.timedelta(days=8)
         total_span = end_dt - start_dt
         if total_span > max_span:

--- a/tests/test_finnhub_disabled.py
+++ b/tests/test_finnhub_disabled.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import logging
 import pytest
 
 pd = pytest.importorskip("pandas")
@@ -6,7 +7,7 @@ pd = pytest.importorskip("pandas")
 from ai_trading.data import fetch as data_fetcher
 
 
-def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch):
+def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch, caplog):
     monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
     monkeypatch.setenv("ENABLE_FINNHUB", "0")
 
@@ -17,9 +18,11 @@ def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch):
     monkeypatch.setattr(data_fetcher, "_fetch_bars", lambda *a, **k: pd.DataFrame())
     monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", lambda *a, **k: pd.DataFrame())
 
-    df = data_fetcher.get_minute_df(
-        "AAPL",
-        dt.datetime(2023, 1, 1, tzinfo=dt.UTC),
-        dt.datetime(2023, 1, 2, tzinfo=dt.UTC),
-    )
+    with caplog.at_level(logging.WARNING):
+        df = data_fetcher.get_minute_df(
+            "AAPL",
+            dt.datetime(2023, 1, 1, tzinfo=dt.UTC),
+            dt.datetime(2023, 1, 2, tzinfo=dt.UTC),
+        )
     assert df.empty
+    assert any(r.message == "FINNHUB_DISABLED_NO_DATA" for r in caplog.records)


### PR DESCRIPTION
## Summary
- warn to enable Finnhub when Alpaca minute data is empty
- clarify environment variables for Finnhub fallback in config docs
- test warning emitted when Finnhub disabled

## Testing
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check ai_trading/data/fetch.py tests/test_finnhub_disabled.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*

------
https://chatgpt.com/codex/tasks/task_e_68b9d2302d588330b7afefdfb23f206c