### PR TITLE
Short-circuit run_cycle when market closed

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -18,8 +18,10 @@ sudo systemctl status ai-trading.service
 The timer schedules the bot to start at market open and the service exits automatically after 6.5 hours (16:00 US/Eastern). On normal completion the process returns exit code `0` so systemd records a clean shutdown.
 
 If the bot is started manually outside regular hours, it waits until the next
-NYSE session before trading. Set `ALLOW_AFTER_HOURS=1` to disable this wait
-when running tests or after-hours experiments.
+NYSE session before trading, and run cycles invoked while the market is closed
+exit immediately without fetching data or computing indicators. Set
+`ALLOW_AFTER_HOURS=1` to disable these guards when running tests or after-hours
+experiments.
 
 Check logs and health:
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -542,7 +542,9 @@ HEALTH_CHECK_INTERVAL=30
 ```
 
 The service waits for the next NYSE session if it starts outside regular market
-hours. Set `ALLOW_AFTER_HOURS=1` to bypass this check during testing.
+hours, and run cycles triggered while the market is closed exit immediately
+without data or indicator work. Set `ALLOW_AFTER_HOURS=1` to bypass these
+checks during testing.
 
 ### Configuration Validation
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ These map to `ai_trading.settings.Settings` and are applied at startup by `main.
 
 ### Market hours
 
-The bot checks NYSE trading hours at startup. If launched while the market is
-closed, it sleeps until the next session begins. Set `ALLOW_AFTER_HOURS=1` to
-skip this guard for testing or after-hours experimentation.
+The bot checks NYSE trading hours at startup and before each trading cycle. If
+launched while the market is closed, it sleeps until the next session begins,
+and any cycles triggered during closed hours exit immediately without fetching
+data or computing indicators. Set `ALLOW_AFTER_HOURS=1` to skip these guards for
+testing or after-hours experimentation.
 
 ## Timezones
 

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -97,6 +97,16 @@ def _check_alpaca_sdk() -> None:
 
 def run_cycle() -> None:
     """Execute a single trading cycle using the core bot engine."""
+
+    allow_after_hours = bool(get_env("ALLOW_AFTER_HOURS", "0", cast=bool))
+    if not allow_after_hours:
+        try:
+            if not _is_market_open_base():
+                logger.info("MARKET_CLOSED_SKIP_CYCLE")
+                return
+        except Exception:
+            logger.debug("MARKET_OPEN_CHECK_FAILED", exc_info=True)
+
     from ai_trading.core.bot_engine import (
         BotState,
         run_all_trades_worker,

--- a/tests/test_run_cycle_after_hours.py
+++ b/tests/test_run_cycle_after_hours.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sys
+
+from ai_trading import main
+
+
+def test_run_cycle_skips_when_market_closed(monkeypatch):
+    """run_cycle should exit early when the market is closed."""
+    sys.modules.pop("ai_trading.core.bot_engine", None)
+    monkeypatch.setattr(main, "_is_market_open_base", lambda: False)
+    monkeypatch.setenv("ALLOW_AFTER_HOURS", "0")
+
+    main.run_cycle()
+
+    assert "ai_trading.core.bot_engine" not in sys.modules


### PR DESCRIPTION
## Summary
- exit `main.run_cycle` early when the market is closed unless `ALLOW_AFTER_HOURS=1`
- document after-hours behavior and flag
- test that `run_cycle` skips heavy imports after hours

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c47ee252d0833088a489f0a6190a0c