### PR TITLE
feat: include side in Alpaca submit_order API

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -683,6 +683,17 @@ def submit_order(
 ) -> dict[str, Any]:
     """Submit an order via Alpaca SDK or HTTP.
 
+    Parameters
+    ----------
+    symbol:
+        Asset ticker to trade.
+    qty:
+        Quantity of shares to submit.
+    side:
+        ``"buy"`` or ``"sell"`` direction for the order.
+
+    Notes
+    -----
     - Supports shadow mode for offline testing.
     - Raises :class:`AttributeError` if a provided client lacks ``submit_order``.
     - Maps HTTP errors (incl. 429) to :class:`AlpacaOrderHTTPError`.
@@ -692,12 +703,13 @@ def submit_order(
     do_shadow = cfg.shadow if shadow is None else bool(shadow)
     q_int = _as_int(qty)
     timeout = clamp_request_timeout(timeout)
+    idempotency_key = idempotency_key or generate_client_order_id()
 
     if do_shadow:
         oid = f"shadow-{uuid.uuid4().hex[:16]}"
         return {
             "id": oid,
-            "client_order_id": idempotency_key or oid,
+            "client_order_id": idempotency_key,
             "symbol": symbol,
             "qty": str(q_int),
             "side": side,

--- a/tests/test_alpaca_contract.py
+++ b/tests/test_alpaca_contract.py
@@ -8,7 +8,9 @@ from tests.mocks.alpaca_mocks import MockClient
 def test_submit_order_contract():
     api = MockClient()
     req = types.SimpleNamespace(symbol="AAPL", qty=1, side="buy", time_in_force="day")
-    result = alpaca_api.submit_order(api, req)
-    assert getattr(result, "id", None) == "1"
+    result = alpaca_api.submit_order(
+        req.symbol, req.qty, req.side, time_in_force=req.time_in_force, client=api
+    )
+    assert result["id"] == "1"
     assert getattr(api.last_payload, "symbol", None) == "AAPL"
     assert hasattr(api.last_payload, "client_order_id")

--- a/tests/test_client_order_id.py
+++ b/tests/test_client_order_id.py
@@ -5,7 +5,7 @@ from ai_trading import alpaca_api  # AI-AGENT-REF: canonical import
 
 class DummyAPI:
     def __init__(self):
-        self.ids = []
+        self.ids: list[str] = []
 
     def submit_order(self, **order_data):
         self.ids.append(order_data["client_order_id"])
@@ -18,6 +18,12 @@ def make_req(symbol="AAPL"):
 
 def test_unique_client_order_id():
     api = DummyAPI()
-    alpaca_api.submit_order(api, make_req())
-    alpaca_api.submit_order(api, make_req())
+    req1 = make_req()
+    req2 = make_req()
+    alpaca_api.submit_order(
+        req1.symbol, req1.qty, req1.side, time_in_force=req1.time_in_force, client=api
+    )
+    alpaca_api.submit_order(
+        req2.symbol, req2.qty, req2.side, time_in_force=req2.time_in_force, client=api
+    )
     assert len(set(api.ids)) == 2


### PR DESCRIPTION
## Summary
- generate client order IDs automatically and expose order side in Alpaca submit_order
- adapt contract and idempotency tests for new submit_order signature

## Testing
- `ruff check ai_trading/alpaca_api.py tests/test_client_order_id.py tests/test_alpaca_contract.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3676058d48330bc9d5fa6e7324ce5