### PR TITLE
feat: add robust sleep utility

### DIFF
--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 import importlib
 
-from .timing import HTTP_TIMEOUT, clamp_timeout, sleep  # AI-AGENT-REF: small re-exports
+from .timing import HTTP_TIMEOUT, clamp_timeout  # AI-AGENT-REF: small re-exports
+from .sleep import sleep  # AI-AGENT-REF: dedicated sleep helper
 from .optdeps import OptionalDependencyError, module_ok  # AI-AGENT-REF: tiny helpers
 
 _BASE_EXPORTS = {

--- a/ai_trading/utils/sleep.py
+++ b/ai_trading/utils/sleep.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import time as _time
+from time import perf_counter as _perf
+
+__all__ = ["sleep"]
+
+# Capture the original OS-level sleep to avoid monkeypatch interference
+_real_sleep = _time.sleep
+
+
+def sleep(seconds: float | int) -> float:
+    """Sleep for at least ``seconds`` seconds and return actual duration.
+
+    The underlying :func:`time.sleep` function is captured at import time so
+    later monkeypatching of ``time.sleep`` will not short-circuit this helper.
+    A minimum delay of ~10ms is enforced to ensure a measurable pause even when
+    ``seconds`` is 0 or negative.
+    """
+    try:
+        s = float(seconds)
+    except (TypeError, ValueError):
+        s = 0.0
+    target = max(s, 0.01)
+    start = _perf()
+    _real_sleep(target)
+    elapsed = _perf() - start
+    tries = 0
+    while elapsed < 0.009 and tries < 5:
+        _real_sleep(0.005)
+        elapsed = _perf() - start
+        tries += 1
+    return elapsed

--- a/ai_trading/utils/timing.py
+++ b/ai_trading/utils/timing.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import os
-import time as _time
-from time import perf_counter as _perf
-
-_real_sleep = _time.sleep
 from typing import Optional, Union
 
+from .sleep import sleep
+
 # Prefer AI_HTTP_TIMEOUT when present (tests set this); fallback to HTTP_TIMEOUT env
-HTTP_TIMEOUT: Union[int, float] = float(os.getenv("AI_HTTP_TIMEOUT", os.getenv("HTTP_TIMEOUT", "10")))  # AI-AGENT-REF: canonical timeout across runtime
+HTTP_TIMEOUT: Union[int, float] = float(
+    os.getenv("AI_HTTP_TIMEOUT", os.getenv("HTTP_TIMEOUT", "10"))
+)  # AI-AGENT-REF: canonical timeout across runtime
 
 
 def clamp_timeout(value: Optional[float]) -> float:
@@ -21,32 +21,5 @@ def clamp_timeout(value: Optional[float]) -> float:
     except (TypeError, ValueError):
         return HTTP_TIMEOUT
 
-
-def _robust_sleep(seconds: Union[int, float]) -> None:
-    """Block for at least ~10ms even under monkeypatched time.sleep.
-
-    Uses the original OS sleep captured at import time and a short
-    perf_counter-based busy wait to ensure measurable elapsed time.
-    """  # AI-AGENT-REF: deterministic sleep
-
-    try:
-        s = float(seconds)
-    except (TypeError, ValueError):
-        s = 0.0
-    target = max(s, 0.01)
-    start = _perf()
-    _real_sleep(target)
-    # Ensure we cross ~9ms even if scheduler wakes early; cap iterations to avoid hangs
-    _tries = 0
-    while (_perf() - start) < 0.009 and _tries < 5:
-        _real_sleep(0.005)
-        _tries += 1
-
-
-_force_local_sleep = str(os.getenv("AI_TRADING_FORCE_LOCAL_SLEEP", "1")).lower() in {"1", "true", "yes", "on"}
-if _force_local_sleep:
-    sleep = _robust_sleep  # type: ignore[assignment]
-else:  # pragma: no cover
-    sleep = _time.sleep
 
 __all__ = ["HTTP_TIMEOUT", "clamp_timeout", "sleep"]

--- a/tests/test_utils_sleep_shadowing.py
+++ b/tests/test_utils_sleep_shadowing.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from time import perf_counter
+from ai_trading.utils.sleep import sleep
 
-from ai_trading.utils.timing import sleep
 
 def test_sleep_unaffected_by_monkeypatch(monkeypatch) -> None:
     """sleep should block even if time.sleep is monkeypatched."""  # AI-AGENT-REF: ensure robustness
@@ -14,8 +13,6 @@ def test_sleep_unaffected_by_monkeypatch(monkeypatch) -> None:
     import time as real_time
 
     monkeypatch.setattr(real_time, "sleep", fake_sleep)
-    start = perf_counter()
-    sleep(0)  # request 0 -> enforced minimum
-    elapsed = perf_counter() - start
+    elapsed = sleep(0)  # request 0 -> enforced minimum
     assert slept["count"] == 0
     assert elapsed >= 0.009


### PR DESCRIPTION
## Summary
- add `ai_trading.utils.sleep.sleep` capturing original `time.sleep` and returning elapsed duration
- simplify `ai_trading.utils.timing` to reuse new helper
- update tests to verify sleep can't be bypassed by monkeypatching

## Testing
- `ruff check ai_trading/utils/sleep.py ai_trading/utils/timing.py ai_trading/utils/__init__.py tests/test_utils_sleep_shadowing.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_utils_sleep_shadowing.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc8775c7a08330ad1d58c6400c4a87