### PR TITLE
test: import TradingConfig via config package

### DIFF
--- a/tests/config/test_trading_config_callsites.py
+++ b/tests/config/test_trading_config_callsites.py
@@ -1,4 +1,4 @@
-from ai_trading.config.management import TradingConfig
+from ai_trading.config import TradingConfig
 
 
 def test_trading_config_accepts_known_callsites():


### PR DESCRIPTION
## Summary
- test TradingConfig via ai_trading.config rather than management submodule

## Testing
- `rg 'logging\.warn\(' -n || echo 'no matches'`
- `ruff check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `python - <<'PY'
import ai_trading
print('ai_trading import OK')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c599d9e98883309cbd91d403288427