### PR TITLE
feat(logging): add date-based deduplication

### DIFF
--- a/ai_trading/logging/emit_once.py
+++ b/ai_trading/logging/emit_once.py
@@ -1,18 +1,24 @@
-"""Helper to emit a log record only once per process."""
+"""Helper to emit a log record only once per day per process."""
 from __future__ import annotations
 import threading
+from datetime import date
 from logging import Logger
 
-_emitted: set[str] = set()
+_emitted: dict[str, tuple[date, int]] = {}
 _lock = threading.Lock()
 
 def emit_once(logger: Logger, key: str, level: str, msg: str, **extra) -> bool:
-    """Emit ``msg`` at ``level`` only once per process keyed by ``key``."""
+    """Emit ``msg`` at ``level`` only once per day keyed by ``key``."""
     token = f"{logger.name}:{key}"
+    today = date.today()
     with _lock:
-        if token in _emitted:
+        last_date, count = _emitted.get(token, (None, 0))
+        if last_date != today:
+            count = 0
+        count += 1
+        _emitted[token] = (today, count)
+        if count > 1:
             return False
-        _emitted.add(token)
     fn = getattr(logger, level.lower(), logger.info)
     fn(msg, extra=extra or None)
     return True

--- a/tests/test_emit_once.py
+++ b/tests/test_emit_once.py
@@ -1,15 +1,32 @@
 import logging
+from datetime import date as real_date
 
-from ai_trading.logging.emit_once import emit_once
+import ai_trading.logging.emit_once as emit_once_mod
 
 
-def test_emit_once_emits_only_first_time(caplog):
+def test_emit_once_emits_once_per_day(caplog, monkeypatch):
     logger = logging.getLogger("ai_trading.test")
     caplog.set_level(logging.INFO)
 
-    assert emit_once(logger, "UNIQUE_KEY", "info", "Hello") is True
-    assert emit_once(logger, "UNIQUE_KEY", "info", "Hello") is False
+    class Day1(real_date):
+        @classmethod
+        def today(cls) -> real_date:
+            return real_date(2024, 1, 1)
+
+    monkeypatch.setattr(emit_once_mod, "date", Day1)
+
+    assert emit_once_mod.emit_once(logger, "UNIQUE_KEY", "info", "Hello") is True
+    assert emit_once_mod.emit_once(logger, "UNIQUE_KEY", "info", "Hello") is False
+
+    class Day2(real_date):
+        @classmethod
+        def today(cls) -> real_date:
+            return real_date(2024, 1, 2)
+
+    monkeypatch.setattr(emit_once_mod, "date", Day2)
+
+    assert emit_once_mod.emit_once(logger, "UNIQUE_KEY", "info", "Hello") is True
 
     msgs = [r.message for r in caplog.records]
-    assert msgs.count("Hello") == 1
+    assert msgs.count("Hello") == 2
 

--- a/tests/test_finnhub_disabled.py
+++ b/tests/test_finnhub_disabled.py
@@ -36,7 +36,7 @@ def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch, caplog):
 def test_duplicate_info_suppressed(monkeypatch, caplog):
     from ai_trading.logging import logger_once
 
-    monkeypatch.setattr(logger_once, "_emitted_keys", set())
+    monkeypatch.setattr(logger_once, "_emitted_keys", {})
     monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
     monkeypatch.setenv("ENABLE_FINNHUB", "0")
     monkeypatch.setattr(data_fetcher, "_fetch_bars", lambda *a, **k: pd.DataFrame())


### PR DESCRIPTION
## Summary
- ensure emit_once and EmitOnceLogger only log once per key per day
- test emit_once daily caching
- add EmitOnceLogger daily reset unit test

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68bc746ec33883309b722fd0d608c922