### PR TITLE
Quiet charset_normalizer logger and add test

### DIFF
--- a/ai_trading/logging/setup.py
+++ b/ai_trading/logging/setup.py
@@ -23,7 +23,10 @@ def _apply_library_filters() -> None:
     """
     from ai_trading.config import management as config
 
-    filters: dict[str, str] = {"charset_normalizer": "INFO"}
+    # ``charset_normalizer`` is particularly noisy at DEBUG level when used by
+    # ``requests``. Elevate it to WARNING by default so debug logs from that
+    # dependency do not clutter our output.
+    filters: dict[str, str] = {"charset_normalizer": "WARNING"}
     raw = config.get_env("LOG_QUIET_LIBRARIES", "")
     for item in raw.split(","):
         name, _, level = item.partition("=")

--- a/tests/logging/test_charset_normalizer_no_debug.py
+++ b/tests/logging/test_charset_normalizer_no_debug.py
@@ -1,0 +1,31 @@
+"""Validate that charset_normalizer does not emit debug logs once configured."""
+
+import logging
+
+import ai_trading.logging as base_logger
+import ai_trading.logging.setup as log_setup
+
+
+def _reset_logging_state() -> None:
+    """Reset global logging state for isolated tests."""
+    base_logger._configured = False
+    base_logger._LOGGING_CONFIGURED = False
+    base_logger._listener = None
+    base_logger._log_queue = None
+    logging.getLogger().handlers.clear()
+
+
+def test_charset_normalizer_no_debug(monkeypatch, caplog) -> None:
+    """After setup, charset_normalizer debug logs should be suppressed."""
+    _reset_logging_state()
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.delenv("LOG_QUIET_LIBRARIES", raising=False)
+
+    log_setup.setup_logging()
+
+    with caplog.at_level(logging.DEBUG):
+        logging.getLogger("charset_normalizer").debug("noisy debug")
+
+    assert "noisy debug" not in caplog.text
+    _reset_logging_state()
+


### PR DESCRIPTION
## Summary
- raise charset_normalizer logger level to WARNING to avoid noisy debug output
- add test ensuring charset_normalizer emits no debug logs once logging configured

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/logging/test_charset_normalizer_no_debug.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb304b12ec8330a47fc5adb0c67200