### PR TITLE
Add warning log for subprocess timeouts

### DIFF
--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -71,8 +71,8 @@ _LAZY_MAP = {
     "portfolio_lock": ("ai_trading.utils.base", "portfolio_lock"),
     "safe_to_datetime": ("ai_trading.utils.base", "safe_to_datetime"),
     "validate_ohlcv": ("ai_trading.utils.base", "validate_ohlcv"),
-    "SUBPROCESS_TIMEOUT_DEFAULT": ("ai_trading.utils.base", "SUBPROCESS_TIMEOUT_DEFAULT"),
-    "safe_subprocess_run": ("ai_trading.utils.base", "safe_subprocess_run"),
+    "SUBPROCESS_TIMEOUT_DEFAULT": ("ai_trading.utils.safe_subprocess", "SUBPROCESS_TIMEOUT_DEFAULT"),
+    "safe_subprocess_run": ("ai_trading.utils.safe_subprocess", "safe_subprocess_run"),
 }
 
 if TYPE_CHECKING:  # pragma: no cover - for static analyzers only

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -19,32 +19,16 @@ from zoneinfo import ZoneInfo
 from ai_trading.config import get_settings
 from ai_trading.exc import COMMON_EXC
 from ai_trading.settings import get_verbose_logging
+from .safe_subprocess import (
+    SUBPROCESS_TIMEOUT_DEFAULT,
+    safe_subprocess_run,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd  # pylint: disable=unused-import
     from pandas import DataFrame, Series, Index, Timestamp
 else:  # pragma: no cover - runtime when pandas missing
     DataFrame = Series = Index = Timestamp = object
-SUBPROCESS_TIMEOUT_S = 5.0
-
-# Back-compat alias expected by ai_trading.core.bot_engine.get_git_hash()
-SUBPROCESS_TIMEOUT_DEFAULT = SUBPROCESS_TIMEOUT_S
-
-
-def safe_subprocess_run(cmd: list[str] | tuple[str, ...], timeout: float | int | None = None) -> str:
-    """Run a subprocess safely and return stdout text.
-
-    Returns an empty string on any failure so callers can degrade gracefully.
-    """
-    try:
-        t = float(timeout) if timeout is not None else SUBPROCESS_TIMEOUT_DEFAULT
-        res = subprocess.run(list(cmd), timeout=t, check=True, capture_output=True)
-        return (res.stdout or b"").decode(errors="ignore").strip()
-    except (subprocess.SubprocessError, subprocess.TimeoutExpired, OSError) as exc:
-        logger.warning("safe_subprocess_run(%s) failed: %s", cmd, exc)
-        return ""
-
-
 def ensure_utc_index(df: DataFrame) -> DataFrame:
     """Return DataFrame with UTC tz-aware ``DatetimeIndex`` if applicable."""
     try:

--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -1,0 +1,35 @@
+"""Utilities for running subprocesses with safety guards."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Sequence
+
+from ai_trading.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Default timeout for subprocess operations in seconds
+SUBPROCESS_TIMEOUT_S = 5.0
+
+# Back-compat alias expected by callers
+SUBPROCESS_TIMEOUT_DEFAULT = SUBPROCESS_TIMEOUT_S
+
+
+def safe_subprocess_run(cmd: Sequence[str], timeout: float | int | None = None) -> str:
+    """Run ``cmd`` with ``subprocess.run`` and capture stdout text.
+
+    Any errors are swallowed and emitted as warnings so callers can degrade
+    gracefully. When a timeout occurs a dedicated warning message is emitted
+    before returning an empty string.
+    """
+    t = float(timeout) if timeout is not None else SUBPROCESS_TIMEOUT_DEFAULT
+    try:
+        res = subprocess.run(list(cmd), timeout=t, check=True, capture_output=True)
+    except subprocess.TimeoutExpired:
+        logger.warning("safe_subprocess_run(%s) timed out after %.2f seconds", cmd, t)
+        return ""
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.warning("safe_subprocess_run(%s) failed: %s", cmd, exc)
+        return ""
+    return (res.stdout or b"").decode(errors="ignore").strip()

--- a/tests/utils/test_safe_subprocess_run.py
+++ b/tests/utils/test_safe_subprocess_run.py
@@ -1,7 +1,7 @@
 import sys
 import pytest
 
-from ai_trading.utils.base import safe_subprocess_run
+from ai_trading.utils.safe_subprocess import safe_subprocess_run
 
 
 def test_safe_subprocess_run_success():
@@ -14,7 +14,7 @@ def test_safe_subprocess_run_timeout(caplog):
     with caplog.at_level("WARNING"):
         out = safe_subprocess_run(cmd, timeout=0.1)
     assert out == ""
-    assert any(str(cmd) in rec.message for rec in caplog.records)
+    assert any("timed out" in rec.message for rec in caplog.records)
 
 
 def test_safe_subprocess_run_nonzero_exit(caplog):


### PR DESCRIPTION
## Summary
- create `safe_subprocess` helper that warns when a command exceeds its timeout
- re-export helper via `ai_trading.utils` package
- test that timeout warnings are captured in logs

## Testing
- `ruff check ai_trading/utils/safe_subprocess.py ai_trading/utils/base.py ai_trading/utils/__init__.py tests/utils/test_safe_subprocess_run.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/utils/test_safe_subprocess_run.py -q`
- `python -m pip install -e . -q` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*

------
https://chatgpt.com/codex/tasks/task_e_68bc8c25bbec83309973dcfa9d5b3522