### PR TITLE
Handle TLS clock warnings

### DIFF
--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -19,6 +19,14 @@ from urllib3.util.retry import Retry
 from ai_trading.utils import clamp_request_timeout
 from urllib.parse import urlparse
 
+try:  # handle TLS validation clock skew warnings gracefully
+    import urllib3
+    urllib3.disable_warnings(
+        getattr(urllib3.exceptions, "SystemTimeWarning", urllib3.exceptions.HTTPWarning)
+    )
+except Exception:  # pragma: no cover - urllib3 missing or misbehaving
+    pass
+
 
 _SessionBase = cast(
     "type[object]", requests.Session if getattr(requests, "Session", None) else object


### PR DESCRIPTION
## Summary
- Silence urllib3 SystemTimeWarning to avoid TLS clock skew noise
- Patch tests to mock urllib3.disable_warnings and verify no warning

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_and_screen.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc6a43065483309991f393b86435ec