### PR TITLE
Skip reconciliation when broker context missing

### DIFF
--- a/ai_trading/execution/reconcile.py
+++ b/ai_trading/execution/reconcile.py
@@ -309,10 +309,10 @@ def reconcile_positions_and_orders(ctx=None) -> ReconciliationResult:
         Reconciliation outcome including any detected drifts.  The result's
         ``reconciled_at`` timestamp reflects when the reconciliation occurred.
     """
-    broker_client = getattr(ctx, "api", None) if ctx else None
-    if broker_client is None:
-        logger.debug("No broker context available for reconciliation")
+    if not getattr(ctx, "api", None):
         return ReconciliationResult([], [], [], datetime.now(UTC))
+
+    broker_client = ctx.api
 
     # Extract local state
     local_positions: dict[str, int] = {}


### PR DESCRIPTION
## Summary
- avoid reconciliation when context lacks broker API
- return empty result instead of logging warnings

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `python - <<'PY'
from ai_trading.execution.reconcile import reconcile_positions_and_orders
import logging
logging.basicConfig(level=logging.INFO)
reconcile_positions_and_orders()
print('done')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c1d2d9724c8330ab016a28910663d6