### PR TITLE
Track attempted symbols during empty bar backoff

### DIFF
--- a/ai_trading/data/empty_bar_backoff.py
+++ b/ai_trading/data/empty_bar_backoff.py
@@ -1,0 +1,29 @@
+"""Helpers for tracking empty-bar fetch backoffs.
+
+This module centralizes bookkeeping around symbols that should be skipped
+because prior fetch attempts resulted in empty bar responses.  It exposes a
+shared ``_SKIPPED_SYMBOLS`` set along with convenience helpers for recording
+attempts and marking successful fetches.
+"""
+from __future__ import annotations
+
+# Symbols that have recently triggered empty-bar skips.
+# Each entry is keyed by ``(symbol, timeframe)``.
+_SKIPPED_SYMBOLS: set[tuple[str, str]] = set()
+
+
+def record_attempt(symbol: str, timeframe: str) -> None:
+    """Record that a symbol/timeframe fetch attempt was made.
+
+    The pair is added to ``_SKIPPED_SYMBOLS`` so subsequent calls can detect
+    in-flight or failed attempts and avoid redundant network requests.
+    """
+    _SKIPPED_SYMBOLS.add((symbol, timeframe))
+
+
+def mark_success(symbol: str, timeframe: str) -> None:
+    """Mark a previously attempted fetch as succeeded.
+
+    Removes the pair from ``_SKIPPED_SYMBOLS`` allowing future fetches.
+    """
+    _SKIPPED_SYMBOLS.discard((symbol, timeframe))


### PR DESCRIPTION
## Summary
- centralize skipped-symbol tracking in `empty_bar_backoff`
- record attempted minute-bar fetches and clear on fallback success

## Testing
- `ruff check ai_trading/data/empty_bar_backoff.py ai_trading/data/fetch.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: `alpaca-py is required for tests`)*

------
https://chatgpt.com/codex/tasks/task_e_68ba24ce8bb88330bbf6d958c90d6cba