### PR TITLE
feat: fallback after empty Alpaca responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Config: validate Alpaca data feed entitlement and allow override via `ALPACA_DATA_FEED`, warning if switched.
 - Data fetch: switch to SIP feed after first empty IEX result and record `data.fetch.feed_switch` metric.
-- Data fetch: detect consecutive empty responses and trigger backup provider after two attempts, logging `ALPACA_EMPTY_RESPONSE_THRESHOLD`.
+ - Data fetch: track consecutive `error="empty"` responses per symbol/timeframe and, after `ALPACA_EMPTY_ERROR_THRESHOLD` attempts, switch to the backup provider while recording `data.fetch.empty` metrics.
 - Data fetch: add provider outage monitor that alerts on authentication, rate limit, or timeout failures and temporarily disables the primary feed to enable automatic fallback.
 - Main: finite `SCHEDULER_ITERATIONS` now exits promptly after completing
   the requested cycles instead of keeping the API thread alive. This

--- a/tests/test_alpaca_empty_error_fallback.py
+++ b/tests/test_alpaca_empty_error_fallback.py
@@ -1,0 +1,83 @@
+import json
+import types
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import ai_trading.data.fetch as fetch
+
+
+def _dt_range():
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+    return start, end
+
+
+def test_error_empty_switches_to_backup(monkeypatch):
+    pd = pytest.importorskip("pandas")
+    start, end = _dt_range()
+    fetch._ALPACA_EMPTY_ERROR_COUNTS.clear()
+    monkeypatch.setattr(fetch, "_ALLOW_SIP", False, raising=False)
+    monkeypatch.setattr(fetch, "_ENABLE_HTTP_FALLBACK", False, raising=False)
+    monkeypatch.setattr(fetch, "max_data_fallbacks", lambda: 0)
+    monkeypatch.setattr(fetch, "provider_priority", lambda: ["alpaca_iex"])
+    monkeypatch.setattr(fetch, "_ALPACA_EMPTY_ERROR_THRESHOLD", 2, raising=False)
+    monkeypatch.setattr(fetch, "_FETCH_BARS_MAX_RETRIES", 1, raising=False)
+    monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
+    monkeypatch.setattr(fetch, "_outside_market_hours", lambda *a, **k: False)
+    monkeypatch.setattr(fetch, "is_market_open", lambda: True)
+    monkeypatch.setattr(
+        fetch,
+        "get_settings",
+        lambda: types.SimpleNamespace(backup_data_provider="yahoo"),
+    )
+
+    class _Resp:
+        def __init__(self, corr_id: str):
+            self.status_code = 200
+            self.headers = {"Content-Type": "application/json", "x-request-id": corr_id}
+            self.text = json.dumps({"error": "empty"})
+
+        def json(self):
+            return {"error": "empty"}
+
+    class _Requests:
+        def __init__(self):
+            self.calls = 0
+
+        def get(self, url, params=None, headers=None, timeout=None):
+            self.calls += 1
+            return _Resp(f"id{self.calls}")
+
+    req = _Requests()
+    monkeypatch.setattr(fetch, "requests", req)
+
+    backup_calls = {"count": 0}
+
+    def fake_backup(symbol, start, end, interval):
+        backup_calls["count"] += 1
+        return pd.DataFrame(
+            [
+                {
+                    "timestamp": start,
+                    "open": 1.0,
+                    "high": 1.0,
+                    "low": 1.0,
+                    "close": 1.0,
+                    "volume": 1,
+                }
+            ]
+        )
+
+    monkeypatch.setattr(fetch, "_backup_get_bars", fake_backup)
+
+    out1 = fetch._fetch_bars("AAPL", start, end, "1Min", feed="iex")
+    assert out1.empty
+    assert req.calls == 1
+
+    out2 = fetch._fetch_bars("AAPL", start, end, "1Min", feed="iex")
+    assert not out2.empty
+    assert req.calls == 2
+    assert backup_calls["count"] == 1
+
+    assert ("AAPL", "1Min") not in fetch._ALPACA_EMPTY_ERROR_COUNTS


### PR DESCRIPTION
## Summary
- track consecutive Alpaca `error="empty"` responses per symbol/timeframe
- fall back to backup provider after hitting `ALPACA_EMPTY_ERROR_THRESHOLD`
- add regression test for empty-error fallback

## Testing
- `ruff check ai_trading/data/fetch/__init__.py tests/test_alpaca_empty_error_fallback.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_empty_error_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d46c2e348330914e971e8b3540c7