### PR TITLE
Improve Alpaca feed fallback handling and document configuration

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -70,6 +70,15 @@ startup the validation result is cached and `/healthz` reuses it, returning
 | --- | --- | --- |
 | `AI_TRADING_CONF_THRESHOLD` | Minimum model confidence required before acting | 0.75 |
 
+### Feed tuning
+
+| Key | Purpose | Default |
+| --- | --- | --- |
+| `ALPACA_FEED_FAILOVER` | Ordered Alpaca feeds to try when a 200 OK response is empty (comma separated) | `sip`* |
+| `ALPACA_EMPTY_TO_BACKUP` | Route empty Alpaca responses straight to the backup provider when set to `1` | `1` |
+
+\* `sip` is honoured only when the account has SIP access (`ALPACA_ALLOW_SIP=1`).
+
 ### Persistent directories
 
 The service writes state, cache, logs, models, and run outputs to paths governed by the environment variables `AI_TRADING_DATA_DIR`, `AI_TRADING_CACHE_DIR`, `AI_TRADING_LOG_DIR`, `AI_TRADING_MODELS_DIR`, and `AI_TRADING_OUTPUT_DIR`.

--- a/README.md
+++ b/README.md
@@ -755,6 +755,8 @@ exits early with a clear error message when these values are invalid.
   # ALPACA_DATA_FEED=sip
   # ALPACA_HAS_SIP=1      # set to 1 if your Alpaca account has SIP access
   # ALPACA_ALLOW_SIP=1    # enable SIP feed and SIP fallback
+  # ALPACA_FEED_FAILOVER=sip,iex  # retry SIP first when Alpaca returns an empty payload
+  # ALPACA_EMPTY_TO_BACKUP=1      # hop straight to the backup provider after empty Alpaca responses
   # Without ALPACA_HAS_SIP, the fetcher uses the backup provider instead of SIP
   # ALPACA_SIP_UNAUTHORIZED=1  # legacy flag to suppress SIP after a 403
    ALPACA_ADJUSTMENT=all

--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -35,6 +35,21 @@ def max_data_fallbacks(s: Settings | None = None) -> int:
     return int(getattr(s, 'max_data_fallbacks', 2))
 
 
+def alpaca_feed_failover(s: Settings | None = None) -> tuple[str, ...]:
+    """Return preferred Alpaca feed fallback order."""
+    s = s or get_settings()
+    feeds = getattr(s, 'alpaca_feed_failover', ())
+    if isinstance(feeds, tuple):
+        return feeds
+    return tuple(feeds or ())
+
+
+def alpaca_empty_to_backup(s: Settings | None = None) -> bool:
+    """Return whether to route empty payloads to the backup provider."""
+    s = s or get_settings()
+    return bool(getattr(s, 'alpaca_empty_to_backup', True))
+
+
 def sentiment_retry_max(s: Settings | None = None) -> int:
     """Return maximum sentiment fetch retry count."""
     s = s or get_settings()
@@ -52,4 +67,15 @@ def sentiment_backoff_strategy(s: Settings | None = None) -> str:
     s = s or get_settings()
     return str(getattr(s, 'sentiment_backoff_strategy', 'exponential'))
 
-__all__ = ['Settings', 'get_settings', 'broker_keys', 'provider_priority', 'max_data_fallbacks', 'sentiment_retry_max', 'sentiment_backoff_base', 'sentiment_backoff_strategy']
+__all__ = [
+    'Settings',
+    'get_settings',
+    'broker_keys',
+    'provider_priority',
+    'max_data_fallbacks',
+    'alpaca_feed_failover',
+    'alpaca_empty_to_backup',
+    'sentiment_retry_max',
+    'sentiment_backoff_base',
+    'sentiment_backoff_strategy',
+]

--- a/docs/provider_configuration.md
+++ b/docs/provider_configuration.md
@@ -17,6 +17,14 @@ export ENABLE_FINNHUB=1
 ## Alpaca Feed
 
 - `ALPACA_DATA_FEED`: choose `iex` (default) or `sip`. The `sip` option requires a SIP-enabled Alpaca account.
+- `ALPACA_FEED_FAILOVER`: comma-separated Alpaca feeds to try when a 200 OK response is empty. Example: `sip,iex` tells the bot to
+  retry SIP first, then fall back to IEX if SIP is also empty or unavailable. Feeds that are not permitted by entitlement are
+  ignored.
+- `ALPACA_EMPTY_TO_BACKUP`: when set to `1`, the bot will jump directly to the configured backup provider if every preferred
+  Alpaca feed responds with an empty payload.
+
+When a fallback feed returns usable data, the system records the switch per `(symbol, timeframe)` and logs `ALPACA_FEED_SWITCH`
+once. Future requests for the same pair use the working feed immediately, eliminating redundant retries against an empty feed.
 
 ## Backup Provider
 

