### PR TITLE
refactor: add data client check for ATR

### DIFF
--- a/tests/test_risk_engine_atr_fetch.py
+++ b/tests/test_risk_engine_atr_fetch.py
@@ -1,0 +1,39 @@
+import os
+import types
+import logging
+
+import pytest
+
+from ai_trading.risk.engine import RiskEngine
+
+os.environ.setdefault("PYTEST_RUNNING", "1")
+
+
+class DummyBar:
+    def __init__(self, h: float, l: float, c: float) -> None:
+        self.h = h
+        self.l = l
+        self.c = c
+
+
+def _make_valid_client():
+    def get_bars(symbol: str, limit: int):
+        return [DummyBar(2.0, 1.0, 1.5) for _ in range(limit)]
+
+    return types.SimpleNamespace(get_bars=get_bars)
+
+
+def test_get_atr_data_with_valid_client():
+    eng = RiskEngine()
+    eng.ctx = types.SimpleNamespace(data_client=_make_valid_client())
+    atr = eng._get_atr_data("AAPL", lookback=14)
+    assert atr == 1.0
+
+
+def test_get_atr_data_missing_get_bars(caplog: pytest.LogCaptureFixture):
+    eng = RiskEngine()
+    eng.ctx = types.SimpleNamespace(data_client=object())
+    caplog.set_level(logging.WARNING)
+    atr = eng._get_atr_data("AAPL", lookback=14)
+    assert atr is None
+    assert "missing get_bars" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- use StockHistoricalDataClient instead of TradingClient for ATR data
- guard ATR retrieval when data client lacks get_bars
- test ATR fetch with and without data client

## Testing
- `ruff check ai_trading/risk/engine.py tests/test_risk_engine_atr_fetch.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_risk_engine_atr_fetch.py tests/test_risk_engine_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c32f99e68083309ccabf1b6dbad22f