### PR TITLE
fail fast when alpaca sdk missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A sophisticated **AI-powered algorithmic trading system** that combines machine 
 ```bash
 python -m pip install -U pip
 pip install -e .  # installs alpaca-py==0.42.0
+python -c "from alpaca.trading.client import TradingClient"  # verify alpaca-py
 python -m ai_trading --dry-run
 ruff check .
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
@@ -26,6 +27,8 @@ RUN_HEALTHCHECK=1 python -m ai_trading.app &
 curl -s http://127.0.0.1:9001/healthz
 curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9001/metrics
 ```
+
+The import test confirms the Alpaca SDK is ready; if it fails, install it with `pip install alpaca-py`.
 
 The dry run exits with status **0** and prints `INDICATOR_IMPORT_OK`, confirming optional indicator modules are available.
 

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -55,6 +55,7 @@ from ai_trading.config.management import (
     _resolve_alpaca_env,
 )
 from ai_trading.metrics import get_histogram, get_counter
+from ai_trading.alpaca_api import ALPACA_AVAILABLE
 from time import monotonic as _mono
 
 
@@ -502,6 +503,9 @@ def parse_cli(argv: list[str] | None = None):
 def main(argv: list[str] | None = None) -> None:
     """Start the API thread and repeatedly run trading cycles."""
     ensure_dotenv_loaded()
+    if not ALPACA_AVAILABLE:
+        logger.error("ALPACA_PY_REQUIRED: pip install alpaca-py is required")
+        raise SystemExit(1)
     _fail_fast_env()
     args = parse_cli(argv)
     global config

--- a/tests/test_main_alpaca_py_required.py
+++ b/tests/test_main_alpaca_py_required.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+def test_main_exits_when_alpaca_sdk_missing(monkeypatch, caplog):
+    import ai_trading.main as m
+
+    monkeypatch.setattr(m, "ALPACA_AVAILABLE", False)
+    with caplog.at_level("ERROR"):
+        with pytest.raises(SystemExit) as excinfo:
+            m.main([])
+    assert excinfo.value.code == 1
+    assert any("pip install alpaca-py" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Summary
- exit at startup if `alpaca-py` isn't installed with a clear log message
- document verifying `alpaca-py` via a simple import
- test coverage for missing Alpaca SDK path

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0818193f083308228c1ad6eb4b1de