### PR TITLE
Refine slippage guard and limit conversion

### DIFF
--- a/tests/execution/test_execute_entry_trade_log.py
+++ b/tests/execution/test_execute_entry_trade_log.py
@@ -6,13 +6,14 @@ import os
 import pandas as pd
 import pytest
 
-from ai_trading.core import bot_engine, execution_flow
 from ai_trading.execution import ExecutionEngine
 from ai_trading.core.enums import OrderSide, OrderType
 
 
 def test_execute_entry_logs_trade(tmp_path, monkeypatch):
     """execute_entry should create trade log and append entry."""
+
+    from ai_trading.core import bot_engine, execution_flow
 
     log_path = tmp_path / "trades.jsonl"
     monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(log_path))
@@ -60,11 +61,11 @@ def test_slippage_converts_market_to_limit(monkeypatch):
     monkeypatch.setenv("SLIPPAGE_LIMIT_TOLERANCE_BPS", "5")
     monkeypatch.setattr("ai_trading.execution.engine.hash", lambda x: 99, raising=False)
     engine = ExecutionEngine()
-    oid = engine.execute_order("AAPL", OrderSide.BUY, 10, expected_price=100.0)
+    monkeypatch.setattr(engine, "_guess_price", lambda symbol: 100.0)
+    oid = engine.execute_order("AAPL", OrderSide.BUY, 10)
     order = engine.order_manager.orders[oid]
     assert order.order_type == OrderType.LIMIT
-    expected_price = round(100.0 + (100.0 * 5 / 10000), 4)
-    assert round(float(order.price), 4) == expected_price
+    assert round(float(order.price), 2) == 100.05
 
 
 def test_slippage_reduces_order_size(monkeypatch):

--- a/tests/test_delayed_quote_slippage.py
+++ b/tests/test_delayed_quote_slippage.py
@@ -1,19 +1,31 @@
 import pytest
 
+import sys
+from types import SimpleNamespace
+
 from ai_trading.execution import ExecutionEngine
 from ai_trading.core.enums import OrderSide
 
 
 def test_delayed_quote_slippage_flagged(monkeypatch):
     """Large move between quote and fill should trigger slippage alert."""
-    monkeypatch.setenv("TESTING", "true")
+    monkeypatch.setenv("TESTING", "false")
     monkeypatch.setenv("MAX_SLIPPAGE_BPS", "50")
     prices = iter([100.0, 102.0])
-    monkeypatch.setattr(
-        "ai_trading.core.bot_engine.get_latest_price",
-        lambda symbol: next(prices),
-    )
+    stub = SimpleNamespace(get_latest_price=lambda symbol: next(prices))
+    monkeypatch.setitem(sys.modules, "ai_trading.core.bot_engine", stub)
     monkeypatch.setattr("ai_trading.execution.engine.hash", lambda x: 50, raising=False)
+
+    def fake_submit(self, order):
+        self.orders[order.id] = order
+        self.active_orders[order.id] = order
+        return SimpleNamespace(id=order.id)
+
+    monkeypatch.setattr(
+        "ai_trading.execution.engine.OrderManager.submit_order",
+        fake_submit,
+        raising=False,
+    )
     engine = ExecutionEngine()
     with pytest.raises(AssertionError):
         engine.execute_order("AAPL", OrderSide.BUY, 10)
@@ -23,14 +35,23 @@ def test_delayed_quote_slippage_flagged(monkeypatch):
 
 def test_delayed_quote_slippage_within_threshold(monkeypatch):
     """Minor quote movement should record slippage without alert."""
-    monkeypatch.setenv("TESTING", "true")
+    monkeypatch.setenv("TESTING", "false")
     monkeypatch.setenv("MAX_SLIPPAGE_BPS", "50")
     prices = iter([100.0, 100.3])
-    monkeypatch.setattr(
-        "ai_trading.core.bot_engine.get_latest_price",
-        lambda symbol: next(prices),
-    )
+    stub = SimpleNamespace(get_latest_price=lambda symbol: next(prices))
+    monkeypatch.setitem(sys.modules, "ai_trading.core.bot_engine", stub)
     monkeypatch.setattr("ai_trading.execution.engine.hash", lambda x: 50, raising=False)
+
+    def fake_submit(self, order):
+        self.orders[order.id] = order
+        self.active_orders[order.id] = order
+        return SimpleNamespace(id=order.id)
+
+    monkeypatch.setattr(
+        "ai_trading.execution.engine.OrderManager.submit_order",
+        fake_submit,
+        raising=False,
+    )
     engine = ExecutionEngine()
     order_id = engine.execute_order("AAPL", OrderSide.BUY, 10)
     assert order_id is not None


### PR DESCRIPTION
## Summary
- convert market orders to limit using computed expected price when predicted slippage exceeds threshold
- avoid expensive latest-price lookup during tests
- extend tests to verify limit conversion at 100.05 and stub bot engine price feed

## Testing
- `ruff check ai_trading/execution/engine.py tests/execution/test_execute_entry_trade_log.py tests/test_delayed_quote_slippage.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_execute_entry_trade_log.py::test_slippage_converts_market_to_limit tests/test_delayed_quote_slippage.py::test_delayed_quote_slippage_flagged tests/test_delayed_quote_slippage.py::test_delayed_quote_slippage_within_threshold -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5ceff889483309d669b262572053b