### PR TITLE
Ensure orders use freshest prices and flag slippage

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8544,6 +8544,16 @@ def submit_order(
             core_side = CoreOrderSide.SELL
         else:
             core_side = CoreOrderSide.BUY
+
+        # If caller didn't supply a price, fetch the most recent quote.
+        if price is None:
+            price = get_latest_price(symbol)
+            if not isinstance(price, (int, float)) or price <= 0:
+                md = getattr(ctx, "market_data", None)
+                try:
+                    price = get_latest_close(md) if md is not None else 0.0
+                except Exception:
+                    price = 0.0
         # Pass through computed price so the execution engine can simulate
         # fills around the actual market price rather than a generic fallback.
         return _exec_engine.execute_order(symbol, core_side, qty, price=price)

--- a/docs/slippage.md
+++ b/docs/slippage.md
@@ -1,0 +1,16 @@
+# Slippage Modeling
+
+The execution engine applies a deterministic slippage model defined in `ai_trading/execution/slippage.py`.
+Prices are adjusted by a configurable number of basis points (bps) to simulate execution friction.
+
+## Configuration
+
+- `EXECUTION_PARAMETERS["MAX_SLIPPAGE_BPS"]` sets the maximum allowed slippage.
+- Override at runtime with the `MAX_SLIPPAGE_BPS` environment variable.
+- During tests (`TESTING=1`), the engine raises an error if absolute slippage exceeds this threshold.
+
+## Diagnostics
+
+After each order is filled, the engine logs a `SLIPPAGE_DIAGNOSTIC` entry comparing the expected
+submission price with the average fill price. This aids in monitoring execution quality and ensures
+that excessive slippage is detected early.

--- a/tests/test_slippage_threshold_enforced.py
+++ b/tests/test_slippage_threshold_enforced.py
@@ -1,0 +1,16 @@
+import os
+import pytest
+
+from ai_trading.execution import ExecutionEngine
+from ai_trading.core.enums import OrderSide
+from ai_trading.core.constants import EXECUTION_PARAMETERS
+
+
+def test_slippage_threshold_enforced(monkeypatch):
+    os.environ["TESTING"] = "true"
+    monkeypatch.setitem(EXECUTION_PARAMETERS, "MAX_SLIPPAGE_BPS", 10)
+    engine = ExecutionEngine()
+    # Force deterministic high slippage
+    monkeypatch.setattr("ai_trading.execution.engine.hash", lambda x: 99, raising=False)
+    with pytest.raises(AssertionError):
+        engine.execute_order("AAPL", OrderSide.BUY, 10, price=100.0)

--- a/tests/test_submit_order_fix.py
+++ b/tests/test_submit_order_fix.py
@@ -83,8 +83,9 @@ def test_submit_order_successful_execution():
     bot_engine._exec_engine = mock_exec_engine
 
     try:
-        # Mock market_is_open to return True
-        with patch('ai_trading.core.bot_engine.market_is_open', return_value=True):
+        # Mock market_is_open to return True and latest price lookup
+        with patch('ai_trading.core.bot_engine.market_is_open', return_value=True), \
+            patch('ai_trading.core.bot_engine.get_latest_price', return_value=101.0):
             mock_ctx = Mock(spec=BotContext)
 
             # Should successfully execute order
@@ -92,7 +93,7 @@ def test_submit_order_successful_execution():
 
             assert result == mock_order
             mock_exec_engine.execute_order.assert_called_once_with(
-                "AAPL", OrderSide.BUY, 10
+                "AAPL", OrderSide.BUY, 10, price=101.0
             )
 
     finally:
@@ -118,8 +119,9 @@ def test_submit_order_execution_error_propagation():
     bot_engine._exec_engine = mock_exec_engine
 
     try:
-        # Mock market_is_open to return True
-        with patch('ai_trading.core.bot_engine.market_is_open', return_value=True):
+        # Mock market_is_open to return True and latest price lookup
+        with patch('ai_trading.core.bot_engine.market_is_open', return_value=True), \
+            patch('ai_trading.core.bot_engine.get_latest_price', return_value=101.0):
             mock_ctx = Mock(spec=BotContext)
 
             # Should propagate the execution error

--- a/tests/vendor_stubs/alpaca/data/__init__.py
+++ b/tests/vendor_stubs/alpaca/data/__init__.py
@@ -1,5 +1,14 @@
 """Data subpackage for alpaca vendor stubs."""
 
 from . import timeframe, requests
+from .requests import StockBarsRequest, StockLatestQuoteRequest
+from .timeframe import TimeFrame, TimeFrameUnit
 
-__all__ = ["timeframe", "requests"]
+__all__ = [
+    "timeframe",
+    "requests",
+    "StockBarsRequest",
+    "StockLatestQuoteRequest",
+    "TimeFrame",
+    "TimeFrameUnit",
+]


### PR DESCRIPTION
## Summary
- fetch latest quote when price not provided in submit_order
- record and check slippage after simulated fills
- document slippage model and configuration

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_submit_order_fix.py tests/test_slippage_threshold_enforced.py tests/test_slippage.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1dc243a90833088944d6cbce42357