### PR TITLE
Apply library filters in setup_logging and add charset_normalizer test

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -428,6 +428,10 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
         atexit.register(_safe_shutdown_logging)
         _LOGGING_CONFIGURED = True
         logging.getLogger(__name__).info('Logging configured successfully - no duplicates possible')
+        # Apply filters for noisy third-party libraries after configuration is complete.
+        from ai_trading.logging.setup import _apply_library_filters
+
+        _apply_library_filters()
         return logger
 
 def _safe_shutdown_logging():

--- a/tests/logging/test_charset_normalizer_no_debug_base.py
+++ b/tests/logging/test_charset_normalizer_no_debug_base.py
@@ -1,0 +1,29 @@
+"""Ensure charset_normalizer debug logs are suppressed using base setup_logging."""
+
+import logging
+
+import ai_trading.logging as base_logger
+
+
+def _reset_logging_state() -> None:
+    """Reset global logging state for isolated tests."""
+    base_logger._configured = False
+    base_logger._LOGGING_CONFIGURED = False
+    base_logger._listener = None
+    base_logger._log_queue = None
+    logging.getLogger().handlers.clear()
+
+
+def test_charset_normalizer_no_debug_with_base(monkeypatch, caplog) -> None:
+    """Calling ai_trading.logging.setup_logging should silence charset_normalizer debug."""
+    _reset_logging_state()
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.delenv("LOG_QUIET_LIBRARIES", raising=False)
+
+    base_logger.setup_logging()
+
+    with caplog.at_level(logging.DEBUG):
+        logging.getLogger("charset_normalizer").debug("noisy debug")
+
+    assert "noisy debug" not in caplog.text
+    _reset_logging_state()


### PR DESCRIPTION
## Summary
- ensure `ai_trading.logging.setup_logging` invokes `_apply_library_filters` so third-party loggers (e.g. `charset_normalizer`) are silenced
- add regression test verifying `charset_normalizer` debug messages are suppressed when using `ai_trading.logging.setup_logging`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/logging/test_charset_normalizer_no_debug_base.py tests/logging/test_charset_normalizer_no_debug.py tests/test_charset_normalizer_logging_filter.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: collection errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3a2e8ff08330b86481d851206918