### PR TITLE
Handle equity cache refresh and errors

### DIFF
--- a/tests/test_position_sizing_error_handling.py
+++ b/tests/test_position_sizing_error_handling.py
@@ -1,10 +1,10 @@
-import types
+from json import JSONDecodeError
 from unittest.mock import Mock, patch
 
 import pytest
 from ai_trading.exc import HTTPError, RequestException
 
-from ai_trading.position_sizing import _get_equity_from_alpaca
+from ai_trading.position_sizing import _CACHE, _get_equity_from_alpaca
 
 
 class _Cfg:
@@ -19,35 +19,43 @@ def _cfg():
 
 def test_get_equity_http_error_returns_zero():
     cfg = _cfg()
+    _CACHE.equity = 123.0
     resp = Mock()
     resp.raise_for_status.side_effect = HTTPError(response=Mock(status_code=500))
     session = Mock(get=Mock(return_value=resp))
     with patch("ai_trading.position_sizing.get_global_session", return_value=session):
-        assert _get_equity_from_alpaca(cfg) == 0.0
+        assert _get_equity_from_alpaca(cfg, force_refresh=True) == 0.0
+    assert _CACHE.equity == 0.0
 
 
 def test_get_equity_request_exception_returns_zero():
     cfg = _cfg()
+    _CACHE.equity = 456.0
     session = Mock()
     session.get.side_effect = RequestException("boom")
     with patch("ai_trading.position_sizing.get_global_session", return_value=session):
-        assert _get_equity_from_alpaca(cfg) == 0.0
+        assert _get_equity_from_alpaca(cfg, force_refresh=True) == 0.0
+    assert _CACHE.equity == 0.0
 
 
 def test_get_equity_invalid_json_returns_zero():
     cfg = _cfg()
+    _CACHE.equity = 789.0
     resp = Mock()
     resp.raise_for_status.return_value = None
-    resp.json.side_effect = ValueError("no json")
+    resp.json.side_effect = JSONDecodeError("no json", "{}", 0)
     session = Mock(get=Mock(return_value=resp))
     with patch("ai_trading.position_sizing.get_global_session", return_value=session):
-        assert _get_equity_from_alpaca(cfg) == 0.0
+        assert _get_equity_from_alpaca(cfg, force_refresh=True) == 0.0
+    assert _CACHE.equity == 0.0
 
 
 def test_get_equity_unexpected_exception_propagates():
     cfg = _cfg()
+    _CACHE.equity = 42.0
     with patch(
         "ai_trading.position_sizing.get_global_session", side_effect=RuntimeError("boom")
     ):
         with pytest.raises(RuntimeError):
-            _get_equity_from_alpaca(cfg)
+            _get_equity_from_alpaca(cfg, force_refresh=True)
+    assert _CACHE.equity is None


### PR DESCRIPTION
## Summary
- Reset equity cache when forcing refresh
- Zero out cached equity on HTTP, request, or JSON errors
- Test equity fetch error paths and unexpected exception propagation

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_position_sizing_error_handling.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb6af20f208330ab84447cdb82c8ac