### PR TITLE
feat: track sentiment optional dependency warning

### DIFF
--- a/ai_trading/analysis/sentiment.py
+++ b/ai_trading/analysis/sentiment.py
@@ -43,9 +43,10 @@ def _init_sentiment() -> None:
 _bs4 = None
 _transformers_bundle = None
 _sentiment_deps_logged: set[str] = set()
+_SENT_DEPS_LOGGED = False
 
 def _load_bs4(log=logger):
-    global _bs4
+    global _bs4, _SENT_DEPS_LOGGED
     if _bs4 is not None:
         return _bs4
     try:
@@ -55,11 +56,12 @@ def _load_bs4(log=logger):
         if 'bs4' not in _sentiment_deps_logged:
             log.warning('SENTIMENT_OPTIONAL_DEP_MISSING', extra={'package': 'bs4'})
             _sentiment_deps_logged.add('bs4')
+            _SENT_DEPS_LOGGED = True
         _bs4 = None
     return _bs4
 
 def _load_transformers(log=logger):
-    global _transformers_bundle
+    global _transformers_bundle, _SENT_DEPS_LOGGED
     if _transformers_bundle is not None:
         return _transformers_bundle
     try:
@@ -74,6 +76,7 @@ def _load_transformers(log=logger):
         if 'transformers' not in _sentiment_deps_logged:
             log.warning('SENTIMENT_OPTIONAL_DEP_MISSING', extra={'package': 'transformers'})
             _sentiment_deps_logged.add('transformers')
+            _SENT_DEPS_LOGGED = True
         _transformers_bundle = None
     return _transformers_bundle
 SENTIMENT_TTL_SEC = 600

--- a/tests/test_sentiment_deps_flag.py
+++ b/tests/test_sentiment_deps_flag.py
@@ -1,0 +1,18 @@
+import importlib
+import sys
+import types
+from unittest.mock import patch
+
+
+def test_sentiment_dep_flag_updates(monkeypatch):
+    sentiment = importlib.reload(importlib.import_module("ai_trading.analysis.sentiment"))
+    assert hasattr(sentiment, "_SENT_DEPS_LOGGED")
+    assert sentiment._SENT_DEPS_LOGGED is False
+
+    dummy_bs4 = types.ModuleType("bs4")
+    monkeypatch.setitem(sys.modules, "bs4", dummy_bs4)
+    sentiment._sentiment_deps_logged.clear()
+    with patch.object(sentiment.logger, "warning") as warn:
+        sentiment._load_bs4()
+        assert warn.called
+    assert sentiment._SENT_DEPS_LOGGED is True


### PR DESCRIPTION
## Summary
- track whether sentiment optional dependency warnings have been emitted
- add test ensuring the flag exists and flips when bs4 import fails

## Testing
- `ruff check ai_trading/analysis/sentiment.py tests/test_sentiment_deps_flag.py tests/test_sentiment_interface.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_sentiment_deps_flag.py tests/test_sentiment_interface.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc7a2a42f08330914eb01016c8f284