### PR TITLE
refactor: use module-level functions for ML model test pipeline

### DIFF
--- a/tests/test_ml_model_integration.py
+++ b/tests/test_ml_model_integration.py
@@ -9,13 +9,23 @@ import pytest
 from ai_trading import ml_model  # AI-AGENT-REF: canonical import
 
 
+def _fit_noop(X, y):
+    return None
+
+
+def _predict_zero(X):
+    return [0] * len(X)
+
+
+def _make_pipeline() -> types.SimpleNamespace:
+    return types.SimpleNamespace(fit=_fit_noop, predict=_predict_zero, version="1")
+
+
 def test_save_and_load_roundtrip():
     if ml_model.joblib is None:
         pytest.skip("joblib not available")
     model_dir = Path(ml_model.__file__).resolve().parent / "models"
-    pipe = types.SimpleNamespace(
-        fit=lambda X, y: None, predict=lambda X: [0] * len(X), version="1"
-    )
+    pipe = _make_pipeline()
     model = ml_model.MLModel(pipe)
     df = pd.DataFrame({"a": [1.0]})
     model.fit(df, [1.0])
@@ -27,7 +37,7 @@ def test_save_and_load_roundtrip():
 
 
 def test_save_outside_model_dir_raises(tmp_path):
-    pipe = types.SimpleNamespace(fit=lambda X, y: None, predict=lambda X: [0])
+    pipe = _make_pipeline()
     model = ml_model.MLModel(pipe)
     with pytest.raises(RuntimeError):
         model.save(tmp_path / "m.pkl")


### PR DESCRIPTION
## Summary
- replace inline lambdas with module-level helper functions
- ensure pickled pipeline uses functions defined at module scope

## Testing
- `ruff check tests/test_ml_model_integration.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_ml_model_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b409ebd883308a14411f73358a2a