### PR TITLE
Add GS symbol spec and test

### DIFF
--- a/ai_trading/market/symbol_specs.py
+++ b/ai_trading/market/symbol_specs.py
@@ -38,6 +38,7 @@ DEFAULT_SYMBOL_SPECS: dict[str, SymbolSpec] = {
     "AMGN": SymbolSpec(tick=Decimal("0.01"), lot=1, trading_hours="09:30-16:00"),
     "XOM": SymbolSpec(tick=Decimal("0.01"), lot=1, trading_hours="09:30-16:00"),
     "BAC": SymbolSpec(tick=Decimal("0.01"), lot=1, trading_hours="09:30-16:00"),
+    "GS": SymbolSpec(tick=Decimal("0.01"), lot=1),
     "V": SymbolSpec(tick=Decimal("0.01"), lot=1, trading_hours="09:30-16:00"),
     "MA": SymbolSpec(tick=Decimal("0.01"), lot=1, currency="USD"),
     "COST": SymbolSpec(tick=Decimal("0.01"), lot=1),

--- a/tests/market/test_symbol_specs.py
+++ b/tests/market/test_symbol_specs.py
@@ -8,3 +8,10 @@ def test_ma_symbol_spec() -> None:
     assert spec.tick == Decimal("0.01")
     assert spec.lot == 1
     assert spec.currency == "USD"
+
+
+def test_gs_symbol_spec() -> None:
+    spec = get_symbol_spec("GS")
+    assert spec.tick == Decimal("0.01")
+    assert spec.lot == 1
+    assert spec.currency == "USD"


### PR DESCRIPTION
## Summary
- add default spec for GS
- test retrieval of GS spec

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c32701a0008330855c0b8ee39c68bc