### PR TITLE
Add symbol specs for GD and ORCL

### DIFF
--- a/ai_trading/market/symbol_specs.py
+++ b/ai_trading/market/symbol_specs.py
@@ -63,6 +63,8 @@ DEFAULT_SYMBOL_SPECS: dict[str, SymbolSpec] = {
     "XLV": SymbolSpec(tick=Decimal("0.01"), lot=1),
     "TMO": SymbolSpec(tick=Decimal("0.01"), lot=1),
     "CAT": SymbolSpec(tick=Decimal("0.01"), lot=1),
+    "GD": SymbolSpec(tick=Decimal("0.01"), lot=1),
+    "ORCL": SymbolSpec(tick=Decimal("0.01"), lot=1),
 }
 
 


### PR DESCRIPTION
## Summary
- include GD and ORCL in default symbol specifications

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

## Rollback Plan
- Revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68c47342dadc833084863f843fcdae21