### PR TITLE
Make equity fetch patchable and cache-aware

### DIFF
--- a/ai_trading/position_sizing.py
+++ b/ai_trading/position_sizing.py
@@ -232,7 +232,8 @@ def resolve_max_position_size(cfg, tcfg, *, force_refresh: bool=False) -> tuple[
                 raise ValueError('max_position_size must be positive')
             eq = getattr(tcfg, 'equity', getattr(cfg, 'equity', None))
             if eq in (None, 0.0):
-                fetched = _fetch_equity(cfg, force_refresh=force_refresh)
+                # Allow tests to patch the public alias used by runtime.
+                fetched = _get_equity_from_alpaca(cfg, force_refresh=force_refresh)
                 if fetched > 0:
                     eq = fetched
                     for obj in (cfg, tcfg):
@@ -259,7 +260,8 @@ def resolve_max_position_size(cfg, tcfg, *, force_refresh: bool=False) -> tuple[
         )
     if not force_refresh and (not _should_refresh(ttl)) and (_CACHE.value is not None):
         return (_CACHE.value, {'mode': mode, 'source': 'cache', 'capital_cap': cap, 'refreshed_at': (_CACHE.ts or _now_utc()).isoformat()})
-    eq = _fetch_equity(cfg, force_refresh=force_refresh)
+    # Use public alias so callers/tests can patch equity retrieval.
+    eq = _get_equity_from_alpaca(cfg, force_refresh=force_refresh)
     if eq <= 0.0:
         eq = _coerce_float(
             getattr(

--- a/tests/test_position_sizing_equity.py
+++ b/tests/test_position_sizing_equity.py
@@ -36,8 +36,8 @@ def test_get_max_position_size_uses_cached_equity(monkeypatch, caplog):
     logger_once._emitted_keys.clear()
 
     # Stub equity fetcher to return a positive value
-    monkeypatch.setattr(ps, "_get_equity_from_alpaca", lambda cfg: 1000.0)
-    monkeypatch.setattr(rt, "_get_equity_from_alpaca", lambda cfg: 1000.0)
+    monkeypatch.setattr(ps, "_get_equity_from_alpaca", lambda cfg, force_refresh=False: 1000.0)
+    monkeypatch.setattr(rt, "_get_equity_from_alpaca", lambda cfg, force_refresh=False: 1000.0)
 
     class Cfg:
         capital_cap = 0.04
@@ -75,7 +75,7 @@ def test_resolve_max_position_size_uses_real_equity_and_caches(monkeypatch, capl
     logger_once._emitted_keys.clear()
     calls = {"n": 0}
 
-    def fake_fetch(cfg):
+    def fake_fetch(cfg, force_refresh=False):
         calls["n"] += 1
         return 50000.0
 
@@ -98,7 +98,7 @@ def test_failed_equity_fetch_warns_once_and_caches(monkeypatch, caplog):
     logger_once._emitted_keys.clear()
     calls = {"n": 0}
 
-    def fake_fetch(cfg):
+    def fake_fetch(cfg, force_refresh=False):
         calls["n"] += 1
         return 0.0
 
@@ -120,7 +120,7 @@ def test_equity_recovered_emits_warning_once(monkeypatch, caplog):
     ps._CACHE.value, ps._CACHE.ts, ps._CACHE.equity = (None, None, None)
     logger_once._emitted_keys.clear()
 
-    monkeypatch.setattr(ps, "_get_equity_from_alpaca", lambda cfg: 0.0)
+    monkeypatch.setattr(ps, "_get_equity_from_alpaca", lambda cfg, force_refresh=False: 0.0)
 
     cfg = SimpleNamespace(alpaca_api_key="k", alpaca_secret_key_plain="s", alpaca_base_url="https://paper-api.alpaca.markets")
     tcfg = SimpleNamespace(capital_cap=0.02, max_position_mode="STATIC")


### PR DESCRIPTION
## Summary
- use public `_get_equity_from_alpaca` alias inside `resolve_max_position_size` so callers can force refresh and patch equity retrieval
- adjust position sizing tests to stub equity fetch with `force_refresh` kwarg and verify caching/warning behaviour

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_position_sizing_equity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c3890ac8330a481d1090bdf04a3