### PR TITLE
Add retrain module stub

### DIFF
--- a/ai_trading/retrain/__init__.py
+++ b/ai_trading/retrain/__init__.py
@@ -1,0 +1,16 @@
+"""Utilities for retraining models.
+
+This module currently exposes a placeholder ``main`` function so that
+imports succeed during testing.
+"""
+
+from __future__ import annotations
+
+
+def main() -> None:
+    """Entry point for retraining CLI stubs."""
+    print("ai_trading.retrain main stub")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ai_trading.retrain` package with a placeholder `main` entry point

## Testing
- `ruff check ai_trading/retrain/__init__.py`
- `python -c "import ai_trading.retrain as r; r.main()"`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68bc8079a58483308b3501b41723262e