### PR TITLE
Fail fast when API port is occupied

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -95,6 +95,10 @@ Set `RUN_HEALTHCHECK=1` to expose `/healthz` and `/metrics` on the port defined 
 | `RUN_HEALTHCHECK` | Enable lightweight Flask health server |
 | `HEALTHCHECK_PORT` | Port for `/healthz` and `/metrics` |
 
+### API port fail-fast semantics
+
+The primary Flask API binds to `settings.api_port` (default **9001**). If that port is already in use the process now raises an error and exits with status **98** instead of retrying higher ports. The systemd unit is configured with `RestartPreventExitStatus=98`, so the service will stay stopped until the conflict is resolved. Free the port or update `API_PORT` before restarting.
+
 ### CLI
 
 `ai-trade`, `ai-backtest`, and `ai-health` share flags:

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -30,6 +30,7 @@ ExecStart=/home/aiuser/ai-trading-bot/venv/bin/python -m ai_trading
 RuntimeMaxSec=0
 Restart=on-failure
 RestartSec=10
+RestartPreventExitStatus=98
 StandardOutput=journal
 StandardError=journal
 NoNewPrivileges=true


### PR DESCRIPTION
## Summary
- introduce a `PortInUseError` and update API startup so port conflicts raise and surface as exit code 98 instead of auto-incrementing
- propagate API startup failures through the main loop and add `RestartPreventExitStatus=98` so systemd leaves the service stopped on conflicts
- document the new fail-fast behavior and update the unit test to assert the configured port raises when occupied

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_start_api_port_increment.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/runtime/test_runtime_behavior.py::test_start_api_with_signal_sets_error_on_failure


------
https://chatgpt.com/codex/tasks/task_e_68c8423e9464833093aa75317cb28b52