### PR TITLE
Use keyword arguments with Alpaca TradingClient

### DIFF
--- a/ai_trading/config/alpaca.py
+++ b/ai_trading/config/alpaca.py
@@ -34,7 +34,7 @@ def get_alpaca_config() -> AlpacaConfig:
     try:
         from alpaca.trading.client import TradingClient  # type: ignore
 
-        client = TradingClient(key_id, secret, paper=use_paper)
+        client = TradingClient(api_key=key_id, secret_key=secret, paper=use_paper)
         acct = client.get_account()
         sub = getattr(acct, 'market_data_subscription', None) or getattr(acct, 'data_feed', None)
         if isinstance(sub, str):


### PR DESCRIPTION
## Summary
- update `get_alpaca_config` to initialize `TradingClient` with explicit keyword arguments

## Testing
- `ruff check ai_trading/config/alpaca.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib', 'ai_trading.execution', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb57e101c48330b6f0f8456a800c21