### PR TITLE
Add bounded-concurrency fallback scheduler

### DIFF
--- a/ai_trading/data/fallback/__init__.py
+++ b/ai_trading/data/fallback/__init__.py
@@ -1,0 +1,3 @@
+"""Fallback helpers for ai_trading.data."""
+
+__all__ = ["concurrency"]

--- a/ai_trading/data/fallback/concurrency.py
+++ b/ai_trading/data/fallback/concurrency.py
@@ -1,0 +1,88 @@
+"""Async helpers for running fallback tasks with bounded concurrency.
+
+The scheduler limits the number of in-flight tasks and aggregates their results
+into per-symbol mappings and result sets.  It avoids spawning more than
+``max_concurrency`` tasks at a time, preventing unbounded queue growth when
+processing large symbol lists.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Iterable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+# Result sets populated after ``run_with_concurrency`` completes.
+SUCCESSFUL_SYMBOLS: set[str] = set()
+FAILED_SYMBOLS: set[str] = set()
+
+
+async def run_with_concurrency(
+    symbols: Iterable[str],
+    worker: Callable[[str], Awaitable[T]],
+    *,
+    max_concurrency: int = 4,
+) -> tuple[dict[str, T | None], set[str], set[str]]:
+    """Execute ``worker`` for each symbol with a concurrency limit.
+
+    Parameters
+    ----------
+    symbols:
+        Iterable of symbol strings to process.
+    worker:
+        Awaitable callable invoked with each symbol. Its return value becomes
+        the entry in the result mapping. Exceptions are caught and return
+        ``None`` entries.
+    max_concurrency:
+        Maximum number of tasks scheduled at any time.
+
+    Returns
+    -------
+    tuple[dict[str, T | None], set[str], set[str]]
+        A tuple of ``(results, successful, failed)`` where ``results`` maps
+        symbols to worker return values or ``None``.
+    """
+
+    SUCCESSFUL_SYMBOLS.clear()
+    FAILED_SYMBOLS.clear()
+
+    results: dict[str, T | None] = {}
+    iterator = iter(symbols)
+    running: set[asyncio.Task[tuple[str, T | None]]] = set()
+
+    async def _run(sym: str) -> tuple[str, T | None]:
+        try:
+            return sym, await worker(sym)
+        except Exception:  # pragma: no cover - worker errors become None
+            return sym, None
+
+    def _schedule_next() -> bool:
+        try:
+            sym = next(iterator)
+        except StopIteration:
+            return False
+        running.add(asyncio.create_task(_run(sym)))
+        return True
+
+    for _ in range(max_concurrency):
+        if not _schedule_next():
+            break
+
+    while running:
+        done, _ = await asyncio.wait(running, return_when=asyncio.FIRST_COMPLETED)
+        for task in done:
+            running.remove(task)
+            sym, res = task.result()
+            results[sym] = res
+            if res is None:
+                FAILED_SYMBOLS.add(sym)
+            else:
+                SUCCESSFUL_SYMBOLS.add(sym)
+            _schedule_next()
+
+    return results, SUCCESSFUL_SYMBOLS.copy(), FAILED_SYMBOLS.copy()
+
+
+__all__ = ["run_with_concurrency", "SUCCESSFUL_SYMBOLS", "FAILED_SYMBOLS"]

--- a/tests/data/test_fallback_concurrency.py
+++ b/tests/data/test_fallback_concurrency.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from ai_trading.data.fallback import concurrency
+
+
+def test_run_with_concurrency_returns_results():
+    async def worker(sym: str) -> str:
+        await asyncio.sleep(0)
+        return sym
+
+    symbols = ["AAPL", "MSFT", "GOOG"]
+    results, succeeded, failed = asyncio.run(
+        concurrency.run_with_concurrency(symbols, worker, max_concurrency=2)
+    )
+
+    assert results and set(results) == set(symbols)
+    assert succeeded == set(symbols)
+    assert not failed
+
+
+def test_run_with_concurrency_respects_limit():
+    max_seen = 0
+    current = 0
+    lock = asyncio.Lock()
+
+    async def worker(sym: str) -> str:
+        nonlocal max_seen, current
+        async with lock:
+            current += 1
+            if current > max_seen:
+                max_seen = current
+        await asyncio.sleep(0.01)
+        async with lock:
+            current -= 1
+        return sym
+
+    symbols = [f"SYM{i}" for i in range(5)]
+    asyncio.run(concurrency.run_with_concurrency(symbols, worker, max_concurrency=2))
+
+    assert max_seen <= 2


### PR DESCRIPTION
## Summary
- add async fallback task runner that limits in-flight jobs and records successes/failures
- expose result sets and scheduler via new `ai_trading.data.fallback` package
- test for non-empty results and concurrency bound

## Testing
- `ruff check ai_trading/data/fallback/concurrency.py ai_trading/data/fallback/__init__.py tests/data/test_fallback_concurrency.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/data/test_fallback_concurrency.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc6a41f5108330ac2ac55fa9a21ed1