### PR TITLE
Use configure_logging in main and test logging once

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -18,22 +18,10 @@ import ai_trading.logging as _logging
 
 # Determine log file from environment
 LOG_FILE = os.getenv("BOT_LOG_FILE", "logs/bot.log")
-
-# Reset any prior logging configuration to apply new settings
-if getattr(_logging, "_listener", None):
-    try:
-        _logging._listener.stop()
-    except Exception:  # pragma: no cover - best effort cleanup
-        pass
-    _logging._listener = None
-_logging._configured = False
-_logging._LOGGING_CONFIGURED = False
-logging.getLogger().handlers.clear()
-
 # Configure logging with the desired file
 # Logging must be initialized once here before importing heavy modules like
 # ``ai_trading.core.bot_engine``.
-_logging.setup_logging(log_file=LOG_FILE)
+_logging.configure_logging(log_file=LOG_FILE)
 
 # Module logger
 logger = _logging.get_logger(__name__)

--- a/tests/test_configure_logging_once.py
+++ b/tests/test_configure_logging_once.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import os
 
@@ -10,32 +11,12 @@ def test_configure_logging_logs_once(capsys):
     try:
         root.handlers.clear()
         os.environ['PYTEST_RUNNING'] = '1'
-        with L._LOGGING_LOCK:
-            L._LOGGING_CONFIGURED = False
-            L._configured = False
-            if L._listener is not None:
-                try:
-                    L._listener.stop()
-                except Exception:
-                    pass
-            L._listener = None
-            L._log_queue = None
-            L._loggers.clear()
-        L.configure_logging()
-        L.configure_logging()
+        log_mod = importlib.reload(L)
+        log_mod.configure_logging()
+        log_mod.configure_logging()
         out = capsys.readouterr().out
         assert out.count('Logging configured successfully - no duplicates possible') == 1
     finally:
         root.handlers = original_handlers
-        with L._LOGGING_LOCK:
-            L._LOGGING_CONFIGURED = False
-            L._configured = False
-            if L._listener is not None:
-                try:
-                    L._listener.stop()
-                except Exception:
-                    pass
-            L._listener = None
-            L._log_queue = None
-            L._loggers.clear()
+        importlib.reload(L)
         os.environ.pop('PYTEST_RUNNING', None)


### PR DESCRIPTION
## Summary
- Replace manual `setup_logging` call with idempotent `configure_logging`
- Simplify logging initialization by removing manual state resets
- Add regression test to ensure "Logging configured successfully" only logs once

## Testing
- `ruff check ai_trading/main.py tests/test_configure_logging_once.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ad6537e08330b40ada90a1793f9f