### PR TITLE
Ensure Alpaca SDK preflight checks and deployment install

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -55,7 +55,6 @@ from ai_trading.config.management import (
     _resolve_alpaca_env,
 )
 from ai_trading.metrics import get_histogram, get_counter
-from ai_trading.alpaca_api import ALPACA_AVAILABLE
 from time import monotonic as _mono
 
 
@@ -89,6 +88,15 @@ def preflight_import_health() -> None:
             raise SystemExit(1)
     logger.info("IMPORT_PREFLIGHT_OK")
     ensure_trade_log_path()
+
+
+def _check_alpaca_sdk() -> None:
+    """Ensure the Alpaca SDK is installed before continuing."""
+    import importlib.util
+
+    if importlib.util.find_spec("alpaca") is None:
+        logger.error("ALPACA_PY_REQUIRED: pip install alpaca-py is required")
+        raise SystemExit(1)
 
 
 def run_cycle() -> None:
@@ -503,9 +511,7 @@ def parse_cli(argv: list[str] | None = None):
 def main(argv: list[str] | None = None) -> None:
     """Start the API thread and repeatedly run trading cycles."""
     ensure_dotenv_loaded()
-    if not ALPACA_AVAILABLE:
-        logger.error("ALPACA_PY_REQUIRED: pip install alpaca-py is required")
-        raise SystemExit(1)
+    _check_alpaca_sdk()
     _fail_fast_env()
     args = parse_cli(argv)
     global config

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,7 @@ ssh "$SERVER" << EOF
   fi
   source venv/bin/activate
   pip install --upgrade pip setuptools >/dev/null
-  pip install --quiet -r requirements.txt
+  pip install --quiet -e .
   sudo systemctl restart tradingbot
   echo "✅ Bot restarted on $SERVER"
 EOF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "idna>=3.4,<4",
   "psutil>=5.9,<6",
   "portalocker==2.7.0",
-  "alpaca-py>=0.42.0,<1",  # AI-AGENT-REF: include Alpaca SDK
+  "alpaca-py>=0.42.1,<1",  # AI-AGENT-REF: include Alpaca SDK
   "joblib>=1.3,<2",
   "Flask>=3,<4",
   "beautifulsoup4>=4.12,<5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer>=3.2,<4
 idna>=3.4,<4
 psutil>=5.9,<6
 portalocker==2.7.0
-alpaca-py==0.42.0  # AI-AGENT-REF: official Alpaca SDK (prod)
+alpaca-py==0.42.1  # AI-AGENT-REF: official Alpaca SDK (prod)
 finnhub-python>=2.4,<3  # AI-AGENT-REF: optional Finnhub provider
 joblib>=1.3,<2
 Flask>=3,<4


### PR DESCRIPTION
## Summary
- pin Alpaca SDK to 0.42.1 in project config and requirements
- install package dependencies via `pip install -e .` during deploy
- fail fast when Alpaca SDK is missing

## Testing
- `python -m pip install --ignore-requires-python -e .`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: multiple test failures)*
- `AI_TRADING_MAX_POSITION_SIZE=1 ALPACA_API_KEY=key ALPACA_SECRET_KEY=secret ALPACA_DATA_FEED=iex WEBHOOK_SECRET=foo CAPITAL_CAP=0.5 DOLLAR_RISK_LIMIT=0.5 ALPACA_API_URL=https://paper-api.alpaca.markets IMPORT_PREFLIGHT_DISABLED=1 python -m ai_trading.main --iterations 1 --interval 1`


------
https://chatgpt.com/codex/tasks/task_e_68c08477717c833093341db06e428067