### PR TITLE
Ensure production engine run is awaitable

### DIFF
--- a/ai_trading/execution/production_engine.py
+++ b/ai_trading/execution/production_engine.py
@@ -364,3 +364,20 @@ class ProductionExecutionCoordinator:
         except (APIError, TimeoutError, ConnectionError) as e:
             logger.error('ORDER_API_FAILED', extra={'cause': e.__class__.__name__, 'detail': str(e), 'op': 'cancel', 'order_id': order_id})
             raise
+
+
+async def run(
+    account_equity: float = 100_000.0,
+    risk_level: RiskLevel = RiskLevel.MODERATE,
+) -> "ProductionExecutionCoordinator":
+    """Create and return a :class:`ProductionExecutionCoordinator` instance.
+
+    The coroutine performs a tiny ``await`` so callers can drive it using
+    :func:`asyncio.run` or ``await`` the result in tests without triggering
+    "coroutine was never awaited" warnings.
+    """
+    await asyncio.sleep(0)
+    return ProductionExecutionCoordinator(account_equity, risk_level)
+
+
+__all__ = ["ProductionExecutionCoordinator", "run"]

--- a/tests/test_production_system.py
+++ b/tests/test_production_system.py
@@ -9,7 +9,10 @@ import asyncio
 
 try:
     from ai_trading.core.enums import OrderSide, OrderType, RiskLevel
-    from ai_trading.execution.production_engine import ProductionExecutionCoordinator
+    from ai_trading.execution.production_engine import (
+        ProductionExecutionCoordinator,
+        run,
+    )
     from ai_trading.monitoring.alerting import AlertManager, AlertSeverity
     from ai_trading.risk.circuit_breakers import (
         DrawdownCircuitBreaker,
@@ -176,13 +179,15 @@ async def test_production_execution_coordinator():
         from ai_trading.core.enums import OrderSide, OrderType, RiskLevel
         from ai_trading.execution.production_engine import (
             ProductionExecutionCoordinator,
+            run,
         )
 
-        # Initialize coordinator
-        coordinator = ProductionExecutionCoordinator(
+        # Initialize coordinator via async run helper
+        coordinator = await run(
             account_equity=100000,
-            risk_level=RiskLevel.MODERATE
+            risk_level=RiskLevel.MODERATE,
         )
+        assert isinstance(coordinator, ProductionExecutionCoordinator)
 
         # Test order submission
         result = await coordinator.submit_order(


### PR DESCRIPTION
## Summary
- expose `production_engine.run` as an async coroutine returning a `ProductionExecutionCoordinator`
- exercise the async run helper in tests

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c380deac8330a856d676b5b7694f