### PR TITLE
Simplify sleep helper and adjust tests

### DIFF
--- a/ai_trading/utils/sleep.py
+++ b/ai_trading/utils/sleep.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import time as _time
-from time import perf_counter as _perf
 
 __all__ = ["sleep"]
 
@@ -10,24 +9,19 @@ _real_sleep = _time.sleep
 
 
 def sleep(seconds: float | int) -> float:
-    """Sleep for at least ``seconds`` seconds and return actual duration.
+    """Sleep for ``seconds`` using :func:`time.sleep` and report elapsed time.
 
-    The underlying :func:`time.sleep` function is captured at import time so
-    later monkeypatching of ``time.sleep`` will not short-circuit this helper.
-    A minimum delay of ~10ms is enforced to ensure a measurable pause even when
-    ``seconds`` is 0 or negative.
+    ``time.sleep`` is captured at import time so monkeypatching ``time.sleep``
+    later will not affect this helper. The elapsed duration is measured using
+    :func:`time.monotonic` and returned to the caller. If ``seconds`` is zero or
+    negative, the function returns ``0.0`` without sleeping.
     """
     try:
         s = float(seconds)
     except (TypeError, ValueError):
-        s = 0.0
-    target = max(s, 0.01)
-    start = _perf()
-    _real_sleep(target)
-    elapsed = _perf() - start
-    tries = 0
-    while elapsed < 0.009 and tries < 5:
-        _real_sleep(0.005)
-        elapsed = _perf() - start
-        tries += 1
-    return elapsed
+        return 0.0
+    if s <= 0:
+        return 0.0
+    start = _time.monotonic()
+    _real_sleep(s)
+    return _time.monotonic() - start

--- a/ai_trading/utils/timing.py
+++ b/ai_trading/utils/timing.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import os
+import time as _time
+from time import perf_counter as _perf
 from typing import Optional, Union
 
-from .sleep import _perf, _real_sleep, _time, sleep
+from .sleep import _real_sleep, sleep
 
 # Prefer AI_HTTP_TIMEOUT when present (tests set this); fallback to HTTP_TIMEOUT env
 HTTP_TIMEOUT: Union[int, float] = float(

--- a/tests/test_utils_sleep_shadowing.py
+++ b/tests/test_utils_sleep_shadowing.py
@@ -4,7 +4,7 @@ from ai_trading.utils.sleep import sleep
 
 
 def test_sleep_unaffected_by_monkeypatch(monkeypatch) -> None:
-    """sleep should block even if time.sleep is monkeypatched."""  # AI-AGENT-REF: ensure robustness
+    """sleep should still block even if time.sleep is monkeypatched."""
     slept = {"count": 0}
 
     def fake_sleep(_: float) -> None:
@@ -13,6 +13,6 @@ def test_sleep_unaffected_by_monkeypatch(monkeypatch) -> None:
     import time as real_time
 
     monkeypatch.setattr(real_time, "sleep", fake_sleep)
-    elapsed = sleep(0)  # request 0 -> enforced minimum
+    elapsed = sleep(0.01)
     assert slept["count"] == 0
     assert elapsed >= 0.01

--- a/tests/test_utils_timing.py
+++ b/tests/test_utils_timing.py
@@ -1,23 +1,15 @@
 """Sanity checks for centralized timing helpers exported by ai_trading.utils."""
 from __future__ import annotations
 
-from time import perf_counter
-
 import pytest
 
-from ai_trading.utils.timing import HTTP_TIMEOUT, clamp_timeout, sleep
+from ai_trading.utils.timing import HTTP_TIMEOUT, clamp_timeout
+from ai_trading.utils.sleep import sleep
 
 
-def test_timing_exports_exist_and_behave():
+def test_timing_exports_exist_and_behave() -> None:
     assert isinstance(HTTP_TIMEOUT, (int, float)) and HTTP_TIMEOUT > 0
     assert clamp_timeout(None) == pytest.approx(float(HTTP_TIMEOUT))
     assert clamp_timeout(0.0) >= 0.0
     assert clamp_timeout(-1) == pytest.approx(float(HTTP_TIMEOUT))
-    # measure sleep roughly (<= 2x tolerance to absorb CI variability)
-    start = perf_counter()
-    sleep(0)  # request 0 -> enforced minimum
-    elapsed = perf_counter() - start
-    if elapsed == 0.0:
-        pytest.skip("perf_counter frozen")
-    assert elapsed >= 0.01
-
+    assert sleep(0) == 0.0

--- a/tests/unit/test_sleep_binding.py
+++ b/tests/unit/test_sleep_binding.py
@@ -1,9 +1,6 @@
-from time import perf_counter
 from ai_trading.utils import sleep
 
 
-def test_utils_sleep_is_measurable():
-    start = perf_counter()
-    sleep(0)  # request 0 -> enforced minimum
-    elapsed = perf_counter() - start
-    assert elapsed >= 0.01  # AI-AGENT-REF: ensure busy-wait measurable
+def test_utils_sleep_zero_returns_zero() -> None:
+    """sleep should return 0 when duration is 0."""
+    assert sleep(0) == 0.0


### PR DESCRIPTION
## Summary
- Implement `sleep` with `time.monotonic` and `time.sleep`, returning elapsed time and 0 for non-positive durations
- Update timing module imports to match new helper
- Refresh tests to validate zero-duration sleeps and monkeypatch robustness

## Testing
- `ruff check ai_trading/utils/sleep.py ai_trading/utils/timing.py tests/unit/test_sleep_binding.py tests/test_utils_sleep_shadowing.py tests/test_utils_timing.py`
- `python -m pip install requests`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_sleep_binding.py tests/test_utils_sleep_shadowing.py tests/test_utils_timing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c37b5eb883309ec88107f630b9ec