### PR TITLE
Validate Alpaca base URL and update defaults

### DIFF
--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -289,6 +289,25 @@ class Settings(BaseSettings):
     def _force_trades_cast(cls, v):
         return _to_bool(v, False)
 
+    @field_validator('alpaca_base_url', mode='before')
+    @classmethod
+    def _validate_alpaca_base_url(cls, v):
+        if isinstance(v, FieldInfo):
+            v = getattr(v, 'default', None)
+        if v is not None and not isinstance(v, str):
+            v = str(v)
+        from ai_trading.config.management import (
+            ALPACA_URL_GUIDANCE,
+            _normalize_alpaca_base_url,
+        )
+
+        normalized, message = _normalize_alpaca_base_url(
+            v, source_key='ALPACA_API_URL/ALPACA_BASE_URL'
+        )
+        if normalized is None:
+            raise ValueError(message or ALPACA_URL_GUIDANCE)
+        return normalized
+
     @computed_field
     @property
     def alpaca_secret_key_plain(self) -> str | None:

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -15,6 +15,7 @@ Environment=AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot
 Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
 Environment=AI_TRADING_MODELS_DIR=/var/lib/ai-trading-bot/models
 Environment=AI_TRADING_OUTPUT_DIR=/var/lib/ai-trading-bot/output
+Environment="ALPACA_API_URL=https://paper-api.alpaca.markets"
 EnvironmentFile=-/home/aiuser/ai-trading-bot/.env
 ExecStartPre=/usr/bin/install -d -m 700 -o aiuser -g aiuser \
     /var/lib/ai-trading-bot \

--- a/scripts/final_validation.py
+++ b/scripts/final_validation.py
@@ -9,7 +9,7 @@ def test_ticker_loading():
     logging.info('🔍 Testing ticker loading functionality...')
     os.environ.setdefault('ALPACA_API_KEY', 'dummy')
     os.environ.setdefault('ALPACA_SECRET_KEY', 'dummy')
-    os.environ.setdefault('ALPACA_BASE_URL', 'paper')
+    os.environ.setdefault('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
     os.environ.setdefault('WEBHOOK_SECRET', 'dummy')
     os.environ.setdefault('FLASK_PORT', '5000')
     try:

--- a/tests/config/test_settings_validation.py
+++ b/tests/config/test_settings_validation.py
@@ -25,6 +25,14 @@ def test_max_position_size_positive():
     assert s.max_position_size == 1000
 
 
+def test_alpaca_base_url_requires_full_endpoint(monkeypatch):
+    monkeypatch.delenv("ALPACA_BASE_URL", raising=False)
+    monkeypatch.delenv("ALPACA_API_URL", raising=False)
+    monkeypatch.setenv("MAX_DRAWDOWN_THRESHOLD", "0.1")
+    with pytest.raises(ValueError, match="must include an HTTP scheme"):
+        Settings(ALPACA_API_URL="paper")
+
+
 def test_missing_risk_parameter():
     with pytest.raises(ValidationError, match="Input should be a valid number"):
         Settings(capital_cap=None)

--- a/tests/test_config_validation_max_position_size.py
+++ b/tests/test_config_validation_max_position_size.py
@@ -39,7 +39,7 @@ def test_no_mutation_of_settings(monkeypatch):  # AI-AGENT-REF: ensure env fallb
     m.logger = getattr(m, "logger", None) or importlib.import_module("logging").getLogger(__name__)
 
     class CfgDummy:  # AI-AGENT-REF: minimal cfg for validation
-        alpaca_base_url = "paper"
+        alpaca_base_url = "https://paper-api.alpaca.markets"
         paper = True
 
     with _temp_env("AI_TRADING_MAX_POSITION_SIZE", None):

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -46,7 +46,7 @@ def test_talib_imports():
         # Set dummy environment variables to avoid config errors
         os.environ.setdefault('ALPACA_API_KEY', 'dummy')
         os.environ.setdefault('ALPACA_SECRET_KEY', 'dummy')
-        os.environ.setdefault('ALPACA_BASE_URL', 'paper')
+        os.environ.setdefault('ALPACA_BASE_URL', 'https://paper-api.alpaca.markets')
         os.environ.setdefault('WEBHOOK_SECRET', 'dummy')
         os.environ.setdefault('FLASK_PORT', '5000')
 

--- a/tests/test_missing_max_position_size.py
+++ b/tests/test_missing_max_position_size.py
@@ -24,7 +24,7 @@ def test_startup_without_max_position_size(monkeypatch, caplog):
     assert snapshot["ALPACA_SECRET_KEY"] == "***"
 
     class DummyCfg:
-        alpaca_base_url = "paper"
+        alpaca_base_url = "https://paper-api.alpaca.markets"
         paper = True
 
     class DummySettings:


### PR DESCRIPTION
## Summary
- validate `alpaca_base_url` during settings construction using the shared normalizer so invalid endpoints raise immediately
- set the systemd unit’s Alpaca URL to the full HTTPS endpoint and update helper scripts/tests to use the canonical value
- add a regression test ensuring placeholder Alpaca URLs are rejected

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/config/test_settings_validation.py tests/test_config_validation_max_position_size.py tests/test_missing_max_position_size.py tests/test_fixes.py

------
https://chatgpt.com/codex/tasks/task_e_68c8376dd56c8330896abcadfda31d1f