### PR TITLE
refactor: extract dummy model utility

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,16 @@
 import os
 import random
 import importlib
+import importlib.util
 import sys
 import types
 from pathlib import Path
+from typing import Any
+
+from tests.dummy_model_util import _DummyModel, _get_model
 
 import pytest
+
 
 # Ensure optional light-weight stubs are available only when real deps are missing
 def _ensure_test_stubs() -> None:
@@ -13,13 +18,16 @@ def _ensure_test_stubs() -> None:
     stubs = repo / "tests" / "stubs"
     if not stubs.exists():
         return
+
     def _missing(mod: str) -> bool:
         try:
             return importlib.util.find_spec(mod) is None
         except ValueError:
             return True
+
     need_stubs = any(
-        _missing(m) for m in (
+        _missing(m)
+        for m in (
             "pydantic",
             "pydantic_settings",
             # Use a stub for Retry if urllib3 not installed
@@ -29,30 +37,15 @@ def _ensure_test_stubs() -> None:
     if need_stubs and str(stubs) not in sys.path:
         sys.path.insert(0, str(stubs))
 
+
 _ensure_test_stubs()
 
 # Provide a lightweight default model so bot initialization can preload it
+
 _dummy_mod = types.ModuleType("dummy_model")
 
-
-class _DummyModel:
-    def predict(self, _x):
-        return [0]
-
-    def predict_proba(self, _x):
-        return [[0.5, 0.5]]
-
-def _get_model() -> _DummyModel:
-    """Return an instance of the dummy model.
-
-    Using a named function keeps the test helper picklable with the standard
-    ``pickle`` module, whereas inline lambdas cannot be pickled.
-    """
-
-    return _DummyModel()
-
-
-_dummy_mod.get_model = _get_model
+setattr(_dummy_mod, "get_model", _get_model)
+setattr(_dummy_mod, "_DummyModel", _DummyModel)
 sys.modules["dummy_model"] = _dummy_mod
 os.environ.setdefault("AI_TRADING_MODEL_MODULE", "dummy_model")
 
@@ -79,7 +72,7 @@ def _seed_tests() -> None:
         torch.manual_seed(0)
 
 
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(path: Path, config: Any) -> bool:
     """Ignore heavy or optional-dep tests when prerequisites are missing."""
     p = Path(str(path))
     needs_sklearn = p.name == "test_meta_learning_heavy.py" or "slow" in p.parts

--- a/tests/dummy_model_util.py
+++ b/tests/dummy_model_util.py
@@ -1,0 +1,31 @@
+"""Utilities providing a minimal ML model for tests.
+
+This module exposes a small model class and a factory function used across
+multiple tests. Keeping these objects in a dedicated module ensures they are
+picklable by the standard library ``pickle`` module.
+"""
+
+from __future__ import annotations
+
+
+class _DummyModel:
+    """Trivial model with ``predict`` and ``predict_proba`` methods."""
+
+    def predict(self, _x):  # pragma: no cover - trivial
+        return [0]
+
+    def predict_proba(self, _x):  # pragma: no cover - trivial
+        return [[0.5, 0.5]]
+
+
+def _get_model() -> _DummyModel:
+    """Return an instance of the dummy model.
+
+    Using a named function keeps the helper picklable with the standard
+    library ``pickle`` module, whereas lambdas cannot be pickled.
+    """
+
+    return _DummyModel()
+
+
+__all__ = ["_DummyModel", "_get_model"]

--- a/tests/test_dummy_model_pickling.py
+++ b/tests/test_dummy_model_pickling.py
@@ -1,6 +1,9 @@
 """Tests for dummy model pickling functionality."""
+
 import pickle
 import sys
+
+from tests.dummy_model_util import _DummyModel, _get_model
 
 
 def test_dummy_model_function_picklable(tmp_path):
@@ -11,8 +14,8 @@ def test_dummy_model_function_picklable(tmp_path):
         pickle.dump(get_model, fh)
     with path.open("rb") as fh:
         loaded = pickle.load(fh)
-    assert callable(loaded)
-    assert loaded().__class__.__name__ == "_DummyModel"
+    assert loaded is _get_model
+    assert isinstance(loaded(), _DummyModel)
 
 
 def test_dummy_model_instance_picklable(tmp_path):
@@ -23,4 +26,5 @@ def test_dummy_model_instance_picklable(tmp_path):
         pickle.dump(model, fh)
     with path.open("rb") as fh:
         loaded = pickle.load(fh)
+    assert isinstance(loaded, _DummyModel)
     assert loaded.predict([0]) == [0]


### PR DESCRIPTION
## Summary
- extract dummy ML model and factory into `tests/dummy_model_util.py`
- import dummy model helper in `conftest` and tests
- verify dummy model and factory are picklable

## Testing
- `pre-commit run --files conftest.py tests/dummy_model_util.py tests/test_dummy_model_pickling.py` *(fails: repo-guard, check-no-legacy-symbols)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_dummy_model_pickling.py tests/bot_engine/test_signal_ml.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5b017b838833095c6fad09d0b0c4d