### PR TITLE
Use lazy Alpaca client lookup for account equity

### DIFF
--- a/ai_trading/config/alpaca.py
+++ b/ai_trading/config/alpaca.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 import logging
 import os
+from ai_trading.alpaca_api import ALPACA_AVAILABLE, get_trading_client_cls
 from .settings import broker_keys, get_settings
 
 @dataclass(frozen=True)
@@ -31,26 +32,29 @@ def get_alpaca_config() -> AlpacaConfig:
     feed = (os.getenv('ALPACA_DATA_FEED') or getattr(s, 'alpaca_data_feed', 'iex')).lower()
     if not key_id or not secret:
         raise RuntimeError('Missing Alpaca credentials in broker_keys() (ALPACA_KEY_ID/ALPACA_SECRET_KEY)')
-    try:
-        from alpaca.trading.client import TradingClient  # type: ignore
-
-        client = TradingClient(api_key=key_id, secret_key=secret, paper=use_paper)
-        acct = client.get_account()
-        sub = getattr(acct, 'market_data_subscription', None) or getattr(acct, 'data_feed', None)
-        if isinstance(sub, str):
-            entitled = {sub.lower()}
-        elif isinstance(sub, (set, list, tuple)):
-            entitled = {str(x).lower() for x in sub}
-        else:
-            entitled = set()
-        if entitled and feed not in entitled:
-            alt = next(iter(entitled))
-            logging.getLogger(__name__).warning(
-                'ALPACA_FEED_UNENTITLED_SWITCH', extra={'requested': feed, 'using': alt}
-            )
-            feed = alt
-    except Exception:
-        pass
+    if ALPACA_AVAILABLE:
+        try:
+            TradingClient = get_trading_client_cls()
+            client = TradingClient(api_key=key_id, secret_key=secret, paper=use_paper)
+            if hasattr(client, 'get_account'):
+                acct = client.get_account()
+                sub = getattr(acct, 'market_data_subscription', None) or getattr(acct, 'data_feed', None)
+                if isinstance(sub, str):
+                    entitled = {sub.lower()}
+                elif isinstance(sub, (set, list, tuple)):
+                    entitled = {str(x).lower() for x in sub}
+                else:
+                    entitled = set()
+                if entitled and feed not in entitled:
+                    alt = next(iter(entitled))
+                    logging.getLogger(__name__).warning(
+                        'ALPACA_FEED_UNENTITLED_SWITCH', extra={'requested': feed, 'using': alt}
+                    )
+                    feed = alt
+            else:
+                logging.getLogger(__name__).warning('ALPACA_CLIENT_NO_GET_ACCOUNT')
+        except Exception:
+            pass
     return AlpacaConfig(
         base_url=base_url,
         key_id=key_id,


### PR DESCRIPTION
## Summary
- defer TradingClient imports to `get_trading_client_cls` and only instantiate when Alpaca SDK is available
- warn and fall back to HTTP account fetch when the client lacks `get_account`
- guard Alpaca feed entitlement check behind lazy client detection

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `RUN_HEALTHCHECK=1 python -m ai_trading.app` *(fails: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68c07b7f66e48330b10dfcb032386905