### PR TITLE
feat: add finnhub provider toggle

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -35,6 +35,7 @@ from ai_trading.data.empty_bar_backoff import (
 from ai_trading.data.metrics import metrics, provider_fallback
 from ai_trading.net.http import HTTPSession, get_http_session
 from ai_trading.utils.http import clamp_request_timeout
+from ai_trading.data.finnhub import fh_fetcher, FinnhubAPIException
 
 logger = get_logger(__name__)
 
@@ -122,13 +123,6 @@ DataFetchException = DataFetchError
 class EmptyBarsError(DataFetchError, ValueError):
     """Raised when a data provider returns no bars for a request."""
 
-
-class FinnhubAPIException(Exception):
-    """Minimal Finnhub API error for tests."""
-
-    def __init__(self, status_code: int):
-        self.status_code = status_code
-        super().__init__(str(status_code))
 
 
 def ensure_datetime(value: Any) -> _dt.datetime:
@@ -425,18 +419,6 @@ def _sip_fallback_allowed(session: HTTPSession | None, headers: dict[str, str], 
         )
         return False
     return True
-
-
-class _FinnhubFetcherStub:
-    """Minimal stub with a fetch() method; tests monkeypatch this."""
-
-    is_stub = True
-
-    def fetch(self, *args, **kwargs):
-        raise NotImplementedError
-
-
-fh_fetcher = _FinnhubFetcherStub()
 
 
 def get_last_available_bar(symbol: str) -> pd.DataFrame:

--- a/ai_trading/data/finnhub.py
+++ b/ai_trading/data/finnhub.py
@@ -1,0 +1,85 @@
+"""Finnhub optional dependency handling."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from ai_trading.config import management as config
+from ai_trading.logging import logger_once, log_finnhub_disabled
+
+_SENT_DEPS_LOGGED: set[str] = set()
+
+
+class FinnhubAPIException(Exception):
+    """Thin Finnhub API error wrapper used in tests."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        super().__init__(str(status_code))
+
+
+class _FinnhubFetcherStub:
+    """Minimal stub with a ``fetch`` method; tests may monkeypatch this."""
+
+    is_stub = True
+
+    def fetch(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - defensive
+        raise NotImplementedError
+
+
+def _build_fetcher() -> Any:
+    enable = config.get_env("ENABLE_FINNHUB", "1").lower() not in ("0", "false")
+    if not enable:
+        if "finnhub" not in _SENT_DEPS_LOGGED:
+            log_finnhub_disabled("GLOBAL")
+            _SENT_DEPS_LOGGED.add("finnhub")
+        return _FinnhubFetcherStub()
+    try:
+        import finnhub  # type: ignore
+    except Exception:
+        if "finnhub" not in _SENT_DEPS_LOGGED:
+            logger_once.warning(
+                "FINNHUB_OPTIONAL_DEP_MISSING",
+                extra={"package": "finnhub-python"},
+            )
+            _SENT_DEPS_LOGGED.add("finnhub")
+        return _FinnhubFetcherStub()
+    api_key = config.get_env("FINNHUB_API_KEY")
+    if not api_key:
+        if "finnhub" not in _SENT_DEPS_LOGGED:
+            log_finnhub_disabled("GLOBAL")
+            _SENT_DEPS_LOGGED.add("finnhub")
+        return _FinnhubFetcherStub()
+
+    class FinnhubFetcher:
+        """Simple wrapper around ``finnhub.Client``."""
+
+        is_stub = False
+
+        def __init__(self, client: Any) -> None:
+            self._client = client
+
+        def fetch(
+            self,
+            symbol: str,
+            start: datetime,
+            end: datetime,
+            *,
+            resolution: str = "1",
+        ) -> Any:
+            pd = __import__("pandas")
+            resp = self._client.stock_candle(
+                symbol,
+                resolution,
+                int(start.timestamp()),
+                int(end.timestamp()),
+            )
+            return pd.DataFrame(resp)
+
+    return FinnhubFetcher(finnhub.Client(api_key))
+
+
+fh_fetcher = _build_fetcher()
+
+__all__ = ["fh_fetcher", "FinnhubAPIException", "_SENT_DEPS_LOGGED"]

--- a/tests/test_finnhub_module.py
+++ b/tests/test_finnhub_module.py
@@ -1,0 +1,33 @@
+import importlib
+import logging
+import types
+import sys
+
+import pytest
+
+
+def _reload_module():
+    import ai_trading.data.finnhub as fh
+    return importlib.reload(fh)
+
+
+def test_disabled_logs_once(monkeypatch, caplog):
+    monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
+    monkeypatch.setenv("ENABLE_FINNHUB", "0")
+    sys.modules.pop("finnhub", None)
+    with caplog.at_level(logging.DEBUG):
+        mod = _reload_module()
+    assert getattr(mod.fh_fetcher, "is_stub", False)
+    assert mod._SENT_DEPS_LOGGED == {"finnhub"}
+    assert any(r.message == "FINNHUB_DISABLED" for r in caplog.records)
+
+
+def test_enabled_fetcher(monkeypatch):
+    monkeypatch.setenv("ENABLE_FINNHUB", "1")
+    monkeypatch.setenv("FINNHUB_API_KEY", "test")
+    finnhub_stub = types.ModuleType("finnhub")
+    finnhub_stub.Client = lambda key: object()
+    monkeypatch.setitem(sys.modules, "finnhub", finnhub_stub)
+    mod = _reload_module()
+    assert not getattr(mod.fh_fetcher, "is_stub", False)
+    assert mod._SENT_DEPS_LOGGED == set()


### PR DESCRIPTION
## Summary
- add configurable Finnhub fetcher with optional dependency logging
- log when Finnhub is disabled and surface via data.fetch
- test enabled and disabled Finnhub paths

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_finnhub_module.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib', 'ai_trading.execution.engine', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bc704a68a88330bc53980a4783b258