### PR TITLE
Add MockSeries helper for position management tests

### DIFF
--- a/tests/support/mock_series.py
+++ b/tests/support/mock_series.py
@@ -1,0 +1,41 @@
+"""Lightweight stand-in for pandas Series used in tests."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+
+class MockSeries:
+    """Minimal Series-like object for testing without pandas."""
+
+    def __init__(self, values: Iterable[float]):
+        self._values = list(values)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._values)
+
+    def __getitem__(self, idx):  # pragma: no cover - trivial
+        return self._values[idx]
+
+    class _ILoc:
+        def __init__(self, outer: "MockSeries") -> None:
+            self._outer = outer
+
+        def __getitem__(self, idx):  # pragma: no cover - simple
+            return self._outer._values[idx]
+
+    @property
+    def iloc(self) -> "MockSeries._ILoc":  # pragma: no cover - simple
+        return MockSeries._ILoc(self)
+
+    def tail(self, n: int = 5) -> "MockSeries":  # pragma: no cover - trivial
+        return MockSeries(self._values[-n:])
+
+    def tolist(self) -> List[float]:  # pragma: no cover - trivial
+        return list(self._values)
+
+    def diff(self, *_args, **_kwargs) -> "MockSeries":
+        """Placeholder diff returning self."""
+        return self
+
+
+__all__ = ["MockSeries"]


### PR DESCRIPTION
## Summary
- add lightweight `MockSeries` with stub `diff` method for tests
- refactor intelligent position manager tests to use `MockSeries`
- assert component extraction using the new mock

## Testing
- `ruff check tests/support/mock_series.py tests/test_intelligent_position_management.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_intelligent_position_management.py::TestIntelligentPositionManager::test_initialization -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_intelligent_position_management.py::TestIntelligentPositionManager::test_should_hold_position_integration tests/test_intelligent_position_management.py::TestIntelligentPositionManager::test_analyze_position_basic -q`

## Rollback Plan
- Revert commit `Add MockSeries helper and update tests` to remove the mock and restore prior test behavior.


------
https://chatgpt.com/codex/tasks/task_e_68bc7c37fd88833082449c401dda9db7