### PR TITLE
feat: prevent duplicate metric registration

### DIFF
--- a/ai_trading/metrics/registry.py
+++ b/ai_trading/metrics/registry.py
@@ -23,4 +23,23 @@ def reset_registry(registry: CollectorRegistry | None = None) -> CollectorRegist
     return _REGISTRY
 
 
-__all__ = ["get_registry", "reset_registry"]
+def register(metric) -> object:
+    """Register ``metric`` in the global registry if not already present.
+
+    ``prometheus_client`` will raise ``ValueError`` when attempting to register
+    a metric with a name that already exists.  Older versions expose a
+    ``_names_to_collectors`` mapping that we can query directly.  This helper
+    checks for an existing collector with the same name and returns it instead
+    of re-registering, preventing duplicate metrics and avoiding exceptions.
+    """
+
+    registry = _REGISTRY
+    name = getattr(metric, "_name", getattr(metric, "name", None))
+    existing = getattr(registry, "_names_to_collectors", {}).get(name) if name else None
+    if existing is not None:
+        return existing
+    registry.register(metric)
+    return metric
+
+
+__all__ = ["get_registry", "reset_registry", "register"]

--- a/tests/test_metrics_registry.py
+++ b/tests/test_metrics_registry.py
@@ -20,3 +20,18 @@ def test_registry_instance_persists_across_reloads():
     mod = importlib.reload(registry)
     second = mod.get_registry()
     assert first is second
+
+
+def test_register_checks_existing_keys():
+    registry.reset_registry()
+    reg = registry.get_registry()
+
+    first = metrics.Counter("dup_total", "Doc", registry=reg)
+    # registering the same metric again should simply return the existing instance
+    same = registry.register(first)
+    assert same is first
+
+    # registering a different metric with the same name should also return the existing one
+    second = metrics.Counter("dup_total", "Doc")
+    retrieved = registry.register(second)
+    assert retrieved is first


### PR DESCRIPTION
## Summary
- add `register` helper to metrics registry to avoid duplicate metric registration
- add tests ensuring registry reuse and duplicate protection

## Testing
- `ruff check ai_trading/metrics/registry.py tests/test_metrics_registry.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_metrics_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c36f9f3f048330a778c9c999e1d0b7