### PR TITLE
feat: validate alpaca sdk availability on initialize

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, TYPE_CHECKING
 from ai_trading.net.http import HTTPSession, get_http_session
 from ai_trading.exc import RequestException
 from ai_trading.utils.http import clamp_request_timeout
-import importlib.util
+import importlib
 from ai_trading.logging import get_logger
 from ai_trading.config.management import is_shadow_mode
 from ai_trading.logging.normalize import canon_symbol as _canon_symbol
@@ -79,6 +79,21 @@ ALPACA_AVAILABLE = (
     and _module_exists("alpaca.common.exceptions")
 )
 HAS_PANDAS: bool = _module_exists("pandas")  # AI-AGENT-REF: expose pandas availability
+
+
+def initialize() -> None:
+    """Ensure required Alpaca SDK modules are importable.
+
+    Raises:
+        RuntimeError: If the Alpaca SDK cannot be imported, providing a
+            helpful message for installation.
+    """
+    try:
+        importlib.import_module("alpaca.trading.client")
+        importlib.import_module("alpaca.data.historical")
+        importlib.import_module("alpaca.common.exceptions")
+    except Exception as exc:  # pragma: no cover - exercised in tests
+        raise RuntimeError("alpaca-py SDK is required") from exc
 
 if not ALPACA_AVAILABLE:  # pragma: no cover - exercised in tests
     from dataclasses import dataclass
@@ -753,4 +768,5 @@ __all__ = [
     'get_bars_df',
     'alpaca_get',
     'start_trade_updates_stream',
+    'initialize',
 ]

--- a/tests/test_alpaca_initialize.py
+++ b/tests/test_alpaca_initialize.py
@@ -1,0 +1,13 @@
+import importlib
+import pytest
+
+from ai_trading import alpaca_api
+
+
+def test_initialize_missing_sdk(monkeypatch):
+    def fail(_name, package=None):  # pragma: no cover - used in test
+        raise ModuleNotFoundError("missing")
+
+    monkeypatch.setattr(importlib, "import_module", fail)
+    with pytest.raises(RuntimeError, match="alpaca-py SDK is required"):
+        alpaca_api.initialize()


### PR DESCRIPTION
## Summary
- ensure alpaca_api.initialize verifies required Alpaca SDK modules and raises RuntimeError with a helpful message
- add unit test covering the failure path when SDK import is missing

## Testing
- `ruff check ai_trading/alpaca_api.py tests/test_alpaca_initialize.py`
- `ruff check .` *(fails: F821 Undefined name `_real_sleep`, `_time`)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_initialize.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bc89cb6aac8330821e8f9112a210ee