### PR TITLE
feat: expose fetch metrics counters for tests

### DIFF
--- a/ai_trading/data/fetch/metrics.py
+++ b/ai_trading/data/fetch/metrics.py
@@ -12,7 +12,13 @@ snapshot instead of propagating the exception.
 from dataclasses import asdict
 from typing import Any, Mapping
 
-from ai_trading.data.metrics import metrics
+from ai_trading.data.metrics import (
+    backup_provider_used as _backup_provider_used,
+    metrics,
+    provider_disable_total as _provider_disable_total,
+    provider_disabled as _provider_disabled,
+    provider_fallback as _provider_fallback,
+)
 
 
 def snapshot(resp: Any | None = None) -> dict[str, int]:
@@ -21,10 +27,10 @@ def snapshot(resp: Any | None = None) -> dict[str, int]:
     Parameters
     ----------
     resp:
-        Optional HTTP-like response object supplying a ``json()`` method.  If
-        the response is missing or malformed the function will gracefully
-        fall back to returning the current in-memory counters instead of
-        raising ``ValueError('invalid_response')``.
+        Optional HTTP-like response object supplying a ``json()`` method. If
+        the response is missing or malformed the function will gracefully fall
+        back to returning the current in-memory counters instead of raising
+        ``ValueError('invalid_response')``.
     """
     try:
         if resp is None or not hasattr(resp, "json"):
@@ -38,4 +44,40 @@ def snapshot(resp: Any | None = None) -> dict[str, int]:
         return asdict(metrics)
 
 
-__all__ = ["snapshot"]
+def backup_provider_used(provider: str, symbol: str) -> int:
+    """Return times ``provider`` served data for ``symbol``."""
+
+    return int(
+        _backup_provider_used.labels(provider=provider, symbol=symbol)._value.get()
+    )
+
+
+def provider_fallback(from_provider: str, to_provider: str) -> int:
+    """Return fallback count from ``from_provider`` to ``to_provider``."""
+
+    return int(
+        _provider_fallback.labels(
+            from_provider=from_provider, to_provider=to_provider
+        )._value.get()
+    )
+
+
+def provider_disabled(provider: str) -> int:
+    """Return 1 if ``provider`` is currently disabled, else 0."""
+
+    return int(_provider_disabled.labels(provider=provider)._value.get())
+
+
+def provider_disable_total(provider: str) -> int:
+    """Return total times ``provider`` was disabled."""
+
+    return int(_provider_disable_total.labels(provider=provider)._value.get())
+
+
+__all__ = [
+    "snapshot",
+    "backup_provider_used",
+    "provider_fallback",
+    "provider_disabled",
+    "provider_disable_total",
+]

--- a/tests/test_backup_provider_switch.py
+++ b/tests/test_backup_provider_switch.py
@@ -6,7 +6,7 @@ pd = pytest.importorskip("pandas")
 
 from ai_trading.data import fetch as data_fetcher
 from ai_trading.config import settings as config_settings
-from ai_trading.data.metrics import backup_provider_used
+from ai_trading.data.fetch.metrics import backup_provider_used
 
 
 def test_switches_to_backup_provider(monkeypatch, caplog):
@@ -40,11 +40,11 @@ def test_switches_to_backup_provider(monkeypatch, caplog):
 
     monkeypatch.setattr(data_fetcher, "_fetch_bars", empty_fetch)
     monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", fake_backup)
-    before = backup_provider_used.labels(provider="yahoo", symbol="AAPL")._value.get()
+    before = backup_provider_used("yahoo", "AAPL")
     with caplog.at_level(logging.INFO):
         df = data_fetcher.get_minute_df("AAPL", start, end)
 
-    after = backup_provider_used.labels(provider="yahoo", symbol="AAPL")._value.get()
+    after = backup_provider_used("yahoo", "AAPL")
     assert called.get("used")
     assert not df.empty
     assert after == before + 1

--- a/tests/test_iex_sip_fallback.py
+++ b/tests/test_iex_sip_fallback.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import ai_trading.data.fetch as fetch
-from ai_trading.data.metrics import provider_fallback
+from ai_trading.data.fetch.metrics import provider_fallback
 
 
 def test_iex_empty_switches_to_sip(monkeypatch, caplog):
@@ -44,14 +44,10 @@ def test_iex_empty_switches_to_sip(monkeypatch, caplog):
 
     monkeypatch.setattr(fetch, "_sip_fallback_allowed", sip_allowed)
 
-    before = provider_fallback.labels(
-        from_provider="alpaca_iex", to_provider="alpaca_sip"
-    )._value.get()
+    before = provider_fallback("alpaca_iex", "alpaca_sip")
     with caplog.at_level("INFO"):
         df = fetch._fetch_bars(symbol, start, end, "1Min", feed="iex")
-    after = provider_fallback.labels(
-        from_provider="alpaca_iex", to_provider="alpaca_sip"
-    )._value.get()
+    after = provider_fallback("alpaca_iex", "alpaca_sip")
 
     assert feeds == ["iex", "sip"]
     assert not df.empty

--- a/tests/test_yahoo_fallback_order.py
+++ b/tests/test_yahoo_fallback_order.py
@@ -6,7 +6,7 @@ import pytest
 pd = pytest.importorskip("pandas")
 
 import ai_trading.data.fetch as fetch
-from ai_trading.data.metrics import provider_fallback
+from ai_trading.data.fetch.metrics import provider_fallback
 import ai_trading.data.fetch.fallback_order as fo
 
 
@@ -51,15 +51,11 @@ def test_yahoo_used_after_two_alpaca_failures(monkeypatch):
     monkeypatch.setattr(fetch, "_yahoo_get_bars", fake_yahoo)
     fo.reset()
 
-    before = provider_fallback.labels(
-        from_provider="alpaca_sip", to_provider="yahoo"
-    )._value.get()
+    before = provider_fallback("alpaca_sip", "yahoo")
 
     df = fetch._fetch_bars(symbol, start, end, "1Min", feed="iex")
 
-    after = provider_fallback.labels(
-        from_provider="alpaca_sip", to_provider="yahoo"
-    )._value.get()
+    after = provider_fallback("alpaca_sip", "yahoo")
 
     assert called.get("yahoo")
     assert not df.empty

--- a/tests/unit/test_data_fetcher_http.py
+++ b/tests/unit/test_data_fetcher_http.py
@@ -246,7 +246,10 @@ def test_rate_limit_backoff(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_rate_limit_disable_and_recover(monkeypatch: pytest.MonkeyPatch):
-    from ai_trading.data.metrics import provider_disable_total, provider_disabled
+    from ai_trading.data.fetch.metrics import (
+        provider_disable_total,
+        provider_disabled,
+    )
     from ai_trading.config import settings as config_settings
 
     monkeypatch.setenv("BACKUP_DATA_PROVIDER", "yahoo")
@@ -281,12 +284,12 @@ def test_rate_limit_disable_and_recover(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(df._HTTP_SESSION, "get", rate_limit_resp)
     monkeypatch.setattr(df, "_backup_get_bars", backup_resp)
     start, end = _dt_range(2)
-    before = provider_disable_total.labels(provider="alpaca")._value.get()
+    before = provider_disable_total("alpaca")
     out = df._fetch_bars("TEST", start, end, "1Min", feed="iex")
     assert calls["alpaca"] == 1
     assert calls["backup"] == 1
-    assert provider_disabled.labels(provider="alpaca")._value.get() == 1.0
-    assert provider_disable_total.labels(provider="alpaca")._value.get() == before + 1
+    assert provider_disabled("alpaca") == 1
+    assert provider_disable_total("alpaca") == before + 1
     assert isinstance(out, pd.DataFrame) and not out.empty
     assert df._alpaca_disabled_until is not None
 
@@ -310,6 +313,6 @@ def test_rate_limit_disable_and_recover(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(df._HTTP_SESSION, "get", ok_resp)
     out3 = df._fetch_bars("TEST", start, end, "1Min", feed="iex")
     assert calls["alpaca"] == 2
-    assert provider_disabled.labels(provider="alpaca")._value.get() == 0.0
+    assert provider_disabled("alpaca") == 0
     assert df._alpaca_disabled_until is None
     assert isinstance(out3, pd.DataFrame) and not out3.empty


### PR DESCRIPTION
## Summary
- expose simple helper functions for data fetch metrics counters
- switch HTTP fallback tests to use these helpers

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c371291ad08330befccf82f6c30528