### PR TITLE
Validate Alpaca base URL and update systemd configuration

### DIFF
--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -289,6 +289,22 @@ class Settings(BaseSettings):
     def _force_trades_cast(cls, v):
         return _to_bool(v, False)
 
+    @field_validator('alpaca_base_url', mode='after')
+    @classmethod
+    def _validate_alpaca_base_url(cls, value: str) -> str:
+        """Ensure Alpaca base URL is normalized and explicitly https://."""
+
+        from ai_trading.config import management as config_management
+
+        env_key = 'ALPACA_API_URL' if os.getenv('ALPACA_API_URL') else 'ALPACA_BASE_URL'
+        normalized, message = config_management._normalize_alpaca_base_url(
+            value, source_key=env_key
+        )
+        if normalized:
+            return normalized
+        guidance = message or config_management.ALPACA_URL_GUIDANCE
+        raise ValueError(guidance)
+
     @computed_field
     @property
     def alpaca_secret_key_plain(self) -> str | None:

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -16,6 +16,7 @@ Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
 Environment=AI_TRADING_MODELS_DIR=/var/lib/ai-trading-bot/models
 Environment=AI_TRADING_OUTPUT_DIR=/var/lib/ai-trading-bot/output
 Environment=TRADE_LOG_PATH=/home/aiuser/ai-trading-bot/logs/trades.jsonl
+Environment=ALPACA_API_URL=https://paper-api.alpaca.markets
 EnvironmentFile=-/home/aiuser/ai-trading-bot/.env
 ExecStartPre=/usr/bin/install -d -m 700 -o aiuser -g aiuser \
     /var/lib/ai-trading-bot \


### PR DESCRIPTION
## Summary
- add a Pydantic field validator for `alpaca_base_url` that reuses the shared normalization helper and raises if the value is invalid
- ensure the systemd unit explicitly exports `ALPACA_API_URL` with the full paper trading endpoint

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_credentials_env.py

------
https://chatgpt.com/codex/tasks/task_e_68c839daa0dc83309b7ef4b4df014554