### PR TITLE
Forward adjustment to minute bar resampling

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -294,10 +294,23 @@ def _fetch_daily_bars(client, symbol, start, end, **kwargs):
         _log.exception('ALPACA_DAILY_FAILED', extra={'symbol': symbol, 'error': str(e)})
         raise
 
-def _get_minute_bars(symbol: str, start_dt: datetime, end_dt: datetime, feed: str) -> pd.DataFrame:
+def _get_minute_bars(
+    symbol: str,
+    start_dt: datetime,
+    end_dt: datetime,
+    feed: str,
+    adjustment: str | None = None,
+) -> pd.DataFrame:
     symbol = _canon_symbol(symbol)
     try:
-        df = get_bars(symbol=symbol, timeframe='1Min', start=start_dt, end=end_dt, feed=feed)
+        df = get_bars(
+            symbol=symbol,
+            timeframe='1Min',
+            start=start_dt,
+            end=end_dt,
+            feed=feed,
+            adjustment=adjustment,
+        )
     except (ValueError, TypeError):
         df = None
     if df is None or not hasattr(df, 'empty') or getattr(df, 'empty', True):
@@ -345,7 +358,7 @@ def get_daily_bars(symbol: str, client, start: datetime, end: datetime, feed: st
         return df
     try:
         minutes_start = end - timedelta(days=5)
-        mdf = _get_minute_bars(symbol, minutes_start, end, feed=feed)
+        mdf = _get_minute_bars(symbol, minutes_start, end, feed=feed, adjustment=adjustment)
         if mdf is not None and (not mdf.empty):
             rdf = _resample_minutes_to_daily(mdf)
             if rdf is not None and (not rdf.empty):

--- a/tests/test_resample_daily.py
+++ b/tests/test_resample_daily.py
@@ -15,7 +15,7 @@ def test_get_daily_bars_resamples_minutes(monkeypatch):
     monkeypatch.setattr(
         bars,
         "_fetch_daily_bars",
-        lambda client, symbol, start, end, feed=None: empty,
+        lambda client, symbol, start, end, feed=None, **kwargs: empty,
     )
 
     idx = pd.date_range(
@@ -35,7 +35,9 @@ def test_get_daily_bars_resamples_minutes(monkeypatch):
         index=idx,
     )
     monkeypatch.setattr(
-        bars, "_get_minute_bars", lambda symbol, start_dt, end_dt, feed: data
+        bars,
+        "_get_minute_bars",
+        lambda symbol, start_dt, end_dt, feed, adjustment=None: data,
     )
 
     out = bars.get_daily_bars(
@@ -45,3 +47,44 @@ def test_get_daily_bars_resamples_minutes(monkeypatch):
     assert not out.empty
     assert len(out) == 1
     assert float(out.iloc[0]["open"]) == 1
+
+
+def test_resample_passes_adjustment(monkeypatch):
+    """Minute fallback should forward the adjustment parameter."""
+    empty = pd.DataFrame()
+    monkeypatch.setattr(
+        bars,
+        "_fetch_daily_bars",
+        lambda client, symbol, start, end, feed=None, **kwargs: empty,
+    )
+
+    idx = pd.date_range(
+        "2024-01-02 14:30",
+        periods=1,
+        freq="1min",
+        tz="UTC",
+    )
+    data = pd.DataFrame(
+        {
+            "open": [1],
+            "high": [1],
+            "low": [1],
+            "close": [1],
+            "volume": [10],
+        },
+        index=idx,
+    )
+
+    captured: dict[str, str | None] = {}
+
+    def fake_get_minute_bars(symbol, start_dt, end_dt, feed, adjustment=None):
+        captured["adjustment"] = adjustment
+        return data
+
+    monkeypatch.setattr(bars, "_get_minute_bars", fake_get_minute_bars)
+
+    bars.get_daily_bars(
+        "SPY", None, datetime(2024, 1, 2, tzinfo=UTC), datetime(2024, 1, 3, tzinfo=UTC)
+    )
+
+    assert captured["adjustment"] == bars.get_settings().alpaca_adjustment


### PR DESCRIPTION
## Summary
- allow `_get_minute_bars` to accept an optional `adjustment` and forward it to the Alpaca API
- ensure daily bar resampling passes the adjustment parameter down to minute fetches
- expand resample tests to handle kwargs and verify adjustment forwarding

## Testing
- `ruff check ai_trading/data/bars.py tests/test_resample_daily.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_resample_daily.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc8078ebc88330883b3a8e3ad31ac3