### PR TITLE
Gracefully handle missing credentials in env validation script

### DIFF
--- a/ai_trading/validation/validate_env.py
+++ b/ai_trading/validation/validate_env.py
@@ -6,7 +6,10 @@ from datetime import datetime
 from pydantic import BaseModel
 from pydantic import field_validator, Field
 
+from ai_trading.logging import get_logger
 from ai_trading.logging.redact import redact_env
+
+logger = get_logger(__name__)
 
 class Settings(BaseModel):
     ALPACA_API_KEY: str = Field(default_factory=lambda: os.environ["ALPACA_API_KEY"])
@@ -99,4 +102,27 @@ def validate_specific_env_var(name: str, required: bool = False) -> dict:
         "value": val,
         "issues": [],
     }
-__all__ = ['Settings', 'debug_environment', 'validate_specific_env_var']
+
+
+def main() -> int:
+    """Validate critical environment variables.
+
+    Missing credentials are tolerated for dry-run scenarios.
+    """
+    try:
+        Settings()
+    except KeyError as exc:
+        logger.warning("Missing credential: %s", exc)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    'Settings',
+    'debug_environment',
+    'validate_specific_env_var',
+    'main',
+]

--- a/tests/test_validate_env_script.py
+++ b/tests/test_validate_env_script.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_validate_env_main_exits_zero_without_credentials():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    for key in ["ALPACA_API_KEY", "ALPACA_SECRET_KEY", "ALPACA_BASE_URL"]:
+        env.pop(key, None)
+    env["PYTHONPATH"] = str(repo_root)
+    script = repo_root / "ai_trading" / "validation" / "validate_env.py"
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- add logger and CLI wrapper to `validate_env` that catches missing credential `KeyError`
- include subprocess test ensuring validation script exits cleanly without credentials

## Testing
- `ruff check .`
- `PYTHONPATH=. pytest tests/test_validate_env_script.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_68bc8773f808833084e6b485df743768