### PR TITLE
feat: dedupe finnhub warnings

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -478,6 +478,27 @@ def get_logger(name: str) -> SanitizingLoggerAdapter:
 logger = SanitizingLoggerAdapter(logging.getLogger(__name__), {})
 logger_once = EmitOnceLogger(logger)
 
+
+def log_finnhub_disabled(symbol: str) -> None:
+    """Debug once when Finnhub is disabled for ``symbol``."""
+    logger_once.debug(
+        "FINNHUB_DISABLED",
+        key=f"FINNHUB_DISABLED:{symbol}",
+        extra={"symbol": symbol},
+    )
+
+
+def warn_finnhub_disabled_no_data(symbol: str) -> None:
+    """Warn once per symbol when Finnhub is disabled and no data is returned."""
+    logger_once.warning(
+        "FINNHUB_DISABLED_NO_DATA",
+        key=f"FINNHUB_DISABLED_NO_DATA:{symbol}",
+        extra={
+            "symbol": symbol,
+            "recommendation": "set ENABLE_FINNHUB=1 and provide FINNHUB_API_KEY",
+        },
+    )
+
 def log_fetch_attempt(provider: str, *, status: int | None = None, error: str | None = None, **extra: Any) -> None:
     """Log a market data fetch attempt and its outcome.
 
@@ -849,4 +870,4 @@ def validate_logging_setup(logger: logging.Logger | None=None, *, dedupe: bool=F
     else:
         get_logger(__name__).error('Logging validation failed: %s', validation_result['issues'])
     return validation_result
-__all__ = ['setup_logging', 'get_logger', 'get_phase_logger', 'init_logger', 'logger', 'logger_once', 'log_fetch_attempt', 'log_empty_retries_exhausted', 'log_performance_metrics', 'log_trading_event', 'setup_enhanced_logging', 'validate_logging_setup', 'dedupe_stream_handlers', 'EmitOnceLogger', 'CompactJsonFormatter', 'with_extra', 'info_kv', 'warning_kv', 'error_kv', 'SanitizingLoggerAdapter', 'sanitize_extra']
+__all__ = ['setup_logging', 'get_logger', 'get_phase_logger', 'init_logger', 'logger', 'logger_once', 'log_fetch_attempt', 'log_empty_retries_exhausted', 'log_performance_metrics', 'log_trading_event', 'log_finnhub_disabled', 'warn_finnhub_disabled_no_data', 'setup_enhanced_logging', 'validate_logging_setup', 'dedupe_stream_handlers', 'EmitOnceLogger', 'CompactJsonFormatter', 'with_extra', 'info_kv', 'warning_kv', 'error_kv', 'SanitizingLoggerAdapter', 'sanitize_extra']

--- a/docs/provider_configuration.md
+++ b/docs/provider_configuration.md
@@ -7,6 +7,13 @@ This project supports multiple market data sources. Operators can toggle provide
 - `ENABLE_FINNHUB`: set to `1` to enable, `0` to disable.
 - `FINNHUB_API_KEY`: required when Finnhub access is enabled.
 
+Example:
+
+```bash
+export FINNHUB_API_KEY=your_finnhub_key
+export ENABLE_FINNHUB=1
+```
+
 ## Alpaca Feed
 
 - `ALPACA_DATA_FEED`: choose `iex` (default) or `sip`. The `sip` option requires a SIP-enabled Alpaca account.

--- a/tests/test_finnhub_disabled.py
+++ b/tests/test_finnhub_disabled.py
@@ -31,3 +31,20 @@ def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch, caplog):
         )
     assert df.empty
     assert any(r.message == "FINNHUB_DISABLED_NO_DATA" for r in caplog.records)
+
+
+def test_duplicate_warning_suppressed(monkeypatch, caplog):
+    from ai_trading.logging import logger_once
+
+    monkeypatch.setattr(logger_once, "_emitted_keys", set())
+    monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
+    monkeypatch.setenv("ENABLE_FINNHUB", "0")
+    monkeypatch.setattr(data_fetcher, "_fetch_bars", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", lambda *a, **k: pd.DataFrame())
+    start = dt.datetime(2023, 1, 1, tzinfo=dt.UTC)
+    end = dt.datetime(2023, 1, 2, tzinfo=dt.UTC)
+    with caplog.at_level(logging.WARNING):
+        data_fetcher.get_minute_df("MSFT", start, end)
+        data_fetcher.get_minute_df("MSFT", start, end)
+    warnings = [r for r in caplog.records if r.message == "FINNHUB_DISABLED_NO_DATA"]
+    assert len(warnings) == 1


### PR DESCRIPTION
## Summary
- log FINNHUB_DISABLED only once per symbol
- explain how to enable Finnhub in provider configuration guide
- add regression test for warning dedupe

## Testing
- `ruff check ai_trading/logging/__init__.py ai_trading/data/fetch.py tests/test_finnhub_disabled.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_finnhub_disabled.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9ebc79cd88330b09c5c9772f24894