### PR TITLE
Handle trade log fallback to user state dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ permissions during startup.
 
 Trade logs write to the path resolved by `TRADE_LOG_PATH` (or the legacy
 `AI_TRADING_TRADE_LOG_PATH`). When unset, the bot prefers
-`/var/log/ai-trading-bot/trades.jsonl`; if that directory—or an explicit
-override—cannot be created or written, it falls back to `./logs/trades.jsonl`
-next to the working directory.
+`/var/log/ai-trading-bot/trades.jsonl`. If that directory—or an explicit
+override—cannot be created or written, the engine emits a once-per-process
+warning and falls back to a user-writable state directory such as
+`$XDG_STATE_HOME/ai-trading-bot/trades.jsonl` (or
+`~/.local/state/ai-trading-bot/trades.jsonl` when `XDG_STATE_HOME` is unset),
+preserving the configured filename.
 Startup logs the final trade log location via `ensure_trade_log_path()` so
 operators can confirm where records are stored.
 


### PR DESCRIPTION
## Summary
- add reusable helpers to detect unwritable trade log directories, warn once, and fall back to the user state path
- update trade log initialization tests to cover the new fallback behaviour and cache reset requirements
- document the state-directory fallback and environment override in the README

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_trade_log_init.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c8423e4e6883308b563cd9244f4d1d