### PR TITLE
Ensure all fallback tasks execute

### DIFF
--- a/ai_trading/data/fallback/concurrency.py
+++ b/ai_trading/data/fallback/concurrency.py
@@ -73,7 +73,8 @@ async def run_with_concurrency(
             else:
                 SUCCESSFUL_SYMBOLS.add(sym)
 
-    await asyncio.gather(*(_run(s) for s in symbols), return_exceptions=True)
+    tasks = [asyncio.create_task(_run(s)) for s in symbols]
+    await asyncio.gather(*tasks, return_exceptions=True)
     return results, SUCCESSFUL_SYMBOLS.copy(), FAILED_SYMBOLS.copy()
 
 


### PR DESCRIPTION
## Summary
- Ensure bounded fallback tasks are created and awaited so each runs even when one errors

## Testing
- `ruff check ai_trading/data/fallback/concurrency.py tests/data/test_fallback_concurrency.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/data/test_fallback_concurrency.py -q`

## Rollback
- Revert commit to restore previous task scheduling

------
https://chatgpt.com/codex/tasks/task_e_68c5db023590833096528529ea63ebce