### PR TITLE
feat: search multiple model directories

### DIFF
--- a/tests/test_ml_model_loading.py
+++ b/tests/test_ml_model_loading.py
@@ -16,6 +16,7 @@ pytest.importorskip("sklearn")
 import ai_trading.core.bot_engine as bot_engine
 import ai_trading.model_loader as model_loader
 from sklearn.dummy import DummyClassifier
+import joblib
 
 
 def setup_function(function):
@@ -35,14 +36,16 @@ def setup_function(function):
                 pass
 
 
-def test_load_missing_trains_model(caplog):
-    caplog.set_level("WARNING")
-    result = bot_engine._load_ml_model("FAKE")
-    assert result is not None
-    assert hasattr(result, "predict_proba")
-    models_dir = Path(os.environ["AI_TRADING_MODELS_DIR"])
-    assert (models_dir / "FAKE.pkl").exists()
-    assert any(r.message.startswith("MODEL_FILE_MISSING") for r in caplog.records)
+def test_load_missing_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("AI_TRADING_MODELS_DIR", str(tmp_path / "ext"))
+    import ai_trading.paths as paths
+
+    importlib.reload(paths)
+    ml = importlib.reload(model_loader)
+    monkeypatch.setattr(ml, "INTERNAL_MODELS_DIR", tmp_path / "int")
+
+    with pytest.raises(RuntimeError):
+        ml.load_model("MISSING")
 
 
 def test_load_corrupt_logs_error(tmp_path, monkeypatch, caplog):
@@ -54,6 +57,7 @@ def test_load_corrupt_logs_error(tmp_path, monkeypatch, caplog):
     be = importlib.reload(bot_engine)
     ml.ML_MODELS.clear()
     be._ML_MODEL_CACHE.clear()
+    monkeypatch.setattr(ml, "INTERNAL_MODELS_DIR", tmp_path)
 
     bad = tmp_path / "BAD.pkl"
     bad.write_text("not a model")
@@ -100,17 +104,41 @@ def test_signal_ml_returns_prediction_and_probability():
     assert 0.0 <= proba <= 1.0
 
 
-def test_external_models_dir(tmp_path, monkeypatch):
+def test_load_model_from_external_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("AI_TRADING_MODELS_DIR", str(tmp_path))
     import ai_trading.paths as paths
 
     importlib.reload(paths)
     ml = importlib.reload(model_loader)
-    be = importlib.reload(bot_engine)
-    ml.ML_MODELS.clear()
-    be._ML_MODEL_CACHE.clear()
 
-    result = be._load_ml_model("EXTSYM")
-    assert result is not None
-    assert (tmp_path / "EXTSYM.pkl").exists()
+    model = DummyClassifier(strategy="most_frequent")
+    X = np.array([[0], [1]])
+    y = np.array([0, 1])
+    model.fit(X, y)
+    joblib.dump(model, tmp_path / "EXT.pkl")
+
+    loaded = ml.load_model("EXT")
+    assert hasattr(loaded, "predict")
+
+
+def test_load_model_from_internal_dir(tmp_path, monkeypatch):
+    external = tmp_path / "ext"
+    internal = tmp_path / "int"
+    external.mkdir()
+    internal.mkdir()
+    monkeypatch.setenv("AI_TRADING_MODELS_DIR", str(external))
+    import ai_trading.paths as paths
+
+    importlib.reload(paths)
+    ml = importlib.reload(model_loader)
+    monkeypatch.setattr(ml, "INTERNAL_MODELS_DIR", internal)
+
+    model = DummyClassifier(strategy="most_frequent")
+    X = np.array([[0], [1]])
+    y = np.array([0, 1])
+    model.fit(X, y)
+    joblib.dump(model, internal / "INT.pkl")
+
+    loaded = ml.load_model("INT")
+    assert hasattr(loaded, "predict")
 


### PR DESCRIPTION
## Summary
- load models from external or built-in directories, erroring when missing
- expand tests to cover missing models and external/built-in search

## Testing
- `ruff check ai_trading/model_loader.py tests/test_ml_model_loading.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_ml_model_loading.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc7848b14883309de32baa49c00450