### PR TITLE
Respect AI_TRADING_HOST_LIMIT for async host pooling

### DIFF
--- a/ai_trading/http/pooling.py
+++ b/ai_trading/http/pooling.py
@@ -10,7 +10,8 @@ _DEFAULT_LIMIT: Final[int] = 8
 
 def _resolve_limit() -> int:
     try:
-        return int(config.get_env("AI_TRADING_MAX_CONCURRENT_HOSTS", str(_DEFAULT_LIMIT), cast=int))
+        limit = int(config.get_env("AI_TRADING_HOST_LIMIT", str(_DEFAULT_LIMIT), cast=int))
+        return max(1, limit)
     except Exception:
         return _DEFAULT_LIMIT
 

--- a/tests/test_http_host_limit.py
+++ b/tests/test_http_host_limit.py
@@ -1,0 +1,28 @@
+import asyncio
+from tests.conftest import reload_module
+
+
+def test_host_limit_enforced(monkeypatch):
+    monkeypatch.setenv("AI_TRADING_HOST_LIMIT", "2")
+    pooling = reload_module("ai_trading.http.pooling")
+    sem = pooling.get_host_semaphore()
+
+    current = 0
+    max_seen = 0
+
+    async def worker():
+        nonlocal current, max_seen
+        async with sem:
+            current += 1
+            max_seen = max(max_seen, current)
+            await asyncio.sleep(0.01)
+            current -= 1
+
+    async def main():
+        await asyncio.gather(*(worker() for _ in range(5)))
+
+    asyncio.run(main())
+    assert max_seen == 2
+
+    monkeypatch.delenv("AI_TRADING_HOST_LIMIT", raising=False)
+    reload_module(pooling)


### PR DESCRIPTION
## Summary
- read AI_TRADING_HOST_LIMIT to size async host semaphore
- exercise host limit with new test

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_http_host_limit.py tests/test_http_pooling.py tests/test_http_timeouts.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc704b96188330b1664f5d8b89b557