### PR TITLE
Enforce numeric order quantities and non-null returns

### DIFF
--- a/tests/test_critical_trading_issues.py
+++ b/tests/test_critical_trading_issues.py
@@ -137,11 +137,9 @@ class TestOrderExecutionTracking(unittest.TestCase):
             if hasattr(bot_engine, 'safe_submit_order'):
                 result = bot_engine.safe_submit_order(self.mock_ctx.api, mock_req)
 
-                # The issue: function returns the order but doesn't validate
-                # that filled_qty (50) matches intended qty (100)
-                self.assertEqual(result.filled_qty, "50")
-                self.assertEqual(result.qty, "100")
-                # This exposes the quantity mismatch issue
+                # The order should expose numeric quantity fields
+                self.assertEqual(result.filled_qty, 50.0)
+                self.assertEqual(result.qty, 100.0)
 
 
 class TestMetaLearningLogFormat(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Ensure `safe_submit_order` always returns an order-like object, supplying a placeholder when markets are closed or orders cannot be placed
- Validate `qty` and `filled_qty` are numeric, defaulting missing fields to 0 and raising `ValueError` otherwise
- Expand tests to cover defaulted fields and non-numeric validation

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bdc9eb8c8330a0c5895f50b0b6e7