### PR TITLE
Return checkpoint data

### DIFF
--- a/ai_trading/meta_learning.py
+++ b/ai_trading/meta_learning.py
@@ -561,6 +561,21 @@ def load_model_checkpoint(filepath: str) -> Any | None:
         logger.error('Failed to load model checkpoint: %s', exc, exc_info=True)
         return None
 
+def load_checkpoint(filepath: str) -> dict[str, Any] | None:
+    """Load a checkpoint dictionary from ``filepath``.
+
+    Uses :func:`load_model_checkpoint` for path validation and safe
+    deserialization. Returns the loaded dictionary or ``None`` when the
+    checkpoint is missing, invalid, or does not contain a mapping.
+    """
+    obj = load_model_checkpoint(filepath)
+    if obj is None:
+        return None
+    if not isinstance(obj, dict):
+        logger.error('Checkpoint file %s did not contain a dict', filepath)
+        return None
+    return obj
+
 def retrain_meta_learner(trade_log_path: str=None, model_path: str='meta_model.pkl', history_path: str='meta_retrain_history.pkl', min_samples: int=10) -> bool:
     """Retrain the meta-learner model from trade logs.
 

--- a/tests/test_checkpoint_roundtrip.py
+++ b/tests/test_checkpoint_roundtrip.py
@@ -1,0 +1,9 @@
+from ai_trading import meta_learning
+
+
+def test_checkpoint_roundtrip(tmp_path):
+    path = tmp_path / "chk.pkl"
+    data = {"foo": 1}
+    meta_learning.save_model_checkpoint(data, str(path))
+    loaded = meta_learning.load_checkpoint(str(path))
+    assert loaded == data

--- a/tests/test_meta_learning_additional.py
+++ b/tests/test_meta_learning_additional.py
@@ -38,6 +38,15 @@ def test_save_and_load_checkpoint(tmp_path):
     assert obj == {"x": 1}
 
 
+def test_load_checkpoint_roundtrip(tmp_path):
+    """`load_checkpoint` returns the stored mapping."""
+    path = tmp_path / "chk.pkl"
+    data = {"foo": 1}
+    meta_learning.save_model_checkpoint(data, str(path))
+    loaded = meta_learning.load_checkpoint(str(path))
+    assert loaded == data
+
+
 def test_retrain_meta_learner(monkeypatch, tmp_path):
     """Meta learner retrains with small dataset."""
     data = Path(tmp_path / "trades.csv")


### PR DESCRIPTION
## Summary
- add `load_checkpoint` to return stored mapping instead of `None`
- cover checkpoint save/load roundtrip with tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_checkpoint_roundtrip.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68bc75e5d38883309a051880a3837673