### PR TITLE
Add peak equity permission handling

### DIFF
--- a/ai_trading/analytics/__init__.py
+++ b/ai_trading/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics helper modules."""

--- a/ai_trading/analytics/peak_equity.py
+++ b/ai_trading/analytics/peak_equity.py
@@ -1,0 +1,39 @@
+"""Utilities for tracking peak equity.
+
+This module provides helpers to read the peak equity value from disk while
+handling permission errors gracefully.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ai_trading.logging import logger
+
+_PEAK_EQUITY_PERMISSION_LOGGED = False
+
+
+def read_peak_equity(path: str | Path) -> float:
+    """Return the peak equity stored at ``path``.
+
+    Returns ``0.0`` when the file cannot be read. If the file is not
+    accessible due to permissions, a warning is logged (once) containing
+    "permission denied".
+    """
+    global _PEAK_EQUITY_PERMISSION_LOGGED
+    p = Path(path)
+    try:
+        return float(p.read_text().strip() or 0.0)
+    except PermissionError:
+        if not _PEAK_EQUITY_PERMISSION_LOGGED:
+            logger.warning(
+                "PEAK_EQUITY_FILE %s permission denied; skipping peak equity tracking",
+                p,
+            )
+            _PEAK_EQUITY_PERMISSION_LOGGED = True
+        return 0.0
+    except (FileNotFoundError, IsADirectoryError, ValueError, OSError):
+        return 0.0
+
+
+__all__ = ["read_peak_equity"]


### PR DESCRIPTION
## Summary
- add `read_peak_equity` helper that logs a warning when the peak equity file can't be accessed
- cover permission-denied scenario with a dedicated unit test

## Testing
- `python -m pre_commit run --files ai_trading/analytics/__init__.py ai_trading/analytics/peak_equity.py tests/test_peak_equity_permission.py` *(fails: check-no-legacy-symbols missing `tools/check_no_legacy_symbols.py`; requests without timeout; mutable default)*
- `ruff check ai_trading/analytics/peak_equity.py tests/test_peak_equity_permission.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_peak_equity_permission.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 20 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7a2b18288330a6c460f700e77936