### PR TITLE
Guard SIP fallback behind capability flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,8 +741,9 @@ exits early with a clear error message when these values are invalid.
    ALPACA_DATA_FEED=iex
    # Set the following only if your Alpaca account has SIP permissions
   # ALPACA_DATA_FEED=sip
-  # ALPACA_ALLOW_SIP=1  # enable SIP feed and SIP fallback (requires SIP subscription)
-  # Without ALPACA_ALLOW_SIP, SIP requests are skipped and a warning is logged
+  # ALPACA_HAS_SIP=1      # set to 1 if your Alpaca account has SIP access
+  # ALPACA_ALLOW_SIP=1    # enable SIP feed and SIP fallback
+  # Without ALPACA_HAS_SIP, the fetcher uses the backup provider instead of SIP
   # ALPACA_SIP_UNAUTHORIZED=1  # legacy flag to suppress SIP after a 403
    ALPACA_ADJUSTMENT=all
    DATA_PROVIDER_PRIORITY=alpaca_iex,alpaca_sip,yahoo

--- a/ai_trading/scripts/self_check.py
+++ b/ai_trading/scripts/self_check.py
@@ -28,7 +28,10 @@ def _bars_time_window(timeframe: "TimeFrame") -> tuple[dt.datetime, dt.datetime]
 
 def main() -> None:
     feed = get_env("ALPACA_DATA_FEED", "iex")
-    if feed.lower() == "sip" and not get_env("ALPACA_ALLOW_SIP", "0", cast=bool):
+    if feed.lower() == "sip" and not (
+        get_env("ALPACA_ALLOW_SIP", "0", cast=bool)
+        and get_env("ALPACA_HAS_SIP", "0", cast=bool)
+    ):
         logger.warning("SIP_FEED_DISABLED", extra={"requested": "sip", "using": "iex"})
         feed = "iex"
     APIError = get_api_error_cls()


### PR DESCRIPTION
## Summary
- add `ALPACA_HAS_SIP` capability flag and `_sip_configured` helper
- skip SIP requests when unavailable and log once per symbol
- document new flag and ensure self-check respects it

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d2dabb4c8330865b62e0b510ab38