### PR TITLE
Guard minute fetch pipeline against NaN closes

### DIFF
--- a/ai_trading/features/indicators.py
+++ b/ai_trading/features/indicators.py
@@ -24,7 +24,11 @@ def compute_macd(df: pd.DataFrame) -> pd.DataFrame:
         if "close" not in df.columns:
             logger.error("Missing 'close' column for MACD calculation")
             return df
-        close = tuple(df["close"].astype(float))
+        close_series = df["close"]
+        if close_series.count() == 0:
+            logger.debug("Skipping MACD computation: close column has no valid values")
+            return df
+        close = tuple(close_series.astype(float))
         df["ema12"] = ema(close, 12)
         df["ema26"] = ema(close, 26)
         df["macd"] = df["ema12"] - df["ema26"]

--- a/tests/test_bot_engine_edge_cases.py
+++ b/tests/test_bot_engine_edge_cases.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 pd = pytest.importorskip("pandas")
 
@@ -20,7 +19,7 @@ def test_prepare_indicators_non_numeric_close(monkeypatch):
     def fake_rsi(close, length=14):
         if not pd.api.types.is_numeric_dtype(close):
             raise TypeError('close column must be numeric')
-        return pd.Series(np.arange(len(close)), dtype=float)
+        return pd.Series(range(len(close)), dtype=float)
 
     monkeypatch.setattr(bot_engine.ta, 'rsi', fake_rsi)
     df = pd.DataFrame({'open': [1, 2], 'high': [1, 2], 'low': [1, 2], 'close': ['a', 'b']})
@@ -46,3 +45,75 @@ def test_prepare_indicators_single_row():
 
     assert isinstance(result, pd.DataFrame)
     assert result.empty
+
+
+def test_fetch_minute_df_nan_closes_triggers_guard(monkeypatch, caplog):
+    from datetime import UTC, datetime, timedelta
+    from ai_trading.core import bot_engine
+
+    now_utc = datetime.now(UTC).replace(second=0, microsecond=0)
+    index = pd.date_range(end=now_utc - timedelta(minutes=1), periods=3, freq="T", tz="UTC")
+    nan_df = pd.DataFrame(
+        {
+            'open': [100.0, 101.0, 102.0],
+            'high': [101.0, 102.0, 103.0],
+            'low': [99.0, 100.0, 101.0],
+            'close': [float('nan')] * len(index),
+            'volume': [1_000, 1_200, 1_500],
+        },
+        index=index,
+    )
+
+    monkeypatch.setattr("ai_trading.utils.base.is_market_open", lambda: True)
+    session_start = now_utc - timedelta(hours=6)
+    session_end = now_utc
+    monkeypatch.setattr(
+        "ai_trading.data.market_calendar.rth_session_utc",
+        lambda _date: (session_start, session_end),
+    )
+    monkeypatch.setattr(
+        bot_engine,
+        "get_minute_df",
+        lambda symbol, start, end: nan_df.copy(),
+    )
+
+    caplog.set_level("DEBUG", logger="ai_trading.core.bot_engine")
+
+    class DummyHaltManager:
+        def __init__(self):
+            self.calls: list[str] = []
+
+        def manual_halt_trading(self, reason: str) -> None:
+            self.calls.append(reason)
+
+    class DummyFetcher:
+        def get_daily_df(self, ctx, symbol):  # pragma: no cover - guard path
+            raise AssertionError("daily fallback should not run")
+
+    halt_manager = DummyHaltManager()
+    ctx = type("Ctx", (), {})()
+    ctx.halt_manager = halt_manager
+    ctx.data_fetcher = DummyFetcher()
+
+    called = {"value": False}
+
+    def marker(frame):
+        called["value"] = True
+        return frame
+
+    monkeypatch.setattr(bot_engine, "prepare_indicators", marker)
+
+    raw_df, feat_df, skip_flag = bot_engine._fetch_feature_data(ctx, None, "TEST")
+
+    assert (raw_df, feat_df, skip_flag) == (None, None, False)
+    assert halt_manager.calls == ["TEST:empty_frame"]
+    assert not called["value"]
+    assert any(
+        rec.getMessage() == "FETCH_MINUTE_CLOSE_ALL_NAN_AFTER_FILTER"
+        for rec in caplog.records
+    )
+    assert not any(
+        "prepare_indicators produced empty dataframe" in rec.getMessage()
+        for rec in caplog.records
+    )
+    assert not any("Error calculating EMA" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- drop NaN close rows in `fetch_minute_df_safe`, emit a dedicated warning, and raise `DataFetchError` when none remain so upstream fallbacks can engage
- short-circuit `compute_macd` when the close series has no valid prices to avoid repeated EMA errors
- add a regression test covering an all-NaN minute frame to ensure indicator preparation is skipped and the new guard logs as expected

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot_engine_edge_cases.py *(skipped: pandas missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b2bfadac83308d1303112c45f38e