### PR TITLE
feat: switch feed on empty result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
   - Updated README/CHANGELOG to document package-only policy
 
 ### Changed
+- Config: validate Alpaca data feed entitlement and allow override via `ALPACA_DATA_FEED`, warning if switched.
+- Data fetch: switch to SIP feed after first empty IEX result and record `data.fetch.feed_switch` metric.
 - Main: finite `SCHEDULER_ITERATIONS` now exits promptly after completing
   the requested cycles instead of keeping the API thread alive. This
   avoids test/CI hangs; production runs continue to use infinite iterations.

--- a/ai_trading/data/metrics.py
+++ b/ai_trading/data/metrics.py
@@ -13,6 +13,7 @@ class Metrics:
     timeout: int = 0
     unauthorized: int = 0
     empty_payload: int = 0
+    feed_switch: int = 0
 
 
 metrics = Metrics()


### PR DESCRIPTION
## Summary
- check Alpaca account entitlements and allow overriding data feed via `ALPACA_DATA_FEED`
- fall back to SIP immediately after the first empty IEX result and record a metric when switching
- track feed-switch events in data metrics

## Testing
- `ruff check ai_trading/config/alpaca.py ai_trading/data/fetch.py ai_trading/data/metrics.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_empty_retry_once.py -q` *(fails: IndexError: list index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3bcc42908330978a5d6bbc26a2b5