### PR TITLE
preserve debug level on charset_normalizer logger

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -9,7 +9,7 @@
 - **`LOG_MARKET_FETCH`** (default: `false`): When enabled, logs periodic market fetch heartbeats at INFO level. When disabled, these messages are demoted to DEBUG level to reduce noise.
 
 - **`LOG_LEVEL_YFINANCE`** (default: `WARNING`): Controls the log level for the `yfinance` package. Set to `INFO` or another level to troubleshoot provider interactions.
-- **`LOG_QUIET_LIBRARIES`** (default: `charset_normalizer=INFO`): Comma-separated `logger=LEVEL` pairs used to suppress noisy third-party libraries.
+- **`LOG_QUIET_LIBRARIES`** (default: `charset_normalizer=WARNING,peewee=WARNING`): Comma-separated `logger=LEVEL` pairs used to suppress noisy third-party libraries. Library loggers are kept at `DEBUG` and filtered to drop messages below the specified level.
 - **`AI_TRADING_WARN_IF_MODEL_MISSING`** (default: `false`): When set, emits an `ML_MODEL_MISSING` warning if a configured model path cannot be found.
 
 ### Features

--- a/ai_trading/logging/setup.py
+++ b/ai_trading/logging/setup.py
@@ -37,8 +37,12 @@ def _apply_library_filters() -> None:
         name, _, level = item.partition("=")
         if name.strip() and level.strip():
             filters[name.strip()] = getattr(logging, level.strip().upper(), logging.INFO)
+    from ai_trading.utils.logging import SuppressBelowLevelFilter
+
     for name, level in filters.items():
-        logging.getLogger(name).setLevel(level)
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        logger.addFilter(SuppressBelowLevelFilter(level))
 
 
 def setup_logging(debug: bool = False, log_file: str | None = None) -> logging.Logger:

--- a/ai_trading/utils/logging.py
+++ b/ai_trading/utils/logging.py
@@ -1,0 +1,20 @@
+"""Utility filters for logging configuration."""
+from __future__ import annotations
+
+import logging
+
+
+class SuppressBelowLevelFilter(logging.Filter):
+    """Filter that drops records below ``min_level``.
+
+    The logger's own level can remain ``DEBUG`` while this filter suppresses
+    lower level messages, allowing callers to keep a debug-effective level but
+    still quiet noisy third-party libraries.
+    """
+
+    def __init__(self, min_level: int) -> None:
+        super().__init__()
+        self.min_level = min_level
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - trivial
+        return record.levelno >= self.min_level

--- a/tests/logging/test_charset_normalizer_default_config.py
+++ b/tests/logging/test_charset_normalizer_default_config.py
@@ -21,7 +21,7 @@ def test_charset_normalizer_default_suppressed(monkeypatch, caplog) -> None:
     log_setup.setup_logging()
 
     noisy = logging.getLogger("charset_normalizer")
-    assert noisy.getEffectiveLevel() == logging.WARNING
+    assert noisy.getEffectiveLevel() == logging.DEBUG
     with caplog.at_level(logging.DEBUG):
         noisy.debug("noisy debug")
     assert "noisy debug" not in caplog.text

--- a/tests/test_charset_normalizer_logging_filter.py
+++ b/tests/test_charset_normalizer_logging_filter.py
@@ -23,11 +23,9 @@ def test_charset_normalizer_debug_suppressed(monkeypatch) -> None:
 
     log_setup.setup_logging()
 
-    regular = logging.getLogger("regular_logger")
     noisy = logging.getLogger("charset_normalizer")
 
-    assert regular.getEffectiveLevel() == logging.DEBUG
-    assert noisy.getEffectiveLevel() >= logging.INFO
+    assert noisy.getEffectiveLevel() == logging.DEBUG
 
     _reset_logging_state()
 


### PR DESCRIPTION
## Summary
- add SuppressBelowLevelFilter to drop noisy library logs
- set charset_normalizer and peewee loggers to DEBUG then filter below WARNING
- update tests and docs

## Testing
- `ruff check ai_trading/logging/setup.py ai_trading/utils/logging.py tests/test_charset_normalizer_logging_filter.py tests/logging/test_charset_normalizer_default_config.py tests/logging/test_charset_normalizer_no_debug.py tests/logging/test_charset_normalizer_no_debug_base.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_charset_normalizer_logging_filter.py tests/logging/test_charset_normalizer_default_config.py tests/logging/test_charset_normalizer_no_debug.py tests/logging/test_charset_normalizer_no_debug_base.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c365c339908330ab8eeb9dee1a32ba