### PR TITLE
feat: retry iex empties with sip before yahoo

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -788,6 +788,13 @@ class DataProviderManager:
             return self._fetch_yahoo_data(symbol, timeframe, start_date, end_date)
 ```
 
+### 3. Automatic IEX→SIP feed fallback
+
+When Alpaca's IEX feed returns consecutive empty responses, the bot now
+automatically retries the same request using the SIP feed before falling back
+to Yahoo Finance. This behavior is logged with the `ALPACA_IEX_FALLBACK_SIP`
+event and helps reduce data gaps caused by temporary IEX outages.
+
 ## FAQ
 
 ### Q: Bot is not making any trades

--- a/tests/test_iex_sip_fallback.py
+++ b/tests/test_iex_sip_fallback.py
@@ -1,0 +1,51 @@
+import json
+import types
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import ai_trading.data.fetch as fetch
+
+
+def test_iex_empty_switches_to_sip(monkeypatch, caplog):
+    symbol = "AAPL"
+    start = datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC"))
+    end = start + timedelta(days=1)
+
+    fetch._IEX_EMPTY_COUNTS.clear()
+    fetch._IEX_EMPTY_COUNTS[(symbol, "1Min")] = fetch._IEX_EMPTY_THRESHOLD + 1
+    monkeypatch.setattr(fetch, "_ALLOW_SIP", True, raising=False)
+    monkeypatch.setattr(fetch, "_SIP_UNAUTHORIZED", False, raising=False)
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
+    monkeypatch.setattr(fetch, "_outside_market_hours", lambda *a, **k: False)
+    monkeypatch.setattr(fetch, "is_market_open", lambda: False)
+
+    feeds = []
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        feeds.append(params.get("feed"))
+        if params.get("feed") == "iex":
+            data = {"bars": []}
+        else:
+            data = {"bars": [{"t": "2024-01-01T00:00:00Z", "o": 1, "h": 1, "l": 1, "c": 1, "v": 1}]}
+        return types.SimpleNamespace(
+            status_code=200,
+            text=json.dumps(data),
+            headers={"Content-Type": "application/json"},
+            json=lambda: data,
+        )
+
+    monkeypatch.setattr(fetch.requests, "get", fake_get)
+
+    allowed = [False, True]
+
+    def sip_allowed(session, headers, timeframe):
+        return allowed.pop(0)
+
+    monkeypatch.setattr(fetch, "_sip_fallback_allowed", sip_allowed)
+
+    with caplog.at_level("INFO"):
+        df = fetch._fetch_bars(symbol, start, end, "1Min", feed="iex")
+
+    assert feeds == ["iex", "sip"]
+    assert not df.empty
+    assert any(rec.message == "ALPACA_IEX_FALLBACK_SIP" for rec in caplog.records)


### PR DESCRIPTION
## Summary
- retry Alpaca IEX requests with SIP when repeated empty responses occur
- log `ALPACA_IEX_FALLBACK_SIP` and document automatic feed fallback
- test SIP retry behaviour

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_iex_sip_fallback.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: joblib)*

------
https://chatgpt.com/codex/tasks/task_e_68bb32aba9648330821a69114b31e818