### PR TITLE
feat: backoff provider switchovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Data fetch: switch to SIP feed after first empty IEX result and record `data.fetch.feed_switch` metric.
  - Data fetch: track consecutive `error="empty"` responses per symbol/timeframe and, after `ALPACA_EMPTY_ERROR_THRESHOLD` attempts, switch to the backup provider while recording `data.fetch.empty` metrics.
 - Data fetch: add provider outage monitor that alerts on authentication, rate limit, or timeout failures and temporarily disables the primary feed to enable automatic fallback.
+- Monitoring: provider switchover alerting now applies exponential cooldown with backoff and logs failure durations for tuning.
 - Main: finite `SCHEDULER_ITERATIONS` now exits promptly after completing
   the requested cycles instead of keeping the API thread alive. This
   avoids test/CI hangs; production runs continue to use infinite iterations.

--- a/ai_trading/data/metrics.py
+++ b/ai_trading/data/metrics.py
@@ -61,6 +61,13 @@ provider_disable_duration_seconds = get_counter(
     ["provider"],
 )
 
+# Counter tracking duration from disable to switchover
+provider_failure_duration_seconds = get_counter(
+    "data_provider_failure_duration_seconds_total",
+    "Seconds from disable until switchover",
+    ["provider"],
+)
+
 __all__ = [
     "Metrics",
     "metrics",
@@ -70,4 +77,5 @@ __all__ = [
     "provider_disable_total",
     "fetch_retry_total",
     "provider_disable_duration_seconds",
+    "provider_failure_duration_seconds",
 ]

--- a/tests/test_provider_monitor_backoff.py
+++ b/tests/test_provider_monitor_backoff.py
@@ -2,6 +2,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from ai_trading.data import provider_monitor as pm
+from ai_trading.data.metrics import provider_failure_duration_seconds
 
 
 class DummyAlerts:
@@ -65,4 +66,69 @@ def test_outage_logging_and_alert(monkeypatch, caplog):
     assert kwargs["metadata"]["disable_count"] == 2
     assert kwargs["metadata"]["duration"] == 40.0
     assert any(r.message == "DATA_PROVIDER_RECOVERED" for r in caplog.records)
+
+
+def test_record_switchover_backoff(monkeypatch):
+    base = datetime(2024, 1, 1, tzinfo=UTC)
+
+    class FakeDT(datetime):
+        current = base
+
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return cls.current
+
+    monkeypatch.setattr(pm, "datetime", FakeDT)
+    alerts = DummyAlerts()
+    monitor = pm.ProviderMonitor(
+        cooldown=10,
+        switchover_threshold=2,
+        backoff_factor=2,
+        max_cooldown=40,
+        alert_manager=alerts,
+    )
+
+    monitor.record_switchover("a", "b")
+    assert monitor.consecutive_switches == 1
+    assert monitor._current_switch_cooldown == 10
+
+    FakeDT.current = base + timedelta(seconds=5)
+    monitor.record_switchover("b", "a")
+    assert monitor.consecutive_switches == 2
+    assert monitor._current_switch_cooldown == 20
+    assert alerts.calls
+
+    FakeDT.current = base + timedelta(seconds=15)
+    monitor.record_switchover("a", "b")
+    assert monitor.consecutive_switches == 3
+    assert monitor._current_switch_cooldown == 40
+    assert len(alerts.calls) == 1
+
+    FakeDT.current = base + timedelta(seconds=60)
+    monitor.record_switchover("b", "a")
+    assert monitor.consecutive_switches == 1
+    assert monitor._current_switch_cooldown == 10
+
+
+def test_failure_duration_metric(monkeypatch, caplog):
+    base = datetime(2024, 1, 1, tzinfo=UTC)
+
+    class FakeDT(datetime):
+        current = base
+
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return cls.current
+
+    monkeypatch.setattr(pm, "datetime", FakeDT)
+    monitor = pm.ProviderMonitor()
+    monitor.disabled_since["a"] = base - timedelta(seconds=30)
+
+    with caplog.at_level(logging.INFO):
+        monitor.record_switchover("a", "b")
+
+    assert (
+        provider_failure_duration_seconds.labels(provider="a")._value.get() == 30
+    )
+    assert any(r.message == "DATA_PROVIDER_FAILURE_DURATION" for r in caplog.records)
 


### PR DESCRIPTION
## Summary
- add exponential cooldown and logging for provider switchovers
- track switchover failure durations via new metric
- test provider switchover backoff and duration metrics

## Testing
- `ruff check ai_trading/data/provider_monitor.py ai_trading/data/metrics.py tests/test_provider_monitor_backoff.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47edfc70c833096e1fc00c4c644b4