### PR TITLE
Optimize indicator preparation

### DIFF
--- a/tests/performance/test_prepare_indicators_perf.py
+++ b/tests/performance/test_prepare_indicators_perf.py
@@ -1,0 +1,30 @@
+import time
+
+import numpy as np
+import pandas as pd
+
+from ai_trading.core.bot_engine import prepare_indicators
+
+
+def test_prepare_indicators_within_budget():
+    """prepare_indicators should run quickly on typical workloads."""
+
+    n = 2000
+    df = pd.DataFrame(
+        {
+            "open": np.random.uniform(100, 200, n),
+            "high": np.random.uniform(100, 200, n),
+            "low": np.random.uniform(100, 200, n),
+            "close": np.random.uniform(100, 200, n),
+            "volume": np.random.randint(1_000_000, 5_000_000, n),
+        }
+    )
+
+    start = time.perf_counter()
+    out = prepare_indicators(df.copy())
+    duration = time.perf_counter() - start
+
+    assert not out.empty
+    # Expect completion well under 100ms on commodity hardware
+    assert duration < 0.1
+


### PR DESCRIPTION
## Summary
- vectorize indicator calculations to avoid repeated rolling operations
- time the indicator stage with StageTimer
- add a performance test ensuring indicator prep stays within budget

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/performance/test_prepare_indicators_perf.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot_engine.py::test_prepare_indicators_creates_required_columns tests/performance/test_prepare_indicators_perf.py -q`
- `python - <<'PY'
import os
os.environ['PYTEST_RUNNING']='1'
import pandas as pd, numpy as np, time
from ai_trading.core.bot_engine import prepare_indicators
n=2000
df=pd.DataFrame({
    'open': np.random.uniform(100,200,n),
    'high': np.random.uniform(100,200,n),
    'low': np.random.uniform(100,200,n),
    'close': np.random.uniform(100,200,n),
    'volume': np.random.randint(1_000_000,5_000_000,n)
})
start=time.perf_counter()
prepare_indicators(df.copy())
print('duration', time.perf_counter()-start)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c31c29bd9c8330acd3b64ec4eed4f0