### PR TITLE
Add basic pipeline transformer with test

### DIFF
--- a/ai_trading/pipeline/basic.py
+++ b/ai_trading/pipeline/basic.py
@@ -1,0 +1,32 @@
+"""Minimal pipeline utilities.
+
+Provides a simple scikit-learn style pipeline with a basic
+transformer that converts input data to a ``numpy`` array.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from ai_trading.logging import get_logger
+from ai_trading.utils.lazy_imports import load_sklearn_pipeline
+
+logger = get_logger(__name__)
+
+
+class SimpleTransformer:
+    """A no-op transformer used for tests and examples."""
+
+    def fit(self, X, y=None):  # pragma: no cover - trivial
+        return self
+
+    def transform(self, X):
+        return np.asarray(X, dtype=float)
+
+
+def create_pipeline():
+    """Create a basic pipeline with the :class:`SimpleTransformer`."""
+    skl_pipe = load_sklearn_pipeline()
+    if skl_pipe is None:  # pragma: no cover - runtime guard
+        raise RuntimeError("sklearn.pipeline not available")
+    Pipeline = skl_pipe.Pipeline
+    return Pipeline([("simple", SimpleTransformer())])

--- a/tests/test_basic_pipeline_module.py
+++ b/tests/test_basic_pipeline_module.py
@@ -1,0 +1,35 @@
+import sys
+import types
+import numpy as np
+
+
+def test_basic_pipeline_runs(monkeypatch):
+    skl_pipeline = types.ModuleType("sklearn.pipeline")
+
+    class Pipeline:
+        def __init__(self, steps):
+            self.steps = steps
+
+        def fit(self, X, y=None):
+            for _, step in self.steps:
+                if hasattr(step, "fit"):
+                    step.fit(X, y)
+            return self
+
+        def transform(self, X):
+            for _, step in self.steps:
+                if hasattr(step, "transform"):
+                    X = step.transform(X)
+            return X
+
+    skl_pipeline.Pipeline = Pipeline
+    monkeypatch.setitem(sys.modules, "sklearn.pipeline", skl_pipeline)
+    monkeypatch.syspath_prepend(".")
+
+    from ai_trading.pipeline.basic import create_pipeline
+
+    pipeline = create_pipeline()
+    X = [[1], [2], [3]]
+    pipeline.fit(X)
+    result = pipeline.transform(X)
+    assert np.asarray(result).shape == (3, 1)


### PR DESCRIPTION
## Summary
- implement `SimpleTransformer` and use it in a basic scikit-learn style pipeline
- add unit test ensuring the basic pipeline can fit and transform data

## Testing
- `ruff check ai_trading/pipeline/basic.py tests/test_basic_pipeline_module.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_basic_pipeline_module.py -q`

## Rollback Plan
- Revert this PR to remove the basic pipeline and test if issues arise.


------
https://chatgpt.com/codex/tasks/task_e_68bc7a2c588c8330a9bbfdf4b0b96198