### PR TITLE
Initialize SoftBudget start time

### DIFF
--- a/ai_trading/utils/prof.py
+++ b/ai_trading/utils/prof.py
@@ -17,18 +17,15 @@ def StageTimer(logger, stage_name: str, **extra):
 class SoftBudget:
 
     def __init__(self, interval_sec: float, fraction: float):
-        self._deadline = time.monotonic() + max(0.0, interval_sec) * max(0.1, min(1.0, fraction))
-        self._start: float | None = None
+        now = time.monotonic()
+        self._deadline = now + max(0.0, interval_sec) * max(0.1, min(1.0, fraction))
+        self._start = now
 
     def remaining(self) -> float:
         return max(0.0, self._deadline - time.monotonic())
 
     def elapsed_ms(self) -> int:
-        now = time.monotonic()
-        if self._start is None:
-            self._start = now
-            return 0
-        return int((now - self._start) * 1000)
+        return int((time.monotonic() - self._start) * 1000)
 
     def over(self) -> bool:
         return time.monotonic() >= self._deadline

--- a/tests/test_prof_budget.py
+++ b/tests/test_prof_budget.py
@@ -5,7 +5,6 @@ from ai_trading.utils.prof import SoftBudget
 
 def test_soft_budget_elapsed_and_over():
     b = SoftBudget(interval_sec=0.1, fraction=0.5)
-    assert b.elapsed_ms() == 0
     time.sleep(0.02)
     assert b.elapsed_ms() >= 20
     time.sleep(0.05)


### PR DESCRIPTION
## Summary
- Begin tracking SoftBudget elapsed time at instantiation
- Update timing tests to expect non-zero elapsed milliseconds after work

## Testing
- `ruff check ai_trading/utils/prof.py tests/test_prof_budget.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c31c28b1a08330b1ff39398805a7bb