### PR TITLE
Retain IEX empty counter after SIP success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Config: validate Alpaca data feed entitlement and allow override via `ALPACA_DATA_FEED`, warning if switched.
 - Data fetch: switch to SIP feed after first empty IEX result and record `data.fetch.feed_switch` metric.
+- IEX fallback: retain empty-response counter after successful SIP responses so
+  later requests continue bypassing IEX until it returns data.
  - Data fetch: track consecutive `error="empty"` responses per symbol/timeframe and, after `ALPACA_EMPTY_ERROR_THRESHOLD` attempts, switch to the backup provider while recording `data.fetch.empty` metrics.
 - Data fetch: add provider outage monitor that alerts on authentication, rate limit, or timeout failures and temporarily disables the primary feed to enable automatic fallback.
 - Monitoring: provider switchover alerting now applies exponential cooldown with backoff and logs failure durations for tuning.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -799,7 +799,9 @@ class DataProviderManager:
 When Alpaca's IEX feed returns consecutive empty responses, the bot now
 automatically retries the same request using the SIP feed before falling back
 to Yahoo Finance. This behavior is logged with the `ALPACA_IEX_FALLBACK_SIP`
-event and helps reduce data gaps caused by temporary IEX outages.
+event and helps reduce data gaps caused by temporary IEX outages. The
+empty-response counter only resets once IEX returns data; successful SIP
+responses leave the counter in place so future requests continue bypassing IEX.
 
 ## FAQ
 

--- a/ai_trading/data/fetch/iex_fallback.py
+++ b/ai_trading/data/fetch/iex_fallback.py
@@ -98,8 +98,11 @@ def fetch_bars(
         payload = resp.json()
         bars = payload.get("bars") or []
         if bars:
-            # Successful fetch from either feed resets the empty counter
-            _IEX_EMPTY_COUNTS.pop(key, None)
+            # Only reset the empty counter when IEX returns data.  Successful
+            # SIP responses keep the counter intact so later calls continue to
+            # bypass IEX until it provides data again.
+            if feed == "iex":
+                _IEX_EMPTY_COUNTS.pop(key, None)
             return _to_df(payload)
 
         # Empty response handling

--- a/tests/test_iex_fallback_module.py
+++ b/tests/test_iex_fallback_module.py
@@ -55,7 +55,7 @@ def test_iex_empty_switches_to_sip(monkeypatch, caplog):
         df = iex_fallback.fetch_bars("AAPL", start, end, "1Min", session=sess)
     assert [c["feed"] for c in sess.calls] == ["iex", "sip"]
     assert not df.empty
-    assert _IEX_EMPTY_COUNTS == {}
+    assert _IEX_EMPTY_COUNTS.get(("AAPL", "1Min"), 0) == 1
     assert any(r.message == "DATA_SOURCE_FALLBACK_ATTEMPT" for r in caplog.records)
 
 
@@ -98,5 +98,5 @@ def test_skip_iex_after_threshold(monkeypatch, caplog):
     assert len(sess2.calls) == 1
     assert sess2.calls[0]["feed"] == "sip"
     assert not df.empty
-    assert _IEX_EMPTY_COUNTS.get(("AAPL", "1Min"), 0) == 0
+    assert _IEX_EMPTY_COUNTS.get(("AAPL", "1Min"), 0) == 1
     assert any(r.message == "DATA_SOURCE_FALLBACK_ATTEMPT" for r in caplog.records)


### PR DESCRIPTION
## Summary
- keep IEX empty-response counter unless an IEX request returns data
- document that SIP success does not reset the counter
- adjust tests for new counter behavior

## Testing
- `ruff check ai_trading/data/fetch/iex_fallback.py tests/test_iex_fallback_module.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c59f5bb33c8330b79c5cd53caadc0f