### PR TITLE
feat: add yfinance bars support

### DIFF
--- a/ai_trading/data/providers/yfinance_provider.py
+++ b/ai_trading/data/providers/yfinance_provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import types
+
 
 def get_yfinance():
     """Return the ``yfinance`` module if installed, else ``None``."""
@@ -34,6 +36,34 @@ class Provider:
         yf = self._yf()
         t = yf.Ticker(symbol)
         return t.history(period=kwargs.get("period", "1y"), interval=interval)
+
+    def get_bars(self, symbol: str, limit: int):
+        """Return recent OHLCV bars for ``symbol``.
+
+        Parameters
+        ----------
+        symbol: str
+            The ticker symbol to fetch.
+        limit: int
+            Number of bars to return.
+        """
+        yf = self._yf()
+        t = yf.Ticker(symbol)
+        try:
+            df = t.history(period=f"{int(limit)}d", interval="1d").tail(limit)
+        except Exception:  # pragma: no cover - network/third-party errors
+            return []
+        bars = []
+        for _, row in df.iterrows():
+            bar = types.SimpleNamespace(
+                o=float(row.get("Open", 0.0)),
+                h=float(row.get("High", 0.0)),
+                l=float(row.get("Low", 0.0)),
+                c=float(row.get("Close", 0.0)),
+                v=float(row.get("Volume", 0.0)),
+            )
+            bars.append(bar)
+        return bars
 
 
 __all__ = ["Provider", "get_yfinance", "has_yfinance"]

--- a/tests/test_risk_engine_atr_fetch.py
+++ b/tests/test_risk_engine_atr_fetch.py
@@ -1,12 +1,15 @@
+import logging
 import os
 import types
-import logging
-
-import pytest
-
-from ai_trading.risk.engine import RiskEngine
 
 os.environ.setdefault("PYTEST_RUNNING", "1")
+os.environ.setdefault("MAX_DRAWDOWN_THRESHOLD", "0.15")
+
+import pandas as pd
+import pytest
+
+from ai_trading.data.providers import yfinance_provider
+from ai_trading.risk.engine import RiskEngine
 
 
 class DummyBar:
@@ -37,3 +40,29 @@ def test_get_atr_data_missing_get_bars(caplog: pytest.LogCaptureFixture):
     atr = eng._get_atr_data("AAPL", lookback=14)
     assert atr is None
     assert "missing get_bars" in caplog.text.lower()
+
+
+def test_get_atr_data_with_yfinance(monkeypatch: pytest.MonkeyPatch):
+    class DummyTicker:
+        def __init__(self, symbol: str) -> None:
+            self.symbol = symbol
+
+        def history(self, period: str, interval: str):
+            n = int(str(period).rstrip("d"))
+            data = {
+                "Open": [1.0] * n,
+                "High": [2.0] * n,
+                "Low": [1.0] * n,
+                "Close": [1.5] * n,
+                "Volume": [10] * n,
+            }
+            return pd.DataFrame(data)
+
+    dummy_yf = types.SimpleNamespace(Ticker=lambda symbol: DummyTicker(symbol))
+    monkeypatch.setattr(yfinance_provider, "get_yfinance", lambda: dummy_yf)
+
+    provider = yfinance_provider.Provider()
+    eng = RiskEngine()
+    eng.ctx = types.SimpleNamespace(data_client=provider)
+    atr = eng._get_atr_data("AAPL", lookback=14)
+    assert atr == 1.0


### PR DESCRIPTION
## Summary
- extend yfinance provider with `get_bars` for OHLCV retrieval
- test RiskEngine ATR calculation using yfinance data client

## Testing
- `ruff check ai_trading/data/providers/yfinance_provider.py tests/test_risk_engine_atr_fetch.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_risk_engine_atr_fetch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c473436b1c833088207a1ba95f3d70