### PR TITLE
Handle None thresholds in strategy allocator

### DIFF
--- a/ai_trading/strategy_allocator.py
+++ b/ai_trading/strategy_allocator.py
@@ -261,13 +261,19 @@ class StrategyAllocator:
                     continue
 
             delta = abs(s.confidence - last_conf) if last_conf else s.confidence
-            if delta < self.config.delta_threshold and last_dir == s.side:
+            threshold_raw = getattr(self.config, "delta_threshold", 0.0)
+            try:
+                threshold = float(threshold_raw) if threshold_raw is not None else 0.0
+            except (TypeError, ValueError):
+                threshold = 0.0
+
+            if delta < threshold and last_dir == s.side:
                 logger.info(
                     "SIGNAL_SKIPPED_DELTA",
                     extra={
                         "symbol": s.symbol,
                         "delta": delta,
-                        "threshold": self.config.delta_threshold,
+                        "threshold": threshold,
                     },
                 )
                 continue

--- a/tests/test_strategy_allocator_regression.py
+++ b/tests/test_strategy_allocator_regression.py
@@ -63,6 +63,20 @@ class TestStrategyAllocatorRegression:
         assert len(out2) == 1, "Should confirm signal with default threshold"
         assert out2[0].symbol == "AAPL", "Should return AAPL signal"
 
+    def test_none_delta_threshold_treated_as_zero(self):
+        """Ensure None delta_threshold is treated as 0 without raising TypeError."""
+        cfg = SimpleNamespace(
+            delta_threshold=None,
+            signal_confirmation_bars=1,
+            min_confidence=0.0,
+        )
+        alloc = strategy_allocator.StrategyAllocator(config=cfg)
+
+        sig = TradeSignal(symbol="AAPL", side="buy", confidence=1.0, strategy="s1")
+
+        out = alloc.select_signals({"s1": [sig]})
+        assert len(out) == 1, "Should confirm signal even when delta_threshold is None"
+
     def test_config_none_min_confidence(self):
         """
         Regression test for None min_confidence value.


### PR DESCRIPTION
## Summary
- Treat `None` as `0` for `delta_threshold` comparisons to avoid TypeError
- Add regression test ensuring allocator works when `delta_threshold` is `None`

## Testing
- `ruff check ai_trading/strategy_allocator.py tests/test_strategy_allocator_regression.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_strategy_allocator_regression.py::TestStrategyAllocatorRegression::test_none_delta_threshold_treated_as_zero tests/test_strategy_allocator_smoke.py::test_allocator tests/test_strategy_allocator_exit.py::test_exit_confirmation -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc8773cbac8330b327881e440fb2d0