### PR TITLE
feat: make symbol processing limit configurable

### DIFF
--- a/PERFORMANCE_OPTIMIZATION.md
+++ b/PERFORMANCE_OPTIMIZATION.md
@@ -868,4 +868,9 @@ Regular performance monitoring and optimization should be part of the developmen
 
 ## Indicator Caching and Compute Budget
 
-The trading loop caches feature-engineered DataFrames by symbol and last bar timestamp to avoid repeating indicator calculations when market data is unchanged. To extend the compute window for heavier cycles, set the environment variable `CYCLE_COMPUTE_BUDGET` to a higher fraction (default inherits `CYCLE_BUDGET_FRACTION`).
+The trading loop caches feature-engineered DataFrames by symbol and last bar timestamp to avoid repeating indicator calculations when market data is unchanged. To extend the compute window for heavier cycles, set the environment variable `CYCLE_COMPUTE_BUDGET` to a higher fraction (default inherits `CYCLE_BUDGET_FRACTION`, now `0.9`).
+
+## Per-cycle Symbol Limit
+
+Use `MAX_SYMBOLS_PER_CYCLE` to cap how many tickers are processed each run. Lowering this value reduces per-cycle latency at the cost of coverage. The default limit is 50 symbols.
+

--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,12 @@ python performance_optimizer.py --monitor --duration 3600
    CLEANUP_INTERVAL_MINUTES=60
    ```
 
+4. **Symbol Limit**
+   ```python
+   # Cap symbols processed each cycle (default 50)
+   MAX_SYMBOLS_PER_CYCLE=25
+   ```
+
 ### Performance Metrics
 
 Monitor key performance indicators:

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -12910,7 +12910,12 @@ def _process_symbols(
     cd_skipped: list[str] = []
 
     # AI-AGENT-REF: Add circuit breaker for symbol processing to prevent resource exhaustion
-    max_symbols_per_cycle = min(50, len(symbols))  # Limit to 50 symbols per cycle
+    _max_syms = get_env("MAX_SYMBOLS_PER_CYCLE", 50)
+    try:
+        _max_syms = int(_max_syms)  # type: ignore[arg-type]
+    except (TypeError, ValueError):  # pragma: no cover - defensive cast
+        _max_syms = 50
+    max_symbols_per_cycle = min(_max_syms, len(symbols))
     processed_symbols = 0
     processing_start_time = time.monotonic()
 

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -786,12 +786,12 @@ def main(argv: list[str] | None = None) -> None:
                     pass
             raw_fraction = get_env(
                 "CYCLE_COMPUTE_BUDGET",
-                get_env("CYCLE_BUDGET_FRACTION", 0.8),
+                get_env("CYCLE_BUDGET_FRACTION", 0.9),
             )
             try:
                 fraction = float(raw_fraction)
             except (TypeError, ValueError):
-                fraction = 0.8
+                fraction = 0.9
             # Dynamic interval: slow down when closed
             effective_interval = int(closed_interval if closed else interval)
             budget = SoftBudget(interval_sec=float(effective_interval), fraction=fraction)


### PR DESCRIPTION
## Summary
- allow configuring per-cycle symbol count via MAX_SYMBOLS_PER_CYCLE
- loosen cycle compute budget default to 90% for latency headroom
- document per-cycle symbol limits and updated budget fraction

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: MAX_DRAWDOWN_THRESHOLD environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_e_68c475389bc0833094c9c07311c4d802