### PR TITLE
Gate Alpaca client missing logs

### DIFF
--- a/ai_trading/core/alpaca_client.py
+++ b/ai_trading/core/alpaca_client.py
@@ -29,7 +29,10 @@ def _validate_trading_api(api: Any) -> bool:
     - Guarantees `list_positions` exists, mapping to `get_all_positions()` if needed.
     """
     if api is None:
-        logger_once.error("ALPACA_CLIENT_MISSING", key="alpaca_client_missing")
+        if ALPACA_AVAILABLE and not is_shadow_mode():
+            logger_once.error("ALPACA_CLIENT_MISSING", key="alpaca_client_missing")
+        else:
+            logger_once.warning("ALPACA_CLIENT_MISSING", key="alpaca_client_missing")
         return False
     if not hasattr(api, "list_orders"):
         if hasattr(api, "get_orders"):
@@ -124,7 +127,14 @@ def ensure_alpaca_attached(ctx) -> None:
     import ai_trading.core.bot_engine as be
     api = getattr(be, "trading_client", None)
     if api is None:
-        logger_once.error("ALPACA_CLIENT_MISSING after initialization", key="alpaca_client_missing")
+        if ALPACA_AVAILABLE and not is_shadow_mode():
+            logger_once.error(
+                "ALPACA_CLIENT_MISSING after initialization", key="alpaca_client_missing"
+            )
+        else:
+            logger_once.warning(
+                "ALPACA_CLIENT_MISSING after initialization", key="alpaca_client_missing"
+            )
         if not is_shadow_mode():
             raise RuntimeError("Alpaca client missing after initialization")
         return

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -252,9 +252,14 @@ def ensure_alpaca_attached(ctx) -> None:
         return
     global trading_client
     if trading_client is None:
-        logger_once.error(
-            "ALPACA_CLIENT_MISSING after initialization", key="alpaca_client_missing"
-        )
+        if ALPACA_AVAILABLE and not is_shadow_mode():
+            logger_once.error(
+                "ALPACA_CLIENT_MISSING after initialization", key="alpaca_client_missing"
+            )
+        else:
+            logger_once.warning(
+                "ALPACA_CLIENT_MISSING after initialization", key="alpaca_client_missing"
+            )
         if not is_shadow_mode():
             raise RuntimeError("Alpaca client missing after initialization")
         return

--- a/tests/test_broker_unavailable_paths.py
+++ b/tests/test_broker_unavailable_paths.py
@@ -1,5 +1,6 @@
 import logging
 from types import SimpleNamespace
+import logging
 
 from ai_trading.core import bot_engine
 from ai_trading.core.bot_engine import check_pdt_rule, safe_alpaca_get_account
@@ -26,19 +27,25 @@ def test_run_all_trades_aborts_without_api(monkeypatch, caplog):
     """run_all_trades_worker should abort early when Alpaca client missing."""
     logger_once._emitted_keys.clear()
     state = bot_engine.BotState()
+    monkeypatch.setenv("SHADOW_MODE", "true")
+    monkeypatch.setenv("WEBHOOK_SECRET", "test")
     runtime = bot_engine.get_ctx()
     runtime.api = None
-    monkeypatch.setenv("SHADOW_MODE", "true")
     monkeypatch.setattr(bot_engine, "is_market_open", lambda: True)
     monkeypatch.setattr(bot_engine, "_ensure_alpaca_classes", lambda: None)
     monkeypatch.setattr(bot_engine, "_ALPACA_IMPORT_ERROR", None)
+    monkeypatch.setattr(bot_engine, "get_minute_df", lambda *a, **k: None)
+    monkeypatch.setattr(bot_engine, "last_minute_bar_age_seconds", lambda *a, **k: 0)
+    monkeypatch.setattr(bot_engine, "get_cached_minute_timestamp", lambda *a, **k: 0)
     heartbeat = {}
     monkeypatch.setattr(bot_engine, "_send_heartbeat", lambda: heartbeat.setdefault("called", True))
     def fail(*a, **k):
         raise AssertionError("PDT should not be called")
     monkeypatch.setattr(bot_engine, "check_pdt_rule", fail)
-    with caplog.at_level("ERROR"):
+    with caplog.at_level(logging.WARNING):
         bot_engine.run_all_trades_worker(state, runtime)
     assert heartbeat.get("called")
     msgs = [r.getMessage() for r in caplog.records]
     assert any("ALPACA_CLIENT_MISSING" in m for m in msgs)
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
+    assert not any(r.levelno >= logging.ERROR for r in caplog.records)


### PR DESCRIPTION
## Summary
- Log `ALPACA_CLIENT_MISSING` as an error only when Alpaca is available and not in shadow mode
- Warn instead of error when Alpaca is intentionally unavailable and a fallback is used
- Update broker unavailable path test to expect warning level and stub data fetchers

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*


------
https://chatgpt.com/codex/tasks/task_e_68c1ad4d74d883309540898a6c91ccae