### PR TITLE
Load validate_env settings from environment

### DIFF
--- a/ai_trading/validation/validate_env.py
+++ b/ai_trading/validation/validate_env.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import os
 from datetime import datetime
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, field_validator, Field
 
 from ai_trading.logging.redact import redact_env
 
 class Settings(BaseModel):
-    ALPACA_API_KEY: str = Field(...)
-    ALPACA_SECRET_KEY: str = Field(...)
-    ALPACA_BASE_URL: str = Field(...)
-    TRADING_MODE: str = Field('testing')
-    FORCE_TRADES: bool = Field(False)
+    ALPACA_API_KEY: str = Field(default_factory=lambda: os.environ["ALPACA_API_KEY"])
+    ALPACA_SECRET_KEY: str = Field(default_factory=lambda: os.environ["ALPACA_SECRET_KEY"])
+    ALPACA_BASE_URL: str = Field(default_factory=lambda: os.environ["ALPACA_BASE_URL"])
+    TRADING_MODE: str = Field(default_factory=lambda: os.environ.get("TRADING_MODE", "testing"))
+    FORCE_TRADES: bool = Field(default_factory=lambda: os.environ.get("FORCE_TRADES", False))
 
     @field_validator('ALPACA_API_KEY')
     @classmethod


### PR DESCRIPTION
## Summary
- Pull environment variable defaults directly in `validate_env.Settings` using `default_factory`
- Normalize import order for Pydantic utilities

## Testing
- `ruff check ai_trading/validation/validate_env.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb55182f0083309d1631964e308563