### PR TITLE
Use staleness module in bot engine for easier patching

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -470,7 +470,7 @@ from ai_trading.core.alpaca_client import (
     _initialize_alpaca_clients,
 )
 from ai_trading.utils.prof import StageTimer, SoftBudget
-from ai_trading.guards.staleness import _ensure_data_fresh
+from ai_trading.guards import staleness
 
 # AI-AGENT-REF: optional pipeline import
 try:
@@ -2484,7 +2484,7 @@ def fetch_minute_df_safe(symbol: str) -> pd.DataFrame:
     # Check data freshness before proceeding with trading logic
     try:
         # Allow data up to 10 minutes old during market hours (600 seconds)
-        _ensure_data_fresh(df, 600, symbol=symbol)
+        staleness._ensure_data_fresh(df, 600, symbol=symbol)
     except RuntimeError as e:
         logger.warning(f"Data staleness check failed for {symbol}: {e}")
         # Still return the data but log the staleness issue


### PR DESCRIPTION
## Summary
- Import the staleness guard module instead of a function
- Call staleness._ensure_data_fresh in fetch_minute_df_safe
- Allow tests to monkeypatch staleness._ensure_data_fresh

## Testing
- `python -m pip install -U pip`
- `pip install -e .` *(fails: Package 'ai-trading-bot' requires a different Python: 3.11.12 not in '<3.13,>=3.12')*
- `ruff check ai_trading/core/bot_engine.py tests/bot_engine/test_fetch_minute_df_safe.py tests/bot_engine/test_fetch_minute_df_safe_filter.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `curl http://127.0.0.1:9001/healthz` *(connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c5d9a0ebc88330acbe40ca0dc4d572