### PR TITLE
Guard against empty indicator frames

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -11115,10 +11115,13 @@ def prepare_indicators(frame: pd.DataFrame) -> pd.DataFrame:
     """
 
     if frame is None or frame.empty:
-        return pd.DataFrame()
-    for col in ("close", "high", "low"):
-        if col not in frame:
-            return pd.DataFrame()
+        logger.warning("Input dataframe is None or empty in prepare_indicators.")
+        raise RuntimeError("Input dataframe is empty")
+    required_cols = ("close", "high", "low")
+    missing = [col for col in required_cols if col not in frame]
+    if missing:
+        logger.warning("Missing required columns in prepare_indicators: %s", missing)
+        raise KeyError(f"Missing required columns: {', '.join(missing)}")
 
     close = frame["close"].astype(float)
     hl = frame[["high", "low"]].astype(float)
@@ -11152,8 +11155,12 @@ def prepare_indicators(frame: pd.DataFrame) -> pd.DataFrame:
         rsi_bounds["max"] - rsi_bounds["min"]
     )
 
-    required = ["ichimoku_conv", "ichimoku_base", "stochrsi"]
-    frame.dropna(subset=required, inplace=True)
+    frame.dropna(inplace=True)
+    if frame.empty:
+        logger.warning(
+            "prepare_indicators produced empty dataframe after dropping NaNs.",
+        )
+        raise RuntimeError("No data available after indicator computation")
     return frame
 
 

--- a/tests/test_bot_engine.py
+++ b/tests/test_bot_engine.py
@@ -57,8 +57,7 @@ def test_prepare_indicators_creates_required_columns():
 
 
 def test_prepare_indicators_insufficient_data():
-    """prepare_indicators should return an empty DataFrame when there is
-    insufficient historical data for rolling calculations."""
+    """prepare_indicators should raise when there is insufficient historical data."""
 
     df = pd.DataFrame({
         'open': np.random.uniform(100, 200, 5),
@@ -68,9 +67,8 @@ def test_prepare_indicators_insufficient_data():
         'volume': np.random.randint(1_000_000, 5_000_000, 5),
     })
 
-    result = prepare_indicators(df.copy())
-
-    assert result.empty or result.shape[0] == 0
+    with pytest.raises(RuntimeError):
+        prepare_indicators(df.copy())
 
 
 @pytest.mark.parametrize("attr", ["trading_client", "data_client"])
@@ -97,7 +95,7 @@ def test_bot_engine_missing_env(monkeypatch, caplog, attr, missing_key):
 
 
 def test_prepare_indicators_all_nan_columns():
-    """prepare_indicators should drop all rows when input columns are entirely NaN."""
+    """prepare_indicators should raise when input columns are entirely NaN."""
 
     df = pd.DataFrame({
         'open': [np.nan] * 30,
@@ -112,8 +110,7 @@ def test_prepare_indicators_all_nan_columns():
     original_rsi = bot_engine.ta.rsi
     bot_engine.ta.rsi = lambda close, length=14: pd.Series([np.nan] * len(close))
     try:
-        result = prepare_indicators(df.copy())
+        with pytest.raises(RuntimeError):
+            prepare_indicators(df.copy())
     finally:
         bot_engine.ta.rsi = original_rsi
-
-    assert result.empty or result.shape[0] == 0

--- a/tests/test_bot_engine_edge_cases.py
+++ b/tests/test_bot_engine_edge_cases.py
@@ -24,13 +24,13 @@ def test_prepare_indicators_non_numeric_close(monkeypatch):
 
     monkeypatch.setattr(bot_engine.ta, 'rsi', fake_rsi)
     df = pd.DataFrame({'open': [1, 2], 'high': [1, 2], 'low': [1, 2], 'close': ['a', 'b']})
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         prepare_indicators(df)
 
 
 def test_prepare_indicators_empty_dataframe():
     df = pd.DataFrame()
-    with pytest.raises(KeyError):
+    with pytest.raises(RuntimeError):
         prepare_indicators(df)
 
 
@@ -42,5 +42,5 @@ def test_prepare_indicators_single_row():
         'close': [100.5],
         'volume': [1000]
     })
-    result = prepare_indicators(df.copy())
-    assert result.empty
+    with pytest.raises(RuntimeError):
+        prepare_indicators(df.copy())


### PR DESCRIPTION
## Summary
- fail fast in `prepare_indicators` when input is empty or required columns are missing
- drop all NaN rows and raise `RuntimeError` if no data remains
- update tests for insufficient data and edge cases

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot_engine.py::test_prepare_indicators_creates_required_columns tests/test_bot_engine.py::test_prepare_indicators_insufficient_data tests/test_bot_engine.py::test_prepare_indicators_all_nan_columns tests/test_bot_engine_edge_cases.py::test_prepare_indicators_missing_close_column tests/test_bot_engine_edge_cases.py::test_prepare_indicators_non_numeric_close tests/test_bot_engine_edge_cases.py::test_prepare_indicators_empty_dataframe tests/test_bot_engine_edge_cases.py::test_prepare_indicators_single_row -q`

## Rollback Plan
- Revert this PR.

------
https://chatgpt.com/codex/tasks/task_e_68c5c187f6f8833083b1c3f935b7018e