### PR TITLE
Validate TRADING_ENV in prediction executor

### DIFF
--- a/ai_trading/prediction/__init__.py
+++ b/ai_trading/prediction/__init__.py
@@ -1,0 +1,5 @@
+"""Prediction utilities and executors."""
+
+from .executor import run
+
+__all__ = ["run"]

--- a/ai_trading/prediction/executor.py
+++ b/ai_trading/prediction/executor.py
@@ -1,0 +1,47 @@
+"""Prediction executor utilities."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+# Supported trading environments
+_SUPPORTED_ENVS: tuple[str, ...] = ("development", "paper", "live", "backtest")
+
+
+def _validate_env(env: str, allowed: Iterable[str] = _SUPPORTED_ENVS) -> str:
+    """Validate trading environment value.
+
+    Parameters
+    ----------
+    env:
+        Environment string to validate.
+    allowed:
+        Iterable of supported environment names.
+
+    Returns
+    -------
+    str
+        The validated environment name.
+
+    Raises
+    ------
+    ValueError
+        If ``env`` is not in ``allowed``.
+    """
+    if env not in allowed:
+        raise ValueError(f"Unsupported TRADING_ENV: {env!r}")
+    return env
+
+
+def run() -> str:
+    """Entry point for prediction execution.
+
+    Reads ``TRADING_ENV`` from the process environment and ensures it is
+    supported. The value is returned for downstream use.
+    """
+    env = os.getenv("TRADING_ENV", "development")
+    return _validate_env(env)
+
+
+__all__ = ["run"]

--- a/tests/test_prediction_run_env.py
+++ b/tests/test_prediction_run_env.py
@@ -1,0 +1,13 @@
+import importlib
+import pytest
+
+def test_run_valid_env(monkeypatch):
+    monkeypatch.setenv("TRADING_ENV", "paper")
+    executor = importlib.import_module("ai_trading.prediction.executor")
+    assert executor.run() == "paper"
+
+def test_run_invalid_env(monkeypatch):
+    monkeypatch.setenv("TRADING_ENV", "invalid")
+    executor = importlib.import_module("ai_trading.prediction.executor")
+    with pytest.raises(ValueError):
+        executor.run()


### PR DESCRIPTION
## Summary
- add prediction executor package with environment validation
- ensure unsupported TRADING_ENV values raise ValueError
- test prediction executor run env handling

## Testing
- `ruff check ai_trading/prediction/executor.py tests/test_prediction_run_env.py`
- `python -m pip install pydantic`
- `python -m pip install pydantic-settings`
- `python -m pip install urllib3`
- `python -m pip install alpaca-py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_prediction_run_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c3a56948330aa0ada06b9ceaaab