### PR TITLE
Handle inline comments in float env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ config.reload_env()
 
 `.env` at the repo root is reloaded at startup with `override=True`; if configuration
 cannot be loaded, the bot exits early with a critical log.
+Float environment values ignore inline comments after `#`, allowing declarations like
+`MAX_DRAWDOWN_THRESHOLD="0.08  # 8% limit"`.
 Rebalance frequency defaults to 60 minutes; override with `AI_TRADING_REBALANCE_INTERVAL_MIN`
 (minutes) or `AI_TRADING_REBALANCE_INTERVAL_HOURS` (hours). The smallest positive value
 is used when multiple sources are set.

--- a/ai_trading/config/__init__.py
+++ b/ai_trading/config/__init__.py
@@ -23,13 +23,19 @@ ORDER_STALE_CLEANUP_INTERVAL = 60
 ORDER_FILL_RATE_TARGET = 0.8
 
 
+def _parse_float_env(val: str) -> float:
+    """Parse a float environment value, ignoring inline comments."""
+    token = val.split("#", 1)[0].strip()
+    return float(token)
+
+
 def _require_float_env(name: str) -> float:
     """Fetch a required environment variable and convert to float."""
     val = os.getenv(name)
     if val is None or val == "":
         raise RuntimeError(f"Missing required env var: {name}")
     try:
-        return float(val)
+        return _parse_float_env(val)
     except ValueError as e:
         raise RuntimeError(f"Invalid value for {name}: {val}") from e
 
@@ -40,7 +46,7 @@ def _optional_float_env(name: str, default: float) -> float:
     if val is None or val == "":
         return default
     try:
-        return float(val)
+        return _parse_float_env(val)
     except ValueError as e:
         raise RuntimeError(f"Invalid value for {name}: {val}") from e
 

--- a/tests/config/test_env_comment_handling.py
+++ b/tests/config/test_env_comment_handling.py
@@ -1,0 +1,32 @@
+import importlib
+import sys
+
+import pytest
+
+
+def _reload_config(monkeypatch, **env):
+    module_name = "ai_trading.config"
+    sys.modules.pop(module_name, None)
+    for key in [
+        "MAX_DRAWDOWN_THRESHOLD",
+        "TRADING_MODE",
+        "KELLY_FRACTION",
+        "CONF_THRESHOLD",
+        "MAX_POSITION_SIZE",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, str(v))
+    return importlib.import_module(module_name)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    sys.modules.pop("ai_trading.config", None)
+
+
+def test_comment_stripped_from_float_env(monkeypatch):
+    cfg = _reload_config(monkeypatch, MAX_DRAWDOWN_THRESHOLD="0.08  # comment")
+    assert cfg.MAX_DRAWDOWN_THRESHOLD == pytest.approx(0.08)
+


### PR DESCRIPTION
## Summary
- allow inline comments in float environment variables via `_parse_float_env`
- document comment stripping for float env values
- add regression test for `MAX_DRAWDOWN_THRESHOLD` comment handling

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5b61b4ed48330b8deedc481036afe