### PR TITLE
Handle exit codes in CLI entrypoint

### DIFF
--- a/tests/test_main_exit.py
+++ b/tests/test_main_exit.py
@@ -1,0 +1,8 @@
+import sys
+
+from ai_trading.__main__ import main
+
+
+def test_main_returns_zero(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["ai_trading", "--dry-run"])
+    assert main() == 0


### PR DESCRIPTION
## Summary
- wrap `ai_trading.__main__.main` in try/except and return 0 on success
- add unit test ensuring `main` exits cleanly when run with `--dry-run`

## Testing
- `pre-commit run --files ai_trading/__main__.py tests/test_main_exit.py` *(fails: missing script tools/check_no_legacy_symbols.py)*
- `ruff check ai_trading/__main__.py tests/test_main_exit.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_main_exit.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc746e14788330825dbd5c81e09004