### PR TITLE
Add safe TimeFrame wrapper with default 1 day

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -226,21 +226,20 @@ def get_stock_bars_request_cls():
 
 
 def get_timeframe_cls():
-    if ALPACA_AVAILABLE:
-        _, cls, unit_cls = _data_classes()
+    """Return the package-level :class:`TimeFrame` wrapper.
 
-        class _TF(cls):  # type: ignore[misc]
-            def __init__(self, amount: int = 1, unit=unit_cls.Day):  # type: ignore[assignment]
-                super().__init__(amount, unit)
+    The wrapper guarantees that ``TimeFrame()`` defaults to ``1 Day`` and that
+    ``amount`` and ``unit`` attributes are always present.
+    """
+    from .timeframe import TimeFrame
 
-        return _TF
     return TimeFrame
 
 
 def get_timeframe_unit_cls():
-    if ALPACA_AVAILABLE:
-        _, _, cls = _data_classes()
-        return cls
+    """Return the package-level ``TimeFrameUnit`` enum."""
+    from .timeframe import TimeFrameUnit
+
     return TimeFrameUnit
 
 

--- a/ai_trading/timeframe.py
+++ b/ai_trading/timeframe.py
@@ -1,0 +1,30 @@
+"""Compat layer for Alpaca ``TimeFrame``.
+
+This module exposes a wrapper around the Alpaca SDK's ``TimeFrame`` class
+that is safe to instantiate with no arguments.  ``TimeFrame()`` will
+produce a timeframe representing ``1 Day``.  The wrapper also ensures that
+all instances expose ``amount`` and ``unit`` attributes, even if the
+underlying SDK changes implementation details.
+"""
+
+from __future__ import annotations
+
+from ai_trading.alpaca_api import ALPACA_AVAILABLE
+
+if ALPACA_AVAILABLE:  # pragma: no cover - depends on alpaca-py
+    from alpaca.data.timeframe import TimeFrame as _BaseTimeFrame, TimeFrameUnit  # type: ignore
+else:  # pragma: no cover - exercised when SDK missing
+    from ai_trading.alpaca_api import TimeFrame as _BaseTimeFrame, TimeFrameUnit  # type: ignore
+
+
+class TimeFrame(_BaseTimeFrame):  # type: ignore[misc]
+    """Timeframe with safe defaults and attribute accessors."""
+
+    def __init__(self, amount: int = 1, unit=TimeFrameUnit.Day):  # type: ignore[assignment]
+        super().__init__(amount, unit)
+        # Guarantee ``amount`` and ``unit`` attributes for downstream code
+        object.__setattr__(self, "amount", getattr(self, "amount", amount))
+        object.__setattr__(self, "unit", getattr(self, "unit", unit))
+
+
+__all__ = ["TimeFrame", "TimeFrameUnit"]

--- a/tests/test_timeframe_zero_arg.py
+++ b/tests/test_timeframe_zero_arg.py
@@ -1,9 +1,9 @@
-from ai_trading.alpaca_api import get_timeframe_cls, get_timeframe_unit_cls
+from ai_trading.timeframe import TimeFrame, TimeFrameUnit
 
 
 def test_timeframe_zero_arg_defaults():
-    TimeFrame = get_timeframe_cls()
-    unit_cls = get_timeframe_unit_cls()
     tf = TimeFrame()
-    assert tf.amount == 1
-    assert getattr(tf.unit, "name", "") == getattr(unit_cls.Day, "name", "Day")
+    assert hasattr(tf, "amount")
+    assert getattr(tf, "amount", None) == 1
+    assert hasattr(tf, "unit")
+    assert getattr(tf.unit, "name", "") == getattr(TimeFrameUnit.Day, "name", "Day")


### PR DESCRIPTION
## Summary
- Provide TimeFrame wrapper defaulting to 1 Day and ensuring amount/unit attributes
- Re-export wrapper through alpaca_api helpers
- Normalize tests for zero-arg TimeFrame usage

## Testing
- `ruff check ai_trading/timeframe.py tests/test_timeframe_zero_arg.py ai_trading/alpaca_api.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_timeframe_zero_arg.py tests/test_alpaca_timeframe_mapping.py -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68c5b01804148330a7c93c3158b83e50