### PR TITLE
feat(config): support min position size

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -255,6 +255,7 @@ class TradingConfig:
     daily_loss_limit: Optional[float] = 0.03
     max_position_size: Optional[float] = None
     max_position_equity_fallback: float = 200000.0
+    position_size_min_usd: float | None = 0.0
     sector_exposure_cap: Optional[float] = None
     max_drawdown_threshold: Optional[float] = None
     trailing_factor: Optional[float] = None
@@ -338,6 +339,7 @@ class TradingConfig:
             "daily_loss_limit",
             "max_position_size",
             "max_position_equity_fallback",
+            "position_size_min_usd",
             "sector_exposure_cap",
             "max_drawdown_threshold",
             "trailing_factor",
@@ -435,6 +437,12 @@ class TradingConfig:
             max_position_size=mps,
             max_position_equity_fallback=_get(
                 "MAX_POSITION_EQUITY_FALLBACK", float, default=200000.0
+            ),
+            position_size_min_usd=_get(
+                "POSITION_SIZE_MIN_USD",
+                float,
+                default=0.0,
+                aliases=("AI_TRADING_POSITION_SIZE_MIN_USD",),
             ),
             sector_exposure_cap=_get("SECTOR_EXPOSURE_CAP", float),
             max_drawdown_threshold=_get("MAX_DRAWDOWN_THRESHOLD", float),

--- a/tests/mocks/app_mocks.py
+++ b/tests/mocks/app_mocks.py
@@ -1,3 +1,4 @@
 class MockConfig:
     def __init__(self, **kwargs):
+        self.position_size_min_usd = 0.0
         self.__dict__.update(kwargs)

--- a/tests/test_runtime_params_hydration.py
+++ b/tests/test_runtime_params_hydration.py
@@ -20,11 +20,13 @@ def test_trading_config_has_required_parameters():
     assert hasattr(cfg, 'capital_cap')
     assert hasattr(cfg, 'dollar_risk_limit')
     assert hasattr(cfg, 'max_position_size')
+    assert hasattr(cfg, 'position_size_min_usd')
 
     # Verify default values
     assert cfg.capital_cap == 0.04
     assert cfg.dollar_risk_limit == 0.05
     assert cfg.max_position_size == 8000.0
+    assert cfg.position_size_min_usd == 0.0
 
 
 def test_trading_config_from_env_loads_parameters():
@@ -36,6 +38,7 @@ def test_trading_config_from_env_loads_parameters():
         'CAPITAL_CAP': '0.06',
         'DOLLAR_RISK_LIMIT': '0.08',
         'MAX_POSITION_SIZE': '2.0',
+        'POSITION_SIZE_MIN_USD': '25',
     }
 
     with patch.dict(os.environ, env_vars):
@@ -44,6 +47,7 @@ def test_trading_config_from_env_loads_parameters():
         assert cfg.capital_cap == 0.06
         assert cfg.dollar_risk_limit == 0.08
         assert cfg.max_position_size == 2.0
+        assert cfg.position_size_min_usd == 25.0
 
 
 def test_trading_config_from_env_market_calendar(monkeypatch):
@@ -170,6 +174,7 @@ def test_build_runtime_ignores_none_values(monkeypatch):
         dollar_risk_limit=None,
         max_position_size=None,
         kelly_fraction_max=None,  # unrelated field to ensure None doesn't break
+        buy_threshold=None,
     )
 
     runtime = build_runtime(cfg)

--- a/tests/unit/test_trading_config_fields.py
+++ b/tests/unit/test_trading_config_fields.py
@@ -13,6 +13,7 @@ def test_defaults_present():
     assert cfg.signal_confirmation_bars == 2
     assert cfg.delta_threshold == 0.02
     assert cfg.min_confidence == 0.6
+    assert cfg.position_size_min_usd == 0.0
 
 
 def test_env_overrides_and_defaults(monkeypatch):
@@ -22,6 +23,7 @@ def test_env_overrides_and_defaults(monkeypatch):
     monkeypatch.setenv('SIGNAL_CONFIRMATION_BARS', '3')
     monkeypatch.setenv('DELTA_THRESHOLD', '0.05')
     monkeypatch.setenv('MIN_CONFIDENCE', '0.75')
+    monkeypatch.setenv('POSITION_SIZE_MIN_USD', '50')
     cfg = TradingConfig.from_env()
     assert cfg.kelly_fraction_max == 0.20
     assert cfg.min_sample_size == 12
@@ -29,6 +31,7 @@ def test_env_overrides_and_defaults(monkeypatch):
     assert cfg.signal_confirmation_bars == 3
     assert cfg.delta_threshold == 0.05
     assert cfg.min_confidence == 0.75
+    assert cfg.position_size_min_usd == 50.0
 
 
 def test_update_and_to_dict():
@@ -43,6 +46,7 @@ def test_update_and_to_dict():
     assert "signal_confirmation_bars" in snap
     assert "delta_threshold" in snap
     assert "min_confidence" in snap
+    assert "position_size_min_usd" in snap
 
 
 def test_update_unknown_key():


### PR DESCRIPTION
## Summary
- add `position_size_min_usd` field to `TradingConfig` and hydrate from env vars
- cover new config field in unit tests and test helpers

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_trading_config_fields.py tests/test_runtime_params_hydration.py tests/test_trigger_meta_learning_conversion.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*

------
https://chatgpt.com/codex/tasks/task_e_68c32f9967dc8330bb7761b91b430ba9