### PR TITLE
Add provider outage alerting and re-enable logic

### DIFF
--- a/ai_trading/data/metrics.py
+++ b/ai_trading/data/metrics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ai_trading.metrics import get_counter
+from ai_trading.metrics import get_counter, get_gauge
 
 
 @dataclass
@@ -33,4 +33,17 @@ provider_fallback = get_counter(
     ["from_provider", "to_provider"],
 )
 
-__all__ = ["Metrics", "metrics", "backup_provider_used", "provider_fallback"]
+# Gauge indicating whether a primary provider is currently disabled
+provider_disabled = get_gauge(
+    "data_provider_disabled",
+    "Flag set to 1 when a data provider is disabled",
+    ["provider"],
+)
+
+__all__ = [
+    "Metrics",
+    "metrics",
+    "backup_provider_used",
+    "provider_fallback",
+    "provider_disabled",
+]

--- a/tests/data/test_primary_provider_alerts.py
+++ b/tests/data/test_primary_provider_alerts.py
@@ -82,10 +82,10 @@ def test_primary_provider_missing_keys_alert(monkeypatch):
     assert "credentials" in args[2].lower()
 
 
-def test_primary_provider_disabled_no_alert(monkeypatch):
+def test_primary_provider_disabled_alert(monkeypatch):
     start, end = _dt_range()
     monkeypatch.setattr(fetch, "_has_alpaca_keys", lambda: True)
-    monkeypatch.setattr(fetch, "_alpaca_disabled_until", datetime.now(UTC) + timedelta(minutes=1), raising=False)
+    fetch._disable_alpaca(timedelta(minutes=1))
     monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
     monkeypatch.setattr(fetch, "_outside_market_hours", lambda *a, **k: False)
     monkeypatch.setattr(fetch, "is_market_open", lambda: True)
@@ -102,4 +102,4 @@ def test_primary_provider_disabled_no_alert(monkeypatch):
     df = fetch._fetch_bars("AAPL", start, end, "1Min", feed="iex")
 
     assert not df.empty
-    assert alerts.calls == []
+    assert alerts.calls


### PR DESCRIPTION
## Summary
- track when a data provider is disabled via new Prometheus gauge
- emit alerts and fallback when primary provider is temporarily disabled
- automatically clear disable state and log when provider is re-enabled

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c31c2a4d788330b4ac17a9e6b8652c