### PR TITLE
Add delay metadata for empty fetch retries

### DIFF
--- a/tests/test_fetch_empty_retry_once.py
+++ b/tests/test_fetch_empty_retry_once.py
@@ -54,6 +54,9 @@ def test_single_retry_and_warning(monkeypatch, caplog):
     monkeypatch.setattr(fetch, "_HTTP_SESSION", sess)
     monkeypatch.setattr(fetch, "is_market_open", lambda: True)
     monkeypatch.setattr(fetch, "_sip_fallback_allowed", lambda *a, **k: False)
+    monkeypatch.setattr(fetch, "_ALLOW_SIP", False)
+    monkeypatch.setattr(fetch, "max_data_fallbacks", lambda: 0)
+    monkeypatch.setattr(fetch, "_symbol_exists", lambda *a, **k: True)
     monkeypatch.setattr(fetch, "_outside_market_hours", lambda *a, **k: False)
     monkeypatch.setattr(fetch, "_empty_should_emit", lambda *a, **k: True)
     monkeypatch.setattr(fetch, "_empty_record", lambda *a, **k: 1)
@@ -92,3 +95,4 @@ def test_single_retry_and_warning(monkeypatch, caplog):
     assert calls[1][1] is None
     assert calls[1][2]["correlation_id"] == "id2"
     assert calls[1][2]["previous_correlation_id"] == "id1"
+    assert calls[1][2]["delay"] == sleep_called["delay"]


### PR DESCRIPTION
## Summary
- include retry delay in metadata returned by `retry_empty_fetch_once`
- propagate delay to fetch attempt logging
- test that retry metadata exposes the delay

## Testing
- `ruff check ai_trading/data/fetch/__init__.py tests/test_fetch_empty_retry_once.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_empty_retry_once.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68bc6cbfed788330a29badb3afeb8918