### PR TITLE
Initialize PositionReconciler with broker client and warn when missing

### DIFF
--- a/docs/API_KEY_SETUP.md
+++ b/docs/API_KEY_SETUP.md
@@ -86,9 +86,17 @@ ALPACA_SECRET_KEY=SKTEST1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCD
 - These keys allow testing without real money
 
 ### Production
-- Use **Live Trading** keys  
+- Use **Live Trading** keys
 - Set `ALPACA_BASE_URL=https://api.alpaca.markets`
 - ⚠️ **WARNING**: These keys trade with real money!
+
+### Position Reconciliation
+- The bot reconciles local positions with the broker only when valid
+  credentials are provided.
+- In test or development environments, supply **paper trading** keys to
+  enable reconciliation against the paper endpoint.
+- If no broker client is configured, the bot logs a single warning and
+  skips the reconciliation step.
 
 ## 🔧 Alternative Configuration Methods
 


### PR DESCRIPTION
## Summary
- wire broker client into `PositionReconciler` and expose `get_reconciler` helper
- guard bot startup reconciliation when no broker client is configured
- document required broker credentials and how to enable reconciliation in dev/test

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d7a092608330b67f2f2c1c4b034b