### PR TITLE
feat: retry SIP on IEX empty bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file.
 - **Data Fetch**: improve Alpaca empty-bar handling by logging timeframe/feed,
   verifying API credentials and market hours, and attempting feed or window
   fallbacks before resorting to alternate providers.
+- **Data Fetch**: retry with SIP feed when initial IEX request returns empty
+  for a symbol that may be delisted or on the wrong feed.
 - **Main**: `validate_environment` now raises `RuntimeError` when required
   environment variables are missing.
 - Normalize broker-unavailable contract; remove false PDT warnings; add regression tests.


### PR DESCRIPTION
## Summary
- retry IEX bar fetches with SIP when empty response suggests symbol is delisted or wrong feed
- document SIP retry in changelog
- cover IEX-empty then SIP-success path with regression test

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_iex_empty_fallback.py::test_iex_bars_empty_retries_sip -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 22 errors during collection; missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bb304b8d848330bac4b180bf5b5023