### PR TITLE
feat: instrument backup data provider usage

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -59,6 +59,17 @@ Daily price requests now log their parameters and outcome:
   remaining retries, and emit `ALPACA_FETCH_RETRY_LIMIT` when no more attempts
   remain, allowing operators to diagnose persistent data issues quickly.
 
+#### Backup Provider Usage
+When the primary data source fails and the backup provider serves a window,
+the system logs `BACKUP_PROVIDER_USED` and increments the
+`backup_provider_used_total` Prometheus counter. The counter is labeled with
+`provider` and `symbol`, allowing operators to track fallback frequency per
+feed and instrument. Query the metric via the `/metrics` endpoint:
+
+```bash
+curl -sf http://localhost:$HEALTHCHECK_PORT/metrics | grep backup_provider_used_total
+```
+
 ### Example Usage
 
 ```bash

--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -19,6 +19,7 @@ from ai_trading.logging.normalize import canon_feed as _canon_feed
 from ai_trading.logging.normalize import canon_timeframe as _canon_tf
 from ai_trading.logging.normalize import normalize_extra as _norm_extra
 from ai_trading.logging import (
+    log_backup_provider_used,
     log_empty_retries_exhausted,
     log_fetch_attempt,
     log_finnhub_disabled,
@@ -198,6 +199,14 @@ def _fallback_key(symbol: str, timeframe: str, start: _dt.datetime, end: _dt.dat
 
 
 def _mark_fallback(symbol: str, timeframe: str, start: _dt.datetime, end: _dt.datetime) -> None:
+    provider = getattr(get_settings(), "backup_data_provider", "yahoo")
+    log_backup_provider_used(
+        provider,
+        symbol=symbol,
+        timeframe=timeframe,
+        start=start,
+        end=end,
+    )
     _FALLBACK_WINDOWS.add(_fallback_key(symbol, timeframe, start, end))
 
 

--- a/ai_trading/data/metrics.py
+++ b/ai_trading/data/metrics.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ai_trading.metrics import get_counter
+
 
 @dataclass
 class Metrics:
@@ -15,4 +17,11 @@ class Metrics:
 
 metrics = Metrics()
 
-__all__ = ["Metrics", "metrics"]
+# Prometheus counter tracking backup provider usage
+backup_provider_used = get_counter(
+    "backup_provider_used_total",
+    "Times backup data provider served data",
+    ["provider", "symbol"],
+)
+
+__all__ = ["Metrics", "metrics", "backup_provider_used"]

--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -22,6 +22,7 @@ from typing import Any
 from ai_trading.exc import COMMON_EXC
 from .json_formatter import JSONFormatter
 from ai_trading.logging.redact import _ENV_MASK
+from ai_trading.data.metrics import backup_provider_used
 
 if os.getenv("FINNHUB_API_KEY") and os.getenv("ENABLE_FINNHUB") is None:
     os.environ["ENABLE_FINNHUB"] = "1"
@@ -530,6 +531,26 @@ def log_fetch_attempt(provider: str, *, status: int | None = None, error: str | 
         logger.info("FETCH_ATTEMPT", extra=payload)
 
 
+def log_backup_provider_used(
+    provider: str,
+    *,
+    symbol: str,
+    timeframe: str,
+    start: datetime,
+    end: datetime,
+) -> None:
+    """Log and record when the backup data provider serves a window."""
+    payload: dict[str, Any] = {
+        "provider": provider,
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+    }
+    backup_provider_used.labels(provider=provider, symbol=symbol).inc()
+    logger.info("BACKUP_PROVIDER_USED", extra=payload)
+
+
 def log_empty_retries_exhausted(
     provider: str,
     *,
@@ -870,4 +891,4 @@ def validate_logging_setup(logger: logging.Logger | None=None, *, dedupe: bool=F
     else:
         get_logger(__name__).error('Logging validation failed: %s', validation_result['issues'])
     return validation_result
-__all__ = ['setup_logging', 'get_logger', 'get_phase_logger', 'init_logger', 'logger', 'logger_once', 'log_fetch_attempt', 'log_empty_retries_exhausted', 'log_performance_metrics', 'log_trading_event', 'log_finnhub_disabled', 'warn_finnhub_disabled_no_data', 'setup_enhanced_logging', 'validate_logging_setup', 'dedupe_stream_handlers', 'EmitOnceLogger', 'CompactJsonFormatter', 'with_extra', 'info_kv', 'warning_kv', 'error_kv', 'SanitizingLoggerAdapter', 'sanitize_extra']
+__all__ = ['setup_logging', 'get_logger', 'get_phase_logger', 'init_logger', 'logger', 'logger_once', 'log_fetch_attempt', 'log_backup_provider_used', 'log_empty_retries_exhausted', 'log_performance_metrics', 'log_trading_event', 'log_finnhub_disabled', 'warn_finnhub_disabled_no_data', 'setup_enhanced_logging', 'validate_logging_setup', 'dedupe_stream_handlers', 'EmitOnceLogger', 'CompactJsonFormatter', 'with_extra', 'info_kv', 'warning_kv', 'error_kv', 'SanitizingLoggerAdapter', 'sanitize_extra']


### PR DESCRIPTION
## Summary
- add Prometheus counter `backup_provider_used_total` to track fallback feed usage by provider and symbol
- log and metric when backup provider serves a window
- document monitoring fallback usage

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb32ae10308330874522d701beb622