### PR TITLE
Retry audit log after fixing permissions

### DIFF
--- a/ai_trading/audit.py
+++ b/ai_trading/audit.py
@@ -251,9 +251,9 @@ def log_trade(
             logger.error("audit.log permission denied %s: %s", path, exc)
             # Invoke repair hook then retry once; swallow if still failing (tests
             # only assert that the repair was attempted).
-            repaired = fix_file_permissions(path)
-            if repaired:
+            if fix_file_permissions(path):
                 try:
+                    _ensure_file_header(path, headers)
                     with open(path, "a", newline="") as f:
                         writer = csv.DictWriter(f, fieldnames=headers)
                         writer.writerow(row)


### PR DESCRIPTION
## Summary
- retry audit log write after invoking `fix_file_permissions` on `PermissionError`

## Testing
- `ruff check ai_trading/audit.py tests/unit/test_audit_log_trade.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_audit_log_trade.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc89cbfcc483309479c1843c6a7573