### PR TITLE
Handle non-positive trade prices in validation

### DIFF
--- a/tests/test_validate_trade_data_quality_negative_prices.py
+++ b/tests/test_validate_trade_data_quality_negative_prices.py
@@ -1,0 +1,28 @@
+from ai_trading.meta_learning import validate_trade_data_quality
+import pytest
+
+
+def test_validate_trade_data_quality_filters_non_positive_prices(tmp_path):
+    """Rows with non-positive entry or exit prices should be ignored."""
+    p = tmp_path / "trades.csv"
+    with p.open("w") as f:
+        f.write(
+            "symbol,entry_time,entry_price,exit_time,exit_price,qty,side,strategy,classification,signal_tags,confidence,reward\n"
+        )
+        # Valid row
+        f.write(
+            "GOOD,2025-01-01T00:00:00Z,10,2025-01-01T00:05:00Z,12,1,buy,strat,test,tag,0.5,1\n"
+        )
+        # Negative entry price
+        f.write(
+            "NEGENTRY,2025-01-01T00:00:00Z,-10,2025-01-01T00:05:00Z,12,1,buy,strat,test,tag,0.5,1\n"
+        )
+        # Negative exit price
+        f.write(
+            "NEGEXIT,2025-01-01T00:00:00Z,10,2025-01-01T00:05:00Z,-12,1,buy,strat,test,tag,0.5,1\n"
+        )
+    report = validate_trade_data_quality(str(p))
+    assert report["row_count"] == 3
+    assert report["valid_price_rows"] == 1
+    assert report["meta_format_rows"] == 1
+    assert report["data_quality_score"] == pytest.approx(1/3)


### PR DESCRIPTION
## Summary
- Ignore trade log rows with non-positive entry or exit prices in `validate_trade_data_quality`
- Add regression test for handling negative trade prices

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_validate_trade_data_quality_negative_prices.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc5b6e6be0833093281cb05277ceb3