### PR TITLE
Expose TradingClient in risk engine

### DIFF
--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -14,6 +14,10 @@ try:
 except ImportError:  # pragma: no cover - allow import without alpaca for tests
     class APIError(Exception):
         pass
+try:
+    from alpaca.trading.client import TradingClient
+except ImportError:  # pragma: no cover - allow import without alpaca for tests
+    TradingClient = object  # type: ignore[assignment]
 from ai_trading.config.management import (
     SEED,
     TradingConfig,

--- a/tests/test_alpaca_auth_credentials.py
+++ b/tests/test_alpaca_auth_credentials.py
@@ -17,7 +17,7 @@ def test_trading_client_api_key_only(monkeypatch):
     monkeypatch.setenv("ALPACA_API_KEY", "key")
     monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
     monkeypatch.delenv("ALPACA_OAUTH", raising=False)
-    monkeypatch.setattr("ai_trading.risk.engine.TradingClient", Dummy)
+    monkeypatch.setattr("ai_trading.risk.engine.StockHistoricalDataClient", Dummy)
     get_settings.cache_clear()
 
     RiskEngine()
@@ -38,7 +38,7 @@ def test_trading_client_oauth_only(monkeypatch):
     monkeypatch.delenv("ALPACA_API_KEY", raising=False)
     monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
     monkeypatch.setenv("ALPACA_OAUTH", "tok")
-    monkeypatch.setattr("ai_trading.risk.engine.TradingClient", Dummy)
+    monkeypatch.setattr("ai_trading.risk.engine.StockHistoricalDataClient", Dummy)
     get_settings.cache_clear()
 
     RiskEngine()


### PR DESCRIPTION
## Summary
- Re-export Alpaca TradingClient in risk engine for compatibility
- Adjust auth tests to patch StockHistoricalDataClient

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5b40b580c8330acc50a72b3060fed