### PR TITLE
feat: add institutional Kelly constant

### DIFF
--- a/ai_trading/institutional/__init__.py
+++ b/ai_trading/institutional/__init__.py
@@ -1,0 +1,5 @@
+"""Institutional package for specialized constants and utilities."""
+
+from .constants import MAX_KELLY_FRACTION
+
+__all__ = ["MAX_KELLY_FRACTION"]

--- a/ai_trading/institutional/constants.py
+++ b/ai_trading/institutional/constants.py
@@ -1,0 +1,9 @@
+"""Institutional-specific trading constants.
+
+The institutional risk specification mandates that the Kelly fraction cap
+is at least 25% to ensure sufficient capital deployment. This module
+records that requirement explicitly.
+"""
+
+# Minimum Kelly fraction cap required by institutional risk standards.
+MAX_KELLY_FRACTION: float = 0.25

--- a/tests/test_institutional_constants.py
+++ b/tests/test_institutional_constants.py
@@ -1,0 +1,8 @@
+"""Tests for institutional constants."""
+
+from ai_trading.institutional.constants import MAX_KELLY_FRACTION
+
+
+def test_max_kelly_fraction():
+    """Ensure institutional Kelly fraction meets spec."""
+    assert MAX_KELLY_FRACTION == 0.25


### PR DESCRIPTION
## Summary
- add institutional constants module with MAX_KELLY_FRACTION set to 0.25 per risk spec
- cover institutional constant with unit test

## Testing
- `ruff check ai_trading/institutional/constants.py ai_trading/institutional/__init__.py tests/test_institutional_constants.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68bc7299045c833090e61acea2bc88ff