### PR TITLE
Raise KeyError when OHLC data missing in signal prep

### DIFF
--- a/ai_trading/signals.py
+++ b/ai_trading/signals.py
@@ -306,7 +306,7 @@ def _validate_input_df(data) -> None:
     if hasattr(data, "columns"):
         missing = [col for col in required if col not in data.columns]
         if missing:
-            raise ValueError(f"Input data missing required column(s): {missing}")
+            raise KeyError(f"Input data missing required column(s): {missing}")
 
 
 def _apply_macd(data) -> Any | None:

--- a/tests/unit/test_prepare_missing_ohlc.py
+++ b/tests/unit/test_prepare_missing_ohlc.py
@@ -1,0 +1,15 @@
+import pytest
+pd = pytest.importorskip("pandas")
+
+from ai_trading import signals
+
+
+def test_prepare_indicators_requires_open_column():
+    df = pd.DataFrame({
+        "high": [2.0],
+        "low": [1.0],
+        "close": [1.5],
+        "volume": [100],
+    })
+    with pytest.raises(KeyError, match="missing required column\(s\): \['open'\]"):
+        signals.prepare_indicators(df)


### PR DESCRIPTION
## Summary
- ensure signal preparation surfaces missing OHLC columns as a KeyError
- add regression test covering missing `open` column scenario

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_prepare_missing_ohlc.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing deps, 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7c398e0483308553e02f3e00438f