### PR TITLE
Add minute bar gap checks and optional backfilling

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -594,6 +594,52 @@ def _post_process(df: pd.DataFrame) -> pd.DataFrame:
     return _flatten_and_normalize_ohlcv(df)
 
 
+def _verify_minute_continuity(
+    df: pd.DataFrame, symbol: str, backfill: str | None = None
+) -> pd.DataFrame:
+    """Verify 1-minute bar continuity and optionally backfill gaps."""
+
+    pd_local = _ensure_pandas()
+    if (
+        pd_local is None
+        or df is None
+        or getattr(df, "empty", True)
+        or "timestamp" not in df.columns
+    ):
+        return df
+
+    df = df.sort_values("timestamp")
+    ts = pd_local.DatetimeIndex(df["timestamp"])
+    diffs = ts.to_series().diff().dt.total_seconds().iloc[1:]
+    missing = diffs[diffs > 60]
+    if missing.empty:
+        return df
+
+    warnings.warn(f"{symbol} minute data has {len(missing)} gaps", RuntimeWarning)
+    if not backfill:
+        return df
+
+    full_index = pd_local.date_range(ts.min(), ts.max(), freq="1min", tz=ts.tz)
+    df = df.set_index("timestamp").reindex(full_index)
+    df.index.name = "timestamp"
+
+    if backfill == "ffill":
+        df["close"] = df["close"].ffill()
+        df["open"] = df["open"].fillna(df["close"])
+        df["high"] = df["high"].fillna(df["close"])
+        df["low"] = df["low"].fillna(df["close"])
+        if "volume" in df.columns:
+            df["volume"] = df["volume"].fillna(0)
+    elif backfill == "interpolate":
+        cols = [c for c in ["open", "high", "low", "close", "volume"] if c in df.columns]
+        df[cols] = df[cols].interpolate(method="time")  # type: ignore[assignment]
+        if "volume" in df.columns:
+            df["volume"] = df["volume"].fillna(0)
+        df[cols] = df[cols].ffill().bfill()
+
+    return df.reset_index()
+
+
 def _ensure_http_client():
     try:
         from importlib import import_module
@@ -1706,8 +1752,16 @@ def _fetch_bars(
     return df
 
 
-def get_minute_df(symbol: str, start: Any, end: Any, feed: str | None = None) -> pd.DataFrame:
-    """Minute bars fetch with provider fallback and downgraded errors.
+def get_minute_df(
+    symbol: str,
+    start: Any,
+    end: Any,
+    feed: str | None = None,
+    *,
+    backfill: str | None = None,
+) -> pd.DataFrame:
+    """Minute bars fetch with provider fallback and gap handling.
+
     Also updates in-memory minute cache for freshness checks."""
     pd = _ensure_pandas()
     start_dt = ensure_datetime(start)
@@ -1832,6 +1886,8 @@ def get_minute_df(symbol: str, start: Any, end: Any, feed: str | None = None) ->
                                 _EMPTY_BAR_COUNTS.pop(tf_key, None)
                                 _IEX_EMPTY_COUNTS.pop(tf_key, None)
                                 mark_success(symbol, "1Min")
+                                df_alt = _post_process(df_alt)
+                                df_alt = _verify_minute_continuity(df_alt, symbol, backfill=backfill)
                                 return df_alt
                     if end_dt - start_dt > _dt.timedelta(days=1):
                         short_start = end_dt - _dt.timedelta(days=1)
@@ -1864,6 +1920,8 @@ def get_minute_df(symbol: str, start: Any, end: Any, feed: str | None = None) ->
                                 _EMPTY_BAR_COUNTS.pop(tf_key, None)
                                 _IEX_EMPTY_COUNTS.pop(tf_key, None)
                                 mark_success(symbol, "1Min")
+                                df_short = _post_process(df_short)
+                                df_short = _verify_minute_continuity(df_short, symbol, backfill=backfill)
                                 return df_short
                     try:
                         df = _backup_get_bars(symbol, start_dt, end_dt, interval="1m")
@@ -1959,7 +2017,9 @@ def get_minute_df(symbol: str, start: Any, end: Any, feed: str | None = None) ->
                 _mark_fallback(symbol, "1Min", start_dt, end_dt)
     except (ValueError, TypeError, KeyError, AttributeError):
         pass
-    return _post_process(df)
+    df = _post_process(df)
+    df = _verify_minute_continuity(df, symbol, backfill=backfill)
+    return df
 
 
 def get_daily_df(

--- a/tests/test_minute_gap_backfill.py
+++ b/tests/test_minute_gap_backfill.py
@@ -1,0 +1,47 @@
+import warnings
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading.data.fetch import _verify_minute_continuity
+
+def _make_gap_df():
+    ts = pd.date_range("2024-01-01 09:30", periods=3, freq="1min", tz="UTC")
+    return pd.DataFrame(
+        {
+            "timestamp": [ts[0], ts[2]],
+            "open": [1.0, 1.2],
+            "high": [1.1, 1.3],
+            "low": [0.9, 1.1],
+            "close": [1.05, 1.25],
+            "volume": [100, 150],
+        }
+    )
+
+def test_warn_on_gaps():
+    df = _make_gap_df()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        out = _verify_minute_continuity(df, "TEST")
+    assert len(w) == 1
+    assert out.equals(df)
+
+def test_backfill_ffill():
+    df = _make_gap_df()
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("ignore")
+        out = _verify_minute_continuity(df, "TEST", backfill="ffill")
+    ts = pd.date_range("2024-01-01 09:30", periods=3, freq="1min", tz="UTC")
+    assert len(out) == 3
+    mid = out.loc[out["timestamp"] == ts[1]].iloc[0]
+    assert mid["close"] == df["close"].iloc[0]
+    assert mid["volume"] == 0
+
+def test_backfill_interpolate():
+    df = _make_gap_df()
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("ignore")
+        out = _verify_minute_continuity(df, "TEST", backfill="interpolate")
+    ts = pd.date_range("2024-01-01 09:30", periods=3, freq="1min", tz="UTC")
+    mid = out.loc[out["timestamp"] == ts[1]].iloc[0]
+    assert mid["close"] == pytest.approx((df["close"].iloc[0] + df["close"].iloc[1]) / 2)


### PR DESCRIPTION
## Summary
- detect and warn about missing 1-minute bars
- backfill gaps via forward-fill or interpolation
- test minute gap warning and backfill paths

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_minute_gap_backfill.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*

------
https://chatgpt.com/codex/tasks/task_e_68c2fe0ba104833088f94b0532f2219c