### PR TITLE
Guard against unauthorized SIP access in data fetch HTTP helper

### DIFF
--- a/ai_trading/data/fetch/http.py
+++ b/ai_trading/data/fetch/http.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import _HTTP_SESSION, _SIP_UNAUTHORIZED
+from ai_trading.net.http import HTTPSession
+
+
+def get(
+    url: str,
+    *,
+    feed: str | None = None,
+    session: HTTPSession | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Issue a ``GET`` request while enforcing SIP authorization.
+
+    Parameters
+    ----------
+    url:
+        Target URL to request.
+    feed:
+        Data feed being accessed, e.g. ``"sip"`` or ``"iex"``.
+    session:
+        Optional HTTP session used to issue the request. Falls back to the
+        package-level session when omitted.
+
+    Returns
+    -------
+    Any
+        Response object returned by ``session.get``.
+
+    Raises
+    ------
+    ValueError
+        If SIP access is unauthorized or the session is missing/invalid.
+    """
+    if feed == "sip" and _SIP_UNAUTHORIZED:
+        raise ValueError("sip_unauthorized")
+
+    session = session or _HTTP_SESSION
+    if session is None or not hasattr(session, "get"):
+        raise ValueError("session_required")
+
+    return session.get(url, **kwargs)
+
+
+__all__ = ["get"]

--- a/tests/unit/test_fetch_http_module.py
+++ b/tests/unit/test_fetch_http_module.py
@@ -1,0 +1,22 @@
+import pytest
+import ai_trading.data.fetch.http as fetch_http
+
+
+class _Session:
+    def __init__(self):
+        self.calls = 0
+
+    def get(self, url, **kwargs):  # noqa: ARG002
+        self.calls += 1
+        return {}
+
+
+def test_unauthorized_sip_raises_before_request(monkeypatch: pytest.MonkeyPatch):
+    session = _Session()
+    monkeypatch.setattr(fetch_http, "_HTTP_SESSION", session, raising=False)
+    monkeypatch.setattr(fetch_http, "_SIP_UNAUTHORIZED", True, raising=False)
+
+    with pytest.raises(ValueError, match="sip_unauthorized"):
+        fetch_http.get("https://example.com", feed="sip")
+
+    assert session.calls == 0


### PR DESCRIPTION
## Summary
- add HTTP helper enforcing SIP authorization before issuing requests
- test unauthorized SIP requests raise without contacting remote

## Testing
- `ruff check ai_trading/data/fetch/http.py tests/unit/test_fetch_http_module.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_fetch_http_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc89cd2dc483309523bba460975c28