### PR TITLE
Refactor submit_order signature and update tests

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -669,11 +669,11 @@ def _http_submit(
 
 def submit_order(
     symbol: str,
-    qty: int | float | str,
     side: str,
+    *,
+    qty: int | float | str,
     type: str = "market",
     time_in_force: str = "day",
-    *,
     limit_price: float | None = None,
     stop_price: float | None = None,
     shadow: bool | None = None,
@@ -687,10 +687,10 @@ def submit_order(
     ----------
     symbol:
         Asset ticker to trade.
-    qty:
-        Quantity of shares to submit.
     side:
         ``"buy"`` or ``"sell"`` direction for the order.
+    qty:
+        Quantity of shares to submit (keyword-only).
 
     Notes
     -----

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -33,7 +33,7 @@ def test_submit_order_shadow(monkeypatch):
             raise AssertionError("should not call in shadow")
 
     monkeypatch.setenv("SHADOW_MODE", "1")
-    resp = alpaca_api.submit_order("AAPL", 1, "buy", client=DummyAPI())
+    resp = alpaca_api.submit_order("AAPL", "buy", qty=1, client=DummyAPI())
     assert resp["status"] == "accepted"
 
 

--- a/tests/test_alpaca_api_extended.py
+++ b/tests/test_alpaca_api_extended.py
@@ -1,5 +1,7 @@
 import types
 
+import pytest
+
 from ai_trading import alpaca_api
 
 
@@ -13,10 +15,9 @@ def test_submit_order_http_error():
         raise HTTPError(500)
 
     api = types.SimpleNamespace(submit_order=submit_order)
-    res = alpaca_api.submit_order(api, symbol="AAPL", qty=1, side="buy")
-    assert not res.success
-    assert res.status == 500
-    assert res.retryable
+    with pytest.raises(HTTPError) as e:
+        alpaca_api.submit_order("AAPL", "buy", qty=1, client=api)
+    assert e.value.status == 500
 
 
 def test_submit_order_generic_error():
@@ -24,7 +25,5 @@ def test_submit_order_generic_error():
         raise Exception("boom")
 
     api = types.SimpleNamespace(submit_order=submit_order)
-    res = alpaca_api.submit_order(api, symbol="AAPL", qty=1, side="buy")
-    assert not res.success
-    assert res.status == 0
-    assert not res.retryable
+    with pytest.raises(Exception):
+        alpaca_api.submit_order("AAPL", "buy", qty=1, client=api)

--- a/tests/test_alpaca_api_module.py
+++ b/tests/test_alpaca_api_module.py
@@ -21,7 +21,7 @@ class DummyAPI:
 def test_submit_order_shadow(monkeypatch):
     api = DummyAPI()
     monkeypatch.setenv("SHADOW_MODE", "1")
-    res = alpaca_api.submit_order("AAPL", 1, "buy", client=api)
+    res = alpaca_api.submit_order("AAPL", "buy", qty=1, client=api)
     assert res["id"].startswith("shadow-")
     assert api.calls == 0
 
@@ -30,13 +30,13 @@ def test_submit_order_missing_submit(monkeypatch):
     monkeypatch.delenv("SHADOW_MODE", raising=False)
     api = object()
     with pytest.raises(AttributeError):
-        alpaca_api.submit_order("AAPL", 1, "buy", client=api)
+        alpaca_api.submit_order("AAPL", "buy", qty=1, client=api)
 
 
 def test_submit_order_rate_limit(monkeypatch):
     monkeypatch.delenv("SHADOW_MODE", raising=False)
     api = DummyAPI(fail_status=429)
     with pytest.raises(Exception) as e:
-        alpaca_api.submit_order("AAPL", 1, "buy", client=api)
+        alpaca_api.submit_order("AAPL", "buy", qty=1, client=api)
     assert getattr(e.value, "status", None) == 429
     assert api.calls == 1

--- a/tests/test_alpaca_contract.py
+++ b/tests/test_alpaca_contract.py
@@ -9,7 +9,11 @@ def test_submit_order_contract():
     api = MockClient()
     req = types.SimpleNamespace(symbol="AAPL", qty=1, side="buy", time_in_force="day")
     result = alpaca_api.submit_order(
-        req.symbol, req.qty, req.side, time_in_force=req.time_in_force, client=api
+        req.symbol,
+        req.side,
+        qty=req.qty,
+        time_in_force=req.time_in_force,
+        client=api,
     )
     assert result["id"] == "1"
     assert getattr(api.last_payload, "symbol", None) == "AAPL"

--- a/tests/test_client_order_id.py
+++ b/tests/test_client_order_id.py
@@ -21,9 +21,17 @@ def test_unique_client_order_id():
     req1 = make_req()
     req2 = make_req()
     alpaca_api.submit_order(
-        req1.symbol, req1.qty, req1.side, time_in_force=req1.time_in_force, client=api
+        req1.symbol,
+        req1.side,
+        qty=req1.qty,
+        time_in_force=req1.time_in_force,
+        client=api,
     )
     alpaca_api.submit_order(
-        req2.symbol, req2.qty, req2.side, time_in_force=req2.time_in_force, client=api
+        req2.symbol,
+        req2.side,
+        qty=req2.qty,
+        time_in_force=req2.time_in_force,
+        client=api,
     )
     assert len(set(api.ids)) == 2

--- a/tests/test_shadow_mode_runtime.py
+++ b/tests/test_shadow_mode_runtime.py
@@ -23,11 +23,11 @@ def test_lazy_alpaca_api_behavior_switch(monkeypatch):
             raise AssertionError("called real submit")
 
     monkeypatch.setenv("SHADOW_MODE", "1")
-    res = api.submit_order("AAPL", 1, "buy", client=Dummy())
+    res = api.submit_order("AAPL", "buy", qty=1, client=Dummy())
     assert res["id"].startswith("shadow-")
 
     monkeypatch.delenv("SHADOW_MODE", raising=False)
     importlib.reload(sys.modules["ai_trading.alpaca_api"])
 
     with pytest.raises(AssertionError):
-        sys.modules["ai_trading.alpaca_api"].submit_order("AAPL", 1, "buy", client=Dummy())
+        sys.modules["ai_trading.alpaca_api"].submit_order("AAPL", "buy", qty=1, client=Dummy())


### PR DESCRIPTION
## Summary
- Ensure `alpaca_api.submit_order` accepts `symbol` and `side` as positional args with keyword-only order fields to avoid duplicate positional values
- Align extended Alpaca API tests with the new signature and error expectations

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c37122e7c48330a074a3038f3d07b0