### PR TITLE
Refactor pandas imports to lazy loader

### DIFF
--- a/ai_trading/core/interfaces.py
+++ b/ai_trading/core/interfaces.py
@@ -15,7 +15,9 @@ from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import numpy as np
-    import pandas as pd
+    from ai_trading.utils.lazy_imports import load_pandas
+
+    pd = load_pandas()
 
 from ai_trading.order.types import OrderSide
 


### PR DESCRIPTION
## Summary
- Lazily load pandas in signals module and guard attribute access for graceful degradation
- Use lazy pandas loader in model training utilities with ImportError fallbacks
- Update interfaces to reference pandas via lazy loader for type checking

## Testing
- `python -m ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5a21143f08330b8d2a875c2b41e89