### PR TITLE
Demote Finnhub disabled no-data to info

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -490,8 +490,8 @@ def log_finnhub_disabled(symbol: str) -> None:
 
 
 def warn_finnhub_disabled_no_data(symbol: str) -> None:
-    """Warn once per symbol when Finnhub is disabled and no data is returned."""
-    logger_once.warning(
+    """Log once per symbol when Finnhub is disabled and no data is returned."""
+    logger_once.info(
         "FINNHUB_DISABLED_NO_DATA",
         key=f"FINNHUB_DISABLED_NO_DATA:{symbol}",
         extra={

--- a/tests/test_finnhub_disabled.py
+++ b/tests/test_finnhub_disabled.py
@@ -23,7 +23,7 @@ def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch, caplog):
     monkeypatch.setattr(data_fetcher, "_fetch_bars", lambda *a, **k: pd.DataFrame())
     monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", lambda *a, **k: pd.DataFrame())
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         df = data_fetcher.get_minute_df(
             "AAPL",
             dt.datetime(2023, 1, 1, tzinfo=dt.UTC),
@@ -33,7 +33,7 @@ def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch, caplog):
     assert any(r.message == "FINNHUB_DISABLED_NO_DATA" for r in caplog.records)
 
 
-def test_duplicate_warning_suppressed(monkeypatch, caplog):
+def test_duplicate_info_suppressed(monkeypatch, caplog):
     from ai_trading.logging import logger_once
 
     monkeypatch.setattr(logger_once, "_emitted_keys", set())
@@ -43,8 +43,8 @@ def test_duplicate_warning_suppressed(monkeypatch, caplog):
     monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", lambda *a, **k: pd.DataFrame())
     start = dt.datetime(2023, 1, 1, tzinfo=dt.UTC)
     end = dt.datetime(2023, 1, 2, tzinfo=dt.UTC)
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         data_fetcher.get_minute_df("MSFT", start, end)
         data_fetcher.get_minute_df("MSFT", start, end)
-    warnings = [r for r in caplog.records if r.message == "FINNHUB_DISABLED_NO_DATA"]
-    assert len(warnings) == 1
+    infos = [r for r in caplog.records if r.message == "FINNHUB_DISABLED_NO_DATA"]
+    assert len(infos) == 1


### PR DESCRIPTION
## Summary
- log missing data when Finnhub is disabled at INFO instead of WARNING
- update Finnhub disabled tests to expect informational logging

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_finnhub_disabled.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3a2f096c8330a6cb3cef5026c6bd