### PR TITLE
Log invalid rolling stats in mean reversion strategy

### DIFF
--- a/ai_trading/strategies/mean_reversion.py
+++ b/ai_trading/strategies/mean_reversion.py
@@ -64,6 +64,7 @@ class MeanReversionStrategy:
                 pass
         mean, std = self._latest_stats(df['close'], lookback)
         if mean is None:
+            log.warning('mean_reversion: invalid rolling')
             return []
         px = float(df['close'].iloc[-1])
         z = (px - mean) / std


### PR DESCRIPTION
## Summary
- log `invalid rolling` when MeanReversionStrategy encounters unusable rolling statistics

## Testing
- `ruff check ai_trading/strategies/mean_reversion.py tests/test_mean_reversion_extra.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_mean_reversion_extra.py::test_generate_invalid_stats -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68bc746f91d88330a4be8398b7bf424e