### PR TITLE
Return success flag from short selling validation

### DIFF
--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -549,9 +549,14 @@ class ExecutionEngine:
         except (ValueError, TypeError) as e:
             logger.info('check_stops: suppressed exception: %s', e)
 
-    def _validate_short_selling(self, symbol: str, qty: float, price: float) -> None:
+    def _validate_short_selling(
+        self, _api, symbol: str, qty: float, price: float | None = None
+    ) -> bool:
+        """Run short selling validation and return True on success."""
+
         from ai_trading.risk.short_selling import validate_short_selling
-        validate_short_selling(symbol, qty, price)
+
+        return validate_short_selling(symbol, qty, price)
 
     def _reconcile_partial_fills(self, *args, requested_qty=None, remaining_qty=None, symbol=None, side=None, **_kwargs) -> None:
         """Detect partial fills and emit guardrail alerts.

--- a/ai_trading/risk/short_selling.py
+++ b/ai_trading/risk/short_selling.py
@@ -21,4 +21,4 @@ def validate_short_selling(symbol: str, qty: float, price: float) -> bool:
         raise ValueError("invalid_qty")
     if price is not None and price <= 0:
         raise ValueError("invalid_price")
-    return True
+    return True  # Engine expects ``True`` on successful validation


### PR DESCRIPTION
## Summary
- Ensure execution engine's `_validate_short_selling` returns a boolean success flag
- Clarify short-selling stub to return `True` upon successful validation for engine compatibility

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'alpaca')*


------
https://chatgpt.com/codex/tasks/task_e_68bb6c792d7c83309a3e959561f13e5b