### PR TITLE
Add environment-driven risk config with mode presets

### DIFF
--- a/CENTRALIZED_PARAMETERS_SUMMARY.md
+++ b/CENTRALIZED_PARAMETERS_SUMMARY.md
@@ -16,12 +16,14 @@
 
 2. **Mode-Specific Parameters** ✅
    - Conservative: Lower risk (kelly_fraction=0.25, conf_threshold=0.85, daily_loss_limit=0.03)
-   - Balanced: Moderate risk (kelly_fraction=0.6, conf_threshold=0.75, daily_loss_limit=0.05) 
+   - Balanced: Moderate risk (kelly_fraction=0.6, conf_threshold=0.75, daily_loss_limit=0.05)
    - Aggressive: Higher risk (kelly_fraction=0.75, conf_threshold=0.65, daily_loss_limit=0.08)
+   - Presets also set `max_position_size` to **5000**, **8000**, and **12000** shares respectively.
 
 3. **Environment Variable Support** ✅
    - All parameters can be overridden via environment variables
    - Example: `export KELLY_FRACTION=0.5` works across entire system
+   - `MAX_DRAWDOWN_THRESHOLD` is now **required**; startup fails fast if missing.
    - Runtime configuration without code changes
 
 4. **Backward Compatibility** ✅

--- a/conftest.py
+++ b/conftest.py
@@ -48,6 +48,7 @@ setattr(_dummy_mod, "get_model", _get_model)
 setattr(_dummy_mod, "_DummyModel", _DummyModel)
 sys.modules["dummy_model"] = _dummy_mod
 os.environ.setdefault("AI_TRADING_MODEL_MODULE", "dummy_model")
+os.environ.setdefault("MAX_DRAWDOWN_THRESHOLD", "0.1")
 
 
 def _missing(mod: str) -> bool:

--- a/tests/config/test_env_aliases_import_safety.py
+++ b/tests/config/test_env_aliases_import_safety.py
@@ -1,14 +1,15 @@
 import importlib
 
 
-def test_import_succeeds_without_optional_thresholds(monkeypatch):
-    monkeypatch.delenv("MAX_DRAWDOWN_THRESHOLD", raising=False)
+def test_import_succeeds_with_required_threshold(monkeypatch):
+    monkeypatch.setenv("MAX_DRAWDOWN_THRESHOLD", "0.1")
     monkeypatch.delenv("AI_TRADING_MAX_DRAWDOWN_THRESHOLD", raising=False)
     import ai_trading.risk.kelly as kelly
     importlib.reload(kelly)
 
 
 def test_alias_for_drawdown_threshold(monkeypatch):
+    monkeypatch.delenv("MAX_DRAWDOWN_THRESHOLD", raising=False)
     monkeypatch.setenv("AI_TRADING_MAX_DRAWDOWN_THRESHOLD", "0.08")
     from ai_trading.config.management import TradingConfig
 

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -1,0 +1,41 @@
+import importlib
+import os
+
+import pytest
+
+
+def _reload_config(monkeypatch, **env):
+    module_name = "ai_trading.config"
+    if module_name in list(importlib.sys.modules):
+        del importlib.sys.modules[module_name]
+    for k in ["MAX_DRAWDOWN_THRESHOLD", "TRADING_MODE", "KELLY_FRACTION", "CONF_THRESHOLD", "MAX_POSITION_SIZE"]:
+        monkeypatch.delenv(k, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, str(v))
+    return importlib.import_module(module_name)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    import sys
+    sys.modules.pop("ai_trading.config", None)
+
+
+def test_missing_drawdown_threshold(monkeypatch):
+    with pytest.raises(RuntimeError):
+        _reload_config(monkeypatch)
+
+
+def test_mode_presets(monkeypatch):
+    cfg = _reload_config(monkeypatch, MAX_DRAWDOWN_THRESHOLD=0.2, TRADING_MODE="conservative")
+    assert cfg.CONF_THRESHOLD == pytest.approx(0.85)
+    assert cfg.MAX_POSITION_SIZE == pytest.approx(5000.0)
+
+    cfg = _reload_config(monkeypatch, MAX_DRAWDOWN_THRESHOLD=0.2)
+    assert cfg.CONF_THRESHOLD == pytest.approx(0.75)
+    assert cfg.MAX_POSITION_SIZE == pytest.approx(8000.0)
+
+    cfg = _reload_config(monkeypatch, MAX_DRAWDOWN_THRESHOLD=0.2, TRADING_MODE="aggressive")
+    assert cfg.CONF_THRESHOLD == pytest.approx(0.65)
+    assert cfg.MAX_POSITION_SIZE == pytest.approx(12000.0)


### PR DESCRIPTION
## Summary
- require `MAX_DRAWDOWN_THRESHOLD` env var and add helpers for optional float envs
- expose mode presets for kelly fraction, confidence threshold, and position sizing
- document and test mode preset behaviour and required drawdown env

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_config_module.py tests/config/test_env_aliases_import_safety.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools'; No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c5b230a94c833094597c62b3d23c8f