### PR TITLE
Expose Alpaca availability flag in main module

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -11,6 +11,7 @@ import sys
 from datetime import datetime, UTC
 from zoneinfo import ZoneInfo
 from pathlib import Path
+import importlib.util
 from ai_trading.env import ensure_dotenv_loaded
 
 # Ensure environment variables are loaded before any logging configuration
@@ -27,6 +28,12 @@ _logging.configure_logging(log_file=LOG_FILE)
 
 # Module logger
 logger = _logging.get_logger(__name__)
+
+# Detect Alpaca SDK availability without importing heavy modules
+ALPACA_AVAILABLE = (
+    importlib.util.find_spec("alpaca") is not None
+    and importlib.util.find_spec("alpaca.trading.client") is not None
+)
 
 from ai_trading.settings import get_seed_int
 from ai_trading.config import get_settings
@@ -82,9 +89,7 @@ def preflight_import_health() -> None:
 
 def _check_alpaca_sdk() -> None:
     """Ensure the Alpaca SDK is installed before continuing."""
-    import importlib.util
-
-    if importlib.util.find_spec("alpaca") is None:
+    if not ALPACA_AVAILABLE:
         logger.error("ALPACA_PY_REQUIRED: pip install alpaca-py is required")
         raise SystemExit(1)
 

--- a/tests/test_main_alpaca_py_required.py
+++ b/tests/test_main_alpaca_py_required.py
@@ -4,6 +4,7 @@ import pytest
 def test_main_exits_when_alpaca_sdk_missing(monkeypatch, caplog):
     import ai_trading.main as m
 
+    assert hasattr(m, "ALPACA_AVAILABLE")
     monkeypatch.setattr(m, "ALPACA_AVAILABLE", False)
     with caplog.at_level("ERROR"):
         with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
## Summary
- expose `ALPACA_AVAILABLE` in `ai_trading.main`
- fail fast in `_check_alpaca_sdk` when Alpaca SDK missing
- assert Alpaca flag presence in main-related tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36de42e1c8330ab683f786589fa3f