### PR TITLE
Add default TimeFrame unit

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -92,8 +92,8 @@ if not ALPACA_AVAILABLE:  # pragma: no cover - exercised in tests
 
     @dataclass(frozen=True)
     class TimeFrame:
-        amount: int
-        unit: TimeFrameUnit
+        amount: int = 1
+        unit: TimeFrameUnit = TimeFrameUnit.Day
 
         def __str__(self) -> str:
             return f"{self.amount}{self.unit.value}"

--- a/ai_trading/data/models.py
+++ b/ai_trading/data/models.py
@@ -92,10 +92,8 @@ def _coerce_timeframe(tf: Any) -> Any:
             return TimeFrame(1, getattr(unit_cls, "Day"))
         except Exception:
             pass
-    try:
-        return TimeFrame(str(tf))  # type: ignore[arg-type]
-    except Exception:
-        return TimeFrame("1Day")
+    # Fall back to default timeframe (1 Day)
+    return TimeFrame()
 
 
 # When the real SDK is available the base request class derives from Pydantic's

--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -19,7 +19,7 @@ except Exception:  # pragma: no cover - inject stub
         Minute = type("Minute", (), {"name": "Minute"})()
 
     class TimeFrame:
-        def __init__(self, amount, unit):
+        def __init__(self, amount=1, unit=TimeFrameUnit.Day):
             self.amount = amount
             self.unit = unit
 

--- a/tests/test_vendor_stub_alpaca_requests.py
+++ b/tests/test_vendor_stub_alpaca_requests.py
@@ -7,11 +7,11 @@ behaviour when instantiated using positional or keyword arguments.
 from datetime import UTC, datetime
 
 from tests.vendor_stubs.alpaca.data.requests import StockBarsRequest
-from tests.vendor_stubs.alpaca.data.timeframe import TimeFrame, TimeFrameUnit
+from tests.vendor_stubs.alpaca.data.timeframe import TimeFrame
 
 
 def _tf_day():
-    return TimeFrame(1, TimeFrameUnit.Day)
+    return TimeFrame()
 
 
 def test_stock_bars_request_keyword_args():

--- a/tests/vendor_stubs/alpaca/data/timeframe.py
+++ b/tests/vendor_stubs/alpaca/data/timeframe.py
@@ -10,7 +10,7 @@ class TimeFrameUnit(Enum):
 
 @dataclass(frozen=True)
 class TimeFrame:
-    amount: int
-    unit: TimeFrameUnit
+    amount: int = 1
+    unit: TimeFrameUnit = TimeFrameUnit.Day
 
 __all__ = ["TimeFrame", "TimeFrameUnit"]


### PR DESCRIPTION
## Summary
- Provide default 1 Day values for fallback `TimeFrame` implementations
- Simplify timeframe coercion fallback logic
- Update vendor stub and tests to accommodate default timeframe

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_vendor_stub_alpaca_requests.py tests/test_alpaca_timeframe_mapping.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc4a1093b08330bf6ff10bfab7e595