### PR TITLE
Add backoff and reset for Alpaca provider

### DIFF
--- a/docs/provider_configuration.md
+++ b/docs/provider_configuration.md
@@ -50,4 +50,6 @@ Two environment variables control the backoff behaviour:
 When a provider recovers after being disabled, the monitor emits a
 `DATA_PROVIDER_RECOVERED` log with the total outage duration and disable
 frequency and raises a warning alert with the same metadata. These signals can
-be scraped by external monitoring to surface provider flapping.
+be scraped by external monitoring to surface provider flapping. On recovery,
+the internal disable alert flag is cleared so subsequent outages trigger fresh
+alerts.


### PR DESCRIPTION
## Summary
- apply exponential backoff when Alpaca is temporarily disabled
- reset Alpaca disable alert flag after successful recovery
- document backoff behaviour and alert reset

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47342d3a88330aad2316c17249a69