### PR TITLE
feat: add requests fallback for HTTP session

### DIFF
--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -1,15 +1,31 @@
 from __future__ import annotations
 
 import os
-import requests
 from typing import cast
-from requests.adapters import HTTPAdapter
+
+try:
+    import requests
+except Exception:  # pragma: no cover - fallback when requests missing
+    class _RequestsFallback:
+        Session = None
+        get = None
+
+    requests = _RequestsFallback()  # type: ignore[assignment]
+try:
+    from requests.adapters import HTTPAdapter
+except Exception:  # pragma: no cover - requests missing
+    HTTPAdapter = cast("type[object]", object)
 from urllib3.util.retry import Retry
 from ai_trading.utils import clamp_request_timeout
 from urllib.parse import urlparse
 
 
-class TimeoutSession(requests.Session):
+_SessionBase = cast(
+    "type[object]", requests.Session if getattr(requests, "Session", None) else object
+)
+
+
+class TimeoutSession(_SessionBase):
     """Requests ``Session`` that injects a default timeout."""
 
     def __init__(self, default_timeout: tuple[float, float] = (5.0, 10.0)) -> None:


### PR DESCRIPTION
## Summary
- handle missing `requests` import with lightweight fallback
- derive `TimeoutSession` base from the imported `requests` object

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; tests skipped)*
- `RUN_HEALTHCHECK=1 python -m ai_trading.app &` and `curl -sf http://127.0.0.1:9001/healthz`


------
https://chatgpt.com/codex/tasks/task_e_68bb55177c588330a1ae2cd2cd6349e7