### PR TITLE
Ensure validate_environment raises on missing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file.
 - **Data Fetch**: improve Alpaca empty-bar handling by logging timeframe/feed,
   verifying API credentials and market hours, and attempting feed or window
   fallbacks before resorting to alternate providers.
+- **Main**: `validate_environment` now raises `RuntimeError` when required
+  environment variables are missing.
 - Normalize broker-unavailable contract; remove false PDT warnings; add regression tests.
 - Fix IndentationError in `bot_engine.py` (pybreaker stub); add static compile guard.
 - **Runtime safety**: improved Alpaca availability checks, stable logging shutdown,

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -293,9 +293,24 @@ def _interruptible_sleep(total_seconds: float) -> None:
 
 def validate_environment() -> None:
     """Ensure required environment variables are present and dependencies are available."""
-    from ai_trading.config.management import validate_required_env
+    from ai_trading.config.management import get_env, _resolve_alpaca_env
 
-    validate_required_env()
+    missing: list[str] = []
+    key, secret, base_url = _resolve_alpaca_env()
+    if not key:
+        missing.append("ALPACA_API_KEY")
+    if not secret:
+        missing.append("ALPACA_SECRET_KEY")
+    if not base_url:
+        missing.append("ALPACA_API_URL")
+    for var in ("WEBHOOK_SECRET", "CAPITAL_CAP", "DOLLAR_RISK_LIMIT"):
+        if not get_env(var):
+            missing.append(var)
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
+
     _ = get_settings()
     import os
 


### PR DESCRIPTION
## Summary
- Check required environment variables in `validate_environment`
- Document behavior in CHANGELOG

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_main_extended2.py -q` *(fails: TypeError: test_run_flask_app.<locals>.App.run() got an unexpected keyword argument 'debug')*


------
https://chatgpt.com/codex/tasks/task_e_68ba331b97a08330b471f03da6934fe1