### PR TITLE
Use getattr for calendar valid_days fallback

### DIFF
--- a/ai_trading/scheduler/aligned_clock.py
+++ b/ai_trading/scheduler/aligned_clock.py
@@ -122,7 +122,8 @@ class AlignedClock:
                 next_close += timedelta(days=1)
         if self.calendar:
             try:
-                trading_days = self.calendar.valid_days(
+                valid_days = getattr(self.calendar, "valid_days", lambda *a, **k: [])
+                trading_days = valid_days(
                     start_date=next_close.date(), end_date=next_close.date() + timedelta(days=7)
                 )
                 if len(trading_days) > 0:


### PR DESCRIPTION
## Summary
- Prevent AttributeError by safely accessing `valid_days` in `AlignedClock`
- Add defensive `valid_days` handling in market calendar utilities

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2adb7e6483309922985f028a7ba3