### PR TITLE
feat: use dill for lambda-friendly model io

### DIFF
--- a/ai_trading/ml/__init__.py
+++ b/ai_trading/ml/__init__.py
@@ -1,0 +1,8 @@
+"""Machine learning helper utilities.
+
+This subpackage currently exposes model persistence helpers.
+"""
+
+from .model_io import load_model, save_model
+
+__all__ = ["load_model", "save_model"]

--- a/ai_trading/ml/model_io.py
+++ b/ai_trading/ml/model_io.py
@@ -1,0 +1,60 @@
+"""Model persistence helpers using :mod:`dill` when available.
+
+The default :mod:`pickle` module cannot serialize lambda functions. To support
+models that may reference lambdas, this module attempts to use :mod:`dill`
+which extends pickle's capabilities. If :mod:`dill` is not installed the
+standard :mod:`pickle` module is used as a fallback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ai_trading.logging import get_logger
+
+logger = get_logger(__name__)
+
+try:  # pragma: no cover - import error path exercised in tests via importorskip
+    import dill as _pickle
+except Exception:  # pragma: no cover - fallback when dill missing
+    import pickle as _pickle  # type: ignore
+
+
+def save_model(model: Any, path: str | Path) -> Path:
+    """Serialize ``model`` to ``path``.
+
+    The parent directory is created if needed. Any serialization error results
+    in a :class:`RuntimeError` with the original exception chained.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with p.open("wb") as fh:
+            _pickle.dump(model, fh)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(
+            "MODEL_SAVE_ERROR", extra={"path": str(p), "error": str(exc)}
+        )
+        raise RuntimeError(f"Failed to save model at '{p}': {exc}") from exc
+    return p
+
+
+def load_model(path: str | Path) -> Any:
+    """Deserialize and return a model from ``path``.
+
+    A :class:`RuntimeError` is raised if the file does not exist or cannot be
+    deserialized.
+    """
+    p = Path(path)
+    if not p.exists():
+        logger.error("MODEL_FILE_MISSING", extra={"path": str(p)})
+        raise RuntimeError(f"Model file not found: '{p}'")
+    try:
+        with p.open("rb") as fh:
+            return _pickle.load(fh)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.error(
+            "MODEL_LOAD_ERROR", extra={"path": str(p), "error": str(exc)}
+        )
+        raise RuntimeError(f"Failed to load model from '{p}': {exc}") from exc

--- a/tests/test_model_io.py
+++ b/tests/test_model_io.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+dill = pytest.importorskip("dill")
+
+from ai_trading.ml import model_io
+
+
+def test_save_and_load_lambda(tmp_path):
+    model = {"f": lambda x: x + 1}
+    path = tmp_path / "lambda.pkl"
+    model_io.save_model(model, path)
+    loaded = model_io.load_model(path)
+    assert loaded["f"](1) == 2
+
+
+def test_load_missing_model_raises(tmp_path):
+    missing = tmp_path / "missing.pkl"
+    with pytest.raises(RuntimeError, match="Model file not found"):
+        model_io.load_model(missing)


### PR DESCRIPTION
## Summary
- add `ai_trading.ml.model_io` using dill when available
- log clear errors for missing model files
- test lambda roundtrip and missing model failure

## Testing
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36fa0774883308891eb6c8b92e031