### PR TITLE
Add TMO and CAT symbol specs

### DIFF
--- a/ai_trading/market/symbol_specs.py
+++ b/ai_trading/market/symbol_specs.py
@@ -61,6 +61,8 @@ DEFAULT_SYMBOL_SPECS: dict[str, SymbolSpec] = {
     "XLE": SymbolSpec(tick=Decimal("0.01"), lot=1),
     "XLI": SymbolSpec(tick=Decimal("0.01"), lot=1),
     "XLV": SymbolSpec(tick=Decimal("0.01"), lot=1),
+    "TMO": SymbolSpec(tick=Decimal("0.01"), lot=1),
+    "CAT": SymbolSpec(tick=Decimal("0.01"), lot=1),
 }
 
 

--- a/docs/precision_and_costs.md
+++ b/docs/precision_and_costs.md
@@ -54,7 +54,7 @@ Centralized mapping of symbol trading specifications ensures consistent tick and
 - Tick size mapping for price quantization
 - Lot size mapping for quantity rounding
 - Currency mapping for settlement
-- Default specifications for major assets
+- Default specifications for major assets (AAPL, MSFT, TMO, CAT, etc.)
 - Runtime specification updates
 
 ### Usage Examples
@@ -230,6 +230,8 @@ from ai_trading.market.symbol_specs import update_specs_from_config
 specs_config = {
     'AAPL': {'tick': '0.01', 'lot': 1},
     'MA': {'tick': '0.01', 'lot': 1, 'currency': 'USD'},
+    'TMO': {'tick': '0.01', 'lot': 1},
+    'CAT': {'tick': '0.01', 'lot': 1},
     'BTC-USD': {'tick': '0.01', 'lot': 1},
     'ES': {'tick': '0.25', 'lot': 1, 'multiplier': 50}
 }

--- a/tests/market/test_symbol_specs.py
+++ b/tests/market/test_symbol_specs.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from ai_trading.market.symbol_specs import get_symbol_spec
+from ai_trading.market.symbol_specs import DEFAULT_SPEC, get_symbol_spec
 
 
 def test_ma_symbol_spec() -> None:
@@ -15,3 +15,17 @@ def test_gs_symbol_spec() -> None:
     assert spec.tick == Decimal("0.01")
     assert spec.lot == 1
     assert spec.currency == "USD"
+
+
+def test_tmo_symbol_spec() -> None:
+    spec = get_symbol_spec("TMO")
+    assert spec is not DEFAULT_SPEC
+    assert spec.tick == Decimal("0.01")
+    assert spec.lot == 1
+
+
+def test_cat_symbol_spec() -> None:
+    spec = get_symbol_spec("CAT")
+    assert spec is not DEFAULT_SPEC
+    assert spec.tick == Decimal("0.01")
+    assert spec.lot == 1


### PR DESCRIPTION
## Summary
- add symbol specifications for TMO and CAT
- test symbol spec lookup for TMO and CAT
- document new symbol specs

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3294e69e08330a2e0cee9368fc084