### PR TITLE
Add data checks and fix moving average crossover buy signal

### DIFF
--- a/tests/test_moving_average_crossover_extra.py
+++ b/tests/test_moving_average_crossover_extra.py
@@ -32,7 +32,7 @@ def test_generate_insufficient_data(caplog):
 
 
 def test_generate_buy_signal():
-    df = pd.DataFrame({"close": [1, 2, 3, 4, 5, 6]})
+    df = pd.DataFrame({"close": [5, 4, 3, 4, 5]})
     ctx = Ctx(df)
     strat = MovingAverageCrossoverStrategy(short=2, long=3)
     signals = strat.generate(ctx)


### PR DESCRIPTION
## Summary
- log and guard insufficient data in SMA crossover strategy
- ensure generated signals are appended instead of returning empty
- cover insufficient data and buy signal scenarios with tests

## Testing
- `ruff check ai_trading/strategies/moving_average_crossover.py tests/test_moving_average_crossover_extra.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_moving_average_crossover_extra.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*

------
https://chatgpt.com/codex/tasks/task_e_68bc784c090483308572f5e13c1c31df