### PR TITLE
Ensure Alpaca import checks top-level package

### DIFF
--- a/ai_trading/broker/alpaca_credentials.py
+++ b/ai_trading/broker/alpaca_credentials.py
@@ -49,6 +49,7 @@ def initialize(env: Mapping[str, str] | None = None, *, shadow: bool = False):
 
     creds = resolve_alpaca_credentials(env)
     try:  # pragma: no cover - optional dependency
+        __import__("alpaca")
         from alpaca.trading.client import TradingClient  # type: ignore
     except ModuleNotFoundError as exc:  # pragma: no cover - tested via unit test
         if shadow:


### PR DESCRIPTION
## Summary
- Ensure Alpaca client initialization explicitly imports top-level `alpaca` before `TradingClient`

## Testing
- `ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: tests/unit/test_trading_config_aliases.py::test_trading_config_env_aliases - assert 0.05 == 0.06)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_alpaca_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e2abf8348330b2f2d71e19e06b41