### PR TITLE
Use reconciled_at for reconciliation timestamp

### DIFF
--- a/ai_trading/execution/reconcile.py
+++ b/ai_trading/execution/reconcile.py
@@ -250,11 +250,25 @@ def reconcile_positions_and_orders() -> ReconciliationResult:
     positions and orders after trading activity.
 
     Returns:
-        ReconciliationResult with any detected drifts
+        ReconciliationResult with any detected drifts. The timestamp of the
+        reconciliation is available via the result's ``reconciled_at`` field.
     """
     try:
         logger.debug('Position/order reconciliation called (mock implementation)')
-        return ReconciliationResult(position_drifts=[], order_drifts=[], timestamp=datetime.now(UTC))
+        # ReconciliationResult already tracks when reconciliation happened via
+        # the ``reconciled_at`` field, which callers should use for timestamping
+        # instead of a separate ``timestamp`` parameter.
+        return ReconciliationResult(
+            position_drifts=[],
+            order_drifts=[],
+            actions_taken=[],
+            reconciled_at=datetime.now(UTC),
+        )
     except (RuntimeError, ValueError) as e:
         logger.error(f'Error in reconciliation: {e}')
-        return ReconciliationResult(position_drifts=[], order_drifts=[], timestamp=datetime.now(UTC))
+        return ReconciliationResult(
+            position_drifts=[],
+            order_drifts=[],
+            actions_taken=[],
+            reconciled_at=datetime.now(UTC),
+        )

--- a/tests/execution/test_reconcile_positions_and_orders.py
+++ b/tests/execution/test_reconcile_positions_and_orders.py
@@ -1,0 +1,15 @@
+from datetime import UTC, datetime
+
+from ai_trading.execution.reconcile import ReconciliationResult, reconcile_positions_and_orders
+
+
+def test_reconcile_positions_and_orders_has_timestamp():
+    """reconcile_positions_and_orders should populate reconciled_at timestamp."""
+    result = reconcile_positions_and_orders()
+    assert isinstance(result, ReconciliationResult)
+    assert isinstance(result.reconciled_at, datetime)
+    assert result.reconciled_at.tzinfo is UTC
+    assert result.position_drifts == []
+    assert result.order_drifts == []
+    assert result.actions_taken == []
+


### PR DESCRIPTION
## Summary
- ensure `reconcile_positions_and_orders` uses `reconciled_at` on `ReconciliationResult`
- add regression test for reconciliation timestamp

## Testing
- `ruff check ai_trading/execution/reconcile.py tests/execution/test_reconcile_positions_and_orders.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_reconcile_positions_and_orders.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c06d92646c83309e2b2afff293c886