### PR TITLE
Use row counts for mixed-format detection

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -332,9 +332,17 @@ def validate_trade_data_quality(trade_log_path: str) -> dict:
 
 
 def has_mixed_format(trade_log_path: str | os.PathLike) -> bool:
-    """Return ``True`` if trade log contains both audit and meta-learning rows."""
+    """Return ``True`` when both audit and meta-learning rows exist.
+
+    Uses the row counts from :func:`validate_trade_data_quality` so the file is
+    parsed only once.  ``True`` is returned only if *both* audit-style rows and
+    meta-learning rows are present in the log.
+    """
+
     report = validate_trade_data_quality(trade_log_path)
-    return bool(report.get('audit_format_rows')) and bool(report.get('meta_format_rows'))
+    audit_rows = int(report.get("audit_format_rows") or 0)
+    meta_rows = int(report.get("meta_format_rows") or 0)
+    return audit_rows > 0 and meta_rows > 0
 
 def normalize_score(score: float, cap: float=1.2) -> float:
     """Clip ``score`` to ``cap`` preserving sign."""


### PR DESCRIPTION
## Summary
- detect mixed trade logs by requiring both audit and meta row counts
- add regression test mixing meta-learning and audit rows

## Testing
- `ruff check ai_trading/meta_learning.py tests/test_trigger_meta_learning_conversion.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_trigger_meta_learning_conversion.py::test_trigger_meta_learning_conversion_mixed_format -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_performance_fixes.py::test_meta_learning_mixed_format -q` *(fails: Trade log file should exist)*

------
https://chatgpt.com/codex/tasks/task_e_68ba359aab74833099dc9bcc33a28806