### PR TITLE
Handle non-iterable positions in sector exposure

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -7561,7 +7561,11 @@ def sector_exposure(ctx: BotContext) -> dict[str, float]:
     ):  # AI-AGENT-REF: narrow exception
         total = 0.0
     exposure: dict[str, float] = {}
-    for pos in positions:
+    try:
+        iter_positions = list(positions)
+    except TypeError:
+        iter_positions = []
+    for pos in iter_positions:
         qty = abs(int(getattr(pos, "qty", 0)))
         price = float(
             getattr(pos, "current_price", 0) or getattr(pos, "avg_entry_price", 0) or 0

--- a/tests/test_critical_trading_fixes.py
+++ b/tests/test_critical_trading_fixes.py
@@ -610,6 +610,21 @@ def test_risk_management_sector_exposure_logging():
     assert result is True  # Should allow initial positions
 
 
+def test_sector_exposure_handles_non_iterable_positions():
+    """sector_exposure should treat non-iterable positions as empty."""
+    from ai_trading.core.bot_engine import sector_exposure
+
+    mock_ctx = Mock()
+    mock_ctx.api = Mock()
+
+    mock_ctx.api.list_positions.return_value = None
+    mock_account = Mock()
+    mock_account.portfolio_value = 1000
+    mock_ctx.api.get_account.return_value = mock_account
+
+    assert sector_exposure(mock_ctx) == {}
+
+
 def test_data_integrity_validation():
     """Test comprehensive data integrity validation."""
     from ai_trading.data_validation import (


### PR DESCRIPTION
## Summary
- guard sector_exposure against non-iterable position results
- add regression test for non-iterable positions

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1fd031c883308ae5ac62b2e38ca4