### PR TITLE
Handle SSL failure in sentiment analysis

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -19,6 +19,8 @@ Startup banners and environment setup messages use emit-once logging to prevent 
 
 - "Alpaca SDK is available" (or a warning if the SDK is missing)
 - "FinBERT loaded successfully"
+- "SENTIMENT_FALLBACK_STUB" when FinBERT cannot be loaded and neutral
+  sentiment is used instead
 - Configuration verification messages
 
 #### Compact JSON Format


### PR DESCRIPTION
## Summary
- Raise a helpful RuntimeError when FinBERT model download hits an SSL error
- Return neutral sentiment via a stub fallback when dependencies or network are unavailable
- Document new `SENTIMENT_FALLBACK_STUB` emit-once log message

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bdc9725c83309a22e76ab068fa00