### PR TITLE
Add slippage threshold handling

### DIFF
--- a/docs/slippage.md
+++ b/docs/slippage.md
@@ -7,10 +7,13 @@ Prices are adjusted by a configurable number of basis points (bps) to simulate e
 
 - `EXECUTION_PARAMETERS["MAX_SLIPPAGE_BPS"]` sets the maximum allowed slippage.
 - Override at runtime with the `MAX_SLIPPAGE_BPS` environment variable.
-- During tests (`TESTING=1`), the engine raises an error if absolute slippage exceeds this threshold.
+- `SLIPPAGE_LIMIT_TOLERANCE_BPS` controls the price buffer when a market order is converted
+  to a limit order after the maximum slippage threshold is breached.
 
 ## Diagnostics
 
 After each order is filled, the engine logs a `SLIPPAGE_DIAGNOSTIC` entry comparing the expected
 submission price with the average fill price. This aids in monitoring execution quality and ensures
-that excessive slippage is detected early.
+that excessive slippage is detected early. When the calculated slippage exceeds the configured
+threshold the engine converts market orders to limit orders at `expected_price ± tolerance` or
+reduces the order quantity.


### PR DESCRIPTION
## Summary
- enforce configurable slippage threshold in execution engine, converting excessive market orders to limits or shrinking size
- document new slippage tolerance settings
- test high-slippage scenarios for limit conversion and quantity reduction

## Testing
- `ruff check ai_trading/execution/engine.py tests/execution/test_execute_entry_trade_log.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_execute_entry_trade_log.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3294f3e7083308781d169cb6551b0