### PR TITLE
Ensure pandas availability for meta-learning recovery

### DIFF
--- a/ai_trading/meta_learning/__init__.py
+++ b/ai_trading/meta_learning/__init__.py
@@ -13,11 +13,15 @@ from .core import _import_pandas  # re-export for tests
 
 # Re-export private helpers needed by contract tests
 from .bootstrap import _generate_bootstrap_training_data  # noqa: F401
-from .recovery import _implement_fallback_data_recovery  # noqa: F401
+from .recovery import (
+    _implement_fallback_data_recovery,
+    recover_dataframe,
+)  # noqa: F401
 
 __all__ = [
     "pd",
     "_import_pandas",
     "_generate_bootstrap_training_data",
+    "recover_dataframe",
     "_implement_fallback_data_recovery",
 ]


### PR DESCRIPTION
## Summary
- Load pandas lazily in meta-learning recovery utilities
- Raise `RuntimeError` when pandas is missing and add `recover_dataframe`
- Re-export recovery helpers from meta-learning package

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5bdcb0b188330ac83080162b6ca34