### PR TITLE
feat: add run_all_trades helper and tests

### DIFF
--- a/ai_trading/run_all_trades.py
+++ b/ai_trading/run_all_trades.py
@@ -1,0 +1,92 @@
+"""Simplified trading loop for tests.
+
+This module provides a small façade around an injected API callable. It
+ensures a trade log exists and adds a bit of behaviour used by tests:
+
+* If the API callable raises an exception, a warning is logged and the
+  symbol is skipped.
+* When no symbols are provided the callable `sleep` is invoked exactly
+  once and the function returns immediately.
+* The trade log ``trades.csv`` is created on first use with a basic CSV
+  header.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+import logging
+import time
+from typing import Callable, Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+TRADE_LOG_FILE = Path("trades.csv")
+
+
+def _ensure_trade_log(path: Path) -> None:
+    """Create the trade log with a header if it does not yet exist."""
+    if path.exists():  # pragma: no cover - early return
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow([
+            "symbol",
+            "entry_time",
+            "entry_price",
+            "exit_time",
+            "exit_price",
+            "qty",
+            "side",
+            "strategy",
+            "classification",
+            "signal_tags",
+            "confidence",
+            "reward",
+        ])
+
+
+def run_all_trades(
+    symbols: Sequence[str],
+    api: Callable[[str], object],
+    *,
+    trade_log: Path | str = TRADE_LOG_FILE,
+    sleep: Callable[[float], object] = time.sleep,
+) -> list[object]:
+    """Execute trades for ``symbols`` using ``api``.
+
+    Parameters
+    ----------
+    symbols:
+        The collection of symbols to trade. If empty a warning is logged and
+        ``sleep`` is invoked once before returning.
+    api:
+        Callable accepting a symbol and performing the trade. Any exception is
+        converted into a warning log and the symbol is skipped.
+    trade_log:
+        Location of the trade log CSV. The file is created with a header on
+        first use.
+    sleep:
+        Sleep function used when ``symbols`` is empty. Exposed for tests.
+    """
+
+    path = Path(trade_log)
+    _ensure_trade_log(path)
+
+    if not symbols:
+        logger.warning("NO_SYMBOLS")
+        sleep(1.0)
+        return []
+
+    results: list[object] = []
+    for sym in symbols:
+        try:
+            res = api(sym)
+        except Exception as exc:  # pragma: no cover - exercised in tests
+            logger.warning("API_ERROR", exc_info=exc)
+            continue
+        results.append(res)
+    return results
+
+
+__all__ = ["run_all_trades"]

--- a/tests/unit/test_run_all_trades_script.py
+++ b/tests/unit/test_run_all_trades_script.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+import logging
+
+from ai_trading.run_all_trades import run_all_trades
+
+
+def test_api_exception_logs_warning(tmp_path, caplog):
+    """API errors should be logged as warnings and skipped."""
+
+    def boom(_symbol: str) -> None:
+        raise RuntimeError("boom")
+
+    caplog.set_level(logging.WARNING)
+    log = tmp_path / "trades.csv"
+    run_all_trades(["AAPL"], boom, trade_log=log)
+
+    assert any("API_ERROR" in r.message for r in caplog.records)
+    assert log.exists()
+
+
+def test_empty_symbols_calls_sleep_once(tmp_path):
+    """When no symbols are supplied the sleep callback is invoked once."""
+
+    sleep_mock = Mock()
+    api_mock = Mock()
+    log = tmp_path / "trades.csv"
+
+    run_all_trades([], api_mock, trade_log=log, sleep=sleep_mock)
+
+    sleep_mock.assert_called_once_with(1.0)
+    api_mock.assert_not_called()
+
+
+def test_creates_trade_log(tmp_path):
+    """A trade log CSV is created with the expected header."""
+
+    api_mock = Mock(return_value={})
+    log = tmp_path / "trades.csv"
+    run_all_trades(["AAPL"], api_mock, trade_log=log)
+
+    assert log.exists()
+    first_line = log.read_text().splitlines()[0]
+    assert (
+        first_line
+        == "symbol,entry_time,entry_price,exit_time,exit_price,qty,side,strategy,classification,signal_tags,confidence,reward"
+    )


### PR DESCRIPTION
## Summary
- add lightweight `run_all_trades` util that logs API errors, sleeps once on empty symbols and writes a trade log
- test API error logging, empty symbol handling and trade log creation

## Testing
- `ruff check ai_trading/run_all_trades.py tests/unit/test_run_all_trades_script.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --noconftest tests/unit/test_run_all_trades_script.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c23e0308330858226bc8c5479d2