### PR TITLE
Handle absent order status constants in safe_submit_order

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8356,7 +8356,8 @@ def safe_submit_order(api: Any, req, *, bypass_market_check: bool = False) -> Or
                     raise
 
             start_ts = time.monotonic()
-            while getattr(order, "status", None) == OrderStatus.PENDING_NEW:
+            pending_new = getattr(OrderStatus, "PENDING_NEW", "pending_new")
+            while getattr(order, "status", None) == pending_new:
                 if time.monotonic() - start_ts > 1:
                     logger.warning(
                         f"Order stuck in PENDING_NEW: {order_args.get('symbol')}, retrying or monitoring required."
@@ -8388,8 +8389,10 @@ def safe_submit_order(api: Any, req, *, bypass_market_check: bool = False) -> Or
                 raise OrderExecutionError(
                     f"Buy failed for {order_args.get('symbol')}: {status}"
                 )
-            elif status == OrderStatus.NEW:
-                logger.info(f"Order for {order_args.get('symbol')} is NEW; awaiting fill")
+            elif status == getattr(OrderStatus, "NEW", "new"):
+                logger.info(
+                    f"Order for {order_args.get('symbol')} is NEW; awaiting fill"
+                )
             else:
                 logger.error(
                     f"Order for {order_args.get('symbol')} status={status}: {getattr(order, 'reject_reason', '')}"


### PR DESCRIPTION
## Summary
- Use `getattr` with sensible defaults for `OrderStatus.PENDING_NEW` and `OrderStatus.NEW`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_safe_submit_order.py::test_safe_submit_order_pending_new -q` *(fails: DummyAPI.__init__.<locals>.<lambda>() got an unexpected keyword argument 'symbol')*

------
https://chatgpt.com/codex/tasks/task_e_68ba22c935ac8330b1afd85e4b77a169