### PR TITLE
Normalize Alpaca credential keys

### DIFF
--- a/docs/API_KEY_SETUP.md
+++ b/docs/API_KEY_SETUP.md
@@ -21,6 +21,11 @@ This trading bot requires API keys from Alpaca Markets to function. This guide e
 - `WEBHOOK_SECRET`: Secret for webhook authentication
 - Alternatively, set `ALPACA_OAUTH` with an OAuth token instead of the API key and secret. **Do not** set both.
 
+> **Note:** The configuration loader trims surrounding whitespace and
+> normalizes common environment prefixes (e.g. `DEV_ALPACA_API_KEY`) to
+> their standard names, so you can keep environment-specific variables
+> without additional code changes.
+
 ### Optional
 - `FINNHUB_API_KEY`: For additional market data
 - `NEWS_API_KEY`: For news sentiment analysis

--- a/tests/unit/test_alpaca_config_normalization.py
+++ b/tests/unit/test_alpaca_config_normalization.py
@@ -1,0 +1,25 @@
+import types
+
+import ai_trading.config.alpaca as alpaca_cfg
+
+
+def test_get_alpaca_config_strips_and_maps(monkeypatch):
+    monkeypatch.setattr(alpaca_cfg, "ALPACA_AVAILABLE", False)
+
+    class DummySettings:
+        env = "dev"
+        alpaca_base_url = None
+        alpaca_rate_limit_per_min = None
+        alpaca_data_feed = "iex"
+
+    monkeypatch.setattr(alpaca_cfg, "get_settings", lambda: DummySettings())
+    monkeypatch.setattr(
+        alpaca_cfg,
+        "broker_keys",
+        lambda: {" DEV_ALPACA_API_KEY ": " foo ", "DEV_ALPACA_SECRET_KEY": " bar "},
+    )
+
+    config = alpaca_cfg.get_alpaca_config()
+    assert config.key_id == "foo"
+    assert config.key == "foo"
+    assert config.secret_key == "bar"


### PR DESCRIPTION
## Summary
- Normalize Alpaca broker key names by stripping whitespace and common environment prefixes
- Expose a `key` property on `AlpacaConfig` for a standard credential field
- Document that Alpaca keys accept environment-specific prefixes and whitespace
- Add unit test covering key normalization behaviour

## Testing
- `ruff check .`
- `python -m pip install requests`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c37cb2908330ac19bde7b19a45a6