### PR TITLE
Cache fallback provider windows to avoid redundant Alpaca fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to this project will be documented in this file.
 - Makefile: add `PYTHON ?= python3` and route all invocations through
   `$(PYTHON)` for compatibility on Debian/Ubuntu where `python` shim is
   absent. Supports using a venv via `make ... PYTHON=.venv/bin/python`.
+
+### Added
+- Cache fallback data provider usage to skip redundant Alpaca requests
+  for the same symbol and window.
 - **Python**: restrict supported version to >=3.12,<3.13
 - **Package Structure**: Root modules previously moved into `ai_trading/` package
   - **Migration Required**: Use `from ai_trading.signals import ...` instead of `from signals import ...`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 import pathlib
 
 import pytest
+import ai_trading.data.fetch as data_fetcher
 
 try:
     from alpaca.trading.client import TradingClient  # type: ignore  # noqa: F401
@@ -138,3 +139,8 @@ def _sanitize_executor_env(monkeypatch):
         return _orig_getenv(key, default)
 
     monkeypatch.setattr(_os, "getenv", _sanitized_getenv, raising=True)
+
+
+@pytest.fixture(autouse=True)
+def _reset_fallback_cache(monkeypatch):
+    monkeypatch.setattr(data_fetcher, "_FALLBACK_WINDOWS", set())

--- a/tests/test_fallback_cache.py
+++ b/tests/test_fallback_cache.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from datetime import datetime, UTC, timedelta
+
+import pytest
+
+import ai_trading.data.fetch as data_fetcher
+
+pd = pytest.importorskip("pandas")
+
+
+@pytest.fixture(autouse=True)
+def _force_window(monkeypatch):
+    monkeypatch.setattr(data_fetcher, "_window_has_trading_session", lambda *a, **k: True)
+
+
+def test_alpaca_skipped_after_yahoo_fallback(monkeypatch):
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+
+    monkeypatch.setenv("ENABLE_HTTP_FALLBACK", "1")
+    monkeypatch.setattr(data_fetcher, "_has_alpaca_keys", lambda: True)
+
+    calls = {"alpaca": 0}
+
+    class DummyResp:
+        status_code = 200
+        text = "{\"bars\": []}"
+        content = text.encode()
+        headers = {"Content-Type": "application/json"}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        calls["alpaca"] += 1
+        return DummyResp()
+
+    monkeypatch.setattr(data_fetcher, "requests", SimpleNamespace(get=fake_get))
+    monkeypatch.setattr(data_fetcher._HTTP_SESSION, "get", fake_get, raising=False)
+
+    yahoo_calls = {"n": 0}
+    df_fallback = pd.DataFrame(
+        {
+            "timestamp": [pd.Timestamp(start)],
+            "open": [1.0],
+            "high": [1.0],
+            "low": [1.0],
+            "close": [1.0],
+            "volume": [1],
+        }
+    )
+
+    def fake_yahoo(symbol, s, e, interval):  # noqa: ARG001 - test stub
+        yahoo_calls["n"] += 1
+        return df_fallback
+
+    monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", fake_yahoo)
+    monkeypatch.setattr(data_fetcher, "_backup_get_bars", fake_yahoo)
+
+    out1 = data_fetcher.get_minute_df("AAPL", start, end)
+    assert not out1.empty
+    assert yahoo_calls["n"] == 1
+    assert calls["alpaca"] == 1
+
+    out2 = data_fetcher.get_minute_df("AAPL", start, end)
+    assert not out2.empty
+    assert yahoo_calls["n"] == 2
+    assert calls["alpaca"] == 1


### PR DESCRIPTION
## Summary
- track symbol/timeframe windows served by fallback provider
- skip redundant Alpaca requests when a Yahoo fallback was already used
- test caching behavior and reset fallback cache for tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*


------
https://chatgpt.com/codex/tasks/task_e_68b9e9bc03748330a77322fe5e3c752d