### PR TITLE
chore: cache trade log reads and limit empty log warning

### DIFF
--- a/tests/test_empty_dataframe_logging.py
+++ b/tests/test_empty_dataframe_logging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 from ai_trading.core import bot_engine
 
@@ -18,11 +19,14 @@ def test_parse_local_positions_logs_info_on_empty(caplog, tmp_path, monkeypatch)
     trade_log = tmp_path / "trades.csv"
     _write_empty_csv(trade_log, ["symbol", "qty", "side", "exit_time"])
     monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(trade_log))
+    monkeypatch.setattr(bot_engine, "_EMPTY_TRADE_LOG_INFO_EMITTED", False, raising=False)
 
     with caplog.at_level(logging.INFO):
         bot_engine._parse_local_positions()
+        bot_engine._parse_local_positions()
 
-    assert any(r.levelno == logging.INFO and str(trade_log) in r.getMessage() for r in caplog.records)
+    records = [r for r in caplog.records if r.levelno == logging.INFO and str(trade_log) in r.getMessage()]
+    assert len(records) == 1
 
 
 def test_parse_local_positions_warns_when_missing(caplog, tmp_path, monkeypatch):
@@ -31,6 +35,7 @@ def test_parse_local_positions_warns_when_missing(caplog, tmp_path, monkeypatch)
     trade_log = tmp_path / "trades.csv"
     # Intentionally do not create the file
     monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(trade_log))
+    monkeypatch.setattr(bot_engine, "_EMPTY_TRADE_LOG_INFO_EMITTED", False, raising=False)
 
     with caplog.at_level(logging.WARNING):
         bot_engine._parse_local_positions()
@@ -83,3 +88,25 @@ def test_average_reward_debug(caplog, tmp_path, monkeypatch):
         bot_engine._average_reward()
 
     assert any(r.levelno == logging.DEBUG and str(reward_file) in r.getMessage() for r in caplog.records)
+
+
+def test_too_correlated_uses_cached_trade_log(monkeypatch):
+    calls: list[None] = []
+
+    def fake_read(*_a, **_k):
+        calls.append(None)
+        import pandas as pd  # type: ignore
+
+        return pd.DataFrame(columns=["symbol", "exit_time"])
+
+    monkeypatch.setattr(bot_engine, "_read_trade_log", fake_read)
+    monkeypatch.setattr(bot_engine, "_TRADE_LOG_CACHE", None, raising=False)
+    monkeypatch.setattr(bot_engine, "_TRADE_LOG_CACHE_LOADED", False, raising=False)
+
+    bot_engine._load_trade_log_cache()
+
+    ctx = SimpleNamespace(data_fetcher=SimpleNamespace(get_daily_df=lambda *_: None))
+    bot_engine.too_correlated(ctx, "AAA")
+    bot_engine.too_correlated(ctx, "BBB")
+
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- cache trade log on startup and reuse in symbol checks
- warn once when trade log is empty
- test that empty-log info only emits once and trade log cache prevents repeated reads

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dfeb9414833085bd764c9e7de591