### PR TITLE
Ensure slippage log file is created on first record

### DIFF
--- a/ai_trading/slippage/__init__.py
+++ b/ai_trading/slippage/__init__.py
@@ -1,0 +1,4 @@
+"""Utilities for recording trade slippage."""
+__all__ = ["log_slippage"]
+from .recorder import log_slippage
+

--- a/ai_trading/slippage/recorder.py
+++ b/ai_trading/slippage/recorder.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Helpers for recording slippage metrics to CSV."""
+
+from datetime import datetime
+import csv
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from ai_trading.logging import get_logger
+from ai_trading.paths import SLIPPAGE_LOG_PATH
+
+logger = get_logger(__name__)
+
+
+def _ensure_file(path: Path) -> None:
+    """Ensure directory exists and file has CSV header."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        with path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["timestamp", "symbol", "expected", "actual", "slippage_cents"])
+
+
+def log_slippage(symbol: str, expected: float, actual: float, log_path: Path | str = SLIPPAGE_LOG_PATH) -> None:
+    """Append a slippage record to CSV, creating directories and file on first use."""
+    path = Path(log_path)
+    try:
+        _ensure_file(path)
+    except OSError as e:  # pragma: no cover - filesystem errors
+        logger.warning("SLIPPAGE_LOG_INIT_FAILED", extra={"cause": e.__class__.__name__, "detail": str(e)})
+        return
+    slippage_cents = (actual - expected) * 100.0
+    ts = datetime.now(ZoneInfo("UTC")).isoformat()
+    try:
+        with path.open("a", newline="") as f:
+            csv.writer(f).writerow([ts, symbol, expected, actual, slippage_cents])
+    except OSError as e:  # pragma: no cover - filesystem errors
+        logger.warning("SLIPPAGE_LOG_WRITE_FAILED", extra={"cause": e.__class__.__name__, "detail": str(e)})
+

--- a/tests/test_slippage_recorder.py
+++ b/tests/test_slippage_recorder.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import shutil
+
+from ai_trading.slippage import log_slippage
+
+
+def test_slippage_log_file_created():
+    log_file = Path("logs/slippage.csv")
+    if log_file.parent.exists():
+        shutil.rmtree(log_file.parent)
+    log_slippage("AAPL", 100.0, 100.0, log_file)
+    assert log_file.exists()
+    assert log_file.parent.is_dir()


### PR DESCRIPTION
## Summary
- add `ai_trading.slippage.recorder` to log slippage data and create its CSV file on first use
- add unit test ensuring the slippage log file and directory are created

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc84f388dc8330b5e4b38b5eba4170