### PR TITLE
Validate feed and session parameters in data fetch

### DIFF
--- a/tests/test_fetch_param_validation.py
+++ b/tests/test_fetch_param_validation.py
@@ -23,8 +23,21 @@ def test_invalid_adjustment_raises():
         fetch._fetch_bars("AAPL", start, end, "1Min", adjustment="bad")
 
 
-def test_window_without_trading_session_raises():
+def test_window_without_trading_session_returns_empty():
     start = datetime(2024, 1, 6, tzinfo=UTC)
     end = start + timedelta(days=1)
+    out = fetch._fetch_bars("AAPL", start, end, "1Min")
+    assert out.empty
+
+
+def test_missing_session_raises(monkeypatch):
+    start = datetime(2024, 1, 2, 15, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+    monkeypatch.setattr(fetch, "_HTTP_SESSION", None, raising=False)
     with pytest.raises(ValueError):
         fetch._fetch_bars("AAPL", start, end, "1Min")
+
+
+def test_sip_fallback_requires_session():
+    with pytest.raises(ValueError):
+        fetch._sip_fallback_allowed(None, {}, "1Min")


### PR DESCRIPTION
## Summary
- reject unsupported market data feeds via strict canonicalization
- ensure Alpaca SIP fallback always receives an HTTP session
- cover validation cases for feeds and sessions in tests

## Testing
- `ruff check ai_trading/data/fetch.py tests/test_fetch_param_validation.py`
- `pytest tests/test_fetch_param_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc53f9ea3c8330af034a6245226e82