### PR TITLE
feat: lazily load cli module

### DIFF
--- a/ai_trading/__init__.py
+++ b/ai_trading/__init__.py
@@ -45,6 +45,11 @@ _PUBLIC_SYMBOLS = {
 __all__ = sorted(set(_PUBLIC_MODULES) | set(_PUBLIC_SYMBOLS))
 
 
+def cli() -> None:  # pragma: no cover - thin wrapper for console script
+    """Console entrypoint that defers heavy CLI imports until invocation."""
+    _import_module("ai_trading.__main__").main()
+
+
 def __getattr__(name: str):  # pragma: no cover - thin lazy loader
     if name in _PUBLIC_MODULES:
         return _import_module(f'ai_trading.{name}')

--- a/tests/test_clean_import.py
+++ b/tests/test_clean_import.py
@@ -1,0 +1,10 @@
+import importlib
+import sys
+
+
+def test_package_import_has_no_cli_side_effects(monkeypatch):
+    for name in list(sys.modules):
+        if name.startswith("ai_trading"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    importlib.import_module("ai_trading")
+    assert "ai_trading.__main__" not in sys.modules


### PR DESCRIPTION
## Summary
- add `ai_trading.cli` entrypoint that imports `ai_trading.__main__` only when invoked
- test that importing `ai_trading` does not load the CLI module

## Testing
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 23 errors during collection)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_clean_import.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc7298cab48330b2e018f2e9ecd56c