### PR TITLE
feat: seed trade history and clarify missing data warnings

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -191,6 +191,13 @@ def validate_trade_data_quality(trade_log_path: str) -> dict:
         if not Path(trade_log_path).exists():
             quality_report['issues'].append(f'Trade log file does not exist: {trade_log_path}')
             quality_report['recommendations'].append('Initialize trade logging system')
+            logger.warning(
+                'TRADE_HISTORY_MISSING: %s',
+                trade_log_path,
+                extra={
+                    'hint': 'Seed with `python -m ai_trading.tools.seed_trade_history` or see docs/SEED_TRADE_HISTORY.md'
+                },
+            )
             return quality_report
         quality_report['file_exists'] = True
         try:
@@ -198,6 +205,13 @@ def validate_trade_data_quality(trade_log_path: str) -> dict:
             if file_size == 0:
                 quality_report['issues'].append('Trade log file is empty')
                 quality_report['recommendations'].append('Ensure trade logging is actively writing data')
+                logger.warning(
+                    'TRADE_HISTORY_EMPTY: %s',
+                    trade_log_path,
+                    extra={
+                        'hint': 'Seed with `python -m ai_trading.tools.seed_trade_history` or see docs/SEED_TRADE_HISTORY.md'
+                    },
+                )
                 return quality_report
         except COMMON_EXC as e:
             quality_report['issues'].append(f'Cannot access file stats: {e}')
@@ -209,12 +223,26 @@ def validate_trade_data_quality(trade_log_path: str) -> dict:
             if not raw_lines:
                 quality_report['issues'].append('Trade log file is empty')
                 quality_report['recommendations'].append('Ensure trade logging is actively writing data')
+                logger.warning(
+                    'TRADE_HISTORY_EMPTY: %s',
+                    trade_log_path,
+                    extra={
+                        'hint': 'Seed with `python -m ai_trading.tools.seed_trade_history` or see docs/SEED_TRADE_HISTORY.md'
+                    },
+                )
                 return quality_report
             # Remove empty lines and split out header row
             lines = [l for l in raw_lines if l.strip()]
             if not lines:
                 quality_report['issues'].append('Trade log file is empty')
                 quality_report['recommendations'].append('Ensure trade logging is actively writing data')
+                logger.warning(
+                    'TRADE_HISTORY_EMPTY: %s',
+                    trade_log_path,
+                    extra={
+                        'hint': 'Seed with `python -m ai_trading.tools.seed_trade_history` or see docs/SEED_TRADE_HISTORY.md'
+                    },
+                )
                 return quality_report
             _header, *data_lines = lines
             audit_format_rows = 0

--- a/ai_trading/tools/seed_trade_history.py
+++ b/ai_trading/tools/seed_trade_history.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Iterable
+from ai_trading.logging import get_logger
+from ai_trading.database.connection import initialize_database, get_session
+from ai_trading.database.models import Trade
+
+logger = get_logger(__name__)
+DEFAULT_PATH = "trade_history.json"
+
+def load_history(path: str | Path = DEFAULT_PATH) -> list[dict]:
+    """Return list of trade records from *path* or empty list when unavailable."""
+    p = Path(path)
+    if not p.exists():
+        logger.warning(
+            "TRADE_HISTORY_SEED_FILE_MISSING", extra={"path": str(p)}
+        )
+        return []
+    try:
+        data = json.loads(p.read_text())
+    except json.JSONDecodeError as exc:
+        logger.error(
+            "TRADE_HISTORY_SEED_PARSE_ERROR", extra={"path": str(p), "error": str(exc)}
+        )
+        return []
+    if not isinstance(data, list):
+        logger.error("TRADE_HISTORY_SEED_INVALID_FORMAT", extra={"path": str(p)})
+        return []
+    return data
+
+def seed_database(trades: Iterable[dict]) -> int:
+    """Insert *trades* into the database."""
+    initialize_database()
+    inserted = 0
+    with get_session() as session:
+        for record in trades:
+            session.add(Trade(**record))
+            inserted += 1
+        session.commit()
+    logger.info("TRADE_HISTORY_SEEDED", extra={"records": inserted})
+    return inserted
+
+def main(path: str = DEFAULT_PATH) -> int:
+    """CLI entry point for seeding trade history."""
+    trades = load_history(path)
+    if not trades:
+        logger.warning("TRADE_HISTORY_SEED_NO_RECORDS", extra={"path": path})
+        return 0
+    return seed_database(trades)
+
+def _main(argv: list[str] | None=None) -> int:
+    path = argv[0] if argv else DEFAULT_PATH
+    main(path)
+    return 0
+
+if __name__ == "__main__":
+    import sys
+    raise SystemExit(_main(sys.argv[1:]))
+
+__all__ = ["main", "_main", "seed_database", "load_history"]

--- a/docs/SEED_TRADE_HISTORY.md
+++ b/docs/SEED_TRADE_HISTORY.md
@@ -1,7 +1,14 @@
 # Seeding Trade History
 
 Meta-learning components rely on a history file to evaluate signal
-performance. Before a new deployment, seed the history so each symbol has
+performance. Deployment now bootstraps the database from
+`trade_history.json` using a helper script invoked during startup:
+
+```bash
+python -m ai_trading.tools.seed_trade_history  # run manually to verify
+```
+
+Before a new deployment, ensure the history file exists so each symbol has
 at least one entry. This avoids warnings and lets the bot collect
 statistics from the first trade cycle.
 

--- a/start.sh
+++ b/start.sh
@@ -21,4 +21,5 @@ VENV_PATH="${VENV_PATH:-venv}"
 source "${VENV_PATH}/bin/activate"
 
 python -m ai_trading.tools.env_validate
+python -m ai_trading.tools.seed_trade_history
 exec python -u -m ai_trading.main


### PR DESCRIPTION
## Summary
- add `seed_trade_history` tool to load `trade_history.json` into DB
- call seeding tool from `start.sh` so deployments always bootstrap trade history
- log explicit guidance in `meta_learning` when history file is missing or empty
- document seeding workflow and helper script

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(skipped: alpaca-py is required for tests)*


------
https://chatgpt.com/codex/tasks/task_e_68bb3e54f4bc8330846b1a4dd35d2d50