### PR TITLE
chore: bump alpaca-py constraint to 0.42.1

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -10,7 +10,7 @@ aiohttp==3.12.15
     # via -r requirements.txt
 aiosignal==1.4.0
     # via aiohttp
-alpaca-py==0.42.0
+alpaca-py==0.42.1
     # via
     #   -r requirements-dev.txt
     #   -r requirements.txt

--- a/constraints.txt
+++ b/constraints.txt
@@ -10,7 +10,7 @@ aiohttp==3.12.15
     # via -r requirements.txt
 aiosignal==1.4.0
     # via aiohttp
-alpaca-py==0.42.0
+alpaca-py==0.42.1
     # via -r requirements.txt
 annotated-types==0.7.0
     # via pydantic


### PR DESCRIPTION
## Summary
- align constraints files with alpaca-py 0.42.1

## Testing
- `pip install --dry-run -r requirements.txt -c constraints.txt` *(fails: large downloads, aborted)*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c08c3087c08330ada059c18c941385