### PR TITLE
feat: expand market calendar with 2024-2025 sessions

### DIFF
--- a/ai_trading/data/market_calendar.py
+++ b/ai_trading/data/market_calendar.py
@@ -22,6 +22,37 @@ class Session:
     start_utc: datetime
     end_utc: datetime
 
+
+# Known session overrides when pandas_market_calendars is unavailable.
+_FALLBACK_SESSIONS: dict[date, Session] = {
+    # Black Friday early closes
+    date(2024, 11, 29): Session(
+        datetime(2024, 11, 29, 9, 30, tzinfo=_ET).astimezone(UTC),
+        datetime(2024, 11, 29, 13, 0, tzinfo=_ET).astimezone(UTC),
+    ),
+    date(2025, 11, 28): Session(
+        datetime(2025, 11, 28, 9, 30, tzinfo=_ET).astimezone(UTC),
+        datetime(2025, 11, 28, 13, 0, tzinfo=_ET).astimezone(UTC),
+    ),
+    # DST transition Mondays (start/end) for regression coverage
+    date(2024, 3, 11): Session(
+        datetime(2024, 3, 11, 9, 30, tzinfo=_ET).astimezone(UTC),
+        datetime(2024, 3, 11, 16, 0, tzinfo=_ET).astimezone(UTC),
+    ),
+    date(2024, 11, 4): Session(
+        datetime(2024, 11, 4, 9, 30, tzinfo=_ET).astimezone(UTC),
+        datetime(2024, 11, 4, 16, 0, tzinfo=_ET).astimezone(UTC),
+    ),
+    date(2025, 3, 10): Session(
+        datetime(2025, 3, 10, 9, 30, tzinfo=_ET).astimezone(UTC),
+        datetime(2025, 3, 10, 16, 0, tzinfo=_ET).astimezone(UTC),
+    ),
+    date(2025, 11, 3): Session(
+        datetime(2025, 11, 3, 9, 30, tzinfo=_ET).astimezone(UTC),
+        datetime(2025, 11, 3, 16, 0, tzinfo=_ET).astimezone(UTC),
+    ),
+}
+
 def is_trading_day(d: date) -> bool:
     """Return True if *d* is a trading day."""
     cal = _get_calendar()
@@ -52,6 +83,9 @@ def rth_session_utc(d: date) -> tuple[datetime, datetime]:
     cal = _get_calendar()
     if cal is not None:
         s = _pmc_session_utc(d)
+        return (s.start_utc, s.end_utc)
+    if d in _FALLBACK_SESSIONS:
+        s = _FALLBACK_SESSIONS[d]
         return (s.start_utc, s.end_utc)
     start_et = datetime(d.year, d.month, d.day, 9, 30, tzinfo=_ET)
     end_et = datetime(d.year, d.month, d.day, 16, 0, tzinfo=_ET)

--- a/tests/test_market_calendar_wrapper.py
+++ b/tests/test_market_calendar_wrapper.py
@@ -22,13 +22,35 @@ def test_rth_dst_summer_standard_times() -> None:
     assert e2.hour == 21 and e2.minute == 0
 
 
-def test_known_early_close_black_friday() -> None:
-    # Black Friday 2024-11-29: early close ~13:00 ET
-    s, e = rth_session_utc(date(2024, 11, 29))
-    assert s.hour == 14 and s.minute == 30  # 09:30 ET -> 14:30 UTC
-    assert e.hour == 18 and e.minute == 0   # 13:00 ET -> 18:00 UTC
+@pytest.mark.parametrize(
+    "d, start_h, start_m, end_h, end_m",
+    [
+        (date(2024, 11, 29), 14, 30, 18, 0),
+        (date(2025, 11, 28), 14, 30, 18, 0),
+    ],
+)
+def test_known_early_close_black_friday(
+    d: date, start_h: int, start_m: int, end_h: int, end_m: int
+) -> None:
+    s, e = rth_session_utc(d)
+    assert s.hour == start_h and s.minute == start_m
+    assert e.hour == end_h and e.minute == end_m
 
 
-def test_is_trading_day_true_black_friday() -> None:
-    assert is_trading_day(date(2024, 11, 29)) is True
+@pytest.mark.parametrize("d", [date(2024, 11, 29), date(2025, 11, 28)])
+def test_is_trading_day_true_black_friday(d: date) -> None:
+    assert is_trading_day(d) is True
+
+
+def test_dst_transition_sessions() -> None:
+    cases = [
+        (date(2024, 3, 11), 13, 30, 20, 0),
+        (date(2024, 11, 4), 14, 30, 21, 0),
+        (date(2025, 3, 10), 13, 30, 20, 0),
+        (date(2025, 11, 3), 14, 30, 21, 0),
+    ]
+    for d, sh, sm, eh, em in cases:
+        s, e = rth_session_utc(d)
+        assert s.hour == sh and s.minute == sm
+        assert e.hour == eh and e.minute == em
 


### PR DESCRIPTION
## Summary
- add fallback calendar entries for 2024-2025 Black Friday and DST transitions
- cover Black Friday and DST transition sessions with regression tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_market_calendar_wrapper.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 22 errors during collection; missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bc507d95388330a51c5b0fc44d70fd