### PR TITLE
Avoid overriding env vars during fail-fast reload

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -228,7 +228,7 @@ def _fail_fast_env() -> None:
         "DOLLAR_RISK_LIMIT",
     )
     try:
-        loaded = reload_env()
+        loaded = reload_env(override=False)
         validate_required_env(required)
         snapshot = {k: get_env(k, "") or "" for k in required}
         _, _, base_url = _resolve_alpaca_env()


### PR DESCRIPTION
## Summary
- ensure `_fail_fast_env` reloads dotenv without overriding existing environment variables

## Testing
- `ruff check ai_trading/main.py tests/unit/test_env_config_redaction.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_env_config_redaction.py::test_base_url_alias_logged -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5cb8093a88330898e5bf240831131