### PR TITLE
feat: expose async production run helper

### DIFF
--- a/ai_trading/production/__init__.py
+++ b/ai_trading/production/__init__.py
@@ -1,0 +1,5 @@
+"""Production package exposing production utilities."""
+
+from .execution_coordinator import run
+
+__all__ = ["run"]

--- a/ai_trading/production/execution_coordinator.py
+++ b/ai_trading/production/execution_coordinator.py
@@ -1,0 +1,33 @@
+"""Lightweight entrypoint for production execution tasks.
+
+The original :func:`run` helper executed asynchronous work internally but was
+implemented as a regular function.  When callers attempted to use
+``asyncio.run(run())`` the function returned ``None`` immediately, leaving the
+background coroutine unawaited.  Exposing ``run`` as an ``async`` coroutine
+allows straightforward execution via ``asyncio.run`` and prevents the
+"coroutine was never awaited" warning.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from ai_trading.core.enums import RiskLevel
+from ai_trading.production_system import ProductionTradingSystem
+
+
+async def run(
+    account_equity: float = 100_000.0,
+    risk_level: RiskLevel = RiskLevel.MODERATE,
+) -> ProductionTradingSystem:
+    """Create and return a :class:`ProductionTradingSystem` instance.
+
+    The coroutine performs a tiny ``await`` so that callers can drive it with
+    :func:`asyncio.run` in tests or scripts.  A fully initialised trading
+    system is returned for further interaction by the caller.
+    """
+    await asyncio.sleep(0)
+    return ProductionTradingSystem(account_equity, risk_level)
+
+
+__all__ = ["run"]


### PR DESCRIPTION
## Summary
- add `ai_trading.production` package with async `run` helper
- allow starting a `ProductionTradingSystem` via `asyncio.run`

## Testing
- `ruff check ai_trading/production/execution_coordinator.py`
- `python - <<'PY'
import asyncio
from ai_trading.production.execution_coordinator import run
system = asyncio.run(run())
print(type(system).__name__)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bc7e07fc688330bc71f1cedcc0fc68