### PR TITLE
Prevent duplicate model registrations

### DIFF
--- a/ai_trading/model_registry.py
+++ b/ai_trading/model_registry.py
@@ -59,7 +59,11 @@ class ModelRegistry:
         dataset_fingerprint: str | None = None,
         tags: list[str] | None = None,
     ) -> str:
-        """Store model + metadata and return deterministic ID."""
+        """Store model + metadata and return deterministic ID.
+
+        Raises:
+            ValueError: If ``model`` is already registered.
+        """
         try:
             blob = pickle.dumps(model)
         except Exception as e:  # pragma: no cover - exercised via tests
@@ -82,6 +86,8 @@ class ModelRegistry:
         if dataset_fingerprint:
             id_components.append(dataset_fingerprint[:16])
         model_id = '-'.join(id_components)
+        if model_id in self.model_index:
+            raise ValueError(f"Model {model_id} already registered")
         model_dir = (self.base_path / model_id).resolve()
         if not model_dir.is_relative_to(self.base_path):
             raise RuntimeError(f"Model path escapes base directory: {model_dir}")

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -187,3 +187,12 @@ class TestModelRegistry:
             m1 = registry.register_model({"a": 1}, "s1", "t1")
             m2 = registry.register_model({"b": 2}, "s2", "t2")
             assert sorted(registry.list_models()) == sorted([m1, m2])
+
+    def test_duplicate_registration(self):
+        """registering the same model twice should raise ValueError."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            registry = ModelRegistry(temp_dir)
+            model = {"a": 1}
+            registry.register_model(model, "s", "t")
+            with pytest.raises(ValueError, match="already registered"):
+                registry.register_model(model, "s", "t")


### PR DESCRIPTION
## Summary
- avoid overwriting existing entries by checking registry before writing a model
- add regression test for duplicate registrations

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_model_registry.py::TestModelRegistry::test_duplicate_registration -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

## Rollback Plan
- Revert this PR.

------
https://chatgpt.com/codex/tasks/task_e_68bc78497e888330a77d197eb8af3ada