### PR TITLE
Ensure daily bar data includes OHLCV fields

### DIFF
--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -339,6 +339,12 @@ def _flatten_and_normalize_ohlcv(df: pd.DataFrame, symbol: str | None = None) ->
         except (AttributeError, TypeError, ValueError):
             pass
         df = df[~df.index.duplicated(keep="last")].sort_index()
+    if "timestamp" not in df.columns and isinstance(df.index, pd.DatetimeIndex):
+        df = df.reset_index().rename(columns={df.index.name or "index": "timestamp"})
+    required = ["open", "high", "low", "close", "volume"]
+    for col in required:
+        if col not in df.columns:
+            df[col] = pd.Series(dtype="float64")
     return df
 
 
@@ -974,6 +980,7 @@ def _fetch_bars(
                 df[col] = pd.to_numeric(df[col], errors="coerce")
         df = df.dropna(subset=["open", "high", "low", "close"])
         df.set_index("timestamp", inplace=True, drop=False)
+        df = _flatten_and_normalize_ohlcv(df, symbol)
         log_fetch_attempt("alpaca", status=status, **log_extra)
         _incr("data.fetch.success", value=1.0, tags=_tags())
         return df

--- a/tests/test_normalize_columns.py
+++ b/tests/test_normalize_columns.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from ai_trading.data.fetch import _flatten_and_normalize_ohlcv
+
+def test_normalize_adds_timestamp_and_volume():
+    df = pd.DataFrame(
+        {
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+        },
+        index=pd.DatetimeIndex([pd.Timestamp("2024-01-01")], name="date"),
+    )
+    out = _flatten_and_normalize_ohlcv(df)
+    for col in ["timestamp", "open", "high", "low", "close", "volume"]:
+        assert col in out.columns


### PR DESCRIPTION
## Summary
- Normalize fetched market data to always include `timestamp`, `open`, `high`, `low`, `close`, and `volume`
- Call the normalizer from `_fetch_bars` so batch requests yield complete OHLCV frames
- Add test verifying the normalizer injects missing columns

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d4476bcc8330bc784180941793bf