### PR TITLE
Abort early on empty Alpaca responses

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -190,12 +190,13 @@ nslookup api.alpaca.markets 8.8.8.8
 - Stale data warnings
 - Data provider fallback messages
 - `ALPACA_EMPTY_BAR_MAX_RETRIES` in logs
-- `ALPACA_FETCH_RETRY_LIMIT` in logs
+- `ALPACA_FETCH_RETRY_LIMIT` in logs (emitted after two consecutive empty responses)
 
-Repeated empty responses trigger this limit. Verify the market is open or that
-data exists for the requested window before retrying. The fetcher now validates
-that the requested time window intersects a trading session and will raise
-`window_no_trading_session` if it does not.
+Repeated empty 200-responses trigger this limit quickly. Verify the market is
+open or that data exists for the requested window (symbol still listed, feed
+correct) before retrying. The fetcher now validates that the requested time
+window intersects a trading session and will raise `window_no_trading_session`
+if it does not.
 
 Per-request retries (default **5**) can be tuned via the
 `FETCH_BARS_MAX_RETRIES` environment variable. When the limit is reached the

--- a/tests/test_fetch_empty_early_exit.py
+++ b/tests/test_fetch_empty_early_exit.py
@@ -1,0 +1,60 @@
+import json
+import logging
+import types
+from datetime import UTC, datetime, timedelta
+
+from ai_trading.data import fetch
+
+
+class _Resp:
+    def __init__(self, payload, corr_id):
+        self.status_code = 200
+        self.headers = {"Content-Type": "application/json", "x-request-id": corr_id}
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, payloads, corr_ids):
+        self._payloads = list(payloads)
+        self._corr_ids = list(corr_ids)
+        self.calls = 0
+        self.get = self._get
+
+    def _get(self, url, params=None, headers=None, timeout=None):
+        idx = self.calls
+        self.calls += 1
+        return _Resp(self._payloads[idx], self._corr_ids[idx])
+
+
+def _dt_range():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+    return start, end
+
+
+def test_persistent_empty_aborts_early(monkeypatch, caplog):
+    start, end = _dt_range()
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
+    payloads = [{"bars": []}, {"bars": []}, {"bars": []}]
+    corr_ids = ["id1", "id2", "id3"]
+    sess = _Session(payloads, corr_ids)
+    monkeypatch.setattr(fetch, "_HTTP_SESSION", sess)
+    monkeypatch.setattr(fetch, "_SIP_UNAUTHORIZED", True)
+    monkeypatch.setattr(fetch, "is_market_open", lambda: True)
+    monkeypatch.setattr(fetch, "_outside_market_hours", lambda *a, **k: False)
+    monkeypatch.setattr(
+        fetch,
+        "time",
+        types.SimpleNamespace(monotonic=lambda: 0.0, sleep=lambda _s: None),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        out = fetch._fetch_bars("AAPL", start, end, "1Min", feed="iex")
+
+    assert out is None
+    assert sess.calls == 2
+    assert sum(r.message == "ALPACA_FETCH_RETRY_LIMIT" for r in caplog.records) == 1

--- a/tests/test_fetch_empty_handling.py
+++ b/tests/test_fetch_empty_handling.py
@@ -65,13 +65,13 @@ def test_warn_on_empty_when_market_open(monkeypatch, caplog):
         out = fetch._fetch_bars("AAPL", start, end, "1Min")
 
     assert out is None
-    assert sess.calls == 4
+    assert sess.calls == 2
     retry_logs = [r for r in caplog.records if r.message == "RETRY_EMPTY_BARS"]
-    assert [r.attempt for r in retry_logs] == [1, 2, 3]
-    assert [r.total_elapsed for r in retry_logs] == [0, 1, 3]
-    assert delays == [1, 2, 4]
+    assert [r.attempt for r in retry_logs] == [1]
+    assert [r.total_elapsed for r in retry_logs] == [0]
+    assert delays == [1]
     assert any(r.message == "EMPTY_DATA" and r.levelno == logging.WARNING for r in caplog.records)
-    assert any(r.message == "ALPACA_FETCH_RETRY_LIMIT" for r in caplog.records)
+    assert sum(r.message == "ALPACA_FETCH_RETRY_LIMIT" for r in caplog.records) == 1
 
 
 def test_silent_fallback_when_market_closed(monkeypatch, caplog):

--- a/tests/test_fetch_empty_retry_once.py
+++ b/tests/test_fetch_empty_retry_once.py
@@ -55,6 +55,9 @@ def test_single_retry_and_warning(monkeypatch, caplog):
     monkeypatch.setattr(fetch, "is_market_open", lambda: True)
     monkeypatch.setattr(fetch, "_sip_fallback_allowed", lambda *a, **k: False)
     monkeypatch.setattr(fetch, "_outside_market_hours", lambda *a, **k: False)
+    monkeypatch.setattr(fetch, "_empty_should_emit", lambda *a, **k: True)
+    monkeypatch.setattr(fetch, "_empty_record", lambda *a, **k: 1)
+    monkeypatch.setattr(fetch, "_empty_classify", lambda **k: logging.WARNING)
 
     sleep_called = {}
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- abort Alpaca fetches after two consecutive empty 200 responses and surface likely causes
- document and test early exit behaviour for empty-bar payloads

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_fetch_empty_handling.py tests/test_fetch_empty_retry_once.py tests/test_fetch_empty_early_exit.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_empty_handling.py tests/test_fetch_empty_early_exit.py tests/test_fetch_empty_retry_exhausted.py tests/test_fetch_empty_retry_once.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68b9e9bb8ec48330b635dd291bb51039