### PR TITLE
refactor: use ffill/bfill for rsi prep

### DIFF
--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -578,7 +578,7 @@ def compute_signal_matrix(df) -> Any | None:
         logger.debug("Computing signal matrix for %d rows", len(df))
         macd_df = calculate_macd(df["close"])
         if rsi is not None:
-            rsi_series = rsi(tuple(df["close"].fillna(method="ffill").astype(float)), 14)
+            rsi_series = rsi(tuple(df["close"].ffill().bfill().astype(float)), 14)
         else:
             rsi_series = pd.Series(50.0, index=df.index)
         sma_diff = df["close"] - df["close"].rolling(20).mean()

--- a/tests/test_forward_backward_fill.py
+++ b/tests/test_forward_backward_fill.py
@@ -1,0 +1,9 @@
+import pandas as pd
+import pandas.testing as pdt
+
+
+def test_ffill_bfill_equivalence():
+    s = pd.Series([None, 1, None, None, 4, None], dtype=float)
+    result = s.ffill().bfill()
+    expected = pd.Series([1.0, 1.0, 1.0, 1.0, 4.0, 4.0])
+    pdt.assert_series_equal(result, expected)


### PR DESCRIPTION
## Summary
- use pandas `ffill().bfill()` when preparing RSI data
- test forward/backward fill equivalence

## Testing
- `ruff check ai_trading/signals.py tests/test_forward_backward_fill.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_forward_backward_fill.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc6a4096888330920db1db80ca607d