### PR TITLE
stabilize module stubs and service config

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -4967,6 +4967,7 @@ class TradeLogger:
             from ai_trading.meta_learning import (
                 validate_trade_data_quality,
             )
+            # from meta_learning import validate_trade_data_quality  # Legacy trigger reference
 
             quality_report = validate_trade_data_quality(self.path)
 

--- a/ai_trading/data/market_calendar.py
+++ b/ai_trading/data/market_calendar.py
@@ -37,12 +37,14 @@ def _pmc_session_utc(d: date) -> Session:
     if cal is None:
         raise RuntimeError("pandas_market_calendars not available")
     pd = load_pandas()
-    sched = cal.schedule(start_date=d, end_date=d, tz=_ET)
+    sched = cal.schedule(start_date=d, end_date=d)
     if sched.empty:
         prev = previous_trading_session(d)
-        sched = cal.schedule(start_date=prev, end_date=prev, tz=_ET)
-    open_et = sched.iloc[0]['market_open'].to_pydatetime().astimezone(_ET)
-    close_et = sched.iloc[0]['market_close'].to_pydatetime().astimezone(_ET)
+        sched = cal.schedule(start_date=prev, end_date=prev)
+    if sched.empty:
+        raise RuntimeError(f"No trading session for {d}")
+    open_et = sched.iloc[0]["market_open"].tz_convert(_ET).to_pydatetime()
+    close_et = sched.iloc[0]["market_close"].tz_convert(_ET).to_pydatetime()
     return Session(open_et.astimezone(UTC), close_et.astimezone(UTC))
 
 def rth_session_utc(d: date) -> tuple[datetime, datetime]:

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -27,6 +27,7 @@ RuntimeMaxSec=23400
 Restart=no
 StandardOutput=journal
 StandardError=journal
+NoNewPrivileges=true
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/test_strategies_module.py
+++ b/tests/test_strategies_module.py
@@ -1,71 +1,82 @@
 import os
 import sys
 import types
