### PR TITLE
Respect config overrides for runtime max position size

### DIFF
--- a/ai_trading/runtime/__init__.py
+++ b/ai_trading/runtime/__init__.py
@@ -1,0 +1,6 @@
+"""Runtime utilities for configuration helpers."""
+
+from .max_position_size import get_max_position_size
+
+__all__ = ["get_max_position_size"]
+

--- a/ai_trading/runtime/max_position_size.py
+++ b/ai_trading/runtime/max_position_size.py
@@ -1,0 +1,34 @@
+"""Runtime helper for resolving maximum position size."""
+
+from __future__ import annotations
+
+from ai_trading.config.management import TradingConfig, get_env
+from ai_trading.position_sizing import get_max_position_size as _get_max_position_size
+
+
+def get_max_position_size(cfg: TradingConfig) -> float:
+    """Return max position size honoring ``TradingConfig`` overrides.
+
+    Parameters
+    ----------
+    cfg:
+        Trading configuration instance. If ``max_position_size`` is set on this
+        config it takes precedence over environment variables or derived
+        values.
+    """
+    val = getattr(cfg, "max_position_size", None)
+    if val is not None:
+        return float(val)
+
+    try:
+        env_val = get_env("MAX_POSITION_SIZE", cast=float)
+    except (ImportError, RuntimeError):
+        env_val = None
+    if env_val is not None:
+        return float(env_val)
+
+    return float(_get_max_position_size(cfg))
+
+
+__all__ = ["get_max_position_size"]
+

--- a/tests/test_runtime_max_position_size.py
+++ b/tests/test_runtime_max_position_size.py
@@ -1,6 +1,9 @@
 from ai_trading.core.runtime import build_runtime
 from ai_trading.config.management import TradingConfig
 from ai_trading.position_sizing import get_max_position_size
+from ai_trading.runtime.max_position_size import (
+    get_max_position_size as runtime_get_max_position_size,
+)
 
 
 def test_runtime_uses_env_max_position_size(monkeypatch):
@@ -24,4 +27,10 @@ def test_runtime_matches_position_sizing(monkeypatch):
     cfg = TradingConfig(capital_cap=0.04)
     runtime = build_runtime(cfg)
     assert runtime.params["MAX_POSITION_SIZE"] == get_max_position_size(cfg)
+
+
+def test_runtime_get_max_position_size_prefers_config(monkeypatch):
+    monkeypatch.setenv("MAX_POSITION_SIZE", "999")
+    cfg = TradingConfig(max_position_size=1234)
+    assert runtime_get_max_position_size(cfg) == 1234.0
 


### PR DESCRIPTION
## Summary
- add `ai_trading.runtime` helper to resolve max position size
- prefer `TradingConfig.max_position_size` over env or derived values
- test runtime helper honors config override

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_max_position_size.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*

------
https://chatgpt.com/codex/tasks/task_e_68bc82244c5483308cd6fbd7fd415d36