### PR TITLE
Implement broker reconciliation and tests

### DIFF
--- a/alpaca/__init__.py
+++ b/alpaca/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal Alpaca SDK stub for tests."""

--- a/alpaca/data/__init__.py
+++ b/alpaca/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data API stubs."""
+
+class TimeFrame:  # pragma: no cover - simple constant container
+    DAY = "1D"
+    MINUTE = "1Min"

--- a/alpaca/trading/__init__.py
+++ b/alpaca/trading/__init__.py
@@ -1,0 +1,2 @@
+"""Trading client stub."""
+from .client import TradingClient

--- a/alpaca/trading/client.py
+++ b/alpaca/trading/client.py
@@ -1,0 +1,27 @@
+"""Minimal TradingClient stub used in tests."""
+
+class TradingClient:  # pragma: no cover - trivial
+    def __init__(self, *args, **kwargs):
+        self._orders = []
+
+    def list_orders(self, *a, **k):
+        return []
+
+    def list_positions(self, *a, **k):
+        return []
+
+    def submit_order(self, *a, **k):  # noqa: D401
+        """Return simple order namespace."""
+        from types import SimpleNamespace
+
+        order = SimpleNamespace(id="0", status="accepted", **k)
+        self._orders.append(order)
+        return order
+
+    def get_order(self, order_id):
+        for o in self._orders:
+            if str(getattr(o, "id", "")) == str(order_id):
+                return o
+        from types import SimpleNamespace
+
+        return SimpleNamespace(id=order_id, status="filled")

--- a/tests/execution/test_reconcile_positions_and_orders.py
+++ b/tests/execution/test_reconcile_positions_and_orders.py
@@ -1,6 +1,9 @@
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 from ai_trading.execution.reconcile import ReconciliationResult, reconcile_positions_and_orders
+from ai_trading.core.interfaces import Order, OrderStatus, OrderType
+from ai_trading.order.types import OrderSide
 
 
 def test_reconcile_positions_and_orders_has_timestamp():
@@ -12,4 +15,54 @@ def test_reconcile_positions_and_orders_has_timestamp():
     assert result.position_drifts == []
     assert result.order_drifts == []
     assert result.actions_taken == []
+
+
+class DummyBroker:
+    """Minimal broker API used for reconciliation tests."""
+
+    def __init__(self):
+        self._order = SimpleNamespace(
+            id="1", status="filled", filled_qty=10, symbol="AAPL"
+        )
+
+    def list_positions(self):
+        return [
+            SimpleNamespace(
+                symbol="AAPL", qty=10, market_value=0, cost_basis=0, unrealized_pl=0
+            )
+        ]
+
+    def list_orders(self, status="open"):
+        return []
+
+    def get_order(self, order_id):
+        return self._order
+
+
+def test_reconciliation_updates_state():
+    """Reconciliation should update holdings and local order statuses."""
+    broker = DummyBroker()
+    ctx = SimpleNamespace(
+        api=broker,
+        positions={"AAPL": 0},
+        orders=[
+            Order(
+                id="1",
+                symbol="AAPL",
+                side=OrderSide.BUY,
+                order_type=OrderType.MARKET,
+                status=OrderStatus.PENDING,
+                quantity=10,
+                filled_quantity=0,
+                price=None,
+                filled_price=None,
+                timestamp=datetime.now(UTC),
+            )
+        ],
+    )
+
+    reconcile_positions_and_orders(ctx)
+
+    assert ctx.positions["AAPL"] == 10
+    assert ctx.orders[0].status is OrderStatus.FILLED
 


### PR DESCRIPTION
## Summary
- Replace mock reconciliation with broker-aware implementation that syncs order statuses and positions
- Add minimal Alpaca SDK stubs for test environment
- Verify reconciliation updates holdings and order states

## Testing
- `ruff check tests/execution/test_reconcile_positions_and_orders.py ai_trading/execution/reconcile.py alpaca`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_reconcile_positions_and_orders.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*

------
https://chatgpt.com/codex/tasks/task_e_68c07458f11083309ad36f269529ac04