### PR TITLE
Track fetch error metrics in snapshot

### DIFF
--- a/tests/unit/test_fetch_metrics_snapshot.py
+++ b/tests/unit/test_fetch_metrics_snapshot.py
@@ -4,56 +4,38 @@ import importlib
 
 import pytest
 
-import ai_trading.data.fetch as df
-from ai_trading.data.metrics import metrics as metrics_state
-
-
-@pytest.fixture(autouse=True)
-def reset_counters():
-    metrics_state.rate_limit = 0
-    metrics_state.timeout = 0
-    metrics_state.unauthorized = 0
-    metrics_state.empty_payload = 0
-    metrics_state.feed_switch = 0
-    yield
-    metrics_state.rate_limit = 0
-    metrics_state.timeout = 0
-    metrics_state.unauthorized = 0
-    metrics_state.empty_payload = 0
-    metrics_state.feed_switch = 0
-
 
 @pytest.fixture
 def fm():
     mod = importlib.import_module("ai_trading.data.fetch.metrics")
-    # Ensure other tests still see the dataclass instance
-    df.metrics = metrics_state
-    return mod
+    mod.reset()
+    yield mod
+    mod.reset()
 
 
 def test_snapshot_rate_limit(fm):
-    metrics_state.rate_limit += 1
+    fm.rate_limit("iex")
     out = fm.snapshot(None)
     assert out["rate_limit"] == 1
     assert out["timeout"] == 0
 
 
 def test_snapshot_timeout(fm):
-    metrics_state.timeout += 2
-    out = fm.snapshot(object())
-    assert out["timeout"] == 2
+    fm.timeout("iex")
+    out = fm.snapshot()
+    assert out["timeout"] == 1
     assert out["rate_limit"] == 0
 
 
 def test_snapshot_unauthorized(fm):
-    metrics_state.unauthorized += 1
-    out = fm.snapshot(None)
+    fm.unauthorized_sip("sip")
+    out = fm.snapshot()
     assert out["unauthorized"] == 1
     assert out["empty_payload"] == 0
 
 
 def test_snapshot_empty_payload(fm):
-    metrics_state.empty_payload += 3
-    out = fm.snapshot(None)
-    assert out["empty_payload"] == 3
+    fm.empty_payload("AAPL", "1Min")
+    out = fm.snapshot()
+    assert out["empty_payload"] == 1
     assert out["rate_limit"] == 0


### PR DESCRIPTION
## Summary
- increment global metrics counters when rate limit, timeout, unauthorized SIP, or empty payload events occur
- default `snapshot()` to internal metrics and reset all counters for reliable tests
- add tests verifying snapshot reflects updated counters

## Testing
- `ruff check ai_trading/data/fetch/metrics.py tests/unit/test_fetch_metrics_snapshot.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_fetch_metrics_snapshot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5b40ab6ec8330af03dc549a73534a