### PR TITLE
refactor: rename fetch metrics helpers

### DIFF
--- a/ai_trading/data/fetch/iex_fallback.py
+++ b/ai_trading/data/fetch/iex_fallback.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from ai_trading.utils.lazy_imports import load_pandas
 from ai_trading.logging import get_logger
-from .metrics import empty_payload, mark_skipped, unauthorized_sip
+from .metrics import inc_empty_payload, mark_skipped, inc_unauthorized_sip
 
 # Import shared state from the package's ``__init__``.  These variables are
 # defined there and are re-used across modules.
@@ -109,7 +109,7 @@ def fetch_bars(
         if feed == "iex":
             attempts += 1
             _IEX_EMPTY_COUNTS[key] = _IEX_EMPTY_COUNTS.get(key, 0) + 1
-            empty_payload(symbol, tf)
+            inc_empty_payload(symbol, tf)
             mark_skipped(symbol, tf)
             if _ALLOW_SIP and not _SIP_UNAUTHORIZED:
                 logger.info(
@@ -125,7 +125,7 @@ def fetch_bars(
                 feed = "sip"
                 continue
             if _SIP_UNAUTHORIZED:
-                unauthorized_sip("alpaca")
+                inc_unauthorized_sip("alpaca")
             return _to_df({})
 
         # If we get here the SIP request was also empty

--- a/ai_trading/data/fetch/metrics.py
+++ b/ai_trading/data/fetch/metrics.py
@@ -38,7 +38,7 @@ def mark_skipped(symbol: str, timeframe: str) -> int:
         return _SKIPPED_SYMBOLS[key]
 
 
-def rate_limit(host: str) -> int:
+def inc_rate_limit(host: str) -> int:
     """Increment rate-limit counter for ``host`` and return the total."""
     with _RATE_LIMIT_LOCK:
         _RATE_LIMITS[host] += 1
@@ -46,7 +46,7 @@ def rate_limit(host: str) -> int:
         return _RATE_LIMITS[host]
 
 
-def timeout(host: str) -> int:
+def inc_timeout(host: str) -> int:
     """Increment timeout counter for ``host`` and return the total."""
     with _TIMEOUT_LOCK:
         _TIMEOUTS[host] += 1
@@ -54,7 +54,7 @@ def timeout(host: str) -> int:
         return _TIMEOUTS[host]
 
 
-def unauthorized_sip(host: str) -> int:
+def inc_unauthorized_sip(host: str) -> int:
     """Increment unauthorized SIP counter for ``host`` and return the total."""
     with _UNAUTH_LOCK:
         _UNAUTH_SIP[host] += 1
@@ -62,7 +62,7 @@ def unauthorized_sip(host: str) -> int:
         return _UNAUTH_SIP[host]
 
 
-def empty_payload(symbol: str, timeframe: str) -> int:
+def inc_empty_payload(symbol: str, timeframe: str) -> int:
     """Increment empty-payload counter for ``symbol``/``timeframe``."""
     key = (symbol, timeframe)
     with _EMPTY_LOCK:
@@ -71,14 +71,14 @@ def empty_payload(symbol: str, timeframe: str) -> int:
         return _EMPTY[key]
 
 
-def fetch_attempt(provider: str) -> int:
+def inc_fetch_attempt(provider: str) -> int:
     """Record a fetch attempt for ``provider`` and return the running total."""
     with _FETCH_ATTEMPT_LOCK:
         _FETCH_ATTEMPTS[provider] += 1
         return _FETCH_ATTEMPTS[provider]
 
 
-def alpaca_failed() -> int:
+def inc_alpaca_failed() -> int:
     """Increment and return the Alpaca failure count."""
     global _ALPACA_FAILED
     with _ALPACA_FAILED_LOCK:
@@ -97,7 +97,7 @@ def _current_value(metric: object) -> int:
         return 0
 
 
-def provider_fallback(from_provider: str, to_provider: str) -> int:
+def inc_provider_fallback(from_provider: str, to_provider: str) -> int:
     """Increment fallback counter and return the current value."""
     metric = _provider_fallback_counter.labels(
         from_provider=from_provider, to_provider=to_provider
@@ -106,14 +106,14 @@ def provider_fallback(from_provider: str, to_provider: str) -> int:
     return _current_value(metric)
 
 
-def backup_provider_used(provider: str, symbol: str) -> int:
+def inc_backup_provider_used(provider: str, symbol: str) -> int:
     """Increment backup-provider counter and return the current value."""
     metric = _backup_provider_used_counter.labels(provider=provider, symbol=symbol)
     metric.inc()
     return _current_value(metric)
 
 
-def provider_disable_total(provider: str) -> int:
+def inc_provider_disable_total(provider: str) -> int:
     """Increment provider-disable counter and return the current value."""
     metric = _provider_disable_total_counter.labels(provider=provider)
     metric.inc()
@@ -152,13 +152,13 @@ def reset() -> None:
 
 __all__ = [
     "mark_skipped",
-    "rate_limit",
-    "timeout",
-    "unauthorized_sip",
-    "empty_payload",
-    "provider_fallback",
-    "backup_provider_used",
-    "provider_disable_total",
+    "inc_rate_limit",
+    "inc_timeout",
+    "inc_unauthorized_sip",
+    "inc_empty_payload",
+    "inc_provider_fallback",
+    "inc_backup_provider_used",
+    "inc_provider_disable_total",
     "snapshot",
     "reset",
     "_SKIPPED_SYMBOLS",
@@ -168,7 +168,7 @@ __all__ = [
     "_EMPTY",
     "_FETCH_ATTEMPTS",
     "_ALPACA_FAILED",
-    "fetch_attempt",
-    "alpaca_failed",
+    "inc_fetch_attempt",
+    "inc_alpaca_failed",
 ]
 

--- a/tests/test_backup_provider_switch.py
+++ b/tests/test_backup_provider_switch.py
@@ -6,7 +6,7 @@ pd = pytest.importorskip("pandas")
 
 from ai_trading.data import fetch as data_fetcher
 from ai_trading.config import settings as config_settings
-from ai_trading.data.fetch.metrics import backup_provider_used
+from ai_trading.data.fetch.metrics import inc_backup_provider_used
 
 
 def test_switches_to_backup_provider(monkeypatch, caplog):
@@ -40,11 +40,11 @@ def test_switches_to_backup_provider(monkeypatch, caplog):
 
     monkeypatch.setattr(data_fetcher, "_fetch_bars", empty_fetch)
     monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", fake_backup)
-    before = backup_provider_used("yahoo", "AAPL")
+    before = inc_backup_provider_used("yahoo", "AAPL")
     with caplog.at_level(logging.INFO):
         df = data_fetcher.get_minute_df("AAPL", start, end)
 
-    after = backup_provider_used("yahoo", "AAPL")
+    after = inc_backup_provider_used("yahoo", "AAPL")
     assert called.get("used")
     assert not df.empty
     assert after == before + 1

--- a/tests/test_iex_sip_fallback.py
+++ b/tests/test_iex_sip_fallback.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import ai_trading.data.fetch as fetch
-from ai_trading.data.fetch.metrics import provider_fallback
+from ai_trading.data.fetch.metrics import inc_provider_fallback
 
 
 def test_iex_empty_switches_to_sip(monkeypatch, caplog):
@@ -44,10 +44,10 @@ def test_iex_empty_switches_to_sip(monkeypatch, caplog):
 
     monkeypatch.setattr(fetch, "_sip_fallback_allowed", sip_allowed)
 
-    before = provider_fallback("alpaca_iex", "alpaca_sip")
+    before = inc_provider_fallback("alpaca_iex", "alpaca_sip")
     with caplog.at_level("INFO"):
         df = fetch._fetch_bars(symbol, start, end, "1Min", feed="iex")
-    after = provider_fallback("alpaca_iex", "alpaca_sip")
+    after = inc_provider_fallback("alpaca_iex", "alpaca_sip")
 
     assert feeds == ["iex", "sip"]
     assert not df.empty

--- a/tests/test_yahoo_fallback_order.py
+++ b/tests/test_yahoo_fallback_order.py
@@ -6,7 +6,7 @@ import pytest
 pd = pytest.importorskip("pandas")
 
 import ai_trading.data.fetch as fetch
-from ai_trading.data.fetch.metrics import provider_fallback
+from ai_trading.data.fetch.metrics import inc_provider_fallback
 import ai_trading.data.fetch.fallback_order as fo
 
 
@@ -51,11 +51,11 @@ def test_yahoo_used_after_two_alpaca_failures(monkeypatch):
     monkeypatch.setattr(fetch, "_yahoo_get_bars", fake_yahoo)
     fo.reset()
 
-    before = provider_fallback("alpaca_sip", "yahoo")
+    before = inc_provider_fallback("alpaca_sip", "yahoo")
 
     df = fetch._fetch_bars(symbol, start, end, "1Min", feed="iex")
 
-    after = provider_fallback("alpaca_sip", "yahoo")
+    after = inc_provider_fallback("alpaca_sip", "yahoo")
 
     assert called.get("yahoo")
     assert not df.empty

--- a/tests/unit/test_data_fetcher_http.py
+++ b/tests/unit/test_data_fetcher_http.py
@@ -247,7 +247,7 @@ def test_rate_limit_backoff(monkeypatch: pytest.MonkeyPatch):
 
 def test_rate_limit_disable_and_recover(monkeypatch: pytest.MonkeyPatch):
     from ai_trading.data.fetch.metrics import (
-        provider_disable_total,
+        inc_provider_disable_total,
         provider_disabled,
     )
     from ai_trading.config import settings as config_settings
@@ -284,12 +284,12 @@ def test_rate_limit_disable_and_recover(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(df._HTTP_SESSION, "get", rate_limit_resp)
     monkeypatch.setattr(df, "_backup_get_bars", backup_resp)
     start, end = _dt_range(2)
-    before = provider_disable_total("alpaca")
+    before = inc_provider_disable_total("alpaca")
     out = df._fetch_bars("TEST", start, end, "1Min", feed="iex")
     assert calls["alpaca"] == 1
     assert calls["backup"] == 1
     assert provider_disabled("alpaca") == 1
-    assert provider_disable_total("alpaca") == before + 1
+    assert inc_provider_disable_total("alpaca") == before + 1
     assert isinstance(out, pd.DataFrame) and not out.empty
     assert df._alpaca_disabled_until is not None
 

--- a/tests/unit/test_fetch_metrics_snapshot.py
+++ b/tests/unit/test_fetch_metrics_snapshot.py
@@ -14,28 +14,28 @@ def fm():
 
 
 def test_snapshot_rate_limit(fm):
-    fm.rate_limit("iex")
+    fm.inc_rate_limit("iex")
     out = fm.snapshot(None)
     assert out["rate_limit"] == 1
     assert out["timeout"] == 0
 
 
 def test_snapshot_timeout(fm):
-    fm.timeout("iex")
+    fm.inc_timeout("iex")
     out = fm.snapshot()
     assert out["timeout"] == 1
     assert out["rate_limit"] == 0
 
 
 def test_snapshot_unauthorized(fm):
-    fm.unauthorized_sip("sip")
+    fm.inc_unauthorized_sip("sip")
     out = fm.snapshot()
     assert out["unauthorized"] == 1
     assert out["empty_payload"] == 0
 
 
 def test_snapshot_empty_payload(fm):
-    fm.empty_payload("AAPL", "1Min")
+    fm.inc_empty_payload("AAPL", "1Min")
     out = fm.snapshot()
     assert out["empty_payload"] == 1
     assert out["rate_limit"] == 0


### PR DESCRIPTION
## Summary
- rename data fetch metric helpers to inc_* names to avoid collisions
- update imports/tests to use new counter helper names

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bb0ad3788330bfc1ee43e0f10533