### PR TITLE
Flush logging handlers after setup

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -7,6 +7,7 @@ key in ``extra`` matching a reserved field is automatically prefixed with
 sanitizing adapter for all modules.
 """
 import atexit
+import contextlib
 import csv
 import json
 import logging
@@ -421,6 +422,9 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
         atexit.register(_safe_shutdown_logging)
         _LOGGING_CONFIGURED = True
         logging.getLogger(__name__).info('Logging configured successfully - no duplicates possible')
+        for h in handlers:
+            with contextlib.suppress(Exception):
+                h.flush()
         # Apply filters for noisy third-party libraries after configuration is complete.
         from ai_trading.logging.setup import _apply_library_filters
 

--- a/tests/test_logging_flush.py
+++ b/tests/test_logging_flush.py
@@ -1,0 +1,21 @@
+import logging
+import ai_trading.logging as base_logger
+import ai_trading.logging.setup as log_setup
+
+
+def reset_logging_state() -> None:
+    base_logger._configured = False
+    base_logger._LOGGING_CONFIGURED = False
+    base_logger._listener = None
+    logging.getLogger().handlers.clear()
+
+
+def test_setup_logging_flushes_handlers(tmp_path, monkeypatch):
+    reset_logging_state()
+    try:
+        monkeypatch.setenv("PYTEST_RUNNING", "1")
+        log_file = tmp_path / "flush.log"
+        log_setup.setup_logging(log_file=str(log_file))
+        assert "Logging configured successfully - no duplicates possible" in log_file.read_text()
+    finally:
+        reset_logging_state()


### PR DESCRIPTION
## Summary
- Flush logging handlers after initial configuration so log records reach disk immediately
- Add regression test ensuring setup log messages are written to the file

## Testing
- `python -m pip install requests`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36de368948330a61bc28bc55f33b1