### PR TITLE
Remove duplicate DataFetchError definition

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -51,7 +51,6 @@ import warnings
 
 import ai_trading.data.fetch as data_fetcher_module
 from ai_trading.data.fetch import (
-    DataFetchError,
     get_bars,
     get_bars_batch,
     get_minute_df,
@@ -3720,10 +3719,6 @@ def _log_health_diagnostics(runtime, reason: str) -> None:
 
 
 # ─── TYPED EXCEPTION ─────────────────────────────────────────────────────────
-class DataFetchError(Exception):
-    """Raised when expected market data is missing or unusable."""
-
-
 class OrderExecutionError(Exception):
     """Raised when an Alpaca order fails after submission."""
 


### PR DESCRIPTION
## Summary
- remove redundant `DataFetchError` class defined near bottom of `bot_engine`
- rely on single top-level `DataFetchError` and drop unused import from `ai_trading.data.fetch`

## Testing
- `ruff check ai_trading/core/bot_engine.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_fetch_minute_df_safe_empty.py -q` *(skipped: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68c5cefe737c8330ae1be81db6f3748d