### PR TITLE
feat: track positions without broker

### DIFF
--- a/tests/test_brokerless_position_ledger.py
+++ b/tests/test_brokerless_position_ledger.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+from ai_trading.execution.engine import ExecutionEngine, OrderSide
+from ai_trading.core.bot_engine import compute_current_positions
+
+
+def test_simulated_fills_update_position_ledger():
+    engine = ExecutionEngine()
+    engine.available_qty = 100
+
+    class DummyApi:
+        pass
+
+    ctx = SimpleNamespace(api=DummyApi(), execution_engine=engine)
+    engine.ctx = ctx
+
+    engine.execute_order("AAPL", OrderSide.BUY, 10)
+    assert engine.position_ledger == {"AAPL": 10}
+
+    engine.execute_order("AAPL", OrderSide.SELL, 4)
+    assert engine.position_ledger == {"AAPL": 6}
+
+    positions = compute_current_positions(ctx)
+    assert positions == {"AAPL": 6}
+


### PR DESCRIPTION
## Summary
- add in-memory position ledger to ExecutionEngine for brokerless runs
- read position ledger when computing current positions
- test that simulated fills update ledger and portfolio queries

## Testing
- `ruff check ai_trading/execution/engine.py ai_trading/core/bot_engine.py tests/test_brokerless_position_ledger.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c45fd4806c83308d859a0fdccf270c