### PR TITLE
Narrow error handling for missing market data

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8662,7 +8662,7 @@ def submit_order(
                 md = getattr(ctx, "market_data", None)
                 try:
                     price = get_latest_close(md) if md is not None else 0.0
-                except Exception:
+                except (KeyError, ValueError):
                     price = 0.0
         # Pass through computed price so the execution engine can simulate
         # fills around the actual market price rather than a generic fallback.

--- a/tests/runtime/test_max_position_size_consistency.py
+++ b/tests/runtime/test_max_position_size_consistency.py
@@ -16,6 +16,7 @@ def test_max_position_size_consistency(monkeypatch, caplog):
     monkeypatch.setenv("CAPITAL_CAP", "0.04")
     monkeypatch.setenv("DOLLAR_RISK_LIMIT", "0.05")
     monkeypatch.setenv("SCHEDULER_ITERATIONS", "1")
+    monkeypatch.setenv("MAX_DRAWDOWN_THRESHOLD", "0.05")
     monkeypatch.delenv("MAX_POSITION_SIZE", raising=False)
     monkeypatch.delenv("AI_TRADING_MAX_POSITION_SIZE", raising=False)
 
@@ -45,10 +46,10 @@ def test_max_position_size_consistency(monkeypatch, caplog):
         if mps is not None:
             try:
                 object.__setattr__(cfg, "max_position_size", float(mps))
-            except Exception:
+            except (AttributeError, TypeError, ValueError):
                 try:
                     setattr(cfg, "max_position_size", float(mps))
-                except Exception:
+                except (AttributeError, TypeError, ValueError):
                     pass
         runtime = build_runtime(cfg)
         captured["runtime"] = runtime

--- a/tests/unit/test_retry_mode.py
+++ b/tests/unit/test_retry_mode.py
@@ -18,7 +18,7 @@ def test_retry_mode_fixed_and_linear():
     for fn in (fixed, linear):
         try:
             fn()
-        except Exception:
+        except RetryError:
             pass
 
     assert calls["fixed"] == 2


### PR DESCRIPTION
## Summary
- Avoid broad exception handling when fetching fallback prices so only `KeyError` and `ValueError` are suppressed
- Replace broad `except Exception` in retry tests with specific exceptions and add missing env for max position size test

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_retry_mode.py tests/runtime/test_max_position_size_consistency.py -q` *(fails: No module named 'bs4')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/runtime/test_no_broad_except_in_hotpaths.py -q` *(fails: broad except present)*

------
https://chatgpt.com/codex/tasks/task_e_68c37120dda4833084d9d911348423d5