### PR TITLE
Add DummyAPI symbol support for pending-new orders

### DIFF
--- a/tests/support/dummy_api.py
+++ b/tests/support/dummy_api.py
@@ -1,0 +1,29 @@
+import types
+
+
+class DummyAPI:
+    """Minimal Alpaca-like API for safe_submit_order tests."""
+
+    def __init__(self):
+        # Simple account state; tests stub these methods directly when needed
+        self.get_account = lambda: types.SimpleNamespace(buying_power="1000")
+        self.list_positions = lambda: []
+        self._order = None
+
+    def submit_order(self, symbol: str, **_kwargs):
+        """Record symbol and return a pending_new order object."""
+        self._order = types.SimpleNamespace(
+            id=1,
+            status="pending_new",
+            filled_qty=0,
+            symbol=symbol,
+        )
+        return self._order
+
+    def get_order(self, order_id):
+        """Return order, transitioning it to filled after first poll."""
+        if self._order and getattr(self._order, "id", None) == order_id:
+            # Simulate broker updating status on subsequent poll
+            self._order.status = "filled"
+            return self._order
+        return types.SimpleNamespace(id=order_id, status="filled", filled_qty=0, symbol=None)


### PR DESCRIPTION
## Summary
- add test DummyAPI that accepts symbol and simulates pending_new orders
- extend safe_submit_order tests to verify symbol is preserved through pending_new polling

## Testing
- `ruff check tests/support/dummy_api.py tests/test_safe_submit_order.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_safe_submit_order.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc82259b788330bfdbab807fd6da7f