### PR TITLE
Validate Alpaca fetch parameters and add fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project will be documented in this file.
   - **Migration Required**: Use `from ai_trading.signals import ...` instead of `from signals import ...`
   - **Breaking**: Root imports are no longer supported as of this version
 - **Utils**: remove legacy `pathlib_shim` re-export; use `ai_trading.utils.paths` instead
+- **Data Fetch**: validate Alpaca request parameters, check trading windows
+  against the market calendar, retry up to 5 times, and optionally fall back to
+  Yahoo when IEX returns empty.
 
 ### Fixed
 - Dev deps: align `packaging` version with `constraints.txt` (25.0) to

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -193,11 +193,15 @@ nslookup api.alpaca.markets 8.8.8.8
 - `ALPACA_FETCH_RETRY_LIMIT` in logs
 
 Repeated empty responses trigger this limit. Verify the market is open or that
-data exists for the requested window before retrying.
+data exists for the requested window before retrying. The fetcher now validates
+that the requested time window intersects a trading session and will raise
+`window_no_trading_session` if it does not.
 
-Per-request retries can be tuned via the `FETCH_BARS_MAX_RETRIES` environment
-variable. When the limit is reached the fetcher returns `None` so callers can
-fall back to cached data or alternate providers.
+Per-request retries (default **5**) can be tuned via the
+`FETCH_BARS_MAX_RETRIES` environment variable. When the limit is reached the
+fetcher returns `None` so callers can fall back to cached data or alternate
+providers. Enable an optional Yahoo fallback by setting
+`ENABLE_HTTP_FALLBACK=1`.
 
 **Data Provider Diagnostics:**
 

--- a/tests/test_empty_bar_backoff.py
+++ b/tests/test_empty_bar_backoff.py
@@ -14,6 +14,11 @@ def _dt_range():
     return start, end
 
 
+@pytest.fixture(autouse=True)
+def _force_window(monkeypatch):
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
+
+
 def test_backoff_uses_alternate_provider(monkeypatch, caplog):
     start, end = _dt_range()
     symbol = "AAPL"

--- a/tests/test_fetch_empty_handling.py
+++ b/tests/test_fetch_empty_handling.py
@@ -37,6 +37,7 @@ def _dt_range():
 
 
 def test_warn_on_empty_when_market_open(monkeypatch, caplog):
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
     start, end = _dt_range()
     sess = _Session([{ "bars": []} for _ in range(4)])
     monkeypatch.setattr(fetch, "_HTTP_SESSION", sess)
