### PR TITLE
chore: update packaging dev constraint

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -191,7 +191,7 @@ nvidia-nvjitlink-cu12==12.9.86
     #   nvidia-cusparse-cu12
 nvidia-nvtx-cu12==12.1.105
     # via torch
-packaging==24.1
+packaging==25.0
     # via
     #   -r requirements-dev.txt
     #   black


### PR DESCRIPTION
## Summary
- bump packaging to 25.0 in constraints-dev to match other requirement files

## Testing
- `pip install -r requirements-dev.txt -c constraints-dev.txt` *(fails: environment killed during large dependency download)*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68bb6eda0c108330ada6010e68a53eb1