### PR TITLE
Document Finnhub env variables for persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ FLASK_PORT=5000
 NEWS_API_KEY=your_news_api_key_here
 
 # Optional: Get from https://finnhub.io/
+ENABLE_FINNHUB=1
 FINNHUB_API_KEY=your_finnhub_api_key_here
 
 # Optional: Sentiment analysis service

--- a/.env.sample
+++ b/.env.sample
@@ -23,5 +23,5 @@ AI_TRADING_MODEL_MODULE=ai_trading.model_loader
 
 # Finnhub data provider (optional)
 FINNHUB_API_KEY=your_finnhub_api_key_here
-# ENABLE_FINNHUB=1
+ENABLE_FINNHUB=1
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -518,6 +518,7 @@ AI_TRADING_TICKERS_CSV=/app/data/tickers.csv    # optional override
 # API Configuration
 ALPACA_BASE_URL=https://api.alpaca.markets
 FINNHUB_API_KEY=your_finnhub_key
+ENABLE_FINNHUB=1
 
 # Logging
 LOG_LEVEL=INFO


### PR DESCRIPTION
## Summary
- expose `ENABLE_FINNHUB` alongside `FINNHUB_API_KEY` in sample env files
- document Finnhub enable flag in deployment guide so values persist across restarts

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_finnhub_symbol_processing.py::test_get_minute_df_uses_finnhub_when_key -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_finnhub_disabled.py::test_get_minute_df_returns_empty_when_finnhub_disabled -q`
- `ENABLE_FINNHUB=1 FINNHUB_API_KEY=dummykey python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b9dfec35e083308f8fb96704a1794f