### PR TITLE
Capture SoftBudget start time on first elapsed call

### DIFF
--- a/ai_trading/utils/prof.py
+++ b/ai_trading/utils/prof.py
@@ -18,13 +18,17 @@ class SoftBudget:
 
     def __init__(self, interval_sec: float, fraction: float):
         self._deadline = time.monotonic() + max(0.0, interval_sec) * max(0.1, min(1.0, fraction))
-        self._start = time.monotonic()
+        self._start: float | None = None
 
     def remaining(self) -> float:
         return max(0.0, self._deadline - time.monotonic())
 
     def elapsed_ms(self) -> int:
-        return int((time.monotonic() - self._start) * 1000)
+        now = time.monotonic()
+        if self._start is None:
+            self._start = now
+            return 0
+        return int((now - self._start) * 1000)
 
     def over(self) -> bool:
         return time.monotonic() >= self._deadline

--- a/tests/test_prof_budget.py
+++ b/tests/test_prof_budget.py
@@ -5,6 +5,7 @@ from ai_trading.utils.prof import SoftBudget
 
 def test_soft_budget_elapsed_and_over():
     b = SoftBudget(interval_sec=0.1, fraction=0.5)
+    assert b.elapsed_ms() == 0
     time.sleep(0.02)
     assert b.elapsed_ms() >= 20
     time.sleep(0.05)


### PR DESCRIPTION
## Summary
- Delay SoftBudget timer start until `elapsed_ms` is called and compute elapsed milliseconds
- Adjust SoftBudget test to capture initial call and assert elapsed time over 20 ms

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib', among others)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_prof_budget.py -q`

## Rollback
- Revert commit `3d98c1b`

------
https://chatgpt.com/codex/tasks/task_e_68bc7e0888d48330842001a5e1937bbc