### PR TITLE
feat: backoff for alpaca disable and provider switch metrics

### DIFF
--- a/ai_trading/data/fetch/backoff.py
+++ b/ai_trading/data/fetch/backoff.py
@@ -9,6 +9,7 @@ from ai_trading.data.metrics import provider_fallback
 from ai_trading.config.management import MAX_EMPTY_RETRIES
 from ai_trading.config.settings import provider_priority, max_data_fallbacks
 from ai_trading.logging import log_backup_provider_used, get_logger
+from ai_trading.data.provider_monitor import provider_monitor
 
 from . import EmptyBarsError, _fetch_bars
 
@@ -74,6 +75,9 @@ def _fetch_feed(
             provider_fallback.labels(
                 from_provider=f"alpaca_{feed}", to_provider=f"alpaca_{alt_feed}"
             ).inc()
+            provider_monitor.record_switchover(
+                f"alpaca_{feed}", f"alpaca_{alt_feed}"
+            )
             log_backup_provider_used(
                 f"alpaca_{alt_feed}",
                 symbol=symbol,

--- a/docs/provider_configuration.md
+++ b/docs/provider_configuration.md
@@ -29,3 +29,11 @@ export ENABLE_FINNHUB=1
 - `MAX_DATA_FALLBACKS`: maximum number of fallbacks allowed before giving up. Default is `2` (tries both Alpaca feeds before Yahoo).
 
 Configure these variables in your deployment environment to control provider availability and failover behavior.
+
+## Adaptive Disabling & Switchover Monitoring
+
+When Alpaca repeatedly returns empty data or errors, the bot now applies an
+exponential backoff when disabling the provider. Each consecutive disable
+period doubles, up to one hour, to avoid rapid flip/flop cycles. Whenever the
+system falls back to another provider, a `DATA_PROVIDER_SWITCHOVER` log entry
+is emitted with the running count for that provider pair to aid diagnostics.


### PR DESCRIPTION
## Summary
- add exponential backoff to Alpaca disable logic to avoid rapid enable/disable cycles
- track and log provider switchovers for diagnostics
- document adaptive disabling and switchover logging

## Testing
- `ruff check .`
- `python -m pip install requests`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3237079c8833084df75c1177dfaa1