### PR TITLE
feat(rl): add optional config alias and tests

### DIFF
--- a/ai_trading/rl/__init__.py
+++ b/ai_trading/rl/__init__.py
@@ -1,0 +1,4 @@
+"""Compatibility shim for RL utilities."""
+from .module import RLConfig, train, load, predict, _C
+
+__all__ = ["RLConfig", "train", "load", "predict", "_C"]

--- a/ai_trading/rl/module.py
+++ b/ai_trading/rl/module.py
@@ -1,0 +1,66 @@
+"""Lightweight RL module wrapper with optional config alias ``_C``.
+
+This shim exposes minimal training and inference helpers while avoiding a
+hard dependency on the full RL stack.  Downstream code may import
+``ai_trading.rl.module`` and optionally access the ``_C`` configuration
+object, but the functions will operate even if ``_C`` is missing.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ai_trading.logging import get_logger
+from ai_trading.rl_trading import train as _train_mod
+from ai_trading.rl_trading import inference as _inf_mod
+import ai_trading.rl_trading as _rl  # noqa: F401
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class RLConfig:
+    """Minimal configuration for RL training."""
+
+    timesteps: int = 0
+
+
+# Backwards-compatibility alias.  Older code expected a module level ``_C``
+# configuration similar to other subsystems.  New code should pass
+# ``RLConfig`` explicitly, but ``_C`` is kept for legacy access.
+_C = RLConfig()
+
+
+def train(data: Any, model_path: str | Path, cfg: RLConfig | None = None):
+    """Train a minimal RL model and save it.
+
+    Parameters
+    ----------
+    data:
+        Training data passed to :mod:`ai_trading.rl_trading.train`.
+    model_path:
+        Destination path for the saved model.
+    cfg:
+        Optional :class:`RLConfig` overriding the legacy ``_C`` defaults.
+    """
+
+    cfg = cfg or _C
+    logger.debug("RL train invoked", extra={"timesteps": cfg.timesteps})
+    return _train_mod.train(data, model_path, timesteps=cfg.timesteps)
+
+
+def load(model_path: str | Path):
+    """Load a previously trained RL policy."""
+
+    return _inf_mod.load_policy(model_path)
+
+
+def predict(agent: Any, state: Any):
+    """Predict a trading signal from *state* using *agent*."""
+
+    return _inf_mod.predict_signal(agent, state)
+
+
+__all__ = ["RLConfig", "train", "load", "predict", "_C"]

--- a/tests/test_rl_module.py
+++ b/tests/test_rl_module.py
@@ -3,6 +3,7 @@ require("numpy")
 import ai_trading.rl_trading.inference as inf
 import ai_trading.rl_trading.train as train_mod
 import numpy as np
+import ai_trading.rl.module as rl_mod
 
 
 def test_rl_train_and_infer(monkeypatch, tmp_path):
@@ -18,8 +19,34 @@ def test_rl_train_and_infer(monkeypatch, tmp_path):
     monkeypatch.setattr(train_mod, "PPO", DummyPPO)
     import ai_trading.rl_trading as rl
     monkeypatch.setattr(rl, "PPO", DummyPPO)
+    monkeypatch.setattr(rl, "is_rl_available", lambda: True)
     path = tmp_path / "model.zip"
     train_mod.train(data, path, timesteps=10)
     agent = inf.load_policy(path)
     sig = inf.predict_signal(agent, data[0])
+    assert sig and sig.side == "buy"
+
+def test_rl_wrapper_without_c(monkeypatch, tmp_path):
+    data = np.random.rand(20, 4)
+    class DummyPPO:
+        def __init__(self, *_a, **_k):
+            pass
+        def learn(self, *a, **k):
+            return None
+        def save(self, path):
+            open(path, "wb").write(b"0")
+        def predict(self, state, deterministic=True):
+            return (1, None)
+        @classmethod
+        def load(cls, path):
+            return cls()
+    monkeypatch.setattr(train_mod, "PPO", DummyPPO)
+    monkeypatch.setattr(rl_mod._rl, "PPO", DummyPPO)
+    monkeypatch.setattr(rl_mod._rl, "is_rl_available", lambda: True)
+    monkeypatch.delattr(rl_mod, "_C", raising=False)
+    cfg = rl_mod.RLConfig(timesteps=5)
+    path = tmp_path / "model.zip"
+    rl_mod.train(data, path, cfg)
+    agent = rl_mod.load(path)
+    sig = rl_mod.predict(agent, data[0])
     assert sig and sig.side == "buy"


### PR DESCRIPTION
## Summary
- expose lightweight RL wrapper with optional `_C` config
- ensure training and inference work without `_C`
- add tests covering wrapper and legacy import

## Testing
- `ruff check ai_trading/rl/module.py tests/test_rl_module.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rl_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b22f996c8330a71492299c9136e5