### PR TITLE
Forward kwargs through retry decorator

### DIFF
--- a/ai_trading/utils/retry.py
+++ b/ai_trading/utils/retry.py
@@ -155,9 +155,19 @@ def retry(
             import tenacity as _tenacity_mod  # type: ignore
 
             _tenacity_mod.retry = dec  # type: ignore[assignment]
-        except Exception:
+        except Exception:  # pragma: no cover - best effort wiring
             pass
-        return dec
+
+        def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+            wrapped = dec(fn)
+
+            @functools.wraps(fn)
+            def inner(*args, **kwargs):
+                return wrapped(*args, **kwargs)
+
+            return inner
+
+        return decorator
 
     if HAS_TENACITY:
         _stop = stop_after_attempt(attempts)
@@ -173,9 +183,19 @@ def retry(
             import tenacity as _tenacity_mod  # type: ignore
 
             _tenacity_mod.retry = dec  # type: ignore[assignment]
-        except Exception:
+        except Exception:  # pragma: no cover - best effort wiring
             pass
-        return dec
+
+        def decorator(fn: Callable[..., T]) -> Callable[..., T]:
+            wrapped = dec(fn)
+
+            @functools.wraps(fn)
+            def inner(*args, **kwargs):
+                return wrapped(*args, **kwargs)
+
+            return inner
+
+        return decorator
 
     # Fallback (no Tenacity installed)
     def _calc_wait(n: int) -> float:
@@ -200,6 +220,7 @@ def retry(
                             raise
                         raise RetryError() from exc
                     time.sleep(max(0.0, _calc_wait(attempt)))
+
         return wrapper
 
     return decorator

--- a/tests/unit/test_retry_reraise.py
+++ b/tests/unit/test_retry_reraise.py
@@ -1,11 +1,6 @@
 import pytest
 
-from tests.optdeps import require
-
 from ai_trading.utils.retry import RetryError, retry
-
-# Skip when tenacity is not installed
-require("tenacity")
 
 
 def test_retry_reraise_false_wraps_exception():
@@ -24,3 +19,18 @@ def test_retry_reraise_true_propagates_exception():
 
     with pytest.raises(ValueError):
         boom()
+
+
+def test_retry_reraise_forwards_kwargs():
+    captured: dict[str, object] = {}
+
+    @retry(retries=1, delay=0.001, reraise=True)
+    def boom(**kw):  # type: ignore[no-untyped-def]
+        captured.update(kw)
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        boom(reraise="call", extra=123)
+
+    assert captured["reraise"] == "call"
+    assert captured["extra"] == 123


### PR DESCRIPTION
## Summary
- wrap tenacity-based retry decorators with an inner wrapper to forward arbitrary kwargs
- ensure fallback retry wrapper preserves kwargs
- test retry decorator propagates original exception and passes kwargs through

## Testing
- `ruff check ai_trading/utils/retry.py tests/unit/test_retry_reraise.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_retry_reraise.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb57e184a08330ad56f78b54d21128