### PR TITLE
Allow zero-arg Alpaca TimeFrame

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -101,7 +101,7 @@ if not ALPACA_AVAILABLE:  # pragma: no cover - exercised in tests
     # Pre-defined shorthand attributes mirroring alpaca-py
     TimeFrame.Minute = TimeFrame(1, TimeFrameUnit.Minute)  # type: ignore[attr-defined]
     TimeFrame.Hour = TimeFrame(1, TimeFrameUnit.Hour)  # type: ignore[attr-defined]
-    TimeFrame.Day = TimeFrame(1, TimeFrameUnit.Day)  # type: ignore[attr-defined]
+    TimeFrame.Day = TimeFrame()  # type: ignore[attr-defined]
 
     @dataclass
     class StockBarsRequest:
@@ -186,8 +186,13 @@ def get_stock_bars_request_cls():
 
 def get_timeframe_cls():
     if ALPACA_AVAILABLE:
-        _, cls, _ = _data_classes()
-        return cls
+        _, cls, unit_cls = _data_classes()
+
+        class _TF(cls):  # type: ignore[misc]
+            def __init__(self, amount: int = 1, unit=unit_cls.Day):  # type: ignore[assignment]
+                super().__init__(amount, unit)
+
+        return _TF
     return TimeFrame
 
 

--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -51,14 +51,14 @@ def test_day_timeframe_normalized(mock_rest_cls):
 
 
 @patch("ai_trading.alpaca_api._get_rest")
-def test_tf_object_normalized(mock_rest_cls):
+def test_tf_zero_arg_normalized(mock_rest_cls):
     mock_rest = MagicMock()
     mock_rest.get_stock_bars.return_value = _Resp(
         pd.DataFrame({"open": [1.0], "close": [1.1]})
     )
     mock_rest_cls.return_value = mock_rest
 
-    df = get_bars_df("SPY", TimeFrame(1, TimeFrameUnit.Day), feed="iex", adjustment="all")
+    df = get_bars_df("SPY", TimeFrame(), feed="iex", adjustment="all")
     mock_rest_cls.assert_called_once_with(bars=True)
     (req,), kwargs = mock_rest.get_stock_bars.call_args
     assert getattr(req.timeframe, "amount", None) == 1

--- a/tests/test_timeframe_zero_arg.py
+++ b/tests/test_timeframe_zero_arg.py
@@ -1,0 +1,9 @@
+from ai_trading.alpaca_api import get_timeframe_cls, get_timeframe_unit_cls
+
+
+def test_timeframe_zero_arg_defaults():
+    TimeFrame = get_timeframe_cls()
+    unit_cls = get_timeframe_unit_cls()
+    tf = TimeFrame()
+    assert tf.amount == 1
+    assert getattr(tf.unit, "name", "") == getattr(unit_cls.Day, "name", "Day")

--- a/tests/vendor_stubs/alpaca/data/timeframe.py
+++ b/tests/vendor_stubs/alpaca/data/timeframe.py
@@ -13,4 +13,13 @@ class TimeFrame:
     amount: int = 1
     unit: TimeFrameUnit = TimeFrameUnit.Day
 
+    def __str__(self) -> str:
+        return f"{self.amount}{self.unit.name}"
+
+
+# Pre-defined shorthand attributes mirroring alpaca-py
+TimeFrame.Minute = TimeFrame(1, TimeFrameUnit.Minute)  # type: ignore[attr-defined]
+TimeFrame.Hour = TimeFrame(1, TimeFrameUnit.Hour)  # type: ignore[attr-defined]
+TimeFrame.Day = TimeFrame()  # type: ignore[attr-defined]
+
 __all__ = ["TimeFrame", "TimeFrameUnit"]


### PR DESCRIPTION
## Summary
- Wrap alpaca-py `TimeFrame` so zero-arg construction defaults to `1 Day`
- Expand vendor test stub to mirror zero-arg `TimeFrame` behavior
- Cover zero-arg `TimeFrame` usage with new tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_timeframe_zero_arg.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib', 'ai_trading.execution' not a package, 'hypothesis', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5b6fbb048330ae8bf9104c1aa78d