### PR TITLE
Handle duplicate model registrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ peak_equity.txt
 metrics/
 !ai_trading/metrics/
 models/
+!ai_trading/models/
 regime_model.pkl
 sklearn_fix_summary.md
 test_critical_type_fix.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable changes to this project will be documented in this file.
   `model_fields[info.field_name].default`.
 - **Position sizing**: fetch real account equity via Alpaca once and cache it to avoid repeated `EQUITY_MISSING` warnings.
 - **Scheduler**: default to UTC when market calendar lacks timezone info.
+- Models: re-registering with the same path returns the existing entry; conflicting paths still raise.
 
 ### Added
 - **Parallel Predictions**: Replaced single-threaded prediction executor with auto-sized thread pool

--- a/ai_trading/models/registry.py
+++ b/ai_trading/models/registry.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+"""Lightweight model path registry.
+
+This module tracks model names and their associated filesystem paths. It
+provides helpers to register and retrieve model paths while avoiding silent
+conflicts.
+"""
+from pathlib import Path
+
+try:  # pragma: no cover - executed on first import
+    _REGISTRY
+except NameError:  # pragma: no cover - executed on first import
+    _REGISTRY: dict[str, Path] = {}
+
+
+def register_model(name: str, path: str | Path) -> Path:
+    """Register ``name`` to ``path`` and return the stored path.
+
+    If ``name`` is already registered to the same path, that existing path is
+    returned. A ``ValueError`` is raised when attempting to re-register ``name``
+    with a different path to avoid accidental divergence.
+    """
+    p = Path(path).resolve()
+    existing = _REGISTRY.get(name)
+    if existing is not None:
+        if existing == p:
+            return existing
+        msg = f"Model '{name}' already registered to '{existing}'"
+        raise ValueError(msg)
+    _REGISTRY[name] = p
+    return p
+
+
+def get_model_path(name: str) -> Path | None:
+    """Return the path registered for ``name`` or ``None`` if missing."""
+    return _REGISTRY.get(name)
+
+
+def reset_registry() -> dict[str, Path]:
+    """Clear and return the internal registry (for tests)."""
+    global _REGISTRY
+    _REGISTRY = {}
+    return _REGISTRY
+
+
+def list_models() -> dict[str, Path]:
+    """Return a copy of the registry mapping."""
+    return dict(_REGISTRY)
+
+
+__all__ = ["register_model", "get_model_path", "reset_registry", "list_models"]

--- a/tests/test_models_registry.py
+++ b/tests/test_models_registry.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pytest
+
+from ai_trading.models.registry import register_model, reset_registry
+
+
+def test_register_same_path_returns_existing(tmp_path: Path) -> None:
+    reset_registry()
+    path = tmp_path / "model.pkl"
+    first = register_model("demo", path)
+    second = register_model("demo", path)
+    assert first == second
+
+
+def test_register_conflicting_path_raises(tmp_path: Path) -> None:
+    reset_registry()
+    register_model("demo", tmp_path / "model1.pkl")
+    with pytest.raises(ValueError):
+        register_model("demo", tmp_path / "model2.pkl")


### PR DESCRIPTION
## Summary
- add lightweight model registry that returns existing path when duplicate registration uses the same file
- document duplicate model behavior in changelog
- test registry for idempotent and conflicting registrations

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c183ebb083309f34dac957aa5d2d