### PR TITLE
feat: centralize portfolio lock singleton

### DIFF
--- a/ai_trading/utils/__init__.py
+++ b/ai_trading/utils/__init__.py
@@ -68,7 +68,7 @@ _LAZY_MAP = {
     "market_open_between": ("ai_trading.utils.base", "market_open_between"),
     "log_warning": ("ai_trading.utils.base", "log_warning"),
     "model_lock": ("ai_trading.utils.base", "model_lock"),
-    "portfolio_lock": ("ai_trading.utils.base", "portfolio_lock"),
+    "portfolio_lock": ("ai_trading.utils.locks", "portfolio_lock"),
     "safe_to_datetime": ("ai_trading.utils.base", "safe_to_datetime"),
     "validate_ohlcv": ("ai_trading.utils.base", "validate_ohlcv"),
     "SUBPROCESS_TIMEOUT_DEFAULT": ("ai_trading.utils.base", "SUBPROCESS_TIMEOUT_DEFAULT"),
@@ -93,12 +93,12 @@ if TYPE_CHECKING:  # pragma: no cover - for static analyzers only
         market_open_between,
         log_warning,
         model_lock,
-        portfolio_lock,
         safe_to_datetime,
         validate_ohlcv,
         SUBPROCESS_TIMEOUT_DEFAULT,
         safe_subprocess_run,
     )
+    from .locks import portfolio_lock  # type: ignore
 
 
 def __getattr__(name: str) -> Any:  # AI-AGENT-REF: importlib-based lazy loader

--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -19,6 +19,7 @@ from zoneinfo import ZoneInfo
 from ai_trading.config import get_settings
 from ai_trading.exc import COMMON_EXC
 from ai_trading.settings import get_verbose_logging
+from .locks import portfolio_lock
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     import pandas as pd  # pylint: disable=unused-import
@@ -189,7 +190,6 @@ def format_order_for_log(order: Any) -> str:
 MARKET_OPEN_TIME = dt.time(9, 30)
 MARKET_CLOSE_TIME = dt.time(16, 0)
 EASTERN_TZ = ZoneInfo("America/New_York")
-portfolio_lock = threading.Lock()
 
 
 class _CallableLock:

--- a/ai_trading/utils/locks.py
+++ b/ai_trading/utils/locks.py
@@ -1,0 +1,10 @@
+"""Synchronization primitives used across the project."""
+
+from __future__ import annotations
+
+import threading
+
+__all__ = ["portfolio_lock"]
+
+# Single lock instance guarding shared portfolio state.
+portfolio_lock = threading.Lock()

--- a/tests/utils/test_portfolio_lock_export.py
+++ b/tests/utils/test_portfolio_lock_export.py
@@ -4,6 +4,8 @@ import threading
 def test_portfolio_lock_is_exported_and_is_same_object():
     from ai_trading.utils import portfolio_lock
     from ai_trading.utils.base import portfolio_lock as base_lock
+    from ai_trading.utils.locks import portfolio_lock as locks_lock
+
     assert isinstance(portfolio_lock, type(threading.Lock()))
-    # same underlying object (identity), not a new lock
-    assert portfolio_lock is base_lock
+    # all modules should reference the exact same lock instance
+    assert portfolio_lock is base_lock is locks_lock


### PR DESCRIPTION
## Summary
- add `ai_trading.utils.locks` with shared `portfolio_lock`
- import that lock from utils modules to ensure a single instance
- test that all imports refer to the same object

## Testing
- `ruff check ai_trading/utils/locks.py ai_trading/utils/base.py ai_trading/utils/__init__.py tests/utils/test_portfolio_lock_export.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: NameError: `_perf` not defined)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/utils/test_portfolio_lock_export.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc8c24b3ac8330895c82d807b30237