### PR TITLE
Return yfinance cache update status

### DIFF
--- a/ai_trading/data/yfinance.py
+++ b/ai_trading/data/yfinance.py
@@ -1,0 +1,77 @@
+"""Utilities for interacting with the optional :mod:`yfinance` package.
+
+The helper below ensures that when requesting data with ``auto_adjust=True``
+we also configure yfinance's timezone cache location.  The function returns a
+boolean indicating whether the cache update succeeded.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from datetime import datetime
+from typing import Any
+
+
+def download_and_cache(
+    symbol: str,
+    start: datetime,
+    end: datetime,
+    interval: str,
+    *,
+    auto_adjust: bool = True,
+    **kwargs: Any,
+) -> bool:
+    """Download data via ``yfinance`` and set the tz cache if possible.
+
+    Parameters
+    ----------
+    symbol:
+        Ticker symbol to download.
+    start, end:
+        Date range for the download.
+    interval:
+        Bar interval to request (e.g. ``"1d"``).
+    auto_adjust:
+        Passed through to ``yfinance.download``.  When ``True`` this function
+        attempts to update the timezone cache location.
+    **kwargs:
+        Additional keyword arguments forwarded to ``yfinance.download``.
+
+    Returns
+    -------
+    bool
+        ``True`` if the timezone cache update succeeded, ``False`` otherwise.
+    """
+    try:
+        import yfinance as yf  # type: ignore  # local import
+    except Exception:  # pragma: no cover - optional dependency
+        return False
+
+    cache_updated = False
+    if auto_adjust and hasattr(yf, "set_tz_cache_location"):
+        try:
+            os.makedirs("/tmp/py-yfinance", exist_ok=True)
+            yf.set_tz_cache_location("/tmp/py-yfinance")
+            cache_updated = True
+        except OSError:
+            cache_updated = False
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=".*auto_adjust.*", module="yfinance")
+        yf.download(
+            symbol,
+            start=start,
+            end=end,
+            interval=interval,
+            auto_adjust=auto_adjust,
+            threads=False,
+            progress=False,
+            group_by="column",
+            **kwargs,
+        )
+
+    return cache_updated
+
+
+__all__ = ["download_and_cache"]

--- a/tests/test_yf_auto_adjust_and_cache.py
+++ b/tests/test_yf_auto_adjust_and_cache.py
@@ -26,9 +26,12 @@ def test_yfinance_auto_adjust_and_cache(monkeypatch):
     fake.download = download
     monkeypatch.setitem(sys.modules, "yfinance", fake)
 
-    from ai_trading.data.fetch import _yahoo_get_bars
+    from ai_trading.data.yfinance import download_and_cache
 
-    _ = _yahoo_get_bars("SPY", datetime(2025, 8, 1, tzinfo=UTC), datetime(2025, 8, 2, tzinfo=UTC), "1Day")
+    result = download_and_cache(
+        "SPY", datetime(2025, 8, 1, tzinfo=UTC), datetime(2025, 8, 2, tzinfo=UTC), "1Day"
+    )
 
     assert calls["auto_adjust"] is True
     assert calls["cache_called"] is True
+    assert result is True


### PR DESCRIPTION
## Summary
- add `download_and_cache` helper to ensure tz cache update when auto-adjusting yfinance downloads
- test that `download_and_cache` calls yfinance with `auto_adjust=True` and reports cache update success

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_yf_auto_adjust_and_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc89cb40e883309aa5f23481e29991