### PR TITLE
Avoid duplicate logging configure messages

### DIFF
--- a/tests/test_configure_logging_once.py
+++ b/tests/test_configure_logging_once.py
@@ -1,0 +1,41 @@
+import logging
+import os
+
+import ai_trading.logging as L
+
+
+def test_configure_logging_logs_once(capsys):
+    root = logging.getLogger()
+    original_handlers = root.handlers.copy()
+    try:
+        root.handlers.clear()
+        os.environ['PYTEST_RUNNING'] = '1'
+        with L._LOGGING_LOCK:
+            L._LOGGING_CONFIGURED = False
+            L._configured = False
+            if L._listener is not None:
+                try:
+                    L._listener.stop()
+                except Exception:
+                    pass
+            L._listener = None
+            L._log_queue = None
+            L._loggers.clear()
+        L.configure_logging()
+        L.configure_logging()
+        out = capsys.readouterr().out
+        assert out.count('Logging configured successfully - no duplicates possible') == 1
+    finally:
+        root.handlers = original_handlers
+        with L._LOGGING_LOCK:
+            L._LOGGING_CONFIGURED = False
+            L._configured = False
+            if L._listener is not None:
+                try:
+                    L._listener.stop()
+                except Exception:
+                    pass
+            L._listener = None
+            L._log_queue = None
+            L._loggers.clear()
+        os.environ.pop('PYTEST_RUNNING', None)


### PR DESCRIPTION
## Summary
- short-circuit configure_logging when logging is already initialized
- avoid reconfiguring in get_logger and return cached logger
- add regression test confirming configure_logging only logs success once

## Testing
- `ruff check tests/test_configure_logging_once.py ai_trading/logging/__init__.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_configure_logging_once.py tests/test_logging_setup_idempotent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c08c323200833097a8c1a154f85d4e