### PR TITLE
Lazily load alpaca API for shadow mode

### DIFF
--- a/ai_trading/shadow_mode/__init__.py
+++ b/ai_trading/shadow_mode/__init__.py
@@ -1,0 +1,5 @@
+"""Shadow mode utilities."""
+
+from .runtime import ensure_alpaca_api
+
+__all__ = ["ensure_alpaca_api"]

--- a/ai_trading/shadow_mode/runtime.py
+++ b/ai_trading/shadow_mode/runtime.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+
+class _LazyModule(ModuleType):
+    """Proxy module that loads the real module on first attribute access."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self._real: ModuleType | None = None
+
+    def _load(self) -> ModuleType:
+        if self._real is None:
+            # Remove the proxy so ``import_module`` loads the real module
+            sys.modules.pop(self.__name__, None)
+            self._real = importlib.import_module(self.__name__)
+            sys.modules[self.__name__] = self._real
+        return self._real
+
+    def __getattr__(self, item: str):  # pragma: no cover - exercised via tests
+        return getattr(self._load(), item)
+
+
+def ensure_alpaca_api() -> ModuleType:
+    """Register a lazy loader for ``ai_trading.alpaca_api``.
+
+    The actual module import is deferred until an attribute is accessed, but a
+    placeholder is inserted into :mod:`sys.modules` so that subsequent imports
+    resolve correctly.
+    """
+
+    name = "ai_trading.alpaca_api"
+    mod = sys.modules.get(name)
+    if isinstance(mod, _LazyModule):
+        return mod
+    if mod is None:
+        mod = _LazyModule(name)
+        sys.modules[name] = mod
+    return mod
+
+
+# Ensure placeholder is registered when this module is imported
+ensure_alpaca_api()


### PR DESCRIPTION
## Summary
- Defer `ai_trading.alpaca_api` import with a lazy proxy that registers in `sys.modules`
- Provide shadow mode package exposing `ensure_alpaca_api`
- Test that toggling `SHADOW_MODE` before first use switches behaviour

## Testing
- `ruff check ai_trading/shadow_mode/runtime.py tests/test_shadow_mode_runtime.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_shadow_mode_runtime.py::test_lazy_alpaca_api_behavior_switch -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68bc8229053c8330bb56014a546c61dc