### PR TITLE
Honor alias base URL in env redaction

### DIFF
--- a/ai_trading/env/__init__.py
+++ b/ai_trading/env/__init__.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import os
 
 _ENV_LOADED = False

--- a/ai_trading/env/config_redaction.py
+++ b/ai_trading/env/config_redaction.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Dict
+
+from ai_trading.logging.redact import redact_env
+
+# Mapping of environment variable aliases to their canonical names.
+_ALIAS_MAP: Dict[str, str] = {
+    "ALPACA_BASE_URL": "ALPACA_API_URL",
+    "APCA_API_BASE_URL": "ALPACA_API_URL",
+}
+
+
+def _apply_aliases(env: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a new mapping with aliases normalized to canonical keys."""
+    resolved: Dict[str, Any] = {}
+    for key, value in env.items():
+        canonical = _ALIAS_MAP.get(key, key)
+        if canonical not in resolved:
+            resolved[canonical] = value
+    return resolved
+
+
+def redact_config_env(env: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Redact *env* while honoring alias mapping.
+
+    Alias variables like ``ALPACA_BASE_URL`` are emitted under their canonical
+    ``ALPACA_API_URL`` key so logs remain consistent regardless of which
+    variant the user provided.
+    """
+    normalized = _apply_aliases(env)
+    return redact_env(normalized, drop=True)
+
+
+__all__ = ["redact_config_env"]

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -42,7 +42,8 @@ from ai_trading.settings import get_seed_int
 from ai_trading.config import get_settings
 from ai_trading.utils import get_free_port, get_pid_on_port
 from ai_trading.utils.prof import StageTimer, SoftBudget
-from ai_trading.logging.redact import redact as _redact, redact_env
+from ai_trading.logging.redact import redact as _redact
+from ai_trading.env.config_redaction import redact_config_env
 from ai_trading.net.http import build_retrying_session, set_global_session, mount_host_retry_profile
 from ai_trading.utils.http import clamp_request_timeout
 from ai_trading.utils.base import is_market_open as _is_market_open_base, next_market_open
@@ -224,7 +225,7 @@ def _fail_fast_env() -> None:
         raise SystemExit(1) from e
     logger.info(
         "ENV_CONFIG_LOADED",
-        extra={"dotenv_path": loaded, **redact_env(snapshot, drop=True)},
+        extra={"dotenv_path": loaded, **redact_config_env(snapshot)},
     )
 
 

--- a/ai_trading/utils/timing.py
+++ b/ai_trading/utils/timing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from typing import Optional, Union
 
-from .sleep import sleep
+from .sleep import _perf, _real_sleep, _time, sleep
 
 # Prefer AI_HTTP_TIMEOUT when present (tests set this); fallback to HTTP_TIMEOUT env
 HTTP_TIMEOUT: Union[int, float] = float(

--- a/tests/unit/test_env_config_redaction.py
+++ b/tests/unit/test_env_config_redaction.py
@@ -2,6 +2,7 @@ import logging
 
 from ai_trading import main
 from ai_trading.logging.redact import _ENV_MASK, _SENSITIVE_ENV, redact_env
+from ai_trading.env.config_redaction import redact_config_env
 
 
 def test_startup_logs_drop_secrets(caplog, monkeypatch):
@@ -38,6 +39,13 @@ def test_redact_env_drop_removes_keys():
     redacted = redact_env(payload, drop=True)
     for k in _SENSITIVE_ENV:
         assert k not in redacted
+
+
+def test_redact_config_env_alias_mapped():
+    payload = {"ALPACA_BASE_URL": "https://alias-api.alpaca.markets"}
+    redacted = redact_config_env(payload)
+    assert redacted["ALPACA_API_URL"] == "https://alias-api.alpaca.markets"
+    assert "ALPACA_BASE_URL" not in redacted
 
 
 def test_base_url_alias_logged(caplog, monkeypatch):


### PR DESCRIPTION
## Summary
- normalize environment alias keys so ALPACA_BASE_URL logs as ALPACA_API_URL
- log redacted env config using alias-aware helper
- tidy imports in timing utilities and tests for lint compliance

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_env_config_redaction.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c23e31c8330890daee3190114b7