### PR TITLE
Ensure graceful shutdown logs and clean exit

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -15,7 +15,7 @@ sudo systemctl enable --now ai-trading.timer
 sudo systemctl status ai-trading.service
 ```
 
-The timer schedules the bot to start at market open and the service exits automatically after 6.5 hours (16:00 US/Eastern).
+The timer schedules the bot to start at market open and the service exits automatically after 6.5 hours (16:00 US/Eastern). On normal completion the process returns exit code `0` so systemd records a clean shutdown.
 
 If the bot is started manually outside regular hours, it waits until the next
 NYSE session before trading. Set `ALLOW_AFTER_HOURS=1` to disable this wait

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -7,6 +7,7 @@ import logging
 from threading import Thread
 import errno
 import signal
+import sys
 from datetime import datetime, UTC
 from zoneinfo import ZoneInfo
 from pathlib import Path
@@ -847,4 +848,15 @@ def main(argv: list[str] | None = None) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 1
+        if code != 0:
+            logger.error("SERVICE_EXIT", extra={"code": code})
+        raise
+    except BaseException:  # noqa: BLE001
+        logger.exception("SERVICE_CRASH")
+        sys.exit(1)
+    else:
+        sys.exit(0)

--- a/tests/test_service_exit.py
+++ b/tests/test_service_exit.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def test_service_exits_cleanly():
+    script = textwrap.dedent(
+        '''
+        import os, sys
+        from ai_trading import main as m
+
+        m.run_cycle = lambda: None
+        m.start_api_with_signal = lambda ready, err: ready.set()
+        m.time.sleep = lambda s: None
+        os.environ["IMPORT_PREFLIGHT_DISABLED"] = "1"
+        sys.exit(m.main(['--iterations','1','--interval','0']) or 0)
+        '''
+    )
+    proc = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
## Summary
- log unhandled top-level exceptions and propagate SystemExit codes
- explicitly return exit code 0 on normal service completion
- document clean shutdown behavior for systemd
- add regression test to confirm service exits with code 0

## Testing
- `python -m pip install -U pip` *(passes)*
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'requests')*

## Rollback Plan
- Revert these commits to restore prior shutdown handling and documentation.

------
https://chatgpt.com/codex/tasks/task_e_68c1d79ec64883309c8c2c256aa72ac9