### PR TITLE
refactor: tighten broad exception handlers

### DIFF
--- a/ai_trading/strategies/momentum.py
+++ b/ai_trading/strategies/momentum.py
@@ -126,7 +126,7 @@ class MomentumStrategy(BaseStrategy):
             df = fetcher.get_daily_df(ctx, sym)
             try:
                 series = df["close"]
-            except Exception:  # pragma: no cover - defensive
+            except KeyError:  # pragma: no cover - missing close column
                 logger.warning("Insufficient data")
                 return []
             if df is None or len(series) <= self.lookback:


### PR DESCRIPTION
## Summary
- replace broad exception catches in `bot_engine.py` with targeted ones or remove
- narrow `momentum` strategy's defensive catch to `KeyError`

## Testing
- `ruff check ai_trading/core/bot_engine.py ai_trading/strategies/momentum.py tests/runtime/test_no_broad_except_*`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/runtime/test_no_broad_except_* -q`


------
https://chatgpt.com/codex/tasks/task_e_68c37120d5c08330af3af3b33adb6d41