### PR TITLE
feat: add sentiment interface wrapper

### DIFF
--- a/ai_trading/sentiment/__init__.py
+++ b/ai_trading/sentiment/__init__.py
@@ -1,0 +1,4 @@
+"""Sentiment package providing a lightweight interface wrapper."""
+from .interface import analyze_text
+
+__all__ = ["analyze_text"]

--- a/ai_trading/sentiment/interface.py
+++ b/ai_trading/sentiment/interface.py
@@ -1,0 +1,28 @@
+"""Compatibility wrapper around :mod:`ai_trading.analysis.sentiment`.
+
+This module exposes a small helper that delegates to the analysis
+sentiment utilities while keeping the public surface area minimal.
+"""
+from __future__ import annotations
+
+from ai_trading.analysis import sentiment as _sentiment
+
+# Backwards-compatibility alias; legacy code expected ``_C`` to exist.
+# It now simply points at the underlying sentiment module. If unused it
+# can be removed in a future cleanup.
+_C = _sentiment
+
+
+def analyze_text(text: str) -> dict[str, float]:
+    """Return sentiment probabilities for *text*.
+
+    Delegates to :func:`ai_trading.analysis.sentiment.analyze_text` and
+    returns a dictionary with the keys ``available``, ``pos``, ``neg`` and
+    ``neu``.
+    """
+
+    return _sentiment.analyze_text(text)
+
+
+__all__ = ["analyze_text"]
+

--- a/tests/test_sentiment_pkg_interface.py
+++ b/tests/test_sentiment_pkg_interface.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+import pytest
+
+sys.modules.pop("tenacity", None)
+pytest.importorskip("tenacity")
+os.environ.setdefault("PYTEST_RUNNING", "1")
+
+from ai_trading.sentiment import interface
+
+
+def test_analyze_text_structure():
+    try:
+        res = interface.analyze_text("markets look good")
+    except ModuleNotFoundError:
+        pytest.skip("transformers not installed")
+    assert isinstance(res, dict)
+    assert {"available", "pos", "neg", "neu"} <= set(res)
+


### PR DESCRIPTION
## Summary
- add `ai_trading.sentiment` package with simple interface wrapper
- expose `analyze_text` and define `_C` alias for backwards compatibility
- test that interface's `analyze_text` returns expected structure

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_sentiment_pkg_interface.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68bc82280430833088b6e6b64c17c476