### PR TITLE
Guard logging setup to avoid duplicates

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -331,6 +331,8 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
     environment variable.
     """
     global _configured, _log_queue, _listener, _LOGGING_CONFIGURED
+    if _LOGGING_CONFIGURED:
+        return logging.getLogger()
     if debug:
         # Deprecated: retain for callers that still pass ``debug=True``.
         # The effective log level is derived from configuration instead.


### PR DESCRIPTION
## Summary
- Ensure `setup_logging` immediately returns when logging is already configured
- Confirm main initializes logging once and other modules do not reconfigure

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `python -m ai_trading.main --dry-run`

------
https://chatgpt.com/codex/tasks/task_e_68c084765fcc833084880d70c4c95f27