### PR TITLE
fix: guard slice qty and fill ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to this project will be documented in this file.
 - **Data Fetch**: improve Alpaca empty-bar handling by logging timeframe/feed,
   verifying API credentials and market hours, and attempting feed or window
   fallbacks before resorting to alternate providers.
+- **Execution**: default missing `slice_qty` to `0` and validate `fill_ratio` inputs.
 - **Data Fetch**: retry with SIP feed when initial IEX request returns empty
   for a symbol that may be delisted or on the wrong feed.
 - **Main**: `validate_environment` now raises `RuntimeError` when required

--- a/ai_trading/execution/order_slicer.py
+++ b/ai_trading/execution/order_slicer.py
@@ -1,0 +1,41 @@
+"""Utility helpers for slicing orders with fill adjustments."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ai_trading.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def apply_fill_ratio(
+    slice_data: Mapping[str, Any] | None,
+    fill_ratio: float | int | None,
+) -> int:
+    """Return filled quantity for a slice safely applying a fill ratio.
+
+    Args:
+        slice_data: Mapping that may contain ``slice_qty``.
+        fill_ratio: Ratio of quantity filled (0-1).
+
+    Returns:
+        Estimated filled quantity. ``0`` when inputs are invalid.
+    """
+    raw_qty = 0
+    if slice_data is not None:
+        raw_qty = slice_data.get("slice_qty", 0)
+    try:
+        slice_qty = int(raw_qty)
+    except (TypeError, ValueError):
+        logger.warning("Invalid slice_qty %s; defaulting to 0", raw_qty)
+        slice_qty = 0
+
+    try:
+        ratio = float(fill_ratio)
+    except (TypeError, ValueError):
+        logger.warning("Invalid fill_ratio %s; defaulting to 0", fill_ratio)
+        ratio = 0.0
+
+    if slice_qty <= 0 or ratio <= 0:
+        return 0
+    return int(slice_qty * ratio)

--- a/tests/test_order_slicer.py
+++ b/tests/test_order_slicer.py
@@ -1,0 +1,14 @@
+"""Tests for order_slicer utilities."""
+from ai_trading.execution.order_slicer import apply_fill_ratio
+
+
+def test_apply_fill_ratio_handles_none():
+    """Ensure None values default to zero."""
+    assert apply_fill_ratio({}, 0.5) == 0
+    assert apply_fill_ratio({"slice_qty": None}, 0.5) == 0
+    assert apply_fill_ratio({"slice_qty": 10}, None) == 0
+
+
+def test_apply_fill_ratio_basic():
+    """Verify normal multiplication works."""
+    assert apply_fill_ratio({"slice_qty": 10}, 0.5) == 5


### PR DESCRIPTION
## Summary
- add order_slicer utility that defaults missing slice_qty to 0 and checks fill_ratio
- test order_slicer handling of None inputs
- document slice_qty default in changelog

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 23 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68bc5b6ef8c883309fdf59666a6b2faf