### PR TITLE
profile indicator calculations and limit per-cycle load

### DIFF
--- a/tests/performance/test_run_cycle_budget.py
+++ b/tests/performance/test_run_cycle_budget.py
@@ -1,0 +1,19 @@
+import time
+
+from ai_trading import main
+import ai_trading.core.bot_engine as bot_engine
+from ai_trading.utils.prof import SoftBudget
+
+
+def test_run_cycle_respects_budget(monkeypatch):
+    """run_cycle should complete within the configured time budget."""
+    # Avoid heavy operations by stubbing the worker
+    monkeypatch.setattr(bot_engine, "run_all_trades_worker", lambda state, runtime: None)
+
+    budget = SoftBudget(interval_sec=0.5, fraction=1.0)
+    start = time.perf_counter()
+    main.run_cycle()
+    duration = time.perf_counter() - start
+
+    assert duration < 0.5
+    assert not budget.over()

--- a/tests/unit/test_symbol_process_budget.py
+++ b/tests/unit/test_symbol_process_budget.py
@@ -1,0 +1,24 @@
+import types
+
+from ai_trading.core import bot_engine
+
+
+def test_symbol_processing_budget(monkeypatch):
+    """Symbol processing stops immediately when budget is exhausted."""
+    monkeypatch.setenv("SYMBOL_PROCESS_BUDGET", "0")
+    monkeypatch.setattr(bot_engine, "ensure_final_bar", lambda s, tf: True)
+    bot_engine.state = types.SimpleNamespace(
+        trade_cooldowns={}, last_trade_direction={}, position_cache={}
+    )
+    dummy_exec = types.SimpleNamespace(
+        submit=lambda fn, *a, **k: types.SimpleNamespace(result=lambda: None)
+    )
+    bot_engine.executors = types.SimpleNamespace(
+        _ensure_executors=lambda: None,
+        prediction_executor=dummy_exec,
+        executor=dummy_exec,
+    )
+    monkeypatch.setattr(bot_engine, "get_ctx", lambda: object())
+
+    processed, _ = bot_engine._process_symbols(["AAPL", "MSFT"], 100.0, None, True)
+    assert processed == []


### PR DESCRIPTION
## Summary
- profile feature and indicator steps with StageTimer for easier bottleneck tracing
- add SoftBudget-based limit via SYMBOL_PROCESS_BUDGET to cap symbols handled per cycle
- test run_cycle runtime and symbol processing budget enforcement

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47ee1aed88330bae08480027de824