### PR TITLE
Support symbol-name tuples in sample fetch

### DIFF
--- a/ai_trading/tools/fetch_sample_universe.py
+++ b/ai_trading/tools/fetch_sample_universe.py
@@ -1,48 +1,91 @@
+"""Utility to fetch sample market data for a set of symbols."""
+
 from __future__ import annotations
+
 import argparse
 import os
 from datetime import UTC, datetime, timedelta
+from typing import Iterable
+
 from ai_trading.logging import get_logger
 from ai_trading.utils import http
+from ai_trading.utils.http import clamp_request_timeout
 from ai_trading.utils.prof import StageTimer
 from ai_trading.utils.timing import HTTP_TIMEOUT
-from ai_trading.utils.http import clamp_request_timeout
-logger = get_logger(__name__)
-__all__ = ['run', 'parse_cli_and_run']
 
-def run(symbols: list[str], timeout: float | None = None) -> int:
-    """Fetch daily data for ``symbols`` using the pooled HTTP client."""
+logger = get_logger(__name__)
+
+__all__ = ["run", "parse_cli_and_run"]
+
+
+def run(symbols: list[tuple[str, str]], timeout: float | None = None) -> int:
+    """Fetch daily data for ``symbols`` using the pooled HTTP client.
+
+    Parameters
+    ----------
+    symbols
+        Sequence of ``(symbol, name)`` pairs. ``name`` is currently unused but
+        included so callers can supply metadata without additional mapping.
+    timeout
+        Optional request timeout passed to the pooled HTTP client.
+    """
+
     if not symbols:
         return 0
+
     from ai_trading.data.fetch import _build_daily_url
+
     end = datetime.now(UTC)
     start = end - timedelta(days=7)
-    urls = [_build_daily_url(sym, start, end) for sym in symbols]
+    urls = [_build_daily_url(sym, start, end) for sym, _ in symbols]
     failures = 0
     timeout = clamp_request_timeout(timeout)
-    with StageTimer(logger, 'UNIVERSE_FETCH', universe_size=len(symbols)):
+    with StageTimer(logger, "UNIVERSE_FETCH", universe_size=len(symbols)):
         results = http.map_get(urls, timeout=timeout)
-    logger.info('HTTP_POOL_STATS', extra=http.pool_stats())
-    for (resp, err), sym in zip(results, symbols, strict=False):
+    logger.info("HTTP_POOL_STATS", extra=http.pool_stats())
+    for (resp, err), (sym, _) in zip(results, symbols, strict=False):
         if err or not resp or resp[1] != 200:
-            logger.error('fetch failed for %s', sym)
+            logger.error("fetch failed for %s", sym)
             failures += 1
     return 0 if failures == 0 else 1
 
+
+def _parse_symbols(raw: Iterable[str]) -> list[tuple[str, str]]:
+    symbols: list[tuple[str, str]] = []
+    for item in raw:
+        sym, _, name = item.partition(":")
+        sym = sym.strip()
+        name = (name or sym).strip()
+        if sym:
+            symbols.append((sym, name))
+    return symbols
+
+
 def parse_cli_and_run() -> int:
-    parser = argparse.ArgumentParser(description='Fetch sample universe using pooled HTTP')
-    parser.add_argument('--symbols', help='Comma separated symbols', default='')
-    parser.add_argument('--timeout', type=float, default=None)
+    parser = argparse.ArgumentParser(description="Fetch sample universe using pooled HTTP")
+    parser.add_argument(
+        "--symbols",
+        help="Comma separated symbols, optionally 'SYM:Name'",
+        default="",
+    )
+    parser.add_argument("--timeout", type=float, default=None)
     args = parser.parse_args()
+
     if args.symbols:
-        symbols = [s.strip() for s in args.symbols.split(',') if s.strip()]
+        raw_syms = [s.strip() for s in args.symbols.split(",") if s.strip()]
     else:
-        env_syms = os.getenv('SAMPLE_UNIVERSE', 'AAPL,MSFT,GOOGL')
-        symbols = [s.strip() for s in env_syms.split(',') if s.strip()]
+        env_syms = os.getenv("SAMPLE_UNIVERSE", "AAPL,MSFT,GOOGL")
+        raw_syms = [s.strip() for s in env_syms.split(",") if s.strip()]
+
+    symbols = _parse_symbols(raw_syms)
+
     timeout = args.timeout
     if timeout is None:
         timeout = HTTP_TIMEOUT
     return run(symbols, timeout=clamp_request_timeout(timeout))
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
     import sys
+
     sys.exit(parse_cli_and_run())

--- a/tests/test_fetch_sample_universe_cli_integration.py
+++ b/tests/test_fetch_sample_universe_cli_integration.py
@@ -1,0 +1,25 @@
+"""Integration test for the fetch_sample_universe CLI."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_runs_with_no_symbols():
+    """The CLI should execute and exit cleanly even with no symbols."""
+
+    env = os.environ.copy()
+    env["SAMPLE_UNIVERSE"] = ""  # avoid network calls
+    cmd = [sys.executable, "-m", "ai_trading.tools.fetch_sample_universe"]
+    result = subprocess.run(
+        cmd,
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=30,
+        check=False,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout


### PR DESCRIPTION
## Summary
- allow `fetch_sample_universe.run` to accept `(symbol, name)` pairs and adjust CLI parsing accordingly
- add integration test verifying `fetch_sample_universe` CLI executes

## Testing
- `ruff check ai_trading/tools/fetch_sample_universe.py tests/test_fetch_sample_universe_cli.py tests/test_fetch_sample_universe_cli_integration.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_sample_universe_cli.py tests/test_fetch_sample_universe_cli_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc6cc1836c8330a7f35b6854f7d6cc