### PR TITLE
Handle inaccessible /proc entries during port lookup

### DIFF
--- a/ai_trading/utils/base.py
+++ b/ai_trading/utils/base.py
@@ -494,7 +494,11 @@ def _pid_from_inode(inode: str) -> int | None:
         fd_dir = f"/proc/{pid}/fd"
         if not os.path.isdir(fd_dir):
             continue
-        for fd in os.listdir(fd_dir):
+        try:
+            fds = os.listdir(fd_dir)
+        except OSError:
+            continue
+        for fd in fds:
             try:
                 if os.readlink(os.path.join(fd_dir, fd)) == f"socket:[{inode}]":
                     return int(pid)
@@ -514,7 +518,7 @@ def get_pid_on_port(port: int) -> int | None:
                 inode = parts[9]
                 if int(local.split(":")[1], 16) == port:
                     return _pid_from_inode(inode)
-    except COMMON_EXC as e:
+    except COMMON_EXC + (OSError,) as e:
         logger.error("get_pid_on_port failed", exc_info=e)
         return None
 


### PR DESCRIPTION
## Summary
- skip unreadable `/proc/<pid>/fd` directories in `_pid_from_inode`
- handle `OSError` in `get_pid_on_port`

## Testing
- `ruff check ai_trading/utils/base.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_main_extended2.py::test_run_flask_app tests/test_main_extended2.py::test_run_flask_app_port_in_use -q`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c08c323cb48330abc8198edf001f1d