### PR TITLE
Guard empty fetch retries

### DIFF
--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -1011,8 +1011,10 @@ def _fetch_bars(
         df = pd.DataFrame(data)
         if df.empty:
             attempt = _state["retries"] + 1
-            log_extra_with_remaining = {"remaining_retries": max_retries - attempt, **log_extra}
-            log_fetch_attempt("alpaca", status=status, error="empty", **log_extra_with_remaining)
+            remaining_retries = max(0, max_retries - attempt)
+            log_extra_with_remaining = {"remaining_retries": remaining_retries, **log_extra}
+            if attempt <= max_retries:
+                log_fetch_attempt("alpaca", status=status, error="empty", **log_extra_with_remaining)
             metrics.empty_payload += 1
             is_empty_error = isinstance(payload, dict) and payload.get("error") == "empty"
             if fallback:

--- a/tests/test_fetch_empty_retry_exhausted.py
+++ b/tests/test_fetch_empty_retry_exhausted.py
@@ -1,0 +1,66 @@
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+
+from ai_trading.data import fetch
+
+
+class _Resp:
+    def __init__(self, payload, corr_id):
+        self.status_code = 200
+        self.headers = {"Content-Type": "application/json", "x-request-id": corr_id}
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, payloads, corr_ids):
+        self._payloads = list(payloads)
+        self._corr_ids = list(corr_ids)
+        self.calls = 0
+        self.get = self._get
+
+    def _get(self, url, params=None, headers=None, timeout=None):
+        idx = self.calls
+        self.calls += 1
+        return _Resp(self._payloads[idx], self._corr_ids[idx])
+
+
+def _dt_range():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+    return start, end
+
+
+def test_skip_log_when_retries_exhausted(monkeypatch, caplog):
+    start, end = _dt_range()
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
+    payloads = [{"bars": []}, {"bars": []}]
+    corr_ids = ["id1", "id2"]
+    sess = _Session(payloads, corr_ids)
+    monkeypatch.setattr(fetch, "_HTTP_SESSION", sess)
+    monkeypatch.setattr(fetch, "_SIP_UNAUTHORIZED", True)
+    monkeypatch.setattr(fetch, "is_market_open", lambda: True)
+    monkeypatch.setattr(fetch, "_sip_fallback_allowed", lambda *a, **k: False)
+    monkeypatch.setattr(fetch, "_outside_market_hours", lambda *a, **k: False)
+    monkeypatch.setattr(fetch, "_FETCH_BARS_MAX_RETRIES", 1)
+
+    calls = []
+
+    def _log_fetch_attempt(provider, *, status=None, error=None, **extra):
+        calls.append((status, error, extra))
+
+    monkeypatch.setattr(fetch, "log_fetch_attempt", _log_fetch_attempt)
+
+    with caplog.at_level(logging.WARNING):
+        out = fetch._fetch_bars("AAPL", start, end, "1Min", feed="iex")
+
+    assert out is None
+    assert sess.calls == 2
+    assert len(calls) == 1
+    assert calls[0][2]["remaining_retries"] == 0
+    assert all(c[2]["remaining_retries"] >= 0 for c in calls)
+    assert any(r.message == "ALPACA_FETCH_RETRY_LIMIT" for r in caplog.records)


### PR DESCRIPTION
## Summary
- avoid negative remaining_retries when Alpaca fetch returns empty payloads
- add regression test covering exhausted empty fetch retries

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_fetch_empty_retry_exhausted.py tests/test_fetch_empty_retry_once.py tests/test_fetch_empty_handling.py`
- `FETCH_BARS_MAX_RETRIES=3 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_empty_retry_once.py tests/test_fetch_empty_handling.py tests/test_fetch_empty_retry_exhausted.py -q`

## Rollback Plan
- Revert the commits to restore previous retry logging behavior

------
https://chatgpt.com/codex/tasks/task_e_68b9dfebb8508330b09a42f819f6ba6d