### PR TITLE
Log aborted Alpaca fetch before retries exhausted

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -54,9 +54,10 @@ Daily price requests now log their parameters and outcome:
   notified once.
 - Empty bar responses are retried with an exponential backoff. The retry
   policy can be tuned via `FETCH_BARS_MAX_RETRIES`, `FETCH_BARS_BACKOFF_BASE`,
-  and `FETCH_BARS_BACKOFF_CAP`. Logs include the remaining retry count and
-  emit a final "retries exhausted" message when no more attempts remain,
-  allowing operators to diagnose persistent data issues quickly.
+  and `FETCH_BARS_BACKOFF_CAP`. Logs include the remaining retry count,
+  emit `ALPACA_FETCH_ABORTED` when a request is terminated early despite
+  remaining retries, and emit `ALPACA_FETCH_RETRY_LIMIT` when no more attempts
+  remain, allowing operators to diagnose persistent data issues quickly.
 
 ### Example Usage
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -190,7 +190,8 @@ nslookup api.alpaca.markets 8.8.8.8
 - Stale data warnings
 - Data provider fallback messages
 - `ALPACA_EMPTY_BAR_MAX_RETRIES` in logs
-- `ALPACA_FETCH_RETRY_LIMIT` in logs (emitted after two consecutive empty responses)
+- `ALPACA_FETCH_ABORTED` in logs (early termination with retries remaining)
+- `ALPACA_FETCH_RETRY_LIMIT` in logs (no retries left)
 
 Repeated empty 200-responses trigger this limit quickly. Verify the market is
 open or that data exists for the requested window (symbol still listed, feed

--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -1169,8 +1169,11 @@ def _fetch_bars(
                         }
                     ),
                 )
+                remaining_retries = max_retries - _state["retries"]
                 logger.warning(
-                    "ALPACA_FETCH_RETRY_LIMIT",
+                    "ALPACA_FETCH_ABORTED"
+                    if remaining_retries > 0
+                    else "ALPACA_FETCH_RETRY_LIMIT",
                     extra=_norm_extra(
                         {
                             "provider": "alpaca",
@@ -1182,6 +1185,7 @@ def _fetch_bars(
                             "end": _end.isoformat(),
                             "correlation_id": _state["corr_id"],
                             "retries": _state["retries"],
+                            "remaining_retries": remaining_retries,
                             "reason": reason,
                         }
                     ),
@@ -1257,8 +1261,11 @@ def _fetch_bars(
                     return pd_mod.DataFrame()
                 except Exception:
                     return pd.DataFrame()
+            remaining_retries = max_retries - _state["retries"]
             logger.warning(
-                "ALPACA_FETCH_RETRY_LIMIT",
+                "ALPACA_FETCH_ABORTED"
+                if remaining_retries > 0
+                else "ALPACA_FETCH_RETRY_LIMIT",
                 extra=_norm_extra(
                     {
                         "provider": "alpaca",
@@ -1270,6 +1277,7 @@ def _fetch_bars(
                         "end": _end.isoformat(),
                         "correlation_id": _state["corr_id"],
                         "retries": _state["retries"],
+                        "remaining_retries": remaining_retries,
                     }
                 ),
             )

--- a/tests/test_fetch_empty_early_exit.py
+++ b/tests/test_fetch_empty_early_exit.py
@@ -57,4 +57,4 @@ def test_persistent_empty_aborts_early(monkeypatch, caplog):
 
     assert out is None
     assert sess.calls == 2
-    assert sum(r.message == "ALPACA_FETCH_RETRY_LIMIT" for r in caplog.records) == 1
+    assert sum(r.message == "ALPACA_FETCH_ABORTED" for r in caplog.records) == 1

--- a/tests/test_fetch_empty_handling.py
+++ b/tests/test_fetch_empty_handling.py
@@ -71,7 +71,7 @@ def test_warn_on_empty_when_market_open(monkeypatch, caplog):
     assert [r.total_elapsed for r in retry_logs] == [0]
     assert delays == [1]
     assert any(r.message == "EMPTY_DATA" and r.levelno == logging.WARNING for r in caplog.records)
-    assert sum(r.message == "ALPACA_FETCH_RETRY_LIMIT" for r in caplog.records) == 1
+    assert sum(r.message == "ALPACA_FETCH_ABORTED" for r in caplog.records) == 1
 
 
 def test_silent_fallback_when_market_closed(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- Distinguish early termination from exhausted retries by logging `ALPACA_FETCH_ABORTED` when retries remain
- Adjust tests for new log message and document early termination behavior

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb304b1ce48330963527296222ff55