### PR TITLE
Add COST and NFLX symbol specs

### DIFF
--- a/ai_trading/market/symbol_specs.py
+++ b/ai_trading/market/symbol_specs.py
@@ -38,6 +38,8 @@ DEFAULT_SYMBOL_SPECS: dict[str, SymbolSpec] = {
     "XOM": SymbolSpec(tick=Decimal("0.01"), lot=1, trading_hours="09:30-16:00"),
     "BAC": SymbolSpec(tick=Decimal("0.01"), lot=1, trading_hours="09:30-16:00"),
     "V": SymbolSpec(tick=Decimal("0.01"), lot=1, trading_hours="09:30-16:00"),
+    "COST": SymbolSpec(tick=Decimal("0.01"), lot=1),
+    "NFLX": SymbolSpec(tick=Decimal("0.01"), lot=1),
     "SPY": SymbolSpec(tick=Decimal("0.01"), lot=1),
     "QQQ": SymbolSpec(tick=Decimal("0.01"), lot=1),
     "IWM": SymbolSpec(tick=Decimal("0.01"), lot=1),

--- a/tests/test_symbol_specs.py
+++ b/tests/test_symbol_specs.py
@@ -20,3 +20,11 @@ def test_unknown_symbol_uses_default_spec() -> None:
     spec = get_symbol_spec("UNKNOWN")
     assert spec is DEFAULT_SPEC
 
+
+@pytest.mark.parametrize("symbol", ["COST", "NFLX"])
+def test_default_specs(symbol: str) -> None:
+    spec = get_symbol_spec(symbol)
+    assert spec is not DEFAULT_SPEC
+    assert spec.tick == Decimal("0.01")
+    assert spec.lot == 1
+


### PR DESCRIPTION
## Summary
- add symbol specs for COST and NFLX
- add regression test covering new symbols

## Testing
- `ruff check ai_trading/market/symbol_specs.py tests/test_symbol_specs.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_symbol_specs.py::test_default_specs -q`

## Rollback Plan
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68c1d46caf148330a95d13afe2306e32