### PR TITLE
Handle unwritable trade log path

### DIFF
--- a/ai_trading/main_trade_log_path.py
+++ b/ai_trading/main_trade_log_path.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from ai_trading.core.bot_engine import get_trade_logger
+from ai_trading.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _is_dir_writable(dir_path: Path) -> bool:
+    """Return True if *dir_path* is writable for the current user."""
+    try:
+        st = dir_path.stat()
+    except OSError:
+        return False
+    mode = st.st_mode
+    uid = os.geteuid()
+    gid = os.getegid()
+    try:
+        groups = set(os.getgroups())
+    except Exception:  # pragma: no cover - platform specific
+        groups = {gid}
+    import stat as _stat
+    if uid == st.st_uid:
+        return bool(mode & _stat.S_IWUSR)
+    if st.st_gid == gid or st.st_gid in groups:
+        return bool(mode & _stat.S_IWGRP)
+    return bool(mode & _stat.S_IWOTH)
+
+
+def ensure_trade_log_path() -> None:
+    """Ensure the trade log file exists and is writable.
+
+    Creates parent directories as needed and exits with status 1 if the path
+    cannot be written.
+    """
+    tl = get_trade_logger()
+    path = Path(tl.path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not _is_dir_writable(path.parent):
+            raise OSError("directory not writable")
+        with open(path, "a"):
+            pass
+    except OSError as exc:  # pragma: no cover - fail fast
+        logger.critical(
+            "TRADE_LOG_PATH_UNWRITABLE",
+            extra={"path": str(path), "error": str(exc)},
+        )
+        sys.exit(1)

--- a/tests/test_main_trade_log_path.py
+++ b/tests/test_main_trade_log_path.py
@@ -1,6 +1,6 @@
 import pytest
 
-import ai_trading.main as main
+import ai_trading.main_trade_log_path as main_trade_log_path
 import ai_trading.core.bot_engine as bot_engine
 
 
@@ -11,7 +11,7 @@ def test_ensure_trade_log_path_creates_file(tmp_path, monkeypatch):
     monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
     bot_engine._TRADE_LOGGER_SINGLETON = None
 
-    main.ensure_trade_log_path()
+    main_trade_log_path.ensure_trade_log_path()
 
     assert log_path.exists()
     assert log_path.read_text().splitlines()[0].startswith("symbol,entry_time")
@@ -27,8 +27,9 @@ def test_ensure_trade_log_path_unwritable(tmp_path, monkeypatch):
     monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
     bot_engine._TRADE_LOGGER_SINGLETON = None
 
-    with pytest.raises(SystemExit):
-        main.ensure_trade_log_path()
+    with pytest.raises(SystemExit) as exc:
+        main_trade_log_path.ensure_trade_log_path()
+    assert exc.value.code == 1
 
     parent.chmod(0o700)
 


### PR DESCRIPTION
## Summary
- add helper to ensure trade log path exists and is writable
- exit with code 1 when trade log path is invalid
- test trade log path helper

## Testing
- `ruff check ai_trading/main_trade_log_path.py tests/test_main_trade_log_path.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_main_trade_log_path.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_68bc746e11fc8330b87db013e7bdd968