### PR TITLE
Add environment validation to main_extended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ All notable changes to this project will be documented in this file.
   for a symbol that may be delisted or on the wrong feed.
 - **Main**: `validate_environment` now raises `RuntimeError` when required
   environment variables are missing.
+- **Main Extended**: `validate_environment` now raises `RuntimeError` when
+  required environment variables are missing.
 - Normalize broker-unavailable contract; remove false PDT warnings; add regression tests.
 - Fix IndentationError in `bot_engine.py` (pybreaker stub); add static compile guard.
 - **Runtime safety**: improved Alpaca availability checks, stable logging shutdown,

--- a/ai_trading/main_extended.py
+++ b/ai_trading/main_extended.py
@@ -1,0 +1,36 @@
+"""Extended main utilities."""
+from __future__ import annotations
+
+import logging
+import os
+
+from ai_trading import config
+
+logger = logging.getLogger(__name__)
+
+
+def validate_environment() -> None:
+    """Ensure required environment variables are present and dependencies are available."""
+    from ai_trading.config.management import get_env, _resolve_alpaca_env
+
+    missing: list[str] = []
+    key, secret, base_url = _resolve_alpaca_env()
+    if not key:
+        missing.append("ALPACA_API_KEY")
+    if not secret:
+        missing.append("ALPACA_SECRET_KEY")
+    if not base_url:
+        missing.append("ALPACA_API_URL")
+    for var in ("WEBHOOK_SECRET", "CAPITAL_CAP", "DOLLAR_RISK_LIMIT"):
+        if not get_env(var):
+            missing.append(var)
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
+
+    _ = config.get_settings()
+    data_dir = "data"
+    if not os.path.exists(data_dir):
+        logger.info("Creating data directory: %s", data_dir)
+        os.makedirs(data_dir, exist_ok=True)

--- a/tests/test_main_extended_validate_env.py
+++ b/tests/test_main_extended_validate_env.py
@@ -1,0 +1,16 @@
+import ai_trading.main_extended as main_extended
+import pytest
+
+
+def test_validate_environment_missing(monkeypatch):
+    """validate_environment errors when required variables are absent."""
+    for var in [
+        "ALPACA_API_KEY",
+        "ALPACA_SECRET_KEY",
+        "WEBHOOK_SECRET",
+        "CAPITAL_CAP",
+        "DOLLAR_RISK_LIMIT",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(RuntimeError):
+        main_extended.validate_environment()


### PR DESCRIPTION
## Summary
- implement `validate_environment` in `ai_trading/main_extended.py` to raise a `RuntimeError` when required environment variables are missing
- cover the new validation with a regression test
- document the new behavior in the changelog

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_main_extended_validate_env.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib', import errors in several modules)*

## Rollback
- Revert these commits.


------
https://chatgpt.com/codex/tasks/task_e_68bc729a46088330a99e0989a489c43f