### PR TITLE
Handle insufficient indicator history

### DIFF
--- a/ai_trading/signals/__init__.py
+++ b/ai_trading/signals/__init__.py
@@ -237,7 +237,12 @@ def _validate_macd_input(close_prices, min_len):
         return False
     if close_prices.isna().any() or np.isinf(close_prices).any():
         return False
-    return not len(close_prices) < min_len
+    if len(close_prices) < min_len:
+        logger.warning(
+            "MACD input length %s below minimum %s", len(close_prices), min_len
+        )
+        return False
+    return True
 
 
 def _compute_macd_df(close_prices, fast_period: int, slow_period: int, signal_period: int):

--- a/tests/test_indicator_window.py
+++ b/tests/test_indicator_window.py
@@ -1,0 +1,40 @@
+import pytest
+pd = pytest.importorskip("pandas")
+
+import sys
+import types
+
+sys.modules.setdefault("portalocker", types.ModuleType("portalocker"))
+bs4_stub = types.ModuleType("bs4")
+bs4_stub.BeautifulSoup = object
+sys.modules.setdefault("bs4", bs4_stub)
+flask_stub = types.ModuleType("flask")
+class _Flask:
+    def __init__(self, *a, **k):
+        pass
+
+    def route(self, *a, **k):  # pragma: no cover - simple stub
+        def _decorator(f):
+            return f
+        return _decorator
+
+flask_stub.Flask = _Flask
+sys.modules.setdefault("flask", flask_stub)
+from ai_trading.core import bot_engine as be
+
+
+def test_macd_insufficient_history_defers():
+    df = pd.DataFrame({"close": range(10)})
+    be._add_macd(df, "TST", None)
+    assert df["macd"].isna().all()
+    assert df["macds"].isna().all()
+
+
+def test_signal_manager_skips_nan_indicators():
+    sm = be.SignalManager()
+    df = pd.DataFrame({"close": [1, 2, 3, float("nan")]})
+    s, w, _ = sm.signal_momentum(df)
+    assert s == -1 and w == 0.0
+    df2 = pd.DataFrame({"close": [1.0] * 20 + [float("nan")]})
+    s2, w2, _ = sm.signal_mean_reversion(df2)
+    assert s2 == -1 and w2 == 0.0


### PR DESCRIPTION
## Summary
- skip MACD calculation when the close price window is shorter than required
- guard strategy signals against NaN indicator values and filter NaN confidences
- test early-session behavior with limited history

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_indicator_window.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: missing dependencies: execution modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fe0849c48330b80ce3d5e71cb08e