### PR TITLE
Handle unwritable trade log directories

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5949,8 +5949,9 @@ def get_trade_logger() -> TradeLogger:
         os.makedirs(log_dir, mode=0o700, exist_ok=True)
     except PermissionError as exc:
         logger.warning(
-            "TRADE_LOG_DIR_CREATE_FAILED",
-            extra={"dir": log_dir, "cause": "PermissionError", "detail": str(exc)},
+            "TRADE_LOG_DIR_NOT_WRITABLE %s",
+            log_dir,
+            extra={"dir": log_dir, "detail": str(exc)},
         )
         return _TRADE_LOGGER_SINGLETON
     except OSError as exc:  # AI-AGENT-REF: ensure trade log dir exists
@@ -5983,7 +5984,11 @@ def get_trade_logger() -> TradeLogger:
         return bool(mode & _stat.S_IWOTH)
 
     if not _is_dir_writable(log_dir):
-        logger.warning("TRADE_LOG_DIR_NOT_WRITABLE", extra={"dir": log_dir})
+        logger.warning(
+            "TRADE_LOG_DIR_NOT_WRITABLE %s",
+            log_dir,
+            extra={"dir": log_dir},
+        )
         return _TRADE_LOGGER_SINGLETON
 
     if not os.path.exists(path) or os.path.getsize(path) == 0:
@@ -6009,8 +6014,12 @@ def get_trade_logger() -> TradeLogger:
                     )
                 finally:
                     portalocker.unlock(f)
-        except PermissionError:
-            logger.debug("TradeLogger init path not writable: %s", path)
+        except PermissionError as exc:
+            logger.warning(
+                "TRADE_LOG_DIR_NOT_WRITABLE %s",
+                log_dir,
+                extra={"dir": log_dir, "detail": str(exc)},
+            )
     return _TRADE_LOGGER_SINGLETON
 
 

--- a/tests/bot_engine/test_trade_log_init.py
+++ b/tests/bot_engine/test_trade_log_init.py
@@ -113,5 +113,24 @@ def test_get_trade_logger_warns_when_dir_not_writable(tmp_path, monkeypatch, cap
         bot_engine.get_trade_logger()
 
     assert "TRADE_LOG_DIR_NOT_WRITABLE" in caplog.text
+    assert str(log_dir) in caplog.text
     assert not log_path.exists()
+
+
+def test_get_trade_logger_warns_on_dir_creation_permission_error(tmp_path, monkeypatch, caplog):
+    """get_trade_logger warns when os.makedirs raises PermissionError."""
+
+    parent = tmp_path / "parent"
+    parent.mkdir()
+    parent.chmod(0o555)
+    log_path = parent / "child" / "trades.jsonl"
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+
+    with caplog.at_level(logging.WARNING):
+        bot_engine.get_trade_logger()
+
+    assert "TRADE_LOG_DIR_NOT_WRITABLE" in caplog.text
+    assert str(log_path.parent) in caplog.text
+    assert not log_path.parent.exists()
 


### PR DESCRIPTION
## Summary
- Warn with `TRADE_LOG_DIR_NOT_WRITABLE` when trade log dir cannot be created or written
- Include directory path in warning for assertions
- Cover unwritable and non-creatable directories in tests

## Testing
- `python -m pip install -U pip`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5b40a154c83309a760785ebcfd3cf