### PR TITLE
feat: make http host concurrency configurable

### DIFF
--- a/ai_trading/http/__init__.py
+++ b/ai_trading/http/__init__.py
@@ -1,0 +1,3 @@
+from .pooling import HOST_SEMAPHORE, get_host_semaphore
+
+__all__ = ["HOST_SEMAPHORE", "get_host_semaphore"]

--- a/ai_trading/http/pooling.py
+++ b/ai_trading/http/pooling.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Final
+
+from ai_trading.config import management as config
+
+_DEFAULT_LIMIT: Final[int] = 8
+
+
+def _resolve_limit() -> int:
+    try:
+        return int(config.get_env("AI_TRADING_MAX_CONCURRENT_HOSTS", str(_DEFAULT_LIMIT), cast=int))
+    except Exception:
+        return _DEFAULT_LIMIT
+
+
+HOST_SEMAPHORE: asyncio.Semaphore = asyncio.Semaphore(_resolve_limit())
+
+
+def get_host_semaphore() -> asyncio.Semaphore:
+    """Return the global semaphore limiting concurrent host requests."""
+    return HOST_SEMAPHORE


### PR DESCRIPTION
## Summary
- allow configuring concurrent host limit via `AI_TRADING_MAX_CONCURRENT_HOSTS`
- expose reusable host semaphore through `ai_trading.http`

## Testing
- `ruff check ai_trading/http/pooling.py ai_trading/http/__init__.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: numpy/pandas binary incompatibility; test suite skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68ba26491cd083309279ae3f9bda7a0c