### PR TITLE
Handle all symbols in portfolio correlation

### DIFF
--- a/ai_trading/portfolio/correlation.py
+++ b/ai_trading/portfolio/correlation.py
@@ -1,0 +1,43 @@
+"""Portfolio correlation utilities."""
+from __future__ import annotations
+
+from typing import Dict, List
+from statistics import StatisticsError, correlation
+
+from ai_trading.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def calculate_correlation_matrix(returns: Dict[str, List[float]]) -> Dict[str, Dict[str, float]]:
+    """Calculate pairwise correlation coefficients for all symbols.
+
+    Args:
+        returns: Mapping of symbols to return series.
+
+    Returns:
+        Nested mapping where ``matrix[s1][s2]`` is the correlation between
+        ``s1`` and ``s2``. Missing or insufficient data yields ``0.0``.
+    """
+    symbols = list(returns.keys())
+    matrix: Dict[str, Dict[str, float]] = {}
+    for i, sym1 in enumerate(symbols):
+        series1 = returns.get(sym1, [])
+        matrix[sym1] = {}
+        for sym2 in symbols:
+            if sym1 == sym2:
+                continue
+            series2 = returns.get(sym2, [])
+            if not series1 or not series2:
+                matrix[sym1][sym2] = 0.0
+                continue
+            length = min(len(series1), len(series2))
+            try:
+                coeff = correlation(series1[:length], series2[:length])
+            except (StatisticsError, ZeroDivisionError):
+                coeff = 0.0
+            matrix[sym1][sym2] = coeff
+    logger.debug("Calculated correlation matrix", extra={"matrix": matrix})
+    return matrix
+
+__all__ = ["calculate_correlation_matrix"]

--- a/tests/test_portfolio_correlation.py
+++ b/tests/test_portfolio_correlation.py
@@ -1,0 +1,17 @@
+"""Test portfolio correlation utilities."""
+
+from ai_trading.portfolio.correlation import calculate_correlation_matrix
+
+
+def test_calculate_correlation_matrix_three_symbols():
+    """Ensure all symbols in the portfolio are correlated against each other."""
+    returns = {
+        "AAPL": [0.01, 0.02, 0.03],
+        "MSFT": [0.02, 0.04, 0.06],
+        "GOOGL": [0.03, 0.06, 0.09],
+    }
+    matrix = calculate_correlation_matrix(returns)
+    assert set(matrix.keys()) == {"AAPL", "MSFT", "GOOGL"}
+    assert set(matrix["AAPL"].keys()) == {"MSFT", "GOOGL"}
+    assert set(matrix["MSFT"].keys()) == {"AAPL", "GOOGL"}
+    assert set(matrix["GOOGL"].keys()) == {"AAPL", "MSFT"}


### PR DESCRIPTION
## Summary
- add correlation utility that iterates over every symbol in the portfolio
- cover three-symbol portfolio case in new unit test

## Testing
- `ruff check ai_trading/portfolio/correlation.py tests/test_portfolio_correlation.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_portfolio_correlation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc7299bf78833082c20194f08150f4