### PR TITLE
Centralize ATR max factor config and validate parameters

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -3333,10 +3333,13 @@ SECONDARY_TRAIL_FACTOR = 1.0
 
 def get_take_profit_factor() -> float:
     """Return configured take-profit factor for ATR stop calculations."""
-    val = config.get_env("TAKE_PROFIT_FACTOR", "2.0", cast=float)
-    if val is None:
-        raise RuntimeError("TAKE_PROFIT_FACTOR must be configured")
-    return val
+    from ai_trading.config.scaling import from_env as scaling_from_env
+
+    cfg = scaling_from_env()
+    val = cfg.max_factor
+    if not isinstance(val, (int, float)) or val <= 0:
+        raise RuntimeError("TAKE_PROFIT_FACTOR must be a positive number")
+    return float(val)
 
 SCALING_FACTOR = params.get(
     "SCALING_FACTOR",

--- a/ai_trading/core/parameter_validator.py
+++ b/ai_trading/core/parameter_validator.py
@@ -92,6 +92,10 @@ class ParameterValidator:
         """Validate a group of parameters."""
         result = {'group': group_name, 'status': 'PASS', 'violations': [], 'warnings': [], 'parameters_checked': len(parameters)}
         for param_name, param_value in parameters.items():
+            if param_value is None:
+                result['status'] = 'FAIL'
+                result['violations'].append(f'{param_name} is None')
+                continue
             if param_name in self.safety_bounds:
                 min_bound, max_bound = self.safety_bounds[param_name]
                 if not min_bound <= param_value <= max_bound:

--- a/docs/MAX_FACTOR.md
+++ b/docs/MAX_FACTOR.md
@@ -1,0 +1,13 @@
+# ATR Stop Max Factor
+
+The ATR-based stop helper scales take-profit targets using a maximum
+factor. The default is `2.0` as defined in `ai_trading.config.scaling`.
+Deployments may override this by setting the `TAKE_PROFIT_FACTOR`
+environment variable:
+
+```bash
+export TAKE_PROFIT_FACTOR=3.0
+```
+
+Only positive numeric values are accepted. The parameter validator will
+reject `None` values before trading starts.

--- a/tests/execution/test_max_factor_config.py
+++ b/tests/execution/test_max_factor_config.py
@@ -38,7 +38,7 @@ def test_execute_entry_uses_config_max_factor(monkeypatch):
     assert captured["max_factor"] == 3.0
 
 
-def test_get_take_profit_factor_none(monkeypatch):
-    monkeypatch.setattr(bot_engine.config, "get_env", lambda *a, **k: None)
-    with pytest.raises(RuntimeError):
+def test_get_take_profit_factor_invalid(monkeypatch):
+    monkeypatch.setenv("TAKE_PROFIT_FACTOR", "not-a-number")
+    with pytest.raises(ValueError):
         bot_engine.get_take_profit_factor()


### PR DESCRIPTION
## Summary
- Add configurable `DEFAULT_MAX_FACTOR` and expose via `ScalingConfig`
- Use scaling config in `get_take_profit_factor` to ensure numeric `max_factor`
- Reject `None` values during parameter validation
- Document `TAKE_PROFIT_FACTOR` override for deployments

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3294cf9c88330bb0191816e1e64d1