### PR TITLE
Implement rate-limit backoff for Alpaca data fetch

### DIFF
--- a/ai_trading/data/metrics.py
+++ b/ai_trading/data/metrics.py
@@ -40,10 +40,18 @@ provider_disabled = get_gauge(
     ["provider"],
 )
 
+# Counter tracking how often a provider is disabled
+provider_disable_total = get_counter(
+    "data_provider_disable_total",
+    "Times a data provider was disabled",
+    ["provider"],
+)
+
 __all__ = [
     "Metrics",
     "metrics",
     "backup_provider_used",
     "provider_fallback",
     "provider_disabled",
+    "provider_disable_total",
 ]


### PR DESCRIPTION
## Summary
- throttle Alpaca requests with exponential backoff when rate-limited
- disable Alpaca temporarily using Retry-After and track disable counts
- add tests for rate-limit backoff and provider recovery

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3270097c08330a791915d95bbbac2