### PR TITLE
refactor: expose momentum strategy pandas handle

### DIFF
--- a/ai_trading/strategies/momentum.py
+++ b/ai_trading/strategies/momentum.py
@@ -5,7 +5,7 @@ This module provides a simple long-only momentum strategy used in tests and
 example workflows.
 """
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 import numpy as np
 from ai_trading.logging import logger
 from ..core.enums import RiskLevel
@@ -15,6 +15,8 @@ from .base import BaseStrategy, StrategySignal
 
 if TYPE_CHECKING:  # pragma: no cover
     import pandas as pd
+
+pd: Any | None = None
 
 class MomentumStrategy(BaseStrategy):
     """Momentum-based trading strategy."""
@@ -30,7 +32,10 @@ class MomentumStrategy(BaseStrategy):
         self._guard_last_summary = 0.0
 
     def generate_signals(self, market_data: dict) -> list[StrategySignal]:
-        import pandas as pd  # heavy import; keep local
+        global pd
+        if pd is None:  # heavy import; keep global for monkeypatching
+            import pandas as _pd
+            pd = _pd
         """
         Generate momentum-based long-only signals using price changes over a
         lookback period. Accepts market_data with keys:


### PR DESCRIPTION
## Summary
- expose module-level `pd` handle for momentum strategy
- lazily import pandas when generating signals so tests can monkeypatch `pd.isna`

## Testing
- `ruff check ai_trading/strategies/momentum.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_momentum_extra.py::test_threshold_skip -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb689bafa88330b8dfcbca2a4d70b6