### PR TITLE
Respect reraise flag in retry decorator

### DIFF
--- a/ai_trading/utils/retry.py
+++ b/ai_trading/utils/retry.py
@@ -128,7 +128,8 @@ def retry(
     - backoff: multiplier for linear/exponential modes
     - mode: one of "fixed", "linear", "exponential"
     - exceptions: tuple of exception types to catch
-    - reraise: when True, propagate the last exception instead of raising RetryError
+    - reraise: when True, propagate the last exception instead of raising RetryError.
+      Forwarded to Tenacity's ``retry`` decorator when available.
     """
 
     attempts = max(0, int(retries))
@@ -148,7 +149,7 @@ def retry(
             else:
                 _wait = _wait_exponential(multiplier=base, min=base, max=None)
         _retry = retry if retry is not None else retry_if_exception_type(exceptions)
-        dec = _tenacity_retry(retry=_retry, stop=_stop, wait=_wait, reraise=True)
+        dec = _tenacity_retry(retry=_retry, stop=_stop, wait=_wait, reraise=reraise)
         # Also point tenacity.retry at this decorator to satisfy identity checks in tests
         try:
             import tenacity as _tenacity_mod  # type: ignore
@@ -167,7 +168,7 @@ def retry(
         else:  # exponential (default)
             _wait = _wait_exponential(multiplier=base, min=base, max=None)
         predicate = retry_if_exception_type(exceptions)
-        dec = _tenacity_retry(retry=predicate, stop=_stop, wait=_wait, reraise=True)
+        dec = _tenacity_retry(retry=predicate, stop=_stop, wait=_wait, reraise=reraise)
         try:
             import tenacity as _tenacity_mod  # type: ignore
 

--- a/tests/unit/test_retry_reraise.py
+++ b/tests/unit/test_retry_reraise.py
@@ -1,0 +1,26 @@
+import pytest
+
+from tests.optdeps import require
+
+from ai_trading.utils.retry import RetryError, retry
+
+# Skip when tenacity is not installed
+require("tenacity")
+
+
+def test_retry_reraise_false_wraps_exception():
+    @retry(retries=2, delay=0.001, reraise=False)
+    def boom():
+        raise ValueError("boom")
+
+    with pytest.raises(RetryError):
+        boom()
+
+
+def test_retry_reraise_true_propagates_exception():
+    @retry(retries=2, delay=0.001, reraise=True)
+    def boom():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        boom()


### PR DESCRIPTION
## Summary
- Allow `retry` decorator to forward `reraise` option to Tenacity
- Document new behavior and add unit tests for `reraise`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_retry.py tests/unit/test_retry_mode.py tests/unit/test_retry_reraise.py tests/test_tenacity_import.py tests/test_retry_idempotency_integration.py -q` *(fails: `ModuleNotFoundError: No module named 'alpaca'` — test session skipped)*
- `python - <<'PY'
from ai_trading.utils.retry import RetryError, retry
@retry(retries=2, delay=0.001, reraise=False)
def boom():
    raise ValueError('boom')
try:
    boom()
except RetryError:
    print('reraise_false_ok')
@retry(retries=2, delay=0.001, reraise=True)
def boom2():
    raise ValueError('boom')
try:
    boom2()
except ValueError:
    print('reraise_true_ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ba2adc14848330b58a43fa8185f792