### PR TITLE
Handle empty retry lists and market closures

### DIFF
--- a/ai_trading/data/fetch/empty_handling.py
+++ b/ai_trading/data/fetch/empty_handling.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import time
+from typing import Callable, Any
+
+from ai_trading.utils.lazy_imports import load_pandas
+from ai_trading.logging import get_logger
+from . import EmptyBarsError, is_market_open
+
+pd = load_pandas()
+logger = get_logger(__name__)
+
+_RETRY_COUNTS: dict[tuple[str, str], int] = {}
+
+
+def _empty_df() -> Any:
+    if pd is None:  # pragma: no cover - defensive
+        return []
+    return pd.DataFrame()
+
+
+def fetch_with_retries(
+    symbol: str,
+    timeframe: str,
+    fetch_fn: Callable[[], Any],
+    retry_delays: list[float],
+) -> Any:
+    """Fetch data with retry handling for empty bar responses.
+
+    Parameters
+    ----------
+    symbol: str
+        Symbol being fetched, used for logging and retry tracking.
+    timeframe: str
+        Timeframe being fetched, used for logging and retry tracking.
+    fetch_fn: Callable[[], Any]
+        Callable returning the data or raising :class:`EmptyBarsError` when
+        the response is empty.
+    retry_delays: list[float]
+        Sequence of delays between retries. The list is mutated in place as
+        delays are consumed. When the list is empty the function will return
+        an empty DataFrame without retrying.
+    """
+    key = (symbol, timeframe)
+    attempts = 0
+    while True:
+        try:
+            data = fetch_fn()
+        except EmptyBarsError:
+            attempts += 1
+            _RETRY_COUNTS[key] = attempts
+            if not is_market_open():
+                logger.info(
+                    "EMPTY_FETCH_MARKET_CLOSED",
+                    extra={"symbol": symbol, "timeframe": timeframe, "attempts": attempts},
+                )
+                _RETRY_COUNTS.pop(key, None)
+                return _empty_df()
+            if not retry_delays:
+                logger.warning(
+                    "EMPTY_FETCH_NO_RETRIES",
+                    extra={"symbol": symbol, "timeframe": timeframe, "attempts": attempts},
+                )
+                _RETRY_COUNTS.pop(key, None)
+                return _empty_df()
+            delay = retry_delays.pop(0)
+            logger.debug(
+                "EMPTY_FETCH_RETRY",
+                extra={
+                    "symbol": symbol,
+                    "timeframe": timeframe,
+                    "attempts": attempts,
+                    "remaining_retries": len(retry_delays),
+                    "retry_delay": delay,
+                },
+            )
+            time.sleep(delay)
+        else:
+            _RETRY_COUNTS.pop(key, None)
+            return data
+
+
+__all__ = ["fetch_with_retries", "_RETRY_COUNTS"]

--- a/tests/test_empty_handling.py
+++ b/tests/test_empty_handling.py
@@ -1,0 +1,72 @@
+import types
+
+import pandas as pd
+import pytest
+
+from ai_trading.data.fetch.empty_handling import fetch_with_retries, _RETRY_COUNTS
+from ai_trading.data.fetch import EmptyBarsError
+
+
+class _Raiser:
+    def __init__(self, fail_times: int, result: pd.DataFrame | None = None) -> None:
+        self.fail_times = fail_times
+        self.calls = 0
+        self.result = result if result is not None else pd.DataFrame({'a': [1]})
+
+    def __call__(self):
+        if self.calls < self.fail_times:
+            self.calls += 1
+            raise EmptyBarsError('empty')
+        self.calls += 1
+        return self.result
+
+
+def test_returns_empty_when_no_retry_delays(monkeypatch):
+    symbol = 'AAPL'
+    timeframe = '1Min'
+    raiser = _Raiser(fail_times=1)
+    monkeypatch.setattr('ai_trading.data.fetch.empty_handling.is_market_open', lambda: True)
+    called: dict[str, float] = {}
+    monkeypatch.setattr(
+        'ai_trading.data.fetch.empty_handling.time',
+        types.SimpleNamespace(sleep=lambda s: called.setdefault('sleep', s)),
+    )
+    df = fetch_with_retries(symbol, timeframe, raiser, [])
+    assert df.empty
+    assert 'sleep' not in called
+    assert (symbol, timeframe) not in _RETRY_COUNTS
+
+
+def test_retry_until_success(monkeypatch):
+    symbol = 'MSFT'
+    timeframe = '1Min'
+    raiser = _Raiser(fail_times=1)
+    monkeypatch.setattr('ai_trading.data.fetch.empty_handling.is_market_open', lambda: True)
+    called: dict[str, float] = {}
+    monkeypatch.setattr(
+        'ai_trading.data.fetch.empty_handling.time',
+        types.SimpleNamespace(sleep=lambda s: called.setdefault('sleep', s)),
+    )
+    df = fetch_with_retries(symbol, timeframe, raiser, [0])
+    assert not df.empty
+    assert called.get('sleep') == 0
+    assert raiser.calls == 2
+    assert (symbol, timeframe) not in _RETRY_COUNTS
+
+
+def test_abort_when_market_closed(monkeypatch):
+    symbol = 'IBM'
+    timeframe = '1Min'
+    raiser = _Raiser(fail_times=1)
+    monkeypatch.setattr('ai_trading.data.fetch.empty_handling.is_market_open', lambda: False)
+    called: dict[str, float] = {}
+    monkeypatch.setattr(
+        'ai_trading.data.fetch.empty_handling.time',
+        types.SimpleNamespace(sleep=lambda s: called.setdefault('sleep', s)),
+    )
+    delays = [0, 1]
+    df = fetch_with_retries(symbol, timeframe, raiser, delays)
+    assert df.empty
+    assert delays == [0, 1]
+    assert 'sleep' not in called
+    assert (symbol, timeframe) not in _RETRY_COUNTS


### PR DESCRIPTION
## Summary
- Add `fetch_with_retries` helper guarding against empty retry lists and tracking retry counts
- Abort retries early when the market is closed
- Cover success, no-retry, and market-closed branches with dedicated tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_empty_handling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc6cbe4b3883308a23df93ce649f37