### PR TITLE
test: add mock client classes

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -569,21 +569,25 @@ class BotEngine:
         api_key = _get_env_str("ALPACA_API_KEY")
         secret_key = _get_env_str("ALPACA_SECRET_KEY")
         cls = self._trading_client_cls
-        return cls(
-            api_key=api_key,
-            secret_key=secret_key,
-            paper="paper" in base_url.lower(),
-            url_override=base_url,
-        )
+        if callable(cls):
+            return cls(
+                api_key=api_key,
+                secret_key=secret_key,
+                paper="paper" in base_url.lower(),
+                url_override=base_url,
+            )
+        return cls
 
     @cached_property
     def data_client(self):
         """Alpaca StockHistoricalDataClient for historical/market data."""
         cls = self._data_client_cls
-        return cls(
-            api_key=_get_env_str("ALPACA_API_KEY"),
-            secret_key=_get_env_str("ALPACA_SECRET_KEY"),
-        )
+        if callable(cls):
+            return cls(
+                api_key=_get_env_str("ALPACA_API_KEY"),
+                secret_key=_get_env_str("ALPACA_SECRET_KEY"),
+            )
+        return cls
 
     @property
     def tickers(self) -> list[str]:


### PR DESCRIPTION
## Summary
- replace placeholder objects with simple mock Trading/Data clients in memoization test
- allow BotEngine client properties to accept either classes or pre-built instances

## Testing
- `ruff check tests/test_clients_memoized.py ai_trading/core/bot_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_clients_memoized.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3676078c08330bac9c23b2a9c18da