### PR TITLE
feat: harden trading config env parsing

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -453,7 +453,7 @@ class TradingConfig:
             min_profit_factor=_get("MIN_PROFIT_FACTOR", float),
             min_sharpe_ratio=_get("MIN_SHARPE_RATIO", float),
             min_win_rate=_get("MIN_WIN_RATE", float),
-            kelly_fraction=_get("KELLY_FRACTION", float),
+            kelly_fraction=_get("KELLY_FRACTION", float, default=0.6),
             kelly_fraction_max=_get(
                 "KELLY_FRACTION_MAX",
                 float,
@@ -487,6 +487,15 @@ class TradingConfig:
             ),
             data_feed=_get("DATA_FEED", str),
             data_provider=_get("DATA_PROVIDER", str),
+            buy_threshold=_get("BUY_THRESHOLD", float),
+            signal_period=_get("SIGNAL_PERIOD", int),
+            fast_period=_get("FAST_PERIOD", int),
+            slow_period=_get("SLOW_PERIOD", int),
+            limit_order_slippage=_get("LIMIT_ORDER_SLIPPAGE", float),
+            max_slippage_bps=_get("MAX_SLIPPAGE_BPS", int),
+            participation_rate=_get("PARTICIPATION_RATE", float),
+            pov_slice_pct=_get("POV_SLICE_PCT", float),
+            order_timeout_seconds=_get("ORDER_TIMEOUT_SECONDS", int),
         )
         # Apply mode presets when explicitly requested (test-only contract).
         if mode in {"balanced", "conservative", "aggressive"}:
@@ -520,10 +529,15 @@ class TradingConfig:
                 ),
             }
             for k, v in presets[mode].items():
+                env_key = k.upper()
+                if env_key in env_map and env_map[env_key] != "":
+                    continue
                 try:
                     object.__setattr__(cfg, k, v)
                 except Exception:
                     pass
+        if cfg.max_drawdown_threshold is None:
+            raise RuntimeError("MAX_DRAWDOWN_THRESHOLD environment variable is required")
         return cfg
 
     def snapshot_sanitized(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- cast numeric TradingConfig env vars and default kelly_fraction to 0.6
- prevent mode presets from overriding explicit env values
- require MAX_DRAWDOWN_THRESHOLD and extend coverage for new defaults

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_centralized_config.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_68c365c25e58833089d7afdf446acb6c