### PR TITLE
Import alpaca package before TradingClient

### DIFF
--- a/ai_trading/broker/alpaca_credentials.py
+++ b/ai_trading/broker/alpaca_credentials.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import importlib
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -51,6 +52,7 @@ def initialize(env: Mapping[str, str] | None = None, *, shadow: bool = False):
     if shadow:
         return object()
     try:  # pragma: no cover - optional dependency
+        importlib.import_module("alpaca")
         from alpaca.trading.client import TradingClient  # type: ignore
     except ModuleNotFoundError as exc:  # pragma: no cover - tested via unit test
         raise RuntimeError("alpaca package is required") from exc


### PR DESCRIPTION
## Summary
- Import the alpaca package before importing TradingClient to ensure clearer error handling when the SDK is missing

## Testing
- `ruff check ai_trading/broker/alpaca_credentials.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_alpaca_api.py::test_initialize_raises_when_sdk_missing -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5cb7d2aa88330bde8da9376669f40