### PR TITLE
Use perf_counter for SoftBudget timing

### DIFF
--- a/ai_trading/utils/prof.py
+++ b/ai_trading/utils/prof.py
@@ -19,13 +19,21 @@ class SoftBudget:
     def __init__(self, interval_sec: float, fraction: float):
         now = time.monotonic()
         self._deadline = now + max(0.0, interval_sec) * max(0.1, min(1.0, fraction))
-        self._start = now
+        self._start = time.perf_counter()
+
+    def __enter__(self) -> "SoftBudget":
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        # nothing to clean up and don't suppress exceptions
+        return None
 
     def remaining(self) -> float:
         return max(0.0, self._deadline - time.monotonic())
 
     def elapsed_ms(self) -> int:
-        return int((time.monotonic() - self._start) * 1000)
+        return int((time.perf_counter() - self._start) * 1000)
 
     def over(self) -> bool:
         return time.monotonic() >= self._deadline


### PR DESCRIPTION
## Summary
- record SoftBudget start time with `time.perf_counter()`
- add `__enter__` to reset timer when used as a context manager
- compute `elapsed_ms` using perf counter difference

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c182d5e083309257cd3e77acde39