### PR TITLE
Remove pandas shim for tests

### DIFF
--- a/tests/test_portfolio_summary.py
+++ b/tests/test_portfolio_summary.py
@@ -1,9 +1,11 @@
 import logging
 import os
 from types import SimpleNamespace
-import sys
+
+import pytest
 
 os.environ.setdefault('MAX_DRAWDOWN_THRESHOLD', '0.2')
+pd = pytest.importorskip("pandas")
 import ai_trading.portfolio.core as core
 
 
@@ -15,11 +17,6 @@ def test_log_portfolio_summary_uses_ledger_when_broker_empty(monkeypatch, caplog
         ),
         risk_engine=SimpleNamespace(_positions={'AAPL': 10}, _adaptive_global_cap=lambda: 0.0),
     )
-    class _Pandas:
-        class errors(Exception):
-            class EmptyDataError(Exception):
-                pass
-    sys.modules['pandas'] = _Pandas
     caplog.set_level(logging.INFO)
     monkeypatch.setattr(core, 'get_latest_price', lambda ctx, symbol: 100.0)
     core.log_portfolio_summary(ctx)


### PR DESCRIPTION
## Summary
- drop `_Pandas` shim and stop injecting stub pandas module
- have portfolio summary test rely on real pandas via `pytest.importorskip`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c5aab5ed348330ab428512cd54243c