### PR TITLE
test: add test strategy helper

### DIFF
--- a/tests/mocks/test_strategy.py
+++ b/tests/mocks/test_strategy.py
@@ -1,0 +1,9 @@
+from ai_trading.strategies.base import BaseStrategy, StrategySignal
+
+
+class TestStrategy(BaseStrategy):
+    """Simple strategy used for unit tests."""
+
+    def generate_signals(self, market_data: dict) -> list[StrategySignal]:
+        """Return no signals for provided market data."""
+        return []

--- a/tests/test_strategy_registry.py
+++ b/tests/test_strategy_registry.py
@@ -1,13 +1,10 @@
-from ai_trading.strategies.base import BaseStrategy, StrategyRegistry
+from ai_trading.strategies.base import StrategyRegistry
 from ai_trading.core.enums import RiskLevel
-
-class DummyStrategy(BaseStrategy):
-    def generate_signals(self, market_data: dict) -> list:
-        return []
+from tests.mocks.test_strategy import TestStrategy
 
 
 def test_register_strategy_populates_position_size():
     registry = StrategyRegistry()
-    strat = DummyStrategy("s1", "dummy", risk_level=RiskLevel.MODERATE)
+    strat = TestStrategy("s1", "dummy", risk_level=RiskLevel.MODERATE)
     assert registry.register_strategy(strat)
     assert registry.strategy_performance[strat.strategy_id]["position_size"] > 0


### PR DESCRIPTION
## Summary
- add TestStrategy subclass used in tests with simple generate_signals
- update strategy registry test to use TestStrategy instead of BaseStrategy

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_strategy_registry.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc84f46dcc833091e93fff592463e1