### PR TITLE
Allow logging reconfiguration after reset

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -332,18 +332,18 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
     environment variable.
     """
     global _configured, _log_queue, _listener, _LOGGING_CONFIGURED
-    if _LOGGING_CONFIGURED:
+    if _LOGGING_CONFIGURED and _configured:
         return logging.getLogger()
     if debug:
         # Deprecated: retain for callers that still pass ``debug=True``.
         # The effective log level is derived from configuration instead.
         pass
     with _LOGGING_LOCK:
-        if _LOGGING_CONFIGURED:
+        if _LOGGING_CONFIGURED and _configured:
             return logging.getLogger()
         if _listener is not None:
             _listener = None
-        if _LOGGING_CONFIGURED:
+        if _LOGGING_CONFIGURED and _configured:
             return logging.getLogger()
         logger = logging.getLogger()
         if _configured:

--- a/tests/test_logger_file.py
+++ b/tests/test_logger_file.py
@@ -5,21 +5,33 @@ import ai_trading.logging as logger  # Use centralized logging module
 
 def test_setup_logging_with_file(monkeypatch, tmp_path):
     """File handler is added when log_file is provided."""
-    logger._configured = False
-    fake = logging.NullHandler()
+    root = logging.getLogger()
+    original_handlers = root.handlers.copy()
+    orig_configured = logger._configured
+    orig_logging_configured = logger._LOGGING_CONFIGURED
+    try:
+        logger._configured = False
+        logger._LOGGING_CONFIGURED = True
+        fake = logging.NullHandler()
 
-    def fake_makedirs(path, exist_ok=False):
-        pass
+        def fake_makedirs(path, exist_ok=False):
+            pass
 
-    calls = []
+        calls = []
 
-    def fake_get_handler(*args, **kwargs):
-        calls.append((args, kwargs))
-        return fake
+        def fake_get_handler(*args, **kwargs):
+            calls.append((args, kwargs))
+            return fake
 
-    monkeypatch.setattr(logger.os, "makedirs", fake_makedirs)
-    monkeypatch.setattr(logger, "get_rotating_handler", fake_get_handler)
+        monkeypatch.setattr(logger.os, "makedirs", fake_makedirs)
+        monkeypatch.setattr(logger, "get_rotating_handler", fake_get_handler)
 
-    log_file = tmp_path / "x" / "app.log"
-    logger.setup_logging(log_file=str(log_file))
-    assert calls
+        log_file = tmp_path / "x" / "app.log"
+        logger.setup_logging(log_file=str(log_file))
+        assert calls
+    finally:
+        root.handlers = original_handlers
+        logger._configured = orig_configured
+        logger._LOGGING_CONFIGURED = orig_logging_configured
+        logger._listener = None
+        logger._log_queue = None


### PR DESCRIPTION
## Summary
- ensure `setup_logging` reconfigures when `_configured` is reset
- test that `get_rotating_handler` is invoked after resetting logging state

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c59f5ca0248330abce989d8816e967