### PR TITLE
Fallback to ledger positions in portfolio summary

### DIFF
--- a/tests/test_portfolio_summary.py
+++ b/tests/test_portfolio_summary.py
@@ -1,0 +1,28 @@
+import logging
+import os
+from types import SimpleNamespace
+import sys
+
+os.environ.setdefault('MAX_DRAWDOWN_THRESHOLD', '0.2')
+import ai_trading.portfolio.core as core
+
+
+def test_log_portfolio_summary_uses_ledger_when_broker_empty(monkeypatch, caplog):
+    ctx = SimpleNamespace(
+        api=SimpleNamespace(
+            get_account=lambda: SimpleNamespace(cash=1000, equity=2000),
+            list_positions=lambda: [],
+        ),
+        risk_engine=SimpleNamespace(_positions={'AAPL': 10}, _adaptive_global_cap=lambda: 0.0),
+    )
+    class _Pandas:
+        class errors(Exception):
+            class EmptyDataError(Exception):
+                pass
+    sys.modules['pandas'] = _Pandas
+    caplog.set_level(logging.INFO)
+    monkeypatch.setattr(core, 'get_latest_price', lambda ctx, symbol: 100.0)
+    core.log_portfolio_summary(ctx)
+    assert any('ledger' in record.getMessage() for record in caplog.records)
+    assert any('exposure=50.00%' in record.getMessage() for record in caplog.records)
+


### PR DESCRIPTION
## Summary
- handle empty broker positions by using risk or execution ledgers for exposure
- log whether portfolio summary is sourced from broker or ledger
- add regression test covering ledger fallback logic

## Testing
- `ruff check ai_trading/portfolio/core.py tests/test_portfolio_summary.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_portfolio_summary.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c475382eb483308dbd4a807cc3f1fc