-
-# AI-AGENT-REF: minimal stubs for heavy optional deps
-os.environ.setdefault("PYTEST_RUNNING", "1")
-sys.modules.setdefault(
-    "pandas_market_calendars",
-    types.SimpleNamespace(get_calendar=lambda *a, **k: None),
-)
-sys.modules.setdefault("alpaca", types.ModuleType("alpaca"))
-sys.modules.setdefault("alpaca.trading", types.ModuleType("alpaca.trading"))
-trading_mod = types.ModuleType("alpaca.trading.client")
-trading_mod.TradingClient = object
-trading_mod.APIError = type("APIError", (Exception,), {})
-sys.modules["alpaca.trading.client"] = trading_mod
-data_mod = types.ModuleType("alpaca.data")
-tf_mod = types.ModuleType("alpaca.data.timeframe")
-tf_mod.TimeFrame = type("TimeFrame", (object,), {})
-tf_mod.TimeFrameUnit = type("TimeFrameUnit", (object,), {})
-req_mod = types.ModuleType("alpaca.data.requests")
-req_mod.StockBarsRequest = type("StockBarsRequest", (object,), {})
-sys.modules["alpaca.data"] = data_mod
-sys.modules["alpaca.data.timeframe"] = tf_mod
-sys.modules["alpaca.data.requests"] = req_mod
-data_mod.TimeFrame = tf_mod.TimeFrame
-data_mod.StockBarsRequest = req_mod.StockBarsRequest
-
-# Stub internal modules pulled in by bot_engine imports we don't exercise
-df_stub = types.ModuleType("ai_trading.data.fetch")
-df_stub.get_bars = df_stub.get_bars_batch = lambda *a, **k: []
-df_stub.get_minute_df = lambda *a, **k: None
-df_stub.DataFetchError = Exception
-df_stub.get_cached_minute_timestamp = lambda *a, **k: 0
-df_stub.last_minute_bar_age_seconds = lambda *a, **k: 0
-sys.modules["ai_trading.data.fetch"] = df_stub
-
-cal_stub = types.ModuleType("ai_trading.market.calendars")
-cal_stub.ensure_final_bar = lambda *a, **k: None
-sys.modules["ai_trading.market.calendars"] = cal_stub
-
-cb_stub = types.ModuleType("ai_trading.risk.circuit_breakers")
-cb_stub.DrawdownCircuitBreaker = object
-sys.modules["ai_trading.risk.circuit_breakers"] = cb_stub
-adaptive_stub = types.ModuleType("ai_trading.risk.adaptive_sizing")
-adaptive_stub.AdaptivePositionSizer = object
-adaptive_stub.MarketRegime = type("MarketRegime", (object,), {})
-sys.modules["ai_trading.risk.adaptive_sizing"] = adaptive_stub
-
-pandas_ta_stub = types.ModuleType("pandas_ta")
-pandas_ta_stub._bind_known_methods = lambda: None
-sys.modules["pandas_ta"] = pandas_ta_stub
-
-rebalancer_stub = types.ModuleType("ai_trading.rebalancer")
-rebalancer_stub.maybe_rebalance = lambda *a, **k: None
-rebalancer_stub.rebalance_if_needed = lambda *a, **k: None
-sys.modules["ai_trading.rebalancer"] = rebalancer_stub
-
-pipeline_stub = types.ModuleType("ai_trading.pipeline")
-pipeline_stub.model_pipeline = lambda *a, **k: None
-sys.modules["ai_trading.pipeline"] = pipeline_stub
-
-finnhub_stub = types.ModuleType("finnhub")
-finnhub_stub.FinnhubAPIException = type("FinnhubAPIException", (Exception,), {})
-sys.modules["finnhub"] = finnhub_stub
+import pytest
 
 from ai_trading.config import settings as settings_module
 from ai_trading.core.bot_engine import get_strategies
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _stub_modules(monkeypatch):
+    """Provide lightweight stubs for optional heavy dependencies."""
+    os.environ.setdefault("PYTEST_RUNNING", "1")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "pandas_market_calendars",
+        types.SimpleNamespace(get_calendar=lambda *a, **k: None),
+    )
+
+    monkeypatch.setitem(sys.modules, "alpaca", types.ModuleType("alpaca"))
+    monkeypatch.setitem(sys.modules, "alpaca.trading", types.ModuleType("alpaca.trading"))
+
+    trading_mod = types.ModuleType("alpaca.trading.client")
+    trading_mod.TradingClient = object
+    trading_mod.APIError = type("APIError", (Exception,), {})
+    monkeypatch.setitem(sys.modules, "alpaca.trading.client", trading_mod)
+
+    data_mod = types.ModuleType("alpaca.data")
+    tf_mod = types.ModuleType("alpaca.data.timeframe")
+    tf_mod.TimeFrame = type("TimeFrame", (object,), {})
+    tf_mod.TimeFrameUnit = type("TimeFrameUnit", (object,), {})
+    req_mod = types.ModuleType("alpaca.data.requests")
+    req_mod.StockBarsRequest = type("StockBarsRequest", (object,), {})
+    monkeypatch.setitem(sys.modules, "alpaca.data", data_mod)
+    monkeypatch.setitem(sys.modules, "alpaca.data.timeframe", tf_mod)
+    monkeypatch.setitem(sys.modules, "alpaca.data.requests", req_mod)
+    data_mod.TimeFrame = tf_mod.TimeFrame
+    data_mod.StockBarsRequest = req_mod.StockBarsRequest
+
+    df_stub = types.ModuleType("ai_trading.data.fetch")
+    df_stub.get_bars = df_stub.get_bars_batch = lambda *a, **k: []
+    df_stub.get_minute_df = lambda *a, **k: None
+    df_stub.DataFetchError = Exception
+    df_stub.get_cached_minute_timestamp = lambda *a, **k: 0
+    df_stub.last_minute_bar_age_seconds = lambda *a, **k: 0
+    monkeypatch.setitem(sys.modules, "ai_trading.data.fetch", df_stub)
+
+    cal_stub = types.ModuleType("ai_trading.market.calendars")
+    cal_stub.ensure_final_bar = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "ai_trading.market.calendars", cal_stub)
+
+    cb_stub = types.ModuleType("ai_trading.risk.circuit_breakers")
+    cb_stub.DrawdownCircuitBreaker = object
+    monkeypatch.setitem(sys.modules, "ai_trading.risk.circuit_breakers", cb_stub)
+
+    adaptive_stub = types.ModuleType("ai_trading.risk.adaptive_sizing")
+    adaptive_stub.AdaptivePositionSizer = object
+    adaptive_stub.MarketRegime = type("MarketRegime", (object,), {})
+    monkeypatch.setitem(sys.modules, "ai_trading.risk.adaptive_sizing", adaptive_stub)
+
+    pandas_ta_stub = types.ModuleType("pandas_ta")
+    pandas_ta_stub._bind_known_methods = lambda: None
+    monkeypatch.setitem(sys.modules, "pandas_ta", pandas_ta_stub)
+
+    rebalancer_stub = types.ModuleType("ai_trading.rebalancer")
+    rebalancer_stub.maybe_rebalance = lambda *a, **k: None
+    rebalancer_stub.rebalance_if_needed = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "ai_trading.rebalancer", rebalancer_stub)
+
+    pipeline_stub = types.ModuleType("ai_trading.pipeline")
+    pipeline_stub.model_pipeline = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "ai_trading.pipeline", pipeline_stub)
+
+    finnhub_stub = types.ModuleType("finnhub")
+    finnhub_stub.FinnhubAPIException = type("FinnhubAPIException", (Exception,), {})
+    monkeypatch.setitem(sys.modules, "finnhub", finnhub_stub)
+
+    yield
 
 
 def _prep_settings(strategies):
@@ -93,4 +104,3 @@ def test_get_strategies_non_empty_when_env_unset(monkeypatch):
     _prep_settings(None)
     monkeypatch.delenv("STRATEGIES", raising=False)
     assert get_strategies()
-


### PR DESCRIPTION
## Summary
- isolate heavy dependency stubs for strategy tests with monkeypatch
- guard calendar schedule lookup and reject missing sessions
- document legacy meta-learning trigger and tighten systemd service security

## Testing
- `make test-all` *(fails: 19 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb724029e0833094e37b2d7ee4f179