### PR TITLE
validate ridge model methods

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -672,6 +672,9 @@ def retrain_meta_learner(trade_log_path: str=None, model_path: str='meta_model.p
         raise ImportError('scikit-learn is required for retrain_meta_learner')
     from sklearn.linear_model import Ridge
     model = Ridge(alpha=1.0, fit_intercept=True)
+    if not (callable(getattr(model, 'fit', None)) and callable(getattr(model, 'predict', None))):
+        logger.error('META_LEARNING_MODEL_INTERFACE: Ridge missing fit or predict method')
+        return False
     import inspect
     try:
         sig = inspect.signature(model.fit)


### PR DESCRIPTION
## Summary
- ensure Ridge model exposes fit and predict before training

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68ba1fcf449483308e47ab1c95c8a23a