### PR TITLE
Ensure metrics registry is singleton across reloads

### DIFF
--- a/ai_trading/metrics/registry.py
+++ b/ai_trading/metrics/registry.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from ai_trading.metrics import CollectorRegistry
+
+try:  # pragma: no cover - executed on first import
+    _REGISTRY
+except NameError:  # pragma: no cover - executed on first import
+    _REGISTRY = CollectorRegistry()
+
+
+def get_registry() -> CollectorRegistry:
+    """Return the module-level :class:`CollectorRegistry` instance."""
+    return _REGISTRY
+
+
+def reset_registry(registry: CollectorRegistry | None = None) -> CollectorRegistry:
+    """Replace and return the active :class:`CollectorRegistry`.
+
+    ``registry`` defaults to a new :class:`CollectorRegistry` when ``None``.
+    """
+    global _REGISTRY
+    _REGISTRY = registry or CollectorRegistry()
+    return _REGISTRY
+
+
+__all__ = ["get_registry", "reset_registry"]

--- a/tests/test_metrics_registry.py
+++ b/tests/test_metrics_registry.py
@@ -1,6 +1,7 @@
 import importlib
 
 from ai_trading import metrics
+from ai_trading.metrics import registry
 
 
 def test_metrics_reimport_does_not_duplicate():
@@ -11,3 +12,11 @@ def test_metrics_reimport_does_not_duplicate():
     mod = importlib.reload(mod)
     second = getattr(metrics.REGISTRY, "_names_to_collectors", {}).get("orders_submitted_total")
     assert second is first
+
+
+def test_registry_instance_persists_across_reloads():
+    registry.reset_registry()
+    first = registry.get_registry()
+    mod = importlib.reload(registry)
+    second = mod.get_registry()
+    assert first is second


### PR DESCRIPTION
## Summary
- implement module-level singleton for metrics registry, retaining instance on module reload
- add test covering registry identity after reload

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_metrics_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc75e683a8833097434d2108865411