### PR TITLE
feat: detect mixed trade log formats

### DIFF
--- a/tests/test_validate_trade_data_quality_mixed_format.py
+++ b/tests/test_validate_trade_data_quality_mixed_format.py
@@ -1,0 +1,28 @@
+import pytest
+from ai_trading.meta_learning import validate_trade_data_quality
+
+
+@pytest.fixture
+def mixed_format_file(tmp_path):
+    """Create a trade log containing both meta-learning and audit rows."""
+    p = tmp_path / "mixed.csv"
+    with p.open("w") as f:
+        f.write(
+            "symbol,entry_time,entry_price,exit_time,exit_price,qty,side,strategy,classification,signal_tags,confidence,reward\n"
+        )
+        # Meta-learning formatted row
+        f.write(
+            "META,2025-01-01T00:00:00Z,10,2025-01-01T01:00:00Z,12,1,buy,strat,test,tag,0.5,1\n"
+        )
+        # Audit formatted row
+        f.write(
+            "123e4567-e89b-12d3-a456-426614174000,2025-01-01T02:00:00Z,AAPL,buy,5,150.0,live,filled\n"
+        )
+    return str(p)
+
+
+def test_mixed_format_detection(mixed_format_file):
+    report = validate_trade_data_quality(mixed_format_file)
+    assert report["mixed_format_detected"] is True
+    assert report["audit_format_rows"] >= 1
+    assert report["meta_format_rows"] >= 1


### PR DESCRIPTION
## Summary
- improve mixed-format detection in `validate_trade_data_quality`
- warn when audit and meta-learning rows coexist
- test mixed trade log parsing

## Testing
- `ruff check ai_trading/meta_learning.py tests/test_validate_trade_data_quality_mixed_format.py tests/test_validate_trade_data_quality_negative_prices.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_validate_trade_data_quality_negative_prices.py tests/test_validate_trade_data_quality_mixed_format.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc7a2bb3dc8330995c3ce2bb4b8849