### PR TITLE
Log config autofix for missing max position size

### DIFF
--- a/ai_trading/core/config_autofix.py
+++ b/ai_trading/core/config_autofix.py
@@ -1,0 +1,46 @@
+"""Configuration auto-fix helpers."""
+
+from __future__ import annotations
+
+from ai_trading.logging import get_logger
+
+_log = get_logger(__name__)
+
+
+def ensure_max_position_size(cfg, tcfg) -> float:
+    """Ensure ``max_position_size`` is populated with a sensible default.
+
+    Parameters
+    ----------
+    cfg:
+        Primary configuration object used for fallback lookups.
+    tcfg:
+        Trading settings object expected to carry ``max_position_size``.
+
+    Returns
+    -------
+    float
+        The resolved ``max_position_size``.
+    """
+    raw = getattr(tcfg, "max_position_size", None)
+    try:
+        if raw is not None and float(raw) > 0:
+            return float(raw)
+    except (TypeError, ValueError):
+        pass
+
+    from ai_trading.position_sizing import _fallback_max_size
+
+    fallback = float(_fallback_max_size(cfg, tcfg))
+    _log.info("CONFIG_AUTOFIX", extra={"field": "max_position_size", "fallback": fallback})
+    try:
+        setattr(tcfg, "max_position_size", fallback)
+    except (AttributeError, TypeError):
+        try:
+            object.__setattr__(tcfg, "max_position_size", fallback)
+        except (AttributeError, TypeError):
+            pass
+    return fallback
+
+
+__all__ = ["ensure_max_position_size"]

--- a/ai_trading/startup/config.py
+++ b/ai_trading/startup/config.py
@@ -1,45 +1,5 @@
 """Startup configuration utilities."""
 
-from __future__ import annotations
-
-from ai_trading.logging import get_logger
-from ai_trading.position_sizing import _fallback_max_size
-
-_log = get_logger(__name__)
-
-
-def ensure_max_position_size(cfg, tcfg) -> float:
-    """Ensure ``max_position_size`` is populated with a sensible default.
-
-    Parameters
-    ----------
-    cfg:
-        Primary configuration object used for fallback lookups.
-    tcfg:
-        Trading settings object expected to carry ``max_position_size``.
-
-    Returns
-    -------
-    float
-        The resolved ``max_position_size``.
-    """
-    raw = getattr(tcfg, "max_position_size", None)
-    try:
-        if raw is not None and float(raw) > 0:
-            return float(raw)
-    except (TypeError, ValueError):
-        pass
-
-    fallback = float(_fallback_max_size(cfg, tcfg))
-    _log.info("CONFIG_AUTOFIX", extra={"field": "max_position_size", "fallback": fallback})
-    try:
-        setattr(tcfg, "max_position_size", fallback)
-    except (AttributeError, TypeError):
-        try:
-            object.__setattr__(tcfg, "max_position_size", fallback)
-        except (AttributeError, TypeError):
-            pass
-    return fallback
-
+from ai_trading.core.config_autofix import ensure_max_position_size
 
 __all__ = ["ensure_max_position_size"]


### PR DESCRIPTION
## Summary
- Add `ai_trading/core/config_autofix.ensure_max_position_size` to populate `max_position_size`
- Emit `CONFIG_AUTOFIX` log with fallback value when `max_position_size` is missing or invalid
- Re-export helper from startup config for backwards compatibility

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36f9fa12083308fcce5e84fad9725