### PR TITLE
Centralize empty-bar retry tracking

### DIFF
--- a/ai_trading/data/empty_bar_backoff.py
+++ b/ai_trading/data/empty_bar_backoff.py
@@ -3,27 +3,59 @@
 This module centralizes bookkeeping around symbols that should be skipped
 because prior fetch attempts resulted in empty bar responses.  It exposes a
 shared ``_SKIPPED_SYMBOLS`` set along with convenience helpers for recording
-attempts and marking successful fetches.
+attempts and marking successful fetches.  Retry counts are tracked per
+``(symbol, timeframe)`` pair and an :class:`EmptyBarsError` is raised once the
+configured limit is exceeded.
 """
 from __future__ import annotations
 
-# Symbols that have recently triggered empty-bar skips.
-# Each entry is keyed by ``(symbol, timeframe)``.
+from ai_trading.config.management import MAX_EMPTY_RETRIES
+
+# Symbols that have recently triggered empty-bar skips. Each entry is keyed by
+# ``(symbol, timeframe)``.
 _SKIPPED_SYMBOLS: set[tuple[str, str]] = set()
+# Consecutive empty-bar attempt counters keyed by ``(symbol, timeframe)``.
+_EMPTY_BAR_COUNTS: dict[tuple[str, str], int] = {}
 
 
-def record_attempt(symbol: str, timeframe: str) -> None:
-    """Record that a symbol/timeframe fetch attempt was made.
+def record_attempt(symbol: str, timeframe: str) -> int:
+    """Record a fetch attempt for ``symbol``/``timeframe``.
 
     The pair is added to ``_SKIPPED_SYMBOLS`` so subsequent calls can detect
-    in-flight or failed attempts and avoid redundant network requests.
+    in-flight or failed attempts.  The retry counter is incremented and returned.
+    Once the counter exceeds :data:`MAX_EMPTY_RETRIES`, an
+    :class:`~ai_trading.data.fetch.EmptyBarsError` is raised.
     """
-    _SKIPPED_SYMBOLS.add((symbol, timeframe))
+
+    key = (symbol, timeframe)
+    cnt = _EMPTY_BAR_COUNTS.get(key, 0) + 1
+    _EMPTY_BAR_COUNTS[key] = cnt
+    _SKIPPED_SYMBOLS.add(key)
+    if cnt > MAX_EMPTY_RETRIES:
+        from ai_trading.data.fetch import EmptyBarsError  # avoid circular import
+
+        raise EmptyBarsError(
+            f"empty_bars: symbol={symbol}, timeframe={timeframe}, max_retries={cnt}"
+        )
+    return cnt
 
 
 def mark_success(symbol: str, timeframe: str) -> None:
     """Mark a previously attempted fetch as succeeded.
 
-    Removes the pair from ``_SKIPPED_SYMBOLS`` allowing future fetches.
+    Removes the pair from ``_SKIPPED_SYMBOLS`` and clears retry counters to
+    allow future fetches.
     """
-    _SKIPPED_SYMBOLS.discard((symbol, timeframe))
+
+    key = (symbol, timeframe)
+    _SKIPPED_SYMBOLS.discard(key)
+    _EMPTY_BAR_COUNTS.pop(key, None)
+
+
+__all__ = [
+    "_SKIPPED_SYMBOLS",
+    "_EMPTY_BAR_COUNTS",
+    "record_attempt",
+    "mark_success",
+    "MAX_EMPTY_RETRIES",
+]

--- a/tests/test_fetch_backoff.py
+++ b/tests/test_fetch_backoff.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 import pandas as pd
 import pytest
 
+from ai_trading.data import fetch
 from ai_trading.data.fetch import backoff as fb
 
 
@@ -27,6 +28,7 @@ def test_fetch_feed_switches_to_alternate_and_shrinks_window(monkeypatch):
     monkeypatch.setattr(fb, "_fetch_bars", fake_fetch)
     fb._EMPTY_BAR_COUNTS.clear()
     fb._SKIPPED_SYMBOLS.clear()
+    fetch._SKIPPED_SYMBOLS.clear()
 
     out = fb._fetch_feed("TEST", start, end, "1Min", feed="iex")
     assert not out.empty
@@ -34,6 +36,7 @@ def test_fetch_feed_switches_to_alternate_and_shrinks_window(monkeypatch):
     assert calls[1][0] == "sip"
     assert calls[1][1] > start  # window shrunk
     assert ("TEST", "1Min") not in fb._SKIPPED_SYMBOLS
+    assert ("TEST", "1Min") not in fetch._SKIPPED_SYMBOLS
 
 
 def test_fetch_feed_adds_skip_list_after_max_retries(monkeypatch):
@@ -44,6 +47,7 @@ def test_fetch_feed_adds_skip_list_after_max_retries(monkeypatch):
 
     monkeypatch.setattr(fb, "_fetch_bars", always_empty)
     fb._SKIPPED_SYMBOLS.clear()
+    fetch._SKIPPED_SYMBOLS.clear()
     key = ("FAIL", "1Min")
     fb._EMPTY_BAR_COUNTS[key] = fb._EMPTY_BAR_MAX_RETRIES - 1
 
@@ -51,3 +55,4 @@ def test_fetch_feed_adds_skip_list_after_max_retries(monkeypatch):
         fb._fetch_feed("FAIL", start, end, "1Min", feed="iex")
 
     assert key in fb._SKIPPED_SYMBOLS
+    assert key in fetch._SKIPPED_SYMBOLS


### PR DESCRIPTION
## Summary
- track per-symbol retry counts and enforce MAX_EMPTY_RETRIES in `empty_bar_backoff`
- wire `fetch.backoff` to shared counters so provider fallbacks keep `_SKIPPED_SYMBOLS` synced
- test retry limit behavior and ensure skip list is shared across modules

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bdc613648330a7cb55040c0c301f