### PR TITLE
Handle missing calendar timezone in aligned clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable changes to this project will be documented in this file.
 - **CLI dry-run**: log indicator import confirmation and exit with code 0 before heavy imports.
 - **Settings**: centralize value normalization and eliminate `FieldInfo` leaks
 - **Position sizing**: fetch real account equity via Alpaca once and cache it to avoid repeated `EQUITY_MISSING` warnings.
+- **Scheduler**: default to UTC when market calendar lacks timezone info.
 
 ### Added
 - **Parallel Predictions**: Replaced single-threaded prediction executor with auto-sized thread pool

--- a/tests/test_aligned_clock_timezone.py
+++ b/tests/test_aligned_clock_timezone.py
@@ -1,0 +1,14 @@
+from datetime import UTC
+
+from ai_trading.scheduler.aligned_clock import AlignedClock
+
+
+class _NoTZCal:
+    """Calendar stub without tz attribute."""
+
+
+def test_default_to_utc_when_calendar_missing_tz(monkeypatch):
+    clock = AlignedClock()
+    clock.calendar = _NoTZCal()
+    now = clock.get_exchange_time()
+    assert now.tzinfo is UTC


### PR DESCRIPTION
## Summary
- default to UTC when market calendar lacks `tz`
- test UTC fallback for calendars without timezone
- document scheduler timezone fallback

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_peak_performance.py::test_aligned_clock tests/test_aligned_clock_timezone.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ba359c9d2083309dc13370f7ffb447