### PR TITLE
Align Alpaca SDK imports and version

### DIFF
--- a/TESTING_FRAMEWORK.md
+++ b/TESTING_FRAMEWORK.md
@@ -427,7 +427,7 @@ import pytest
 import os
 from unittest.mock import patch
 from alpaca.trading.client import TradingClient
-from alpaca.data.historical import StockHistoricalDataClient
+from alpaca.data.historical.stock import StockHistoricalDataClient
 from alpaca.data.requests import StockBarsRequest
 from alpaca.data.timeframe import TimeFrame
 

--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -75,7 +75,7 @@ def _module_exists(name: str) -> bool:
 ALPACA_AVAILABLE = (
     _module_exists("alpaca")
     and _module_exists("alpaca.trading.client")
-    and _module_exists("alpaca.data.historical")
+    and _module_exists("alpaca.data.historical.stock")
     and _module_exists("alpaca.common.exceptions")
 )
 HAS_PANDAS: bool = _module_exists("pandas")  # AI-AGENT-REF: expose pandas availability
@@ -90,7 +90,7 @@ def initialize() -> None:
     """
     try:
         importlib.import_module("alpaca.trading.client")
-        importlib.import_module("alpaca.data.historical")
+        importlib.import_module("alpaca.data.historical.stock")
         importlib.import_module("alpaca.common.exceptions")
     except Exception as exc:  # pragma: no cover - exercised in tests
         raise RuntimeError("alpaca-py SDK is required") from exc
@@ -173,7 +173,7 @@ def get_trading_client_cls():
 
 def get_data_client_cls():
     """Return the Alpaca StockHistoricalDataClient class via lazy import."""
-    from alpaca.data.historical import StockHistoricalDataClient  # type: ignore
+    from alpaca.data.historical.stock import StockHistoricalDataClient  # type: ignore
 
     return StockHistoricalDataClient
 

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -123,7 +123,7 @@ def _alpaca_available() -> bool:
 from ai_trading.data import bars
 
 try:  # pragma: no cover
-    from alpaca.data.historical import StockHistoricalDataClient  # type: ignore
+    from alpaca.data.historical.stock import StockHistoricalDataClient  # type: ignore
 except ImportError:  # pragma: no cover
     class StockHistoricalDataClient:  # type: ignore[no-redef]
         """Fallback when alpaca-py is unavailable."""

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -10,7 +10,7 @@ aiohttp==3.12.15
     # via -r requirements.txt
 aiosignal==1.4.0
     # via aiohttp
-alpaca-py==0.42.0
+alpaca-py==0.42.1
     # via
     #   -r requirements-dev.txt
     #   -r requirements.txt

--- a/constraints.txt
+++ b/constraints.txt
@@ -10,7 +10,7 @@ aiohttp==3.12.15
     # via -r requirements.txt
 aiosignal==1.4.0
     # via aiohttp
-alpaca-py==0.42.0
+alpaca-py==0.42.1
     # via -r requirements.txt
 annotated-types==0.7.0
     # via pydantic

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 -r requirements.txt
 
 # Ensure Alpaca SDK available for tests
-alpaca-py==0.42.0
+alpaca-py==0.42.1
 
 # Lint & format
 ruff==0.5.6

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,4 +14,4 @@ gymnasium>=0.29
 portalocker>=2.7
 joblib>=1.3
 requests>=2.31,<3
-alpaca-py==0.42.0
+alpaca-py==0.42.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ numpy>=1.26
 pandas>=2.2
 pandas-market-calendars>=5.1
 tzdata>=2024.1  # AI-AGENT-REF: ensure timezone data
-alpaca-py==0.42.0
+alpaca-py==0.42.1
 pytest>=7.4
 pytest-xdist>=3.6
 psutil>=5.9

--- a/scripts/download_backtest_data.py
+++ b/scripts/download_backtest_data.py
@@ -11,7 +11,7 @@ from zoneinfo import ZoneInfo
 
 from typing import TYPE_CHECKING
 from ai_trading.utils.lazy_imports import load_pandas
-from alpaca.data.historical import StockHistoricalDataClient
+from alpaca.data.historical.stock import StockHistoricalDataClient
 from alpaca.data.requests import StockBarsRequest
 from alpaca.data.timeframe import TimeFrame
 from ai_trading.env import ensure_dotenv_loaded


### PR DESCRIPTION
## Summary
- Pin `alpaca-py` to 0.42.1 across requirements and constraints
- Update Alpaca historical data imports to new `alpaca.data.historical.stock` path
- Extend runtime Alpaca SDK checks to ensure historical client module exists

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: tests/bot_engine/test_trade_log_init.py::test_get_trade_logger_warns_when_dir_not_writable, tests/data/test_empty_responses.py::test_alpaca_empty_responses_trigger_backup)*
- `ALPACA_API_KEY=foo ALPACA_SECRET_KEY=bar ALPACA_API_URL=https://paper-api.alpaca.markets RUN_HEALTHCHECK=1 python -m ai_trading.app &` + `curl -sf http://127.0.0.1:9001/healthz`

------
https://chatgpt.com/codex/tasks/task_e_68c08c2fcdf08330bdcdc3b25d3ed182