### PR TITLE
feat: support week timeframe

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -252,7 +252,15 @@ def _normalize_timeframe_for_tradeapi(tf_raw):
         TimeFrame = None
     if isinstance(tf_raw, str):
         s = tf_raw.strip()
-        return s if s[:1].isdigit() else f"1{s.capitalize()}"
+        if s[:1].isdigit():
+            import re
+
+            m = re.match(r"(\d+)(\w+)", s)
+            if m:
+                amt, unit = m.groups()
+                return f"{amt}{unit.capitalize()}"
+            return s
+        return f"1{s.capitalize()}"
     if TimeFrame is not None and isinstance(tf_raw, TimeFrame):
         unit = getattr(tf_raw.unit, "name", str(tf_raw.unit)).title()
         return f"{tf_raw.amount}{unit}"

--- a/ai_trading/data/models.py
+++ b/ai_trading/data/models.py
@@ -31,6 +31,8 @@ try:  # best-effort: some SDK versions already provide these
             setattr(TimeFrame, "Minute", TimeFrame(1, getattr(unit_cls, "Minute", "Minute")))  # type: ignore[arg-type]
         if not hasattr(TimeFrame, "Hour"):
             setattr(TimeFrame, "Hour", TimeFrame(1, getattr(unit_cls, "Hour", "Hour")))  # type: ignore[arg-type]
+        if not hasattr(TimeFrame, "Week"):
+            setattr(TimeFrame, "Week", TimeFrame(1, getattr(unit_cls, "Week", "Week")))  # type: ignore[arg-type]
 except Exception:
     pass
 _BaseStockBarsRequest = get_stock_bars_request_cls()

--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -80,3 +80,19 @@ def test_minute_normalized(mock_rest_cls):
     assert getattr(req.timeframe, "amount", None) == 1
     assert getattr(req.timeframe.unit, "name", "") in {"Minute", "Min"}
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
+
+
+@patch("ai_trading.alpaca_api._get_rest")
+def test_week_normalized(mock_rest_cls):
+    mock_rest = MagicMock()
+    mock_rest.get_stock_bars.return_value = _Resp(
+        pd.DataFrame({"open": [1.0], "close": [1.1]})
+    )
+    mock_rest_cls.return_value = mock_rest
+
+    df = get_bars_df("SPY", "1week", feed="iex", adjustment="all")
+    mock_rest_cls.assert_called_once_with(bars=True)
+    (req,), kwargs = mock_rest.get_stock_bars.call_args
+    assert getattr(req.timeframe, "amount", None) == 1
+    assert getattr(req.timeframe.unit, "name", "").lower() == "week"
+    assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -171,6 +171,7 @@ class _TF:
     Minute = "1Min"
     Hour = "1Hour"
     Day = "1Day"
+    Week = "1Week"
 
     def __init__(self, *a, **k):
         pass
@@ -180,6 +181,7 @@ class _TFUnit:
     Minute = "Minute"
     Hour = "Hour"
     Day = "Day"
+    Week = "Week"
 
 
 

--- a/tests/test_stubs_and_prices.py
+++ b/tests/test_stubs_and_prices.py
@@ -6,6 +6,7 @@ def test_timeframe_has_basic_members():
     assert hasattr(TimeFrame, "Day")
     assert hasattr(TimeFrame, "Minute")
     assert hasattr(TimeFrame, "Hour")
+    assert hasattr(TimeFrame, "Week")
 
 
 def test_get_latest_close_handles_empty_and_variants():

--- a/tests/vendor_stubs/alpaca/data/timeframe.py
+++ b/tests/vendor_stubs/alpaca/data/timeframe.py
@@ -21,5 +21,6 @@ class TimeFrame:
 TimeFrame.Minute = TimeFrame(1, TimeFrameUnit.Minute)  # type: ignore[attr-defined]
 TimeFrame.Hour = TimeFrame(1, TimeFrameUnit.Hour)  # type: ignore[attr-defined]
 TimeFrame.Day = TimeFrame()  # type: ignore[attr-defined]
+TimeFrame.Week = TimeFrame(1, TimeFrameUnit.Week)  # type: ignore[attr-defined]
 
 __all__ = ["TimeFrame", "TimeFrameUnit"]


### PR DESCRIPTION
## Summary
- handle week in timeframe parsing and normalization
- extend stubs and tests for week timeframe

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5aab60dac8330946dce5929f260d0