### PR TITLE
Log CONFIG_AUTOFIX for missing startup max_position_size

### DIFF
--- a/ai_trading/startup/__init__.py
+++ b/ai_trading/startup/__init__.py
@@ -1,0 +1,3 @@
+"""Startup helpers for configuration and environment sanity checks."""
+
+__all__ = ["ensure_max_position_size"]

--- a/ai_trading/startup/config.py
+++ b/ai_trading/startup/config.py
@@ -1,0 +1,45 @@
+"""Startup configuration utilities."""
+
+from __future__ import annotations
+
+from ai_trading.logging import get_logger
+from ai_trading.position_sizing import _fallback_max_size
+
+_log = get_logger(__name__)
+
+
+def ensure_max_position_size(cfg, tcfg) -> float:
+    """Ensure ``max_position_size`` is populated with a sensible default.
+
+    Parameters
+    ----------
+    cfg:
+        Primary configuration object used for fallback lookups.
+    tcfg:
+        Trading settings object expected to carry ``max_position_size``.
+
+    Returns
+    -------
+    float
+        The resolved ``max_position_size``.
+    """
+    raw = getattr(tcfg, "max_position_size", None)
+    try:
+        if raw is not None and float(raw) > 0:
+            return float(raw)
+    except (TypeError, ValueError):
+        pass
+
+    fallback = float(_fallback_max_size(cfg, tcfg))
+    _log.info("CONFIG_AUTOFIX", extra={"field": "max_position_size", "fallback": fallback})
+    try:
+        setattr(tcfg, "max_position_size", fallback)
+    except (AttributeError, TypeError):
+        try:
+            object.__setattr__(tcfg, "max_position_size", fallback)
+        except (AttributeError, TypeError):
+            pass
+    return fallback
+
+
+__all__ = ["ensure_max_position_size"]

--- a/tests/test_startup_missing_max_position_size.py
+++ b/tests/test_startup_missing_max_position_size.py
@@ -1,0 +1,18 @@
+import logging
+from types import SimpleNamespace
+
+from ai_trading.startup.config import ensure_max_position_size
+
+
+def test_startup_autofixes_missing_max_position_size(caplog):
+    cfg = SimpleNamespace()
+    tcfg = SimpleNamespace(max_position_size=None)
+    with caplog.at_level(logging.INFO):
+        size = ensure_max_position_size(cfg, tcfg)
+    records = [
+        r for r in caplog.records
+        if r.name == "ai_trading.startup.config" and r.msg == "CONFIG_AUTOFIX"
+    ]
+    assert records, "CONFIG_AUTOFIX log not emitted"
+    assert getattr(records[0], "fallback", 0) == size
+    assert tcfg.max_position_size == size


### PR DESCRIPTION
## Summary
- ensure startup config fills in missing `max_position_size` using a fallback and logs `CONFIG_AUTOFIX`
- add regression test for startup `max_position_size` autofix

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_startup_missing_max_position_size.py tests/test_missing_max_position_size.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*


------
https://chatgpt.com/codex/tasks/task_e_68bc75e79fac833099a525de7b0235b4