### PR TITLE
Require session for core data fetch

### DIFF
--- a/ai_trading/data/fetch/core.py
+++ b/ai_trading/data/fetch/core.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ai_trading.net.http import HTTPSession
+
+
+def fetch(url: str, *, session: HTTPSession | None = None, **kwargs: Any) -> Any:
+    """Fetch ``url`` using the provided HTTP session.
+
+    Parameters
+    ----------
+    url:
+        Target URL to request.
+    session:
+        HTTP session used to issue the request. Must provide a ``get`` method.
+
+    Returns
+    -------
+    Any
+        The response returned by ``session.get``.
+
+    Raises
+    ------
+    ValueError
+        If ``session`` is ``None`` or lacks a ``get`` method.
+    """
+    if session is None or not hasattr(session, "get"):
+        raise ValueError("session_required")
+
+    return session.get(url, **kwargs)
+
+
+__all__ = ["fetch"]

--- a/tests/test_fetch_core.py
+++ b/tests/test_fetch_core.py
@@ -1,0 +1,25 @@
+import pytest
+from types import SimpleNamespace
+
+from ai_trading.data.fetch.core import fetch
+
+
+class DummySession:
+    def __init__(self):
+        self.called = False
+
+    def get(self, url, **kwargs):
+        self.called = True
+        return SimpleNamespace(url=url, kwargs=kwargs)
+
+
+def test_fetch_requires_session():
+    with pytest.raises(ValueError):
+        fetch("https://example.com")
+
+
+def test_fetch_uses_session():
+    sess = DummySession()
+    resp = fetch("https://example.com", session=sess)
+    assert sess.called
+    assert resp.url == "https://example.com"


### PR DESCRIPTION
## Summary
- add `ai_trading.data.fetch.core.fetch` utility that requires an HTTP session
- test that `fetch` raises `ValueError` when `session` is missing

## Testing
- `pre-commit run --files ai_trading/data/fetch/core.py tests/test_fetch_core.py` *(fails: check-no-legacy-symbols missing; requests without timeout)*
- `ruff check ai_trading/data/fetch/core.py tests/test_fetch_core.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 20 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6cc0edac8330ba0ab62c297822a3