### PR TITLE
Ensure API and submit callable for short close

### DIFF
--- a/ai_trading/portfolio/short_close.py
+++ b/ai_trading/portfolio/short_close.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Utilities for closing out short positions."""
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from ai_trading.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def short_close(api: Any, submit: Callable[[str, int, str], Any]) -> int:
+    """Close any open short positions using provided broker API.
+
+    Parameters
+    ----------
+    api:
+        Broker API instance with ``list_positions`` method.
+    submit:
+        Callable used to submit buy orders. It must accept ``symbol``,
+        ``quantity`` and ``side`` arguments.
+
+    Returns
+    -------
+    int
+        Number of close orders submitted.
+    """
+    positions: Iterable[Any] = []
+    if hasattr(api, "list_positions"):
+        try:
+            positions = api.list_positions() or []
+        except Exception:  # pragma: no cover - defensive
+            logger.warning("LIST_POSITIONS_FAIL", exc_info=True)
+            positions = []
+    submitted = 0
+    for p in positions:
+        try:
+            qty = int(float(getattr(p, "qty", 0)))
+        except (TypeError, ValueError):
+            continue
+        if qty < 0:
+            symbol = getattr(p, "symbol", None)
+            if symbol:
+                submit(symbol, abs(qty), "buy")
+                submitted += 1
+                logger.info("SHORT_CLOSE_SUBMIT | symbol=%s qty=%d", symbol, abs(qty))
+    return submitted

--- a/tests/test_short_close.py
+++ b/tests/test_short_close.py
@@ -1,0 +1,21 @@
+import types
+
+from ai_trading.portfolio.short_close import short_close
+
+
+def test_short_close_calls_submit():
+    class DummyAPI:
+        def list_positions(self):
+            return [
+                types.SimpleNamespace(symbol="TSLA", qty=-5),
+                types.SimpleNamespace(symbol="LONG", qty=10),
+            ]
+
+    calls: list[tuple[str, int, str]] = []
+
+    def fake_submit(symbol: str, qty: int, side: str) -> None:
+        calls.append((symbol, qty, side))
+
+    count = short_close(DummyAPI(), fake_submit)
+    assert count == 1
+    assert calls == [("TSLA", 5, "buy")]


### PR DESCRIPTION
## Summary
- add `portfolio.short_close.short_close` utility which accepts broker API and submit callable to close open short positions
- cover short-close via dummy API unit test

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_short_close.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7c37d8e88330bb7d24d605e8752a