### PR TITLE
Track names of missing sentiment dependencies

### DIFF
--- a/ai_trading/analysis/sentiment.py
+++ b/ai_trading/analysis/sentiment.py
@@ -51,8 +51,7 @@ def _init_sentiment() -> None:
     logger.debug("SENTIMENT_INIT")
 _bs4 = None
 _transformers_bundle = None
-_sentiment_deps_logged: set[str] = set()
-_SENT_DEPS_LOGGED = False
+_SENT_DEPS_LOGGED: set[str] = set()
 _SENTIMENT_STUB_LOGGED = False
 
 def _load_bs4(log=logger):
@@ -63,10 +62,9 @@ def _load_bs4(log=logger):
         from bs4 import BeautifulSoup
         _bs4 = BeautifulSoup
     except (ImportError, ValueError, TypeError):
-        if 'bs4' not in _sentiment_deps_logged:
-            log.warning('SENTIMENT_OPTIONAL_DEP_MISSING', extra={'package': 'bs4'})
-            _sentiment_deps_logged.add('bs4')
-            _SENT_DEPS_LOGGED = True
+        if "bs4" not in _SENT_DEPS_LOGGED:
+            log.warning("SENTIMENT_OPTIONAL_DEP_MISSING", extra={"package": "bs4"})
+            _SENT_DEPS_LOGGED.add("bs4")
         _bs4 = None
     return _bs4
 
@@ -83,10 +81,11 @@ def _load_transformers(log=logger):
         model.eval()
         _transformers_bundle = (torch, tokenizer, model)
     except (ImportError, ValueError, TypeError):
-        if 'transformers' not in _sentiment_deps_logged:
-            log.warning('SENTIMENT_OPTIONAL_DEP_MISSING', extra={'package': 'transformers'})
-            _sentiment_deps_logged.add('transformers')
-            _SENT_DEPS_LOGGED = True
+        if "transformers" not in _SENT_DEPS_LOGGED:
+            log.warning(
+                "SENTIMENT_OPTIONAL_DEP_MISSING", extra={"package": "transformers"}
+            )
+            _SENT_DEPS_LOGGED.add("transformers")
         _transformers_bundle = None
     return _transformers_bundle
 SENTIMENT_TTL_SEC = 600

--- a/tests/test_sentiment_deps_flag.py
+++ b/tests/test_sentiment_deps_flag.py
@@ -7,12 +7,12 @@ from unittest.mock import patch
 def test_sentiment_dep_flag_updates(monkeypatch):
     sentiment = importlib.reload(importlib.import_module("ai_trading.analysis.sentiment"))
     assert hasattr(sentiment, "_SENT_DEPS_LOGGED")
-    assert sentiment._SENT_DEPS_LOGGED is False
+    assert sentiment._SENT_DEPS_LOGGED == set()
 
     dummy_bs4 = types.ModuleType("bs4")
     monkeypatch.setitem(sys.modules, "bs4", dummy_bs4)
-    sentiment._sentiment_deps_logged.clear()
+    sentiment._SENT_DEPS_LOGGED.clear()
     with patch.object(sentiment.logger, "warning") as warn:
         sentiment._load_bs4()
         assert warn.called
-    assert sentiment._SENT_DEPS_LOGGED is True
+    assert sentiment._SENT_DEPS_LOGGED == {"bs4"}


### PR DESCRIPTION
## Summary
- track missing optional sentiment dependencies by storing their names in a set
- update tests for the new dependency tracking behavior

## Motivation
- tests compare missing optional packages; previous boolean flag only indicated presence of any missing package

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

## Rollback Plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68c5c18698f083308e77ea6a5707f958