### PR TITLE
Add required imports to conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
-import importlib
 import os
 import random
+import importlib
 import sys
 import types
 from pathlib import Path


### PR DESCRIPTION
## Summary
- ensure `os`, `random`, and `importlib` are imported at the top of `conftest.py`

## Testing
- `ruff check conftest.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'requests')*

## Rollback Plan
- Revert this commit.

------
https://chatgpt.com/codex/tasks/task_e_68c07b7ff3b48330ac37513c05088427