### PR TITLE
Validate psar input columns

### DIFF
--- a/ai_trading/signals/indicators.py
+++ b/ai_trading/signals/indicators.py
@@ -24,6 +24,15 @@ def psar(df: Any) -> Any:
         Copy of ``df`` with ``psar_long`` and ``psar_short`` columns.
     """
     pd = load_pandas()
+    required = {"high", "low", "close"}
+    cols = set(getattr(df, "columns", []))
+    missing = required - cols
+    if missing:
+        missing_cols = ", ".join(sorted(missing))
+        raise ValueError(f"DataFrame missing required column(s): {missing_cols}")
+    if len(df) == 0:
+        raise ValueError("DataFrame is empty")
+
     ta = load_pandas_ta()
     if pd is None or ta is None:
         logger.warning("PANDAS_TA_PSAR_MISSING")

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -106,7 +106,7 @@ def test_composite_signal_confidence(monkeypatch):
     monkeypatch.setattr(sm, 'signal_stochrsi', lambda df, model=None: (1, 0.1, 'stochrsi'))
     monkeypatch.setattr(sm, 'signal_obv', lambda df, model=None: (1, 0.1, 'obv'))
     monkeypatch.setattr(sm, 'signal_vsa', lambda df, model=None: (1, 0.1, 'vsa'))
-    df = pd.DataFrame({'close': np.linspace(1,2,60)})
+    df = pd.DataFrame({'close': np.linspace(1, 2, 210)})
     ctx = types.SimpleNamespace()
     state = types.SimpleNamespace(current_regime='trending', no_signal_events=0)
     model = types.SimpleNamespace(predict=lambda x: [1], predict_proba=lambda x: [[0.4,0.6]], feature_names_in_=['rsi','macd','atr','vwap','sma_50','sma_200'])
@@ -126,6 +126,15 @@ def test_psar_wrapper(sample_df, monkeypatch):
     out = ind.psar(sample_df)
     assert out["psar_long"].iloc[0] == 1.0
     assert out["psar_short"].iloc[0] == 2.0
+
+
+def test_psar_raises_on_invalid_data(sample_df):
+    """psar raises ValueError when data missing required columns or empty."""
+    with pytest.raises(ValueError, match="missing required column"):
+        ind.psar(sample_df.drop(columns=["high"]))
+    empty = pd.DataFrame(columns=["high", "low", "close"])
+    with pytest.raises(ValueError, match="empty"):
+        ind.psar(empty)
 
 
 def test_composite_signal_confidence_dict_and_list():


### PR DESCRIPTION
## Summary
- raise `ValueError` when OHLC data is empty or missing required columns before computing PSAR
- expand signal tests with sufficient data and add negative cases for invalid PSAR input

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'portalocker')*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_signals.py::test_psar_wrapper tests/test_signals.py::test_psar_raises_on_invalid_data -q`

------
https://chatgpt.com/codex/tasks/task_e_68c44b434e1483309fd86974f34ac6dd