### PR TITLE
feat: add IEX SIP fallback helper

### DIFF
--- a/ai_trading/data/fetch/iex_fallback.py
+++ b/ai_trading/data/fetch/iex_fallback.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+"""Utility helpers for handling Alpaca IEX feed fallbacks.
+
+This module implements a very small subset of the logic that the main
+``ai_trading.data.fetch`` package provides.  It focuses on situations where the
+Alpaca IEX feed returns an empty payload.  When that occurs we record the
+attempt, increment the global ``_IEX_EMPTY_COUNTS`` tracker and, when allowed,
+retry the request against the SIP feed.  If both feeds return empty results an
+error is logged so callers can react accordingly.
+
+The functions here are intentionally lightweight so that they can be imported in
+isolation for unit tests without pulling in the entire ``fetch`` module.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from ai_trading.utils.lazy_imports import load_pandas
+from ai_trading.logging import get_logger
+
+# Import shared state from the package's ``__init__``.  These variables are
+# defined there and are re-used across modules.
+from . import (
+    _HTTP_SESSION,
+    _ALLOW_SIP,
+    _SIP_UNAUTHORIZED,
+    _IEX_EMPTY_COUNTS,
+    _IEX_EMPTY_THRESHOLD,
+)
+
+pd = load_pandas()
+logger = get_logger(__name__)
+
+
+def _to_df(payload: dict[str, Any]):
+    """Return a pandas DataFrame for ``payload`` bars.
+
+    The helper mirrors the behaviour in :mod:`ai_trading.data.fetch` by keeping
+    the import of :mod:`pandas` optional.  Tests rely on the ``empty`` attribute
+    being present so an empty DataFrame is returned when no bars are found.
+    """
+
+    bars = payload.get("bars", [])
+    if pd is None:  # pragma: no cover - defensive fallback
+        return bars
+    return pd.DataFrame(bars)
+
+
+def fetch_bars(
+    symbol: str,
+    start: datetime,
+    end: datetime,
+    timeframe: str,
+    *,
+    session=None,
+) -> Any:
+    """Fetch market bars with automatic IEX→SIP fallback.
+
+    Parameters
+    ----------
+    symbol, start, end, timeframe:
+        Basic request parameters mirrored from the full fetcher.  Only the
+        ``feed`` parameter is inspected in tests but keeping the signature close
+        to the real function aids readability.
+    session:
+        HTTP session used for requests.  Falls back to the package level session
+        when ``None``.
+    """
+
+    session = session or _HTTP_SESSION
+    tf = str(timeframe)
+    key = (symbol, tf)
+
+    # If previous attempts yielded an empty IEX response we skip straight to SIP
+    # (when allowed).
+    feed = "iex"
+    if _IEX_EMPTY_COUNTS.get(key, 0) >= _IEX_EMPTY_THRESHOLD and _ALLOW_SIP and not _SIP_UNAUTHORIZED:
+        logger.info(
+            "DATA_SOURCE_FALLBACK_ATTEMPT",
+            extra={"symbol": symbol, "timeframe": tf, "from": "iex", "to": "sip", "attempts": 0},
+        )
+        feed = "sip"
+
+    attempts = 0
+    while True:
+        params = {
+            "symbol": symbol,
+            "start": start,
+            "end": end,
+            "feed": feed,
+            "timeframe": tf,
+        }
+        resp = session.get("https://data.alpaca.markets/v2/stocks/bars", params=params)
+        payload = resp.json()
+        bars = payload.get("bars") or []
+        if bars:
+            # Successful fetch resets counter
+            _IEX_EMPTY_COUNTS.pop(key, None)
+            return _to_df(payload)
+
+        # Empty response handling
+        if feed == "iex":
+            attempts += 1
+            _IEX_EMPTY_COUNTS[key] = _IEX_EMPTY_COUNTS.get(key, 0) + 1
+            if _ALLOW_SIP and not _SIP_UNAUTHORIZED:
+                logger.info(
+                    "DATA_SOURCE_FALLBACK_ATTEMPT",
+                    extra={
+                        "symbol": symbol,
+                        "timeframe": tf,
+                        "from": "iex",
+                        "to": "sip",
+                        "attempts": attempts,
+                    },
+                )
+                feed = "sip"
+                continue
+            return _to_df({})
+
+        # If we get here the SIP request was also empty
+        logger.error(
+            "IEX_EMPTY_SIP_EMPTY",
+            extra={"symbol": symbol, "timeframe": tf, "attempts": attempts + 1},
+        )
+        return _to_df({})
+
+
+__all__ = ["fetch_bars"]

--- a/tests/test_iex_fallback_module.py
+++ b/tests/test_iex_fallback_module.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ai_trading.data.fetch import iex_fallback
+from ai_trading.data.fetch import _IEX_EMPTY_COUNTS
+
+
+class _Resp:
+    def __init__(self, payload, *, status: int = 200):
+        self.status_code = status
+        self.headers = {"Content-Type": "application/json"}
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+        self.get = self._get
+
+    def _get(self, url, params=None, headers=None, timeout=None):
+        self.calls.append(params)
+        return self._responses.pop(0)
+
+
+def _dt_range():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+    return start, end
+
+
+def setup_module(module):  # pragma: no cover - test helper
+    _IEX_EMPTY_COUNTS.clear()
+
+
+def test_iex_empty_switches_to_sip(monkeypatch, caplog):
+    _IEX_EMPTY_COUNTS.clear()
+    start, end = _dt_range()
+    sess = _Session([
+        _Resp({"bars": []}),
+        _Resp({"bars": [{"t": "2024-01-01T00:00:00Z"}]}),
+    ])
+    monkeypatch.setattr(iex_fallback, "_ALLOW_SIP", True)
+    monkeypatch.setattr(iex_fallback, "_SIP_UNAUTHORIZED", False)
+    with caplog.at_level(logging.INFO):
+        df = iex_fallback.fetch_bars("AAPL", start, end, "1Min", session=sess)
+    assert [c["feed"] for c in sess.calls] == ["iex", "sip"]
+    assert not df.empty
+    assert _IEX_EMPTY_COUNTS == {}
+    assert any(r.message == "DATA_SOURCE_FALLBACK_ATTEMPT" for r in caplog.records)
+
+
+def test_both_feeds_empty_logs_error(monkeypatch, caplog):
+    _IEX_EMPTY_COUNTS.clear()
+    start, end = _dt_range()
+    sess = _Session([
+        _Resp({"bars": []}),
+        _Resp({"bars": []}),
+    ])
+    monkeypatch.setattr(iex_fallback, "_ALLOW_SIP", True)
+    monkeypatch.setattr(iex_fallback, "_SIP_UNAUTHORIZED", False)
+    with caplog.at_level(logging.ERROR):
+        df = iex_fallback.fetch_bars("AAPL", start, end, "1Min", session=sess)
+    assert [c["feed"] for c in sess.calls] == ["iex", "sip"]
+    assert getattr(df, "empty", True)
+    assert _IEX_EMPTY_COUNTS.get(("AAPL", "1Min"), 0) == 1
+    assert any(r.message == "IEX_EMPTY_SIP_EMPTY" for r in caplog.records)
+
+
+def test_skip_iex_after_threshold(monkeypatch, caplog):
+    _IEX_EMPTY_COUNTS.clear()
+    start, end = _dt_range()
+    # First call primes the counter
+    sess1 = _Session([
+        _Resp({"bars": []}),
+        _Resp({"bars": []}),
+    ])
+    monkeypatch.setattr(iex_fallback, "_ALLOW_SIP", True)
+    monkeypatch.setattr(iex_fallback, "_SIP_UNAUTHORIZED", False)
+    iex_fallback.fetch_bars("AAPL", start, end, "1Min", session=sess1)
+    assert _IEX_EMPTY_COUNTS.get(("AAPL", "1Min"), 0) == 1
+
+    # Second call should bypass IEX and hit SIP directly
+    sess2 = _Session([
+        _Resp({"bars": [{"t": "2024-01-01T00:00:00Z"}]}),
+    ])
+    with caplog.at_level(logging.INFO):
+        df = iex_fallback.fetch_bars("AAPL", start, end, "1Min", session=sess2)
+    assert len(sess2.calls) == 1
+    assert sess2.calls[0]["feed"] == "sip"
+    assert not df.empty
+    assert _IEX_EMPTY_COUNTS.get(("AAPL", "1Min"), 0) == 0
+    assert any(r.message == "DATA_SOURCE_FALLBACK_ATTEMPT" for r in caplog.records)


### PR DESCRIPTION
## Summary
- add lightweight helper to retry IEX bar fetches and fall back to SIP
- log error when both IEX and SIP feeds are empty
- cover retry and skip behaviour with tests

## Testing
- `ruff check ai_trading/data/fetch/iex_fallback.py tests/test_iex_fallback_module.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_iex_fallback_module.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68bc704c78fc8330af0f2c850b9ec4d8