### PR TITLE
feat: support equity fetch refresh

### DIFF
--- a/tests/test_position_sizing_equity.py
+++ b/tests/test_position_sizing_equity.py
@@ -6,7 +6,7 @@ import ai_trading.core.runtime as rt
 from ai_trading.logging import logger_once
 
 
-def test_get_equity_from_alpaca_sets_paper(monkeypatch):
+def test_fetch_equity_sets_paper(monkeypatch):
     ps._CACHE.value, ps._CACHE.ts, ps._CACHE.equity = (None, None, None)
 
     calls: dict[str, bool] = {}
@@ -26,7 +26,7 @@ def test_get_equity_from_alpaca_sets_paper(monkeypatch):
         alpaca_base_url="https://paper-api.alpaca.markets",
     )
 
-    ps._get_equity_from_alpaca(cfg, force_refresh=True)
+    ps._fetch_equity(cfg, force_refresh=True)
 
     assert calls.get("paper") is True
 


### PR DESCRIPTION
## Summary
- expose `_fetch_equity` with `force_refresh` parameter and document cache semantics
- keep `_get_equity_from_alpaca` as compatibility alias
- adjust test to exercise new fetch path

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(skipped: alpaca-py is required)*

------
https://chatgpt.com/codex/tasks/task_e_68ba359afbf88330a6ea032f86cc8b37