### PR TITLE
Handle missing Alpaca SDK during startup

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -522,7 +522,7 @@ class BotEngine:
         self._trading_client_cls = trading_client_cls or get_trading_client_cls()
         self._data_client_cls = data_client_cls or _get_data_client_cls_cached()
         global APIError
-        if getattr(APIError, "__module__", "") == __name__:
+        if getattr(APIError, "__module__", "") == __name__ and ALPACA_AVAILABLE:
             APIError = get_api_error_cls()
         # Load universe tickers once and store on both engine and runtime
         self._tickers = load_universe()


### PR DESCRIPTION
## Summary
- handle ImportError when initializing Alpaca clients
- skip attaching Alpaca clients when the SDK is absent
- guard BotEngine against missing Alpaca APIError class

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c081808e0c833090766f5adb25075f