### PR TITLE
Add API selector and short selling validation utility

### DIFF
--- a/ai_trading/risk/short_selling.py
+++ b/ai_trading/risk/short_selling.py
@@ -1,0 +1,24 @@
+"""Short selling validation utilities."""
+from __future__ import annotations
+
+def validate_short_selling(symbol: str, qty: float, price: float) -> bool:
+    """Validate a proposed short sale.
+
+    Args:
+        symbol: The trading symbol.
+        qty: Number of shares to short.
+        price: Proposed execution price.
+
+    Returns:
+        ``True`` if parameters appear valid.
+
+    Raises:
+        ValueError: If any parameter is invalid.
+    """
+    if not symbol:
+        raise ValueError("missing_symbol")
+    if qty <= 0:
+        raise ValueError("invalid_qty")
+    if price is not None and price <= 0:
+        raise ValueError("invalid_price")
+    return True


### PR DESCRIPTION
## Summary
- allow `ExecutionEngine` to choose broker API via new `_select_api` helper
- run `_select_api` during order execution for consistent API access
- add basic short selling validation routine

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb689ced6c8330bd521aabac8a6b02