### PR TITLE
Silence charset_normalizer logging and guard DataFrame debug dumps

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8945,23 +8945,28 @@ def _fetch_feature_data(
             logger.warning("Corp actions adjust failed: %s", e)
 
     # AI-AGENT-REF: log initial dataframe and monitor row drops
-    logger.debug(f"Initial tail data for {symbol}:\n{df.tail(5)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Initial tail data for %s: %s", symbol, df.tail(5).to_dict(orient="list"))
     initial_len = len(df)
 
     df = compute_macd(df)
     assert_row_integrity(initial_len, len(df), "compute_macd", symbol)
-    logger.debug(f"[{symbol}] Post MACD: last closes:\n{df[['close']].tail(5)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("[%s] Post MACD: last closes: %s", symbol, df["close"].tail(5).tolist())
 
     df = compute_atr(df)
     assert_row_integrity(initial_len, len(df), "compute_atr", symbol)
-    logger.debug(f"[{symbol}] Post ATR: last closes:\n{df[['close']].tail(5)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("[%s] Post ATR: last closes: %s", symbol, df["close"].tail(5).tolist())
 
     df = compute_vwap(df)
     assert_row_integrity(initial_len, len(df), "compute_vwap", symbol)
-    logger.debug(f"[{symbol}] Post VWAP: last closes:\n{df[['close']].tail(5)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("[%s] Post VWAP: last closes: %s", symbol, df["close"].tail(5).tolist())
 
     df = compute_macds(df)
-    logger.debug(f"{symbol} dataframe columns after indicators: {df.columns.tolist()}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("%s dataframe columns after indicators: %s", symbol, df.columns.tolist())
     df = ensure_columns(df, ["macd", "vwap", "macds"], symbol)
     if df.empty and raw_df is not None:
         df = raw_df.copy()
@@ -9070,7 +9075,8 @@ def _enter_long(
     strat: str,
 ) -> bool:
     current_price = get_latest_close(feat_df)
-    logger.debug(f"Latest 5 rows for {symbol}:\n{feat_df.tail(5)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Latest 5 rows for %s: %s", symbol, feat_df.tail(5).to_dict(orient="list"))
     logger.debug(f"Computed price for {symbol}: {current_price}")
     if current_price <= 0 or pd.isna(current_price):
         logger.critical(f"Invalid price computed for {symbol}: {current_price}")
@@ -9225,7 +9231,8 @@ def _enter_short(
     strat: str,
 ) -> bool:
     current_price = get_latest_close(feat_df)
-    logger.debug(f"Latest 5 rows for {symbol}:\n{feat_df.tail(5)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Latest 5 rows for %s: %s", symbol, feat_df.tail(5).to_dict(orient="list"))
     logger.debug(f"Computed price for {symbol}: {current_price}")
     if current_price <= 0 or pd.isna(current_price):
         logger.critical(f"Invalid price computed for {symbol}: {current_price}")
@@ -9324,7 +9331,8 @@ def _manage_existing_position(
     current_qty: int,
 ) -> bool:
     price = get_latest_close(feat_df)
-    logger.debug(f"Latest 5 rows for {symbol}:\n{feat_df.tail(5)}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Latest 5 rows for %s: %s", symbol, feat_df.tail(5).to_dict(orient="list"))
     logger.debug(f"Computed price for {symbol}: {price}")
     if price <= 0 or pd.isna(price):
         logger.critical(f"Invalid price computed for {symbol}: {price}")
@@ -12559,7 +12567,8 @@ def manage_position_risk(ctx, position) -> None:
         except DataFetchError:
             logger.critical(f"No minute data for {symbol}, skipping.")
             return
-        logger.debug(f"Latest rows for {symbol}:\n{price_df.tail(3)}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("Latest rows for %s: %s", symbol, price_df.tail(3).to_dict(orient="list"))
         if "close" in price_df.columns:
             price_series = price_df["close"].dropna()
             if not price_series.empty:

--- a/ai_trading/logging/setup.py
+++ b/ai_trading/logging/setup.py
@@ -25,15 +25,15 @@ def _apply_library_filters() -> None:
 
     # ``charset_normalizer`` is particularly noisy at DEBUG level when used by
     # ``requests``. Elevate it to WARNING by default so debug logs from that
-    # dependency do not clutter our output.
-    filters: dict[str, str] = {"charset_normalizer": "WARNING"}
+    # dependency do not clutter our output. Additional filters may be provided
+    # via ``LOG_QUIET_LIBRARIES``.
+    filters: dict[str, int] = {"charset_normalizer": logging.WARNING}
     raw = config.get_env("LOG_QUIET_LIBRARIES", "")
     for item in raw.split(","):
         name, _, level = item.partition("=")
         if name.strip() and level.strip():
-            filters[name.strip()] = level.strip().upper()
-    for name, level_name in filters.items():
-        level = getattr(logging, level_name.upper(), logging.INFO)
+            filters[name.strip()] = getattr(logging, level.strip().upper(), logging.INFO)
+    for name, level in filters.items():
         logging.getLogger(name).setLevel(level)
 
 

--- a/tests/logging/test_charset_normalizer_default_config.py
+++ b/tests/logging/test_charset_normalizer_default_config.py
@@ -1,0 +1,28 @@
+"""Verify charset_normalizer logs are suppressed with default setup."""
+import logging
+
+import ai_trading.logging as base_logger
+import ai_trading.logging.setup as log_setup
+
+
+def _reset_logging_state() -> None:
+    base_logger._configured = False
+    base_logger._LOGGING_CONFIGURED = False
+    base_logger._listener = None
+    base_logger._log_queue = None
+    logging.getLogger().handlers.clear()
+
+
+def test_charset_normalizer_default_suppressed(monkeypatch, caplog) -> None:
+    _reset_logging_state()
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.delenv("LOG_QUIET_LIBRARIES", raising=False)
+
+    log_setup.setup_logging()
+
+    noisy = logging.getLogger("charset_normalizer")
+    assert noisy.getEffectiveLevel() == logging.WARNING
+    with caplog.at_level(logging.DEBUG):
+        noisy.debug("noisy debug")
+    assert "noisy debug" not in caplog.text
+    _reset_logging_state()


### PR DESCRIPTION
## Summary
- elevate charset_normalizer logger to WARNING during logging setup
- guard DataFrame debug statements in bot engine behind level checks and summarize output
- add test ensuring charset_normalizer debug logs are suppressed by default

## Testing
- `ruff check ai_trading/logging/setup.py ai_trading/core/bot_engine.py tests/logging/test_charset_normalizer_default_config.py tests/logging/test_charset_normalizer_no_debug.py tests/logging/test_charset_normalizer_no_debug_base.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/logging/test_charset_normalizer_default_config.py tests/logging/test_charset_normalizer_no_debug.py tests/logging/test_charset_normalizer_no_debug_base.py -q`

## Rollback
- Revert the commit to restore previous logging behavior.

------
https://chatgpt.com/codex/tasks/task_e_68bb3bcd63288330bdafbbd0d59446d5