### PR TITLE
feat: derive ATR from context data

### DIFF
--- a/docs/risk_engine.md
+++ b/docs/risk_engine.md
@@ -1,0 +1,9 @@
+# Risk Engine
+
+## ATR Fallback
+
+`RiskEngine._get_atr_data` normally retrieves historical bars via a data
+client's `get_bars` method. When this method is unavailable, the engine now
+falls back to existing OHLC data on the runtime context. If `ctx.minute_data`
+or `ctx.daily_data` contain the required arrays, the ATR is derived directly
+from those values. This allows volatility checks without a network data client.


### PR DESCRIPTION
## Summary
- compute ATR from `ctx.minute_data` or `ctx.daily_data` when `get_bars` is missing
- document ATR fallback in risk engine docs
- test ATR derivation using only OHLC arrays

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47ee06a9883309e71fcf53222808d