### PR TITLE
feat: expose timeout flag in safe subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - Meta-learning: WeightOptimizer now warns when provided an empty DataFrame.
 - Core: gate `ML_MODEL_MISSING` warning behind `AI_TRADING_WARN_IF_MODEL_MISSING` flag.
 - Data fetch: enforce rate limiter in `fetch.core` to comply with Alpaca quotas.
+- Utils: `safe_subprocess_run` now returns a result object exposing `stdout`, `returncode`, and `timeout` flag.
 
 ### Added
 - Cache fallback data provider usage to skip redundant Alpaca requests

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -2741,8 +2741,8 @@ def get_git_hash() -> str:
         from ai_trading.utils import SUBPROCESS_TIMEOUT_DEFAULT, safe_subprocess_run
 
         cmd = ["git", "rev-parse", "--short", "HEAD"]
-        out = safe_subprocess_run(cmd, timeout=SUBPROCESS_TIMEOUT_DEFAULT)
-        return out.strip() or "unknown"
+        res = safe_subprocess_run(cmd, timeout=SUBPROCESS_TIMEOUT_DEFAULT)
+        return res.stdout.strip() or "unknown"
     except COMMON_EXC:
         return "unknown"
 

--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from dataclasses import dataclass
 from typing import Sequence
 
 from ai_trading.logging import get_logger
@@ -16,20 +17,35 @@ SUBPROCESS_TIMEOUT_S = 5.0
 SUBPROCESS_TIMEOUT_DEFAULT = SUBPROCESS_TIMEOUT_S
 
 
-def safe_subprocess_run(cmd: Sequence[str], timeout: float | int | None = None) -> str:
+@dataclass(slots=True)
+class SafeSubprocessResult:
+    """Lightweight result container for ``safe_subprocess_run``."""
+
+    stdout: str
+    returncode: int
+    timeout: bool = False
+
+
+def safe_subprocess_run(
+    cmd: Sequence[str], timeout: float | int | None = None
+) -> SafeSubprocessResult:
     """Run ``cmd`` with ``subprocess.run`` and capture stdout text.
 
     Any errors are swallowed and emitted as warnings so callers can degrade
     gracefully. When a timeout occurs a dedicated warning message is emitted
-    before returning an empty string.
+    before returning an empty string and marking the result as timed out.
     """
     t = float(timeout) if timeout is not None else SUBPROCESS_TIMEOUT_DEFAULT
     try:
         res = subprocess.run(list(cmd), timeout=t, check=True, capture_output=True)
     except subprocess.TimeoutExpired:
         logger.warning("safe_subprocess_run(%s) timed out after %.2f seconds", cmd, t)
-        return ""
+        return SafeSubprocessResult(stdout="", returncode=-1, timeout=True)
+    except subprocess.CalledProcessError as exc:
+        logger.warning("safe_subprocess_run(%s) failed: %s", cmd, exc)
+        return SafeSubprocessResult(stdout="", returncode=exc.returncode, timeout=False)
     except (subprocess.SubprocessError, OSError) as exc:
         logger.warning("safe_subprocess_run(%s) failed: %s", cmd, exc)
-        return ""
-    return (res.stdout or b"").decode(errors="ignore").strip()
+        return SafeSubprocessResult(stdout="", returncode=getattr(exc, "returncode", -1))
+    stdout = (res.stdout or b"").decode(errors="ignore").strip()
+    return SafeSubprocessResult(stdout=stdout, returncode=res.returncode)

--- a/tests/utils/test_safe_subprocess_run.py
+++ b/tests/utils/test_safe_subprocess_run.py
@@ -5,21 +5,27 @@ from ai_trading.utils.safe_subprocess import safe_subprocess_run
 
 
 def test_safe_subprocess_run_success():
-    out = safe_subprocess_run([sys.executable, "-c", "print('ok')"])
-    assert out == "ok"
+    res = safe_subprocess_run([sys.executable, "-c", "print('ok')"])
+    assert res.stdout == "ok"
+    assert res.returncode == 0
+    assert not res.timeout
 
 
 def test_safe_subprocess_run_timeout(caplog):
     cmd = [sys.executable, "-c", "import time; time.sleep(1)"]
     with caplog.at_level("WARNING"):
-        out = safe_subprocess_run(cmd, timeout=0.1)
-    assert out == ""
+        res = safe_subprocess_run(cmd, timeout=0.1)
+    assert res.stdout == ""
+    assert res.timeout
+    assert res.returncode == -1
     assert any("timed out" in rec.message for rec in caplog.records)
 
 
 def test_safe_subprocess_run_nonzero_exit(caplog):
     cmd = [sys.executable, "-c", "import sys; sys.exit(2)"]
     with caplog.at_level("WARNING"):
-        out = safe_subprocess_run(cmd)
-    assert out == ""
+        res = safe_subprocess_run(cmd)
+    assert res.stdout == ""
+    assert res.returncode == 2
+    assert not res.timeout
     assert any(str(cmd) in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- return a `SafeSubprocessResult` object from `safe_subprocess_run` including `timeout` flag
- adjust callers to consume `stdout` from the result
- document safe subprocess behavior change

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c44b4254848330bad857de18094678