### PR TITLE
Ensure broker mock supports submit and test skip duplicates

### DIFF
--- a/tests/test_short_close.py
+++ b/tests/test_short_close.py
@@ -1,21 +1,27 @@
-import types
+"""Tests for short_close utility."""
+
+from types import SimpleNamespace
 
 from ai_trading.portfolio.short_close import short_close
 
 
 def test_short_close_calls_submit():
+    """short_close should call broker.submit for each short position."""
+
     class DummyAPI:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int, str]] = []
+
         def list_positions(self):
             return [
-                types.SimpleNamespace(symbol="TSLA", qty=-5),
-                types.SimpleNamespace(symbol="LONG", qty=10),
+                SimpleNamespace(symbol="TSLA", qty=-5),
+                SimpleNamespace(symbol="LONG", qty=10),
             ]
 
-    calls: list[tuple[str, int, str]] = []
+        def submit(self, symbol: str, qty: int, side: str) -> None:
+            self.calls.append((symbol, qty, side))
 
-    def fake_submit(symbol: str, qty: int, side: str) -> None:
-        calls.append((symbol, qty, side))
-
-    count = short_close(DummyAPI(), fake_submit)
+    api = DummyAPI()
+    count = short_close(api, api.submit)
     assert count == 1
-    assert calls == [("TSLA", 5, "buy")]
+    assert api.calls == [("TSLA", 5, "buy")]

--- a/tests/test_skip_logic.py
+++ b/tests/test_skip_logic.py
@@ -17,12 +17,65 @@ def test_skip_logic(monkeypatch, caplog):
     monkeypatch.setattr(bot_engine, "is_market_open", lambda: True)
     monkeypatch.setattr(bot_engine, "fetch_minute_df_safe", lambda s: pd.DataFrame({"close": [1]}, index=[pd.Timestamp("2023-01-01")]))
     monkeypatch.setattr(bot_engine, "_safe_trade", lambda *a, **k: None)
-    monkeypatch.setattr(bot_engine.prediction_executor, "submit", lambda fn, s: types.SimpleNamespace(result=lambda: fn(s)))
+    monkeypatch.setattr(
+        bot_engine,
+        "prediction_executor",
+        types.SimpleNamespace(submit=lambda fn, s: types.SimpleNamespace(result=lambda: fn(s))),
+    )
     monkeypatch.setattr(bot_engine, "log_skip_cooldown", lambda *a, **k: None)
-    monkeypatch.setattr(bot_engine.skipped_duplicates, "inc", lambda: None)
+    monkeypatch.setattr(
+        bot_engine,
+        "skipped_duplicates",
+        types.SimpleNamespace(inc=lambda: None),
+        raising=False,
+    )
 
     processed, _ = bot_engine._process_symbols(
         ["MSFT", "TSLA"], 1000.0, None, True, True
     )
     assert processed == []
     assert orders == []
+
+
+def test_skip_duplicates(monkeypatch):
+    """Symbols with existing positions are skipped when skip_duplicates=True."""
+
+    state = bot_engine.BotState()
+    state.position_cache = {"AAPL": 5}
+    bot_engine.state = state
+
+    orders: list = []
+    monkeypatch.setattr(
+        bot_engine, "submit_order", lambda ctx, symbol, qty, side: orders.append((symbol, qty, side))
+    )
+    monkeypatch.setattr(bot_engine, "is_market_open", lambda: True)
+    monkeypatch.setattr(
+        bot_engine,
+        "fetch_minute_df_safe",
+        lambda s: pd.DataFrame({"close": [1]}, index=[pd.Timestamp("2023-01-01")]),
+    )
+    monkeypatch.setattr(bot_engine, "_safe_trade", lambda *a, **k: None)
+    monkeypatch.setattr(
+        bot_engine,
+        "prediction_executor",
+        types.SimpleNamespace(submit=lambda fn, s: types.SimpleNamespace(result=lambda: fn(s))),
+    )
+    logs: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        bot_engine, "log_skip_cooldown", lambda symbol, reason: logs.append((symbol, reason))
+    )
+    inc_calls: list[int] = []
+    monkeypatch.setattr(
+        bot_engine,
+        "skipped_duplicates",
+        types.SimpleNamespace(inc=lambda: inc_calls.append(1)),
+        raising=False,
+    )
+
+    processed, _ = bot_engine._process_symbols(
+        ["AAPL"], 1000.0, None, True, False, True
+    )
+    assert processed == []
+    assert orders == []
+    assert logs == [("AAPL", "duplicate")]
+    assert inc_calls == [1]


### PR DESCRIPTION
## Summary
- ensure short_close tests use broker mocks exposing `submit`
- add test covering duplicate skip logic in `_process_symbols`

## Testing
- `ruff check tests/test_skip_logic.py tests/test_short_close.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_short_close.py tests/test_skip_logic.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ImportError while loading tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc84f1526c83308b0a9aaccc7391f0