### PR TITLE
Handle None filled quantities in orders and add test fixture

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8826,7 +8826,7 @@ def safe_submit_order(api: Any, req, *, bypass_market_check: bool = False) -> Or
                 f"Order status for {order_args.get('symbol')}: {getattr(order, 'status', '')}"
             )
             status = getattr(order, "status", "")
-            filled_qty = getattr(order, "filled_qty", "0")
+            filled_qty = getattr(order, "filled_qty", 0) or 0
             if status == "filled":
                 logger.info(
                     "ORDER_ACK",
@@ -8909,7 +8909,7 @@ def poll_order_fill_status(ctx: BotContext, order_id: str, timeout: int = 120) -
         try:
             od = ctx.api.get_order(order_id)
             status = getattr(od, "status", "")
-            filled = getattr(od, "filled_qty", "0")
+            filled = getattr(od, "filled_qty", 0) or 0
             if status not in {"new", "accepted", "partially_filled"}:
                 logger.info(
                     "ORDER_FINAL_STATUS",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import socket
 import sys
 from datetime import datetime, timezone
 import pathlib
+import types
 
 import pytest
 import ai_trading.data.fetch as data_fetcher
@@ -155,3 +156,19 @@ def _sanitize_executor_env(monkeypatch):
 @pytest.fixture(autouse=True)
 def _reset_fallback_cache(monkeypatch):
     monkeypatch.setattr(data_fetcher, "_FALLBACK_WINDOWS", set())
+
+
+@pytest.fixture
+def dummy_order():
+    """Provide a minimal order-like object for tests.
+
+    Ensures required attributes are present and ``filled_qty`` defaults to ``0``
+    so that code paths handling numeric comparisons do not encounter ``None``.
+    """
+
+    return types.SimpleNamespace(
+        id="1",
+        status="filled",
+        filled_qty=0,
+        symbol="TEST",
+    )


### PR DESCRIPTION
## Summary
- add `dummy_order` fixture so tests receive orders with `filled_qty=0`
- ensure `safe_submit_order` and order polling treat missing `filled_qty` as 0

## Testing
- `ruff check ai_trading/core/bot_engine.py tests/conftest.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_safe_submit_order.py tests/test_fill_rate_calculation_fix.py -q`

## Rollback Plan
- Revert commit `chore: add order fixture and handle none filled`

------
https://chatgpt.com/codex/tasks/task_e_68c5b2301f048330b308140f17ce2842