--- a/tests/test_feed_failover.py
+++ b/tests/test_feed_failover.py
@@ -1,0 +1,127 @@
+import json
+from datetime import UTC, datetime, timedelta
+
+from ai_trading.data import fetch
+
+
+class _Resp:
+    def __init__(self, payload: dict, *, status: int = 200, correlation: str | None = None):
+        self.status_code = status
+        self.headers = {"Content-Type": "application/json"}
+        if correlation is not None:
+            self.headers["x-request-id"] = correlation
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, responses: list[_Resp]):
+        self._responses = list(responses)
+        self.calls: list[dict[str, object]] = []
+
+    def get(self, url, params=None, headers=None, timeout=None):  # noqa: D401 - simple stub
+        self.calls.append(params or {})
+        return self._responses.pop(0)
+
+
+def _reset_state():
+    fetch._FEED_OVERRIDE_BY_TF.clear()
+    fetch._FEED_FAILOVER_ATTEMPTS.clear()
+    fetch._FEED_SWITCH_LOGGED.clear()
+    fetch._IEX_EMPTY_COUNTS.clear()
+    fetch._ALPACA_EMPTY_ERROR_COUNTS.clear()
+
+
+def test_empty_payload_switches_to_preferred_feed(monkeypatch):
+    _reset_state()
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+    monkeypatch.setattr(fetch, "_ALLOW_SIP", True)
+    monkeypatch.setattr(fetch, "_HAS_SIP", True)
+    monkeypatch.setattr(fetch, "_SIP_UNAUTHORIZED", False)
+    monkeypatch.setattr(fetch, "alpaca_feed_failover", lambda: ("sip",))
+    monkeypatch.setattr(fetch, "alpaca_empty_to_backup", lambda: False)
+
+    start = datetime(2024, 1, 2, 15, 30, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+
+    session = _Session(
+        [
+            _Resp({"bars": []}, correlation="iex"),
+            _Resp(
+                {
+                    "bars": [
+                        {"t": "2024-01-01T00:00:00Z", "o": 1, "h": 1, "l": 1, "c": 1, "v": 1}
+                    ]
+                },
+                correlation="sip",
+            ),
+        ]
+    )
+    monkeypatch.setattr(fetch, "_HTTP_SESSION", session)
+
+    df = fetch._fetch_bars("AAPL", start, end, "1Min", feed="iex")
+
+    assert hasattr(df, "empty")
+    assert not getattr(df, "empty", True)
+    assert session.calls[0]["feed"] == "iex"
+    assert session.calls[1]["feed"] == "sip"
+    assert fetch._FEED_OVERRIDE_BY_TF[("AAPL", "1Min")] == "sip"
+    assert ("AAPL", "1Min", "sip") in fetch._FEED_SWITCH_LOGGED
+
+
+def test_feed_override_used_on_subsequent_requests(monkeypatch):
+    _reset_state()
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+    monkeypatch.setattr(fetch, "_ALLOW_SIP", True)
+    monkeypatch.setattr(fetch, "_HAS_SIP", True)
+    monkeypatch.setattr(fetch, "_SIP_UNAUTHORIZED", False)
+    monkeypatch.setattr(fetch, "alpaca_feed_failover", lambda: ("sip",))
+    monkeypatch.setattr(fetch, "alpaca_empty_to_backup", lambda: False)
+    monkeypatch.setattr(fetch, "_verify_minute_continuity", lambda df, *a, **k: df)
+
+    start = datetime(2024, 1, 2, 15, 30, tzinfo=UTC)
+    end = start + timedelta(minutes=1)
+
+    first_session = _Session(
+        [
+            _Resp({"bars": []}, correlation="iex"),
+            _Resp(
+                {
+                    "bars": [
+                        {"t": "2024-01-01T00:00:00Z", "o": 1, "h": 1, "l": 1, "c": 1, "v": 1}
+                    ]
+                },
+                correlation="sip",
+            ),
+        ]
+    )
+    monkeypatch.setattr(fetch, "_HTTP_SESSION", first_session)
+
+    df_first = fetch.get_minute_df("AAPL", start, end)
+    assert hasattr(df_first, "empty")
+    assert not getattr(df_first, "empty", True)
+    assert first_session.calls[0]["feed"] == "iex"
+    assert first_session.calls[1]["feed"] == "sip"
+
+    second_session = _Session(
+        [
+            _Resp(
+                {
+                    "bars": [
+                        {"t": "2024-01-01T00:00:00Z", "o": 2, "h": 2, "l": 2, "c": 2, "v": 2}
+                    ]
+                },
+                correlation="sip2",
+            )
+        ]
+    )
+    monkeypatch.setattr(fetch, "_HTTP_SESSION", second_session)
+
+    df_second = fetch.get_minute_df("AAPL", start, end)
+    assert hasattr(df_second, "empty")
+    assert not getattr(df_second, "empty", True)
+    assert len(second_session.calls) == 1
+    assert second_session.calls[0]["feed"] == "sip"


### PR DESCRIPTION
## Summary
- teach the Alpaca fetcher to cache successful feed fallbacks per symbol/timeframe, retry preferred feeds on empty 200s, and bail out to the backup provider when configured
- expose new `ALPACA_FEED_FAILOVER` and `ALPACA_EMPTY_TO_BACKUP` settings/helpers and document the additional environment knobs for operators
- harden test watchdog plugin when `requests` is absent and add unit tests exercising the new feed-selection behaviour

## Testing
- `pytest tests/test_feed_failover.py tests/test_iex_empty_fallback.py`


------
https://chatgpt.com/codex/tasks/task_e_68c84240e5a88330bca676bd7f53b292