### PR TITLE
Fix empty-bar backoff skipping

### DIFF
--- a/ai_trading/data/fetch.py
+++ b/ai_trading/data/fetch.py
@@ -1697,14 +1697,14 @@ def get_minute_df(symbol: str, start: Any, end: Any, feed: str | None = None) ->
                                 _IEX_EMPTY_COUNTS.pop(tf_key, None)
                                 mark_success(symbol, "1Min")
                                 return df_short
-                        try:
-                            df = _backup_get_bars(symbol, start_dt, end_dt, interval="1m")
-                            used_backup = True
-                        except Exception as alt_err:  # pragma: no cover - network failure
-                            logger.warning(
-                                "ALT_PROVIDER_FAILED",
-                                extra={"symbol": symbol, "err": str(alt_err)},
-                            )
+                    try:
+                        df = _backup_get_bars(symbol, start_dt, end_dt, interval="1m")
+                        used_backup = True
+                    except Exception as alt_err:  # pragma: no cover - network failure
+                        logger.warning(
+                            "ALT_PROVIDER_FAILED",
+                            extra={"symbol": symbol, "err": str(alt_err)},
+                        )
                         df = None
                     if df is None or getattr(df, "empty", True):
                         _SKIPPED_SYMBOLS.add(tf_key)


### PR DESCRIPTION
## Summary
- ensure backup provider is always attempted during empty-bar backoff
- mark skipped symbol/timeframe pairs when data remains empty

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_empty_bar_backoff.py tests/test_get_minute_df_fetch_logging.py`
- `pytest tests/test_empty_bar_backoff.py -q`
- `pytest tests/test_get_minute_df_fetch_logging.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib' and other missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4e959750833083c3bb5869d505ac