### PR TITLE
Ensure test-all installs test dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,8 @@ legacy-scan:
 test: smoke
 
 # Run full test suite; disables common auto-loaded plugins for determinism
-test-all:
-	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
-	PYTEST_ADDOPTS="-p no:faulthandler -p no:randomly -p no:cov \
+test-all: ensure-runtime
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS="-p no:faulthandler -p no:randomly -p no:cov \
 	-m 'not integration and not slow and not requires_credentials' \
 	$(if $(VERBOSE),-vv --durations=10 -s,)" \
 	$(PYTHON) tools/run_pytest.py tests

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,7 +15,7 @@ make install-dev
 # Validate environment
 make validate-env
 
-# Run tests
+# Run tests (installs requirements if needed)
 make test-all
 
 # Lint and tests directly
@@ -51,7 +51,7 @@ pip install -r requirements-dev.txt
 ### Available Test Commands
 
 ```bash
-# Run all tests with validation
+# Run all tests with validation (installs requirements)
 make test-all
 
 # Run tests quickly (fail fast)


### PR DESCRIPTION
## Summary
- ensure `make test-all` installs runtime and dev requirements first
- document that `make test-all` automatically installs dependencies

## Testing
- `make test-all VERBOSE=1`

------
https://chatgpt.com/codex/tasks/task_e_68bb7c109f108330971e4be06c0c1cce