### PR TITLE
Handle missing flask.testing gracefully

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -103,6 +103,26 @@ def create_app():
     return app
 
 
+def get_test_client():
+    """Return a Flask test client or ``None`` if unavailable.
+
+    Importing ``flask.testing`` can fail in environments that provide a
+    lightweight Flask stub. This helper guards the import and falls back
+    gracefully when the testing utilities are missing.
+    """
+
+    try:  # Prefer attribute import to avoid accidentally pulling in a top-level
+        from flask import testing as flask_testing  # type: ignore
+    except ImportError:
+        try:
+            flask_testing = import_module("flask.testing")
+        except ImportError:
+            return None
+
+    app = create_app()
+    return flask_testing.FlaskClient(app)
+
+
 if __name__ == '__main__':
     if os.getenv('RUN_HEALTHCHECK') == '1':
         from ai_trading.config.settings import get_settings

--- a/tests/test_flask_testing_import_optional.py
+++ b/tests/test_flask_testing_import_optional.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def test_get_test_client_handles_missing_flask_testing(monkeypatch):
+    """`get_test_client` returns ``None`` when `flask.testing` is missing."""
+    flask_stub = types.ModuleType("flask")
+    flask_stub.__path__ = []  # mark as package
+    flask_app_stub = types.ModuleType("flask.app")
+
+    class Flask:  # minimal stub
+        def __init__(self, *a, **k):
+            pass
+
+    flask_app_stub.Flask = Flask
+    flask_stub.Flask = Flask
+    flask_stub.jsonify = lambda *a, **k: {}
+
+    monkeypatch.setitem(sys.modules, "flask", flask_stub)
+    monkeypatch.setitem(sys.modules, "flask.app", flask_app_stub)
+    monkeypatch.delitem(sys.modules, "flask.testing", raising=False)
+    monkeypatch.setitem(sys.modules, "testing", types.ModuleType("testing"))
+
+    app_module = importlib.reload(importlib.import_module("ai_trading.app"))
+
+    assert app_module.get_test_client() is None


### PR DESCRIPTION
## Summary
- guard optional `flask.testing` import and provide helper to build a test client only when available
- add regression test verifying the helper returns `None` when `flask.testing` cannot be imported

## Testing
- `ruff check ai_trading/app.py tests/test_flask_testing_import_optional.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_flask_testing_import_optional.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc704adee08330a93e4157f99d9bea