### PR TITLE
Add Month timeframe support

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -103,6 +103,7 @@ if not ALPACA_AVAILABLE:  # pragma: no cover - exercised in tests
         Hour = "Hour"
         Day = "Day"
         Week = "Week"
+        Month = "Month"
 
     @dataclass(frozen=True)
     class TimeFrame:
@@ -119,6 +120,9 @@ if not ALPACA_AVAILABLE:  # pragma: no cover - exercised in tests
     _week_unit = getattr(TimeFrameUnit, "Week", None)
     if _week_unit is not None:
         TimeFrame.Week = TimeFrame(1, _week_unit)  # type: ignore[attr-defined]
+    _month_unit = getattr(TimeFrameUnit, "Month", None)
+    if _month_unit is not None:
+        TimeFrame.Month = TimeFrame(1, _month_unit)  # type: ignore[attr-defined]
 
     @dataclass
     class StockBarsRequest:

--- a/ai_trading/data/models.py
+++ b/ai_trading/data/models.py
@@ -33,6 +33,8 @@ try:  # best-effort: some SDK versions already provide these
             setattr(TimeFrame, "Hour", TimeFrame(1, getattr(unit_cls, "Hour", "Hour")))  # type: ignore[arg-type]
         if not hasattr(TimeFrame, "Week"):
             setattr(TimeFrame, "Week", TimeFrame(1, getattr(unit_cls, "Week", "Week")))  # type: ignore[arg-type]
+        if not hasattr(TimeFrame, "Month"):
+            setattr(TimeFrame, "Month", TimeFrame(1, getattr(unit_cls, "Month", "Month")))  # type: ignore[arg-type]
 except Exception:
     pass
 _BaseStockBarsRequest = get_stock_bars_request_cls()

--- a/tests/test_integration_robust.py
+++ b/tests/test_integration_robust.py
@@ -172,6 +172,7 @@ class _TF:
     Hour = "1Hour"
     Day = "1Day"
     Week = "1Week"
+    Month = "1Month"
 
     def __init__(self, *a, **k):
         pass
@@ -182,6 +183,7 @@ class _TFUnit:
     Hour = "Hour"
     Day = "Day"
     Week = "Week"
+    Month = "Month"
 
 
 
@@ -189,6 +191,7 @@ class _TFUnit:
 sys.modules["alpaca.data.timeframe"].TimeFrame = _TF
 sys.modules["alpaca.data.timeframe"].TimeFrameUnit = _TFUnit
 sys.modules["alpaca.data"].TimeFrame = _TF
+sys.modules["alpaca.data"].TimeFrameUnit = _TFUnit
 
 
 class _FClient:

--- a/tests/vendor_stubs/alpaca/data/timeframe.py
+++ b/tests/vendor_stubs/alpaca/data/timeframe.py
@@ -7,6 +7,7 @@ class TimeFrameUnit(Enum):
     Hour = "Hour"
     Day = "Day"
     Week = "Week"
+    Month = "Month"
 
 @dataclass(frozen=True)
 class TimeFrame:
@@ -22,5 +23,6 @@ TimeFrame.Minute = TimeFrame(1, TimeFrameUnit.Minute)  # type: ignore[attr-defin
 TimeFrame.Hour = TimeFrame(1, TimeFrameUnit.Hour)  # type: ignore[attr-defined]
 TimeFrame.Day = TimeFrame()  # type: ignore[attr-defined]
 TimeFrame.Week = TimeFrame(1, TimeFrameUnit.Week)  # type: ignore[attr-defined]
+TimeFrame.Month = TimeFrame(1, TimeFrameUnit.Month)  # type: ignore[attr-defined]
 
 __all__ = ["TimeFrame", "TimeFrameUnit"]


### PR DESCRIPTION
## Summary
- add Month support to stub TimeFrameUnit and helper TimeFrame mappings
- expose TimeFrame.Month in data models and Alpaca API fallback

## Testing
- `ruff check ai_trading/alpaca_api.py ai_trading/data/models.py tests/test_integration_robust.py tests/vendor_stubs/alpaca/data/timeframe.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bb0a9810833089b1924d51680ea5