### PR TITLE
refactor: remove nested lambda and document meta-learning path limits

### DIFF
--- a/ai_trading/meta_learning/core.py
+++ b/ai_trading/meta_learning/core.py
@@ -1,8 +1,9 @@
 """Meta-learning utilities and weight management helpers.
 
-This module uses ``pickle`` for model checkpoints and weights; paths are
-resolved and constrained before deserialization. Prefer :mod:`joblib` or
-``json`` for simple structures when possible.
+File operations are limited to a small set of safe directories to prevent
+arbitrary file access. This module uses ``pickle`` for model checkpoints and
+weights; paths are resolved and constrained before deserialization. Prefer
+:mod:`joblib` or ``json`` for simple structures when possible.
 """
 
 from importlib.util import find_spec

--- a/tests/test_meta_learning_additional.py
+++ b/tests/test_meta_learning_additional.py
@@ -9,6 +9,18 @@ import sklearn.linear_model
 from ai_trading import meta_learning
 
 
+def _stub_ridge(*args, **kwargs):
+    """Return a simple object with ``fit`` and ``predict`` methods."""
+
+    def fit(X, y, sample_weight=None):
+        return None
+
+    def predict(X):
+        return [0] * len(X)
+
+    return types.SimpleNamespace(fit=fit, predict=predict)
+
+
 def test_load_weights_save_fail(monkeypatch, tmp_path, caplog):
     """Failure to write default weights is logged and default returned."""
     p = tmp_path / "w.csv"
@@ -59,7 +71,7 @@ def test_retrain_meta_learner(monkeypatch, tmp_path):
     df.to_csv(data, index=False)
     monkeypatch.setattr(meta_learning, "save_model_checkpoint", lambda *a, **k: None)
     monkeypatch.setattr(meta_learning, "load_model_checkpoint", lambda *a, **k: [])
-    monkeypatch.setattr(sklearn.linear_model, "Ridge", lambda *a, **k: types.SimpleNamespace(fit=lambda X,y, sample_weight=None: None, predict=lambda X:[0]*len(X)))
+    monkeypatch.setattr(sklearn.linear_model, "Ridge", _stub_ridge)
     ok = meta_learning.retrain_meta_learner(str(data), str(tmp_path/"m.pkl"), str(tmp_path/"hist.pkl"), min_samples=1)
     assert ok
 
@@ -82,14 +94,7 @@ def test_retrain_meta_learner_handles_non_iterable_columns(monkeypatch, tmp_path
     monkeypatch.setattr(meta_learning, "getattr", fake_getattr)
     monkeypatch.setattr(meta_learning, "save_model_checkpoint", lambda *a, **k: None)
     monkeypatch.setattr(meta_learning, "load_model_checkpoint", lambda *a, **k: [])
-    monkeypatch.setattr(
-        sklearn.linear_model,
-        "Ridge",
-        lambda *a, **k: types.SimpleNamespace(
-            fit=lambda X, y, sample_weight=None: None,
-            predict=lambda X: [0] * len(X),
-        ),
-    )
+    monkeypatch.setattr(sklearn.linear_model, "Ridge", _stub_ridge)
     result = meta_learning.retrain_meta_learner(
         str(path), str(tmp_path / "m.pkl"), str(tmp_path / "hist.pkl"), min_samples=2
     )


### PR DESCRIPTION
## Summary
- replace nested lambda mocks in meta-learning tests with `_stub_ridge` helper
- document safe-directory restriction for meta-learning file operations

## Testing
- `ruff check tests/test_meta_learning_additional.py ai_trading/meta_learning/core.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_meta_learning_additional.py -q` *(skipped: could not import 'numpy')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_meta_learning.py -q` *(skipped: could not import 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c36f9e9f4883308ab0ee483b9fe702