### PR TITLE
feat: ignore None in runtime params

### DIFF
--- a/ai_trading/runtime/__init__.py
+++ b/ai_trading/runtime/__init__.py
@@ -1,0 +1,3 @@
+"""Runtime parameter utilities."""
+
+from .params import build_runtime  # noqa: F401

--- a/ai_trading/runtime/params.py
+++ b/ai_trading/runtime/params.py
@@ -1,0 +1,30 @@
+"""Helpers for constructing runtime parameter dictionaries."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ai_trading.core.runtime import REQUIRED_PARAM_DEFAULTS
+
+
+def build_runtime(overrides: Mapping[str, Any] | None = None) -> dict[str, float]:
+    """Merge runtime parameter defaults with overrides.
+
+    Parameters with ``None`` values in ``overrides`` are ignored, leaving the
+    existing/default value intact.
+
+    Args:
+        overrides: Optional mapping of parameter overrides.
+
+    Returns:
+        dict[str, float]: Merged runtime parameters where all values are floats.
+    """
+    params: dict[str, float] = {k: float(v) for k, v in REQUIRED_PARAM_DEFAULTS.items()}
+
+    if overrides:
+        for key, value in overrides.items():
+            if value is None:
+                continue
+            params[key] = float(value)
+
+    return params

--- a/tests/test_runtime_params_ignore_none_override.py
+++ b/tests/test_runtime_params_ignore_none_override.py
@@ -1,0 +1,12 @@
+from ai_trading.runtime.params import build_runtime
+from ai_trading.core.runtime import REQUIRED_PARAM_DEFAULTS
+
+
+def test_build_runtime_skips_none_overrides():
+    overrides = {
+        'CAPITAL_CAP': 0.08,
+        'DOLLAR_RISK_LIMIT': None,
+    }
+    params = build_runtime(overrides)
+    assert params['CAPITAL_CAP'] == 0.08
+    assert params['DOLLAR_RISK_LIMIT'] == REQUIRED_PARAM_DEFAULTS['DOLLAR_RISK_LIMIT']


### PR DESCRIPTION
## Summary
- add helper to build runtime params that ignores `None` overrides
- cover merging behavior when overrides contain `None`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68bc8224e3cc83308823d02a3f6c7663