### PR TITLE
feat: enhance MockSeries capabilities

### DIFF
--- a/tests/support/mock_series.py
+++ b/tests/support/mock_series.py
@@ -1,21 +1,40 @@
-"""Lightweight stand-in for pandas Series used in tests."""
+"""Lightweight stand-in for pandas ``Series`` used in tests.
+
+The real project uses ``pandas.Series`` extensively but the full dependency
+is heavy to import in unit tests.  This minimal implementation provides only
+the pieces of the interface that our tests exercise.  It purposely mimics the
+behaviour of a subset of pandas so tests can perform simple computations
+without pulling in the entire library.
+"""
 from __future__ import annotations
 
-from typing import Iterable, List
+from math import isnan
+from typing import Iterable, Iterator, List
 
 
 class MockSeries:
     """Minimal Series-like object for testing without pandas."""
 
     def __init__(self, values: Iterable[float]):
+        # Store a concrete list so operations like ``diff`` can iterate multiple
+        # times over the data.  Values are kept as provided; callers are
+        # responsible for ensuring numeric types where appropriate.
         self._values = list(values)
 
+    # ------------------------------------------------------------------
+    # Python protocol methods
     def __len__(self) -> int:  # pragma: no cover - trivial
         return len(self._values)
 
     def __getitem__(self, idx):  # pragma: no cover - trivial
         return self._values[idx]
 
+    def __iter__(self) -> Iterator[float]:  # pragma: no cover - trivial
+        return iter(self._values)
+
+    # ------------------------------------------------------------------
+    # ``.iloc`` helper used by a few tests.  It intentionally only supports
+    # basic indexing via ``__getitem__``.
     class _ILoc:
         def __init__(self, outer: "MockSeries") -> None:
             self._outer = outer
@@ -27,15 +46,59 @@ class MockSeries:
     def iloc(self) -> "MockSeries._ILoc":  # pragma: no cover - simple
         return MockSeries._ILoc(self)
 
+    # ------------------------------------------------------------------
+    # Convenience helpers ------------------------------------------------
     def tail(self, n: int = 5) -> "MockSeries":  # pragma: no cover - trivial
         return MockSeries(self._values[-n:])
 
     def tolist(self) -> List[float]:  # pragma: no cover - trivial
         return list(self._values)
 
-    def diff(self, *_args, **_kwargs) -> "MockSeries":
-        """Placeholder diff returning self."""
-        return self
+    # ------------------------------------------------------------------
+    # Pandas-like numeric operations ------------------------------------
+    def diff(self, periods: int = 1) -> "MockSeries":
+        """Return the first discrete difference of the series.
+
+        Only ``periods=1`` is implemented which covers the needs of the test
+        suite.  The first value mirrors pandas' behaviour by being ``NaN``.
+        """
+
+        if periods != 1:  # pragma: no cover - defensive, not exercised
+            raise NotImplementedError("MockSeries.diff only supports periods=1")
+
+        if not self._values:
+            return MockSeries([])
+
+        diffs = [float("nan")]
+        diffs.extend(self._values[i] - self._values[i - 1] for i in range(1, len(self._values)))
+        return MockSeries(diffs)
+
+    def isna(self) -> "MockSeries":
+        """Boolean mask indicating ``NaN`` values.
+
+        ``None`` is also treated as ``NaN`` to match the behaviour of
+        ``pandas.isna``.
+        """
+
+        def _is_na(v: float) -> bool:
+            if v is None:  # pragma: no cover - simple guard
+                return True
+            try:
+                return isnan(v)
+            except TypeError:  # pragma: no cover - non-numeric
+                return False
+
+        return MockSeries(_is_na(v) for v in self._values)
+
+    # Boolean reductions -------------------------------------------------
+    def any(self) -> bool:  # pragma: no cover - trivial
+        return any(self._values)
+
+    def all(self) -> bool:  # pragma: no cover - trivial
+        return all(self._values)
+
+    def sum(self) -> float:  # pragma: no cover - trivial
+        return sum(self._values)
 
 
 __all__ = ["MockSeries"]

--- a/tests/test_intelligent_position_management.py
+++ b/tests/test_intelligent_position_management.py
@@ -13,6 +13,7 @@ AI-AGENT-REF: Comprehensive tests for intelligent position management
 """
 
 import importlib.util
+import math
 from unittest.mock import Mock
 
 import pytest
@@ -89,7 +90,16 @@ class TestIntelligentPositionManager:
         # Verify component extraction from mocked data
         close_series = self.mock_ctx.data_fetcher.get_daily_df.return_value.close
         assert isinstance(close_series, MockSeries)
-        assert close_series.diff() is close_series
+
+        # ``diff`` should yield numeric differences with ``NaN`` for the first
+        # element to mirror pandas semantics.
+        diff_values = close_series.diff().tolist()
+        assert math.isnan(diff_values[0])
+        assert diff_values[1:] == [1] * (len(self.mock_daily_data["close"]) - 1)
+
+        # ``isna`` should report no missing values for this dataset.
+        assert not close_series.isna().any()
+
         assert close_series.tail().tolist() == self.mock_daily_data["close"][-5:]
 
     def test_should_hold_position_integration(self):


### PR DESCRIPTION
## Summary
- expand `MockSeries` with pandas-like helpers (`diff`, `isna`, boolean reducers)
- verify numeric diff computations and absence of NaNs in intelligent position tests

## Testing
- `ruff check tests/support/mock_series.py tests/test_intelligent_position_management.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_intelligent_position_management.py::TestIntelligentPositionManager::test_initialization -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b40c06108330a02dc2258ec018a9