### PR TITLE
Track generated client order IDs

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8737,8 +8737,14 @@ def safe_submit_order(api: Any, req, *, bypass_market_check: bool = False) -> Or
     # Ensure client_order_id present for idempotency across retries
     if not order_args.get("client_order_id"):
         try:
-            from ai_trading.alpaca_api import generate_client_order_id as _gen_id
-            order_args["client_order_id"] = _gen_id("ai")
+            from ai_trading.core.order_ids import generate_client_order_id as _gen_id
+            cid = _gen_id("ai")
+            order_args["client_order_id"] = cid
+            ids = getattr(api, "client_order_ids", None)
+            if ids is None:
+                setattr(api, "client_order_ids", [])
+                ids = api.client_order_ids
+            ids.append(cid)
         except (ImportError, AttributeError):
             pass
 

--- a/ai_trading/core/order_ids.py
+++ b/ai_trading/core/order_ids.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Utilities for generating client order IDs.
+
+This module wraps the Alpaca helper so it can be easily patched during tests.
+"""
+
+from ai_trading.alpaca_api import (
+    generate_client_order_id as _generate_client_order_id,
+)
+
+
+def generate_client_order_id(prefix: str = "ai") -> str:
+    """Return a unique client order ID with the given prefix."""
+    return _generate_client_order_id(prefix)


### PR DESCRIPTION
## Summary
- add core.order_ids utility wrapping Alpaca client order ID generator
- ensure safe_submit_order uses generator and records IDs on API objects
- test that generated IDs are tracked and submitted

## Testing
- `python -m ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_safe_submit_order.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68c5bfada0688330bbc9e791169c8dc2