### PR TITLE
Handle missing HTTP adapter and Alpaca APIs

### DIFF
--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -698,8 +698,10 @@ def build_fetcher(config: Any):
     global _FETCHER_SINGLETON
     if _FETCHER_SINGLETON is not None:
         return _FETCHER_SINGLETON
-
-    from ai_trading.alpaca_api import ALPACA_AVAILABLE
+    try:
+        from ai_trading.alpaca_api import ALPACA_AVAILABLE
+    except Exception:  # pragma: no cover - optional dependency
+        ALPACA_AVAILABLE = False
 
     bot_mod = importlib.import_module("ai_trading.core.bot_engine")
     DataFetcher = bot_mod.DataFetcher
@@ -1739,8 +1741,10 @@ def get_daily_df(
     adjustment: str | None = None,
 ) -> pd.DataFrame:
     """Thin wrapper around :func:`bars.get_bars_df` for daily bars."""
-
-    from ai_trading.alpaca_api import get_bars_df as _get_bars_df
+    try:
+        from ai_trading.alpaca_api import get_bars_df as _get_bars_df
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise DataFetchError("Alpaca API unavailable") from exc
 
     return _get_bars_df(
         symbol,

--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -77,6 +77,8 @@ def build_retrying_session(
     connect_timeout_f = cast(float, clamp_request_timeout(connect_timeout))
     read_timeout_f = cast(float, clamp_request_timeout(read_timeout))
     s = TimeoutSession(default_timeout=(connect_timeout_f, read_timeout_f))
+    if HTTPAdapter is object:  # pragma: no cover - requests missing
+        return s
     retry = Retry(
         total=total_retries,
         connect=total_retries,


### PR DESCRIPTION
## Summary
- Avoid HTTP adapter setup when requests isn't installed
- Guard Alpaca API imports in data fetcher for lightweight environments

## Testing
- `ruff check ai_trading/net/http.py ai_trading/data/fetch.py`
- `python - <<'PY'
import builtins, importlib
orig = builtins.__import__

def fake_import(name, *args, **kwargs):
    if name in ('requests', 'yfinance'):
        raise ImportError(f'{name} missing')
    return orig(name, *args, **kwargs)

builtins.__import__ = fake_import
mods = ['ai_trading.net.http', 'ai_trading.data.fetch']
for m in mods:
    importlib.import_module(m)
    print('imported', m)
PY`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_imports_smoke.py::test_submodules_import -q` *(fails: ModuleNotFoundError: No module named 'alpaca'; Skipped: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6c786e008330a6d60f3359e1e733