### PR TITLE
Expose market session times in LazyBotContext

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -6468,6 +6468,16 @@ class LazyBotContext:
         return self._context.volume_threshold
 
     @property
+    def market_open(self):
+        self._ensure_initialized()
+        return self._context.market_open
+
+    @property
+    def market_close(self):
+        self._ensure_initialized()
+        return self._context.market_close
+
+    @property
     def kelly_fraction(self):
         self._ensure_initialized()
         return self._context.kelly_fraction
@@ -6519,6 +6529,10 @@ class LazyBotContext:
         else:
             self._ensure_initialized()
             setattr(self._context, name, value)
+
+    def __getattr__(self, name):
+        self._ensure_initialized()
+        return getattr(self._context, name)
 
 
 # AI-AGENT-REF: No module-level context creation to prevent import-time side effects


### PR DESCRIPTION
## Summary
- expose `market_open` and `market_close` on `LazyBotContext`
- delegate missing attributes via `LazyBotContext.__getattr__`

## Testing
- `python -m pip install -U pip`
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires Python 3.12)*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `SHADOW_MODE=1 TESTING=true AI_TRADING_DATA_CACHE_ENABLE=0 python -u - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c1d2d78e6083308184db1b16de0d8c