### PR TITLE
Filter NaN indicator rows before signal evaluation

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5695,6 +5695,27 @@ class SignalManager:
         df["sma_50"] = df["close"].rolling(window=50).mean()
         df["sma_200"] = df["close"].rolling(window=200).mean()
 
+        indicator_cols = [
+            c
+            for c in (
+                "rsi",
+                "rsi_14",
+                "ichimoku_conv",
+                "ichimoku_base",
+                "stochrsi",
+                "macd",
+                "vwap",
+                "macds",
+                "atr",
+                "sma_50",
+                "sma_200",
+            )
+            if c in df.columns
+        ]
+        df = df.dropna(subset=indicator_cols)
+        if df.empty:
+            return 0.0, 0.0, "no_data"
+
         raw = [
             self.signal_momentum(df, model),
             self.signal_mean_reversion(df, model),
@@ -10828,8 +10849,8 @@ def prepare_indicators(frame: pd.DataFrame) -> pd.DataFrame:
         if col not in frame.columns:
             frame[col] = np.nan
 
-    # Only drop rows where all are missing
-    frame.dropna(subset=required, how="all", inplace=True)
+    # Drop rows with any missing indicator values
+    frame.dropna(subset=required, inplace=True)
 
     return frame
 

--- a/tests/bot_engine/test_nan_indicator_filter.py
+++ b/tests/bot_engine/test_nan_indicator_filter.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+import ai_trading.core.bot_engine as bot_engine
+from ai_trading.core.bot_engine import SignalManager, BotState
+
+pd = pytest.importorskip("pandas")
+
+
+def _patch_signals(monkeypatch):
+    monkeypatch.setattr(SignalManager, "signal_momentum", lambda self, df, model=None: None)
+    monkeypatch.setattr(SignalManager, "signal_mean_reversion", lambda self, df, model=None: None)
+    monkeypatch.setattr(
+        SignalManager,
+        "signal_ml",
+        lambda self, df, model=None, symbol=None: None,
+    )
+    monkeypatch.setattr(
+        SignalManager,
+        "signal_sentiment",
+        lambda self, ctx, ticker, df, model=None: None,
+    )
+    monkeypatch.setattr(
+        SignalManager,
+        "signal_regime",
+        lambda self, ctx, state, df, model=None: None,
+    )
+    monkeypatch.setattr(SignalManager, "signal_obv", lambda self, df, model=None: None)
+    monkeypatch.setattr(SignalManager, "signal_vsa", lambda self, df, model=None: None)
+    monkeypatch.setattr(SignalManager, "load_signal_weights", lambda self: {})
+    monkeypatch.setattr(bot_engine, "load_global_signal_performance", lambda: {})
+    monkeypatch.setattr(bot_engine, "signals_evaluated", None, raising=False)
+
+
+def _base_df(length: int) -> pd.DataFrame:
+    data = {
+        "close": np.arange(length, dtype=float),
+        "open": np.arange(length, dtype=float),
+        "high": np.arange(length, dtype=float) + 1,
+        "low": np.arange(length, dtype=float) - 1,
+        "volume": np.ones(length),
+        "macd": np.zeros(length),
+        "vwap": np.ones(length),
+        "macds": np.zeros(length),
+        "atr": np.ones(length),
+    }
+    return pd.DataFrame(data)
+
+
+def test_nan_indicator_rows_ignored(monkeypatch):
+    _patch_signals(monkeypatch)
+    sm = SignalManager()
+    state = BotState()
+    ctx = SimpleNamespace(signal_manager=sm)
+    length = 210
+    df = _base_df(length)
+    df["rsi"] = [30.0] * (length - 1) + [np.nan]
+    df["rsi_14"] = df["rsi"]
+    df["ichimoku_conv"] = 1.0
+    df["ichimoku_base"] = 1.0
+    df["stochrsi"] = [0.1] * (length - 1) + [np.nan]
+    signal, _, label = sm.evaluate(ctx, state, df, "TEST", None)
+    assert signal == 1
+    assert label == "stochrsi"
+
+
+def test_all_nan_indicators_return_no_data(monkeypatch):
+    _patch_signals(monkeypatch)
+    sm = SignalManager()
+    state = BotState()
+    ctx = SimpleNamespace(signal_manager=sm)
+    length = 210
+    df = _base_df(length)
+    df["rsi"] = np.nan
+    df["rsi_14"] = np.nan
+    df["ichimoku_conv"] = np.nan
+    df["ichimoku_base"] = np.nan
+    df["stochrsi"] = np.nan
+    signal, conf, label = sm.evaluate(ctx, state, df, "TEST", None)
+    assert (signal, conf, label) == (0.0, 0.0, "no_data")
+


### PR DESCRIPTION
## Summary
- drop rows with missing indicator values before generating signals
- ensure indicator preparation removes partial data
- add tests covering NaN indicator handling

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/bot_engine/test_nan_indicator_filter.py`
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_nan_indicator_filter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0762a1cd083308f4c89e2569ce5e2