### PR TITLE
propagate SystemExit for accurate restart

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -148,7 +148,7 @@ Group=ai-trading
 WorkingDirectory=/opt/ai-trading-bot
 Environment=PATH=/opt/ai-trading-bot/venv/bin
 ExecStart=/opt/ai-trading-bot/venv/bin/python -m ai_trading
-Restart=always
+Restart=on-failure
 RestartSec=10
 StandardOutput=journal
 StandardError=journal

--- a/README.md
+++ b/README.md
@@ -1113,7 +1113,7 @@ Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
 Environment=AI_TRADING_MODELS_DIR=/var/lib/ai-trading-bot/models
 Environment=AI_TRADING_OUTPUT_DIR=/var/lib/ai-trading-bot/output
 ExecStart=/opt/ai-trading-bot/venv/bin/python -m ai_trading
-Restart=always
+Restart=on-failure
 RestartSec=10
 
 [Install]

--- a/ai_trading/__main__.py
+++ b/ai_trading/__main__.py
@@ -235,13 +235,10 @@ def main() -> int:
         # Delegate to main; it starts the API server thread and the scheduler loop
         _main.main(mapped_argv)
         return 0
-    except SystemExit as e:  # AI-AGENT-REF: do not propagate non-zero exits
-        try:
-            code = int(getattr(e, "code", 1) or 0)
-        except Exception:
-            code = 1
-        logger.error("ai_trading.main exited with code %s; degrading to 0 to avoid service crash", code, exc_info=True)
-        return 0
+    except SystemExit as e:
+        code = getattr(e, "code", None)
+        logger.error("ai_trading.main exited with code %s", code, exc_info=True)
+        raise
     except (ValueError, HTTPError) as e:
         logger.error("startup error: %s", e, exc_info=True)
         if "--dry-run" in sys.argv:

--- a/docs/peak_performance.md
+++ b/docs/peak_performance.md
@@ -295,7 +295,7 @@ Type=simple
 User=trading
 WorkingDirectory=/opt/ai-trading-bot
 ExecStart=/opt/ai-trading-bot/start.sh
-Restart=always
+Restart=on-failure
 RestartSec=10
 
 # Performance environment

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -25,7 +25,7 @@ ExecStartPre=/usr/bin/install -d -m 700 -o aiuser -g aiuser \
 ExecStart=/home/aiuser/ai-trading-bot/venv/bin/python -m ai_trading
 # Allow long-lived process; systemd will supervise restarts
 RuntimeMaxSec=0
-Restart=always
+Restart=on-failure
 RestartSec=10
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Summary
- re-raise `SystemExit` in `ai_trading.__main__` so the real exit code reaches the supervisor
- rely on `Restart=on-failure` in systemd unit and docs

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `TIMEFRAME=bad python3 -m ai_trading >/tmp/run.log 2>&1 || tail -n 20 /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68c0847a0b588330a88ea8af3b4addaa