### PR TITLE
Normalize fetch_minute_df_safe data types before filtering

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -2655,6 +2655,14 @@ def fetch_minute_df_safe(symbol: str) -> pd.DataFrame:
         setattr(err, "timeframe", "1Min")
         raise err
 
+    # Normalize OHLCV numeric types so placeholder strings become NaN prior to filtering
+    for col in ("open", "high", "low", "close", "volume"):
+        if col in df.columns:
+            try:
+                df.loc[:, col] = pd.to_numeric(df[col], errors="coerce")
+            except Exception as exc:  # pragma: no cover - defensive fallback
+                logger.debug("minute bar %s coercion failed: %s", col, exc)
+
     close_series = df["close"]
     dropped_rows = 0
     initial_rows = len(df)


### PR DESCRIPTION
## Summary
- coerce minute OHLCV columns to numeric values in `fetch_minute_df_safe` so placeholder strings become nulls before filtering
- add a regression test covering string "nan" inputs to ensure cleaned data remains for downstream EMA/MACD calculations

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/bot_engine/test_fetch_minute_df_safe_filter.py tests/test_normalize_columns.py

------
https://chatgpt.com/codex/tasks/task_e_68c9bbc2251c833086293161c37bf6bb