### PR TITLE
test: ensure dummy model picklable

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,8 +18,17 @@ class _DummyModel:
     def predict_proba(self, _x):
         return [[0.5, 0.5]]
 
+def _get_model() -> _DummyModel:
+    """Return an instance of the dummy model.
 
-_dummy_mod.get_model = lambda: _DummyModel()
+    Using a named function keeps the test helper picklable with the standard
+    ``pickle`` module, whereas inline lambdas cannot be pickled.
+    """
+
+    return _DummyModel()
+
+
+_dummy_mod.get_model = _get_model
 sys.modules["dummy_model"] = _dummy_mod
 os.environ.setdefault("AI_TRADING_MODEL_MODULE", "dummy_model")
 

--- a/tests/test_dummy_model_pickling.py
+++ b/tests/test_dummy_model_pickling.py
@@ -1,0 +1,26 @@
+"""Tests for dummy model pickling functionality."""
+import pickle
+import sys
+
+
+def test_dummy_model_function_picklable(tmp_path):
+    """The dummy model's factory function should be picklable with stdlib."""
+    get_model = sys.modules["dummy_model"].get_model
+    path = tmp_path / "factory.pkl"
+    with path.open("wb") as fh:
+        pickle.dump(get_model, fh)
+    with path.open("rb") as fh:
+        loaded = pickle.load(fh)
+    assert callable(loaded)
+    assert loaded().__class__.__name__ == "_DummyModel"
+
+
+def test_dummy_model_instance_picklable(tmp_path):
+    """Instances returned by the factory should also be picklable."""
+    model = sys.modules["dummy_model"].get_model()
+    path = tmp_path / "model.pkl"
+    with path.open("wb") as fh:
+        pickle.dump(model, fh)
+    with path.open("rb") as fh:
+        loaded = pickle.load(fh)
+    assert loaded.predict([0]) == [0]


### PR DESCRIPTION
## Summary
- replace inline lambda with named function for dummy model factory so it can be pickled
- add unit test verifying dummy model factory and instance are picklable

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68bc75e84c5c8330aa06caa93219eb7c