### PR TITLE
Handle offline data checks and unauthorized SIP test

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -390,7 +390,9 @@ def data_check(symbols: Iterable[str], *, feed: str | None = None) -> dict[str, 
     for sym in symbols:
         try:
             df = get_bars_df(sym, bars.TimeFrame.Day, feed=feed)
-        except ValueError:
+        except (ValueError, DataFetchError, RequestException, RuntimeError):
+            # Missing network access or unauthorized feeds are skipped so that
+            # the remaining symbols can still be processed.
             continue
         if df is None or df.empty:
             continue


### PR DESCRIPTION
## Summary
- skip symbols in `data_check` on network or authorization errors
- stub Alpaca bar fetch in offline SIP test to avoid real HTTP requests

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/test_sip_unauthorized.py`
- `pytest tests/test_sip_unauthorized.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc84f09f0883309a83e689c2cef01a