### PR TITLE
Add dictionary-returning checkpoint helpers

### DIFF
--- a/ai_trading/meta/__init__.py
+++ b/ai_trading/meta/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .checkpoint import load_checkpoint, save_checkpoint
+
+__all__ = ["load_checkpoint", "save_checkpoint"]

--- a/ai_trading/meta/checkpoint.py
+++ b/ai_trading/meta/checkpoint.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Any
+
+from ai_trading.logging import get_logger
+from ai_trading.utils.pickle_safe import safe_pickle_load
+
+logger = get_logger(__name__)
+
+
+def save_checkpoint(data: dict[str, Any], filepath: str) -> dict[str, Any]:
+    """Serialize ``data`` to ``filepath`` with :mod:`pickle`.
+
+    Returns a shallow copy of ``data`` or an empty dict if saving fails.
+    """
+    try:
+        with open(filepath, "wb") as fh:
+            pickle.dump(data, fh)
+        logger.info("CHECKPOINT_SAVED", extra={"path": filepath})
+        return dict(data)
+    except (OSError, pickle.PickleError) as exc:  # pragma: no cover - error path
+        logger.error("Failed to save checkpoint: %s", exc, exc_info=True)
+        return {}
+
+
+def load_checkpoint(filepath: str) -> dict[str, Any]:
+    """Load a checkpoint dictionary from ``filepath``.
+
+    Returns the loaded mapping or ``{}`` when the file is missing, invalid or
+    does not contain a mapping.
+    """
+    p = Path(filepath)
+    if not p.exists():
+        logger.warning("Checkpoint file missing: %s", p)
+        return {}
+    try:
+        obj = safe_pickle_load(p, [p.parent])
+    except RuntimeError as exc:  # pragma: no cover - error path
+        logger.error("Failed to load checkpoint: %s", exc, exc_info=True)
+        return {}
+    if not isinstance(obj, dict):
+        logger.error("Checkpoint file %s did not contain a dict", p)
+        return {}
+    logger.info("CHECKPOINT_LOADED", extra={"path": str(p)})
+    return obj

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -12,6 +12,7 @@ np.random.seed(0)
 
 from ai_trading import meta_learning
 from ai_trading.meta_learning import MetaLearning
+from ai_trading.meta import checkpoint
 
 
 def test_meta_learning_instantiation():
@@ -40,22 +41,13 @@ def test_update_signal_weights_normal():
     assert round(res["b"], 2) == 0.75
 
 
-def test_save_and_load_checkpoint(monkeypatch):
-    data = {}
-    buf = {}
-
-    def fake_dump(obj, fh):
-        buf["v"] = obj
-
-    def fake_load(fh):
-        return buf["v"]
-
-    monkeypatch.setattr(meta_learning.pickle, "dump", fake_dump)
-    monkeypatch.setattr(meta_learning.pickle, "load", fake_load)
-    monkeypatch.setattr(meta_learning, "open", lambda *a, **k: open("/dev/null", "wb"))
-    meta_learning.save_model_checkpoint(data, "x.pkl")
-    obj = meta_learning.load_model_checkpoint("x.pkl")
-    assert obj is data
+def test_save_and_load_checkpoint(tmp_path):
+    path = tmp_path / "x.pkl"
+    data = {"x": 1}
+    saved = checkpoint.save_checkpoint(data, str(path))
+    assert saved == data
+    loaded = checkpoint.load_checkpoint(str(path))
+    assert loaded == data
 
 
 def test_optimize_signals(monkeypatch):


### PR DESCRIPTION
## Summary
- add `ai_trading.meta.checkpoint` module for saving/loading checkpoints that return dictionaries
- update meta-learning tests to use new checkpoint helpers

## Testing
- `ruff check ai_trading/meta/checkpoint.py tests/test_meta_learning.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36de538ec833088abf7e98c33d003