### PR TITLE
Cache Alpaca data client availability in bot engine

### DIFF
--- a/tests/test_data_client_import_cache.py
+++ b/tests/test_data_client_import_cache.py
@@ -1,0 +1,23 @@
+import importlib
+
+import pytest
+
+
+def test_data_client_import_failure_cached(monkeypatch):
+    be = importlib.reload(
+        __import__("ai_trading.core.bot_engine", fromlist=["dummy"])
+    )
+    calls = {"n": 0}
+
+    def boom():
+        calls["n"] += 1
+        raise ImportError("boom")
+
+    monkeypatch.setattr(be, "get_data_client_cls", boom)
+    monkeypatch.setattr(be, "_ALPACA_DATA_CLIENT_AVAILABLE", True)
+
+    with pytest.raises(ImportError):
+        be._get_data_client_cls_cached()
+    with pytest.raises(ImportError):
+        be._get_data_client_cls_cached()
+    assert calls["n"] == 1


### PR DESCRIPTION
## Summary
- cache Alpaca data client import failures and skip re-imports once unavailable
- use cached check in `BotEngine` and Alpaca client initialization
- add unit test covering cached ImportError behavior

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `RUN_HEALTHCHECK=1 python -m ai_trading.app &` and `curl -sf http://127.0.0.1:9001/healthz`

## Rollback Plan
- Revert the commits via `git revert` if issues arise.


------
https://chatgpt.com/codex/tasks/task_e_68c07d22a0548330a2010710a3bf5a9d