### PR TITLE
Add fetch metrics snapshot helper

### DIFF
--- a/ai_trading/data/fetch/metrics.py
+++ b/ai_trading/data/fetch/metrics.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Helpers for exposing data fetch metrics.
+
+This module provides a lightweight interface to snapshot the in-memory
+metrics counters used during data fetching operations.  Historically the
+caller would raise ``ValueError('invalid_response')`` when a response object
+could not be parsed.  For robustness we now return a best-effort metric
+snapshot instead of propagating the exception.
+"""
+
+from dataclasses import asdict
+from typing import Any, Mapping
+
+from ai_trading.data.metrics import metrics
+
+
+def snapshot(resp: Any | None = None) -> dict[str, int]:
+    """Return metrics extracted from ``resp`` or current counters.
+
+    Parameters
+    ----------
+    resp:
+        Optional HTTP-like response object supplying a ``json()`` method.  If
+        the response is missing or malformed the function will gracefully
+        fall back to returning the current in-memory counters instead of
+        raising ``ValueError('invalid_response')``.
+    """
+    try:
+        if resp is None or not hasattr(resp, "json"):
+            raise ValueError("invalid_response")
+        payload = resp.json()
+        if not isinstance(payload, Mapping):
+            raise ValueError("invalid_response")
+        return dict(payload)
+    except Exception:
+        # Return the current counters instead of propagating the error.
+        return asdict(metrics)
+
+
+__all__ = ["snapshot"]

--- a/tests/unit/test_fetch_metrics_snapshot.py
+++ b/tests/unit/test_fetch_metrics_snapshot.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import ai_trading.data.fetch as df
+from ai_trading.data.metrics import metrics as metrics_state
+
+
+@pytest.fixture(autouse=True)
+def reset_counters():
+    metrics_state.rate_limit = 0
+    metrics_state.timeout = 0
+    metrics_state.unauthorized = 0
+    metrics_state.empty_payload = 0
+    metrics_state.feed_switch = 0
+    yield
+    metrics_state.rate_limit = 0
+    metrics_state.timeout = 0
+    metrics_state.unauthorized = 0
+    metrics_state.empty_payload = 0
+    metrics_state.feed_switch = 0
+
+
+@pytest.fixture
+def fm():
+    mod = importlib.import_module("ai_trading.data.fetch.metrics")
+    # Ensure other tests still see the dataclass instance
+    df.metrics = metrics_state
+    return mod
+
+
+def test_snapshot_rate_limit(fm):
+    metrics_state.rate_limit += 1
+    out = fm.snapshot(None)
+    assert out["rate_limit"] == 1
+    assert out["timeout"] == 0
+
+
+def test_snapshot_timeout(fm):
+    metrics_state.timeout += 2
+    out = fm.snapshot(object())
+    assert out["timeout"] == 2
+    assert out["rate_limit"] == 0
+
+
+def test_snapshot_unauthorized(fm):
+    metrics_state.unauthorized += 1
+    out = fm.snapshot(None)
+    assert out["unauthorized"] == 1
+    assert out["empty_payload"] == 0
+
+
+def test_snapshot_empty_payload(fm):
+    metrics_state.empty_payload += 3
+    out = fm.snapshot(None)
+    assert out["empty_payload"] == 3
+    assert out["rate_limit"] == 0


### PR DESCRIPTION
## Summary
- Add `snapshot` helper to expose data fetch metrics without raising on invalid responses
- Cover rate limit, timeout, unauthorized, and empty payload scenarios with dedicated unit tests

## Testing
- `ruff check ai_trading/data/fetch/metrics.py tests/unit/test_fetch_metrics_snapshot.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_RUNNING=1 pytest tests/unit/test_data_fetcher_metrics.py tests/unit/test_fetch_metrics_snapshot.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: Missing dependencies such as joblib, hypothesis, and execution modules)*


------
https://chatgpt.com/codex/tasks/task_e_68bc89d8158c8330a61dbb661c74bff6