### PR TITLE
feat: warn when momentum data insufficient

### DIFF
--- a/tests/test_momentum_generate_logging.py
+++ b/tests/test_momentum_generate_logging.py
@@ -1,0 +1,26 @@
+import pytest
+pd = pytest.importorskip("pandas")
+from ai_trading.strategies.momentum import MomentumStrategy
+
+
+class DummyFetcher:
+    def __init__(self, df):
+        self.df = df
+
+    def get_daily_df(self, ctx, sym):
+        return self.df
+
+
+class Ctx:
+    def __init__(self, df):
+        self.tickers = ["A"]
+        self.data_fetcher = DummyFetcher(df)
+
+
+def test_generate_logs_insufficient_data(caplog):
+    df = pd.DataFrame({"close": [1]})
+    ctx = Ctx(df)
+    strat = MomentumStrategy(lookback=2)
+    caplog.set_level("WARNING")
+    assert strat.generate(ctx) == []
+    assert "Insufficient data" in caplog.text


### PR DESCRIPTION
## Summary
- log and early exit when MomentumStrategy generates with insufficient price history
- add regression test capturing the warning

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --noconftest tests/test_momentum_generate_logging.py::test_generate_logs_insufficient_data -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc784b4ab8833081cbf8f0e19e9173