### PR TITLE
Track Yahoo fallback after repeated Alpaca failures

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -36,6 +36,7 @@ from ai_trading.data.metrics import metrics, provider_fallback
 from ai_trading.net.http import HTTPSession, get_http_session
 from ai_trading.utils.http import clamp_request_timeout
 from ai_trading.data.finnhub import fh_fetcher, FinnhubAPIException
+from . import fallback_order
 
 logger = get_logger(__name__)
 
@@ -1559,6 +1560,7 @@ def _fetch_bars(
             or (not can_use_sip and "iex" in providers_tried and max_fb >= 1)
         )
         if y_int and yahoo_allowed and "yahoo" in priority:
+            fallback_order.mark_yahoo()
             try:
                 alt_df = _yahoo_get_bars(symbol, _start, _end, interval=y_int)
             except Exception:  # pragma: no cover - network variance

--- a/ai_trading/data/fetch/fallback_order.py
+++ b/ai_trading/data/fetch/fallback_order.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""State tracking for provider fallback order."""
+
+from typing import Dict
+
+# Public dictionary tracking fallback usage.
+FALLBACK_ORDER: Dict[str, bool] = {}
+
+
+def mark_yahoo() -> None:
+    """Record that Yahoo was used as a fallback."""
+    FALLBACK_ORDER["yahoo"] = True
+
+
+def reset() -> None:
+    """Reset tracked state (used in tests)."""
+    FALLBACK_ORDER.clear()
+
+
+__all__ = ["FALLBACK_ORDER", "mark_yahoo", "reset"]

--- a/tests/test_yahoo_fallback_order.py
+++ b/tests/test_yahoo_fallback_order.py
@@ -7,6 +7,7 @@ pd = pytest.importorskip("pandas")
 
 import ai_trading.data.fetch as fetch
 from ai_trading.data.metrics import provider_fallback
+import ai_trading.data.fetch.fallback_order as fo
 
 
 def test_yahoo_used_after_two_alpaca_failures(monkeypatch):
@@ -48,6 +49,7 @@ def test_yahoo_used_after_two_alpaca_failures(monkeypatch):
         )
 
     monkeypatch.setattr(fetch, "_yahoo_get_bars", fake_yahoo)
+    fo.reset()
 
     before = provider_fallback.labels(
         from_provider="alpaca_sip", to_provider="yahoo"
@@ -62,3 +64,4 @@ def test_yahoo_used_after_two_alpaca_failures(monkeypatch):
     assert called.get("yahoo")
     assert not df.empty
     assert after == before + 1
+    assert fo.FALLBACK_ORDER.get("yahoo")


### PR DESCRIPTION
## Summary
- track Yahoo fallback usage in new `fallback_order` module
- mark Yahoo in data fetcher when two Alpaca attempts fail
- test ensures fallback order dictionary sets `{"yahoo": True}`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68bc87783d888330b89e929a05adbc11