### PR TITLE
Handle optional Flask testing in health monitor

### DIFF
--- a/ai_trading/health_monitor.py
+++ b/ai_trading/health_monitor.py
@@ -21,6 +21,17 @@ from typing import Any
 from ai_trading.monitoring.system_health import _HAS_PSUTIL, snapshot_basic
 from ai_trading.config import get_settings
 
+try:  # pragma: no cover - flask.testing is optional
+    from flask.testing import FlaskClient
+    FLASK_TESTING_AVAILABLE = True
+except Exception:  # ImportError, AttributeError, etc.
+    FLASK_TESTING_AVAILABLE = False
+
+    class FlaskClient:  # type: ignore[no-redef]
+        """Minimal stub used when Flask's testing utilities are unavailable."""
+
+        pass
+
 if _HAS_PSUTIL:
     import psutil
 else:


### PR DESCRIPTION
## Summary
- Guard `FlaskClient` import in `health_monitor` to avoid ImportError when Flask testing utilities are missing
- Provide `FLASK_TESTING_AVAILABLE` flag with minimal stub fallback

## Testing
- `python -m pip install -U pip`
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires Python >=3.12)*
- `pip install requests`
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c37edbb88330be368e9cab18a224