### PR TITLE
Handle IPv6 ports when selecting Flask port

### DIFF
--- a/tests/utils/test_get_pid_on_port_ipv6.py
+++ b/tests/utils/test_get_pid_on_port_ipv6.py
@@ -1,0 +1,16 @@
+import os
+import socket
+
+from ai_trading.utils import get_pid_on_port
+
+
+def test_get_pid_on_port_ipv6():
+    s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    s.bind(("::", 0))
+    s.listen(1)
+    port = s.getsockname()[1]
+    try:
+        pid = get_pid_on_port(port)
+        assert pid == os.getpid()
+    finally:
+        s.close()


### PR DESCRIPTION
## Summary
- search `/proc/net/tcp6` in `get_pid_on_port` so IPv6 listeners are detected
- retry `run_flask_app` on incremented ports when `EADDRINUSE` occurs
- test IPv6 port detection and Flask port fallback

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1c051114c8330a352e3cf47259b63