### PR TITLE
feat: forward run_flask_app kwargs

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -366,8 +366,15 @@ def run_bot(*_a, **_k) -> int:
         return 1
 
 
-def run_flask_app(port: int = 5000, ready_signal: threading.Event = None) -> None:
-    """Launch Flask API on an available port."""
+def run_flask_app(
+    port: int = 5000,
+    ready_signal: threading.Event | None = None,
+    **run_kwargs,
+) -> None:
+    """Launch Flask API on an available port.
+
+    Extra keyword arguments are forwarded to :func:`flask.Flask.run`.
+    """
     max_attempts = 10
     original_port = port
     for _attempt in range(max_attempts):
@@ -377,16 +384,21 @@ def run_flask_app(port: int = 5000, ready_signal: threading.Event = None) -> Non
     else:
         free_port = get_free_port()
         if free_port is None:
-            raise RuntimeError(f"Could not find available port starting from {original_port}")
+            raise RuntimeError(
+                f"Could not find available port starting from {original_port}"
+            )
         port = free_port
     from ai_trading import app
 
     application = app.create_app()
     if ready_signal is not None:
-        logger.info(f"Flask app created successfully, signaling ready on port {port}")
+        logger.info(
+            f"Flask app created successfully, signaling ready on port {port}"
+        )
         ready_signal.set()
     logger.info(f"Starting Flask app on 0.0.0.0:{port}")
-    application.run(host="0.0.0.0", port=port, debug=False)
+    debug = run_kwargs.pop("debug", False)
+    application.run(host="0.0.0.0", port=port, debug=debug, **run_kwargs)
 
 
 def start_api(ready_signal: threading.Event = None) -> None:


### PR DESCRIPTION
## Summary
- allow `run_flask_app` to accept arbitrary kwargs and forward them to `Flask.run`
- test kwargs forwarding and update port-conflict test

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_main_extended2.py::test_run_flask_app tests/test_main_extended2.py::test_run_flask_app_port_in_use -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68ba331aee548330b89b644be2dd71c7