### PR TITLE
Avoid heavy imports from package init

### DIFF
--- a/ai_trading/__init__.py
+++ b/ai_trading/__init__.py
@@ -45,11 +45,6 @@ _PUBLIC_SYMBOLS = {
 __all__ = sorted(set(_PUBLIC_MODULES) | set(_PUBLIC_SYMBOLS))
 
 
-def cli() -> None:  # pragma: no cover - thin wrapper for console script
-    """Console entrypoint that defers heavy CLI imports until invocation."""
-    _import_module("ai_trading.__main__").main()
-
-
 def __getattr__(name: str):  # pragma: no cover - thin lazy loader
     if name in _PUBLIC_MODULES:
         return _import_module(f'ai_trading.{name}')

--- a/tests/test_clean_import.py
+++ b/tests/test_clean_import.py
@@ -7,4 +7,11 @@ def test_package_import_has_no_cli_side_effects(monkeypatch):
         if name.startswith("ai_trading"):
             monkeypatch.delitem(sys.modules, name, raising=False)
     importlib.import_module("ai_trading")
-    assert "ai_trading.__main__" not in sys.modules
+    heavy_modules = {
+        "ai_trading.__main__",
+        "ai_trading.app",
+        "ai_trading.main",
+        "ai_trading.production_system",
+        "ai_trading.run_all_trades",
+    }
+    assert heavy_modules.isdisjoint(sys.modules)


### PR DESCRIPTION
## Summary
- Remove unused CLI wrapper so importing `ai_trading` never touches `ai_trading.__main__`
- Extend clean import test to ensure heavy modules like `app` and `main` remain unloaded

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: MAX_DRAWDOWN_THRESHOLD environment variable is required)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_clean_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36c5f4f0c833093478fa55c81b22a