### PR TITLE
feat: probe port before starting api

### DIFF
--- a/tests/test_start_api_port_increment.py
+++ b/tests/test_start_api_port_increment.py
@@ -1,0 +1,37 @@
+import socket
+
+from ai_trading import main, app
+
+
+def test_start_api_increments_port_when_busy(monkeypatch):
+    # Find an unused port and occupy it to simulate a busy port
+    probe = socket.socket()
+    probe.bind(("0.0.0.0", 0))
+    start_port = probe.getsockname()[1]
+    probe.close()
+    blocker = socket.socket()
+    blocker.bind(("0.0.0.0", start_port))
+    blocker.listen(1)
+
+    captured = {}
+
+    class DummyApp:
+        def run(self, host, port, debug=False, **kwargs):
+            captured["host"] = host
+            captured["port"] = port
+            captured["debug"] = debug
+
+    class DummySettings:
+        def __init__(self, api_port):
+            self.api_port = api_port
+
+    monkeypatch.setattr(main, "get_settings", lambda: DummySettings(start_port))
+    monkeypatch.setattr(main, "ensure_dotenv_loaded", lambda: None)
+    monkeypatch.setattr(app, "create_app", lambda: DummyApp())
+
+    try:
+        main.start_api()
+    finally:
+        blocker.close()
+
+    assert captured["port"] == start_port + 1


### PR DESCRIPTION
## Summary
- probe API port with temporary socket before starting Flask
- log and increment port until free or raise RuntimeError
- add regression test for automatic port increment

## Testing
- `ruff check ai_trading/main.py tests/test_start_api_port_increment.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_start_api_port_increment.py tests/test_main_extended2.py::test_run_flask_app tests/test_main_extended2.py::test_run_flask_app_port_in_use tests/test_main_extended2.py::test_run_flask_app_skips_ipv6_port`

------
https://chatgpt.com/codex/tasks/task_e_68c45fd3b3e88330a2fd2b47871e1612