### PR TITLE
Validate OHLCV columns in indicator prep

### DIFF
--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -293,8 +293,11 @@ def _validate_input_df(data) -> None:
         raise ValueError("Input must be a DataFrame")
     if pd is not None and (not isinstance(data, pd.DataFrame)):
         raise ValueError("Input must be a DataFrame")
-    if hasattr(data, "columns") and "close" not in data.columns:
-        raise ValueError("Input data missing 'close' column")
+    required = ["open", "high", "low", "close", "volume"]
+    if hasattr(data, "columns"):
+        missing = [col for col in required if col not in data.columns]
+        if missing:
+            raise ValueError(f"Input data missing required column(s): {missing}")
 
 
 def _apply_macd(data) -> Any | None:
@@ -320,7 +323,8 @@ def prepare_indicators(data, ticker: str | None = None) -> Any | None:
     Parameters
     ----------
     data
-        Market data containing at least a ``close`` column.
+        Market data containing ``open``, ``high``, ``low``, ``close`` and
+        ``volume`` columns.
 
     Returns
     -------
@@ -330,7 +334,7 @@ def prepare_indicators(data, ticker: str | None = None) -> Any | None:
     Raises
     ------
     ValueError
-        If the MACD indicator fails to calculate or ``close`` column is missing.
+        If the MACD indicator fails to calculate or required columns are missing.
     """
     pd = _get_pandas()
     _validate_input_df(data)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -7,7 +7,7 @@ pd = pytest.importorskip("pandas")
 
 np.random.seed(0)
 
-from ai_trading.signals import GaussianHMM, detect_market_regime_hmm
+from ai_trading.signals import GaussianHMM, detect_market_regime_hmm, prepare_indicators
 
 
 def test_hmm_regime_detection():
@@ -30,6 +30,12 @@ def sample_df():
         'volume': np.linspace(100, 130, n)
     }
     return pd.DataFrame(data)
+
+
+def test_prepare_indicators_requires_ohlcv():
+    df = pd.DataFrame({"open": [1], "high": [2], "low": [1], "close": [1]})
+    with pytest.raises(ValueError, match="missing required column"):
+        prepare_indicators(df)
 
 
 def test_prepare_indicators_calculates(sample_df, monkeypatch):


### PR DESCRIPTION
## Summary
- ensure `ai_trading.signals.prepare_indicators` validates presence of open/high/low/close/volume columns
- document required columns and add regression test

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68ba359c172483309556af639ae0350a