@@ -74,6 +75,7 @@ def test_warn_on_empty_when_market_open(monkeypatch, caplog):
 
 
 def test_silent_fallback_when_market_closed(monkeypatch, caplog):
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
     start, end = _dt_range()
     payloads = [
         {"bars": []},
@@ -98,6 +100,7 @@ def test_silent_fallback_when_market_closed(monkeypatch, caplog):
 
 
 def test_skip_retry_outside_market_hours(monkeypatch, caplog):
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
     start, end = _dt_range()
     sess = _Session([{"bars": []}])
     monkeypatch.setattr(fetch, "_HTTP_SESSION", sess)

--- a/tests/test_fetch_empty_retry_once.py
+++ b/tests/test_fetch_empty_retry_once.py
@@ -40,6 +40,7 @@ def _dt_range():
 
 def test_single_retry_and_warning(monkeypatch, caplog):
     start, end = _dt_range()
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
     payloads = [
         {"bars": []},
         {

--- a/tests/test_fetch_param_validation.py
+++ b/tests/test_fetch_param_validation.py
@@ -1,0 +1,30 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ai_trading.data import fetch
+
+
+def _trading_range():
+    start = datetime(2024, 1, 2, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+    return start, end
+
+
+def test_invalid_feed_raises():
+    start, end = _trading_range()
+    with pytest.raises(ValueError):
+        fetch._fetch_bars("AAPL", start, end, "1Min", feed="bogus")
+
+
+def test_invalid_adjustment_raises():
+    start, end = _trading_range()
+    with pytest.raises(ValueError):
+        fetch._fetch_bars("AAPL", start, end, "1Min", adjustment="bad")
+
+
+def test_window_without_trading_session_raises():
+    start = datetime(2024, 1, 6, tzinfo=UTC)
+    end = start + timedelta(days=1)
+    with pytest.raises(ValueError):
+        fetch._fetch_bars("AAPL", start, end, "1Min")

--- a/tests/test_finnhub_disabled.py
+++ b/tests/test_finnhub_disabled.py
@@ -7,6 +7,11 @@ pd = pytest.importorskip("pandas")
 from ai_trading.data import fetch as data_fetcher
 
 
+@pytest.fixture(autouse=True)
+def _force_window(monkeypatch):
+    monkeypatch.setattr(data_fetcher, "_window_has_trading_session", lambda *a, **k: True)
+
+
 def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch, caplog):
     monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
     monkeypatch.setenv("ENABLE_FINNHUB", "0")

--- a/tests/test_get_bars_env_reload.py
+++ b/tests/test_get_bars_env_reload.py
@@ -2,11 +2,17 @@ from datetime import datetime, timedelta, UTC
 
 from ai_trading.utils.lazy_imports import load_pandas
 
+import pytest
 import ai_trading.config.settings as settings_mod
 from ai_trading.data import fetch
 from ai_trading.config import management
 
 pd = load_pandas()
+
+
+@pytest.fixture(autouse=True)
+def _force_window(monkeypatch):
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
 
 
 def test_get_bars_recovers_after_env_reload(monkeypatch, tmp_path):

--- a/tests/test_get_minute_df_fetch_logging.py
+++ b/tests/test_get_minute_df_fetch_logging.py
@@ -8,6 +8,11 @@ import ai_trading.data.fetch as data_fetcher
 pd = pytest.importorskip("pandas")
 
 
+@pytest.fixture(autouse=True)
+def _force_window(monkeypatch):
+    monkeypatch.setattr(data_fetcher, "_window_has_trading_session", lambda *a, **k: True)
+
+
 def _dt_range():
     start = datetime(2024, 1, 1, tzinfo=UTC)
     end = start + timedelta(minutes=1)

--- a/tests/test_price_snapshot_minute_fallback.py
+++ b/tests/test_price_snapshot_minute_fallback.py
@@ -9,6 +9,11 @@ from ai_trading.data import fetch as data_fetcher
 from ai_trading import utils as _utils  # type: ignore
 
 
+@pytest.fixture(autouse=True)
+def _force_window(monkeypatch):
+    monkeypatch.setattr(data_fetcher, "_window_has_trading_session", lambda *a, **k: True)
+
+
 def test_price_snapshot_minute_fallback(monkeypatch):
     ctx = SimpleNamespace(
         data_fetcher=SimpleNamespace(get_daily_df=lambda ctx, s: pd.DataFrame()),

--- a/tests/unit/test_data_fetcher_http.py
+++ b/tests/unit/test_data_fetcher_http.py
@@ -43,6 +43,11 @@ def _dt_range(minutes: int = 5):
     return start, end
 
 
+@pytest.fixture(autouse=True)
+def _force_window(monkeypatch):
+    monkeypatch.setattr(df, "_window_has_trading_session", lambda *a, **k: True)
+
+
 @pytest.mark.parametrize("status_first", [401, 403])
 def test_sip_unauthorized_returns_empty(monkeypatch: pytest.MonkeyPatch, status_first: int):
     monkeypatch.setattr(df, "_SIP_UNAUTHORIZED", False, raising=False)

--- a/tests/unit/test_data_fetcher_metrics.py
+++ b/tests/unit/test_data_fetcher_metrics.py
@@ -52,6 +52,11 @@ def _ts_window() -> tuple[dt.datetime, dt.datetime]:
     return start, end
 
 
+@pytest.fixture(autouse=True)
+def _force_window(monkeypatch):
+    monkeypatch.setattr(df, "_window_has_trading_session", lambda *a, **k: True)
+
+
 def test_rate_limit_fallback_success(monkeypatch: pytest.MonkeyPatch, capmetrics: list[Rec]):
     monkeypatch.setattr(df, "_SIP_UNAUTHORIZED", False, raising=False)
     start, end = _ts_window()


### PR DESCRIPTION
## Summary
- validate Alpaca request parameters and confirm time windows overlap trading sessions
- extend Alpaca fetcher with optional Yahoo fallback and raise retry limit to 5
- document new validation and fallback flags

## Testing
- `python -m pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(skipped: alpaca-py is required for tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b9d44894a083309a7f21bfa2981b5f