### PR TITLE
Add talib audit utility ensuring data directory exists

### DIFF
--- a/ai_trading/talib/__init__.py
+++ b/ai_trading/talib/__init__.py
@@ -1,0 +1,5 @@
+"""TA-Lib related utilities."""
+
+from . import audit
+
+__all__ = ["audit"]

--- a/ai_trading/talib/audit.py
+++ b/ai_trading/talib/audit.py
@@ -1,0 +1,60 @@
+"""Minimal trade audit for TA-Lib tests."""
+from __future__ import annotations
+
+import csv
+import os
+import uuid
+from pathlib import Path
+
+_LOG_DIR = Path("data")
+_LOG_FILE = _LOG_DIR / "trades.csv"
+_HEADERS = [
+    "id",
+    "timestamp",
+    "symbol",
+    "side",
+    "qty",
+    "price",
+    "exposure",
+    "mode",
+    "result",
+]
+
+
+def log_trade(
+    symbol: str,
+    qty: int | float,
+    side: str,
+    fill_price: float,
+    timestamp: str = "",
+    extra_info: str = "",
+    exposure: float | None = None,
+) -> None:
+    """Append a trade record to ``data/trades.csv`` ensuring directory exists.
+
+    Creates the ``data`` directory on first use and writes a header if the file
+    is new. File permissions are set to ``0o664`` when the file is created.
+    """
+    _LOG_DIR.mkdir(parents=True, exist_ok=True)
+    file_exists = _LOG_FILE.exists()
+    with open(_LOG_FILE, "a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_HEADERS)
+        if not file_exists:
+            writer.writeheader()
+            try:
+                os.chmod(_LOG_FILE, 0o664)
+            except OSError:
+                pass
+        writer.writerow(
+            {
+                "id": str(uuid.uuid4()),
+                "timestamp": timestamp,
+                "symbol": symbol,
+                "side": side,
+                "qty": str(qty),
+                "price": str(fill_price),
+                "exposure": "" if exposure is None else str(exposure),
+                "mode": extra_info,
+                "result": "",
+            }
+        )

--- a/tests/test_talib_audit_permissions.py
+++ b/tests/test_talib_audit_permissions.py
@@ -1,0 +1,31 @@
+import csv
+from pathlib import Path
+
+
+def test_talib_audit_creates_data_dir_and_file(tmp_path, monkeypatch):
+    """ai_trading.talib.audit.log_trade should create data/trades.csv with 664 perms."""
+    monkeypatch.chdir(tmp_path)
+    from ai_trading.talib import audit
+
+    audit.log_trade(
+        symbol="TEST",
+        qty=1,
+        side="buy",
+        fill_price=1.0,
+        timestamp="2024-01-01T00:00:00Z",
+        extra_info="TEST_MODE",
+        exposure=0.5,
+    )
+
+    log_path = tmp_path / "data" / "trades.csv"
+    assert log_path.exists()
+    assert log_path.parent.exists()
+
+    mode = oct(log_path.stat().st_mode)[-3:]
+    assert mode == "664", f"Expected file permissions 664, got {mode}"
+
+    with open(log_path) as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "TEST"
+    assert rows[0]["side"] == "buy"


### PR DESCRIPTION
## Summary
- add minimal `ai_trading.talib.audit` module that writes to `data/trades.csv` and sets `0o664` permissions
- cover audit module with test verifying directory creation and file mode

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_talib_audit_permissions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc8774a0848330978e4f5f0a23f85d