### PR TITLE
Add retry and metrics for sentiment API

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -71,6 +71,14 @@ feed and instrument. Query the metric via the `/metrics` endpoint:
 curl -sf http://localhost:$HEALTHCHECK_PORT/metrics | grep backup_provider_used_total
 ```
 
+#### Sentiment API Monitoring
+The bot tracks upstream sentiment failures and circuit breaker state:
+
+- `sentiment_api_failures_total` counts failed sentiment API calls.
+- `sentiment_circuit_breaker_state` is a gauge where `0` means closed,
+  `1` half-open, and `2` open. A warning is logged if the breaker stays
+  open beyond the normal recovery window.
+
 ### Example Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- add `sentiment_api_failures_total` counter and `sentiment_circuit_breaker_state` gauge
- warn and expose metrics when the sentiment circuit breaker stays open
- retry sentiment API calls with exponential backoff and jitter

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: alpaca-py is required for tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c07456dc5c8330b5a1887160ac0a95