### PR TITLE
chore: drop alpaca extras from requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@
 -r requirements.txt
 
 # Ensure Alpaca SDK available for tests
-alpaca-py[all]==0.42.1
+alpaca-py==0.42.1
 
 # Lint & format
 ruff==0.5.6

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,4 +14,4 @@ gymnasium>=0.29
 portalocker>=2.7
 joblib>=1.3
 requests>=2.31,<3
-alpaca-py[all]==0.42.1
+alpaca-py==0.42.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ charset-normalizer>=3.2,<4
 idna>=3.4,<4
 psutil>=5.9,<6
 portalocker==2.7.0
-alpaca-py[all]==0.42.1  # AI-AGENT-REF: official Alpaca SDK (prod) with historical data extras
+alpaca-py==0.42.1  # AI-AGENT-REF: official Alpaca SDK (prod)
 finnhub-python>=2.4,<3  # AI-AGENT-REF: optional Finnhub provider
 joblib>=1.3,<2
 Flask>=3,<4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ numpy>=1.26
 pandas>=2.2
 pandas-market-calendars>=5.1
 tzdata>=2024.1  # AI-AGENT-REF: ensure timezone data
-alpaca-py[all]==0.42.1
+alpaca-py==0.42.1
 pytest>=7.4
 pytest-xdist>=3.6
 psutil>=5.9


### PR DESCRIPTION
## Summary
- remove invalid `alpaca-py[all]` extras spec from requirements files

## Testing
- `python -m pip install -U pip`
- `pip install -r requirements-dev.txt -r requirements/dev.txt -r requirements-test.txt`
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: Interrupted: 49 errors during collection)*
- `RUN_HEALTHCHECK=1 python -m ai_trading.app & curl -sf http://127.0.0.1:$HEALTHCHECK_PORT/healthz`


------
https://chatgpt.com/codex/tasks/task_e_68c1c59b9e4083309b5a62fbb4ed9038