### PR TITLE
Forward quote price to execution engine

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -13136,7 +13136,11 @@ def run_multi_strategy(ctx) -> None:
 
         try:
             ctx.execution_engine.execute_order(
-                sig.symbol, sig.side, qty, asset_class=sig.asset_class
+                sig.symbol,
+                sig.side,
+                qty,
+                price=price,
+                asset_class=sig.asset_class,
             )
         except AssertionError as exc:
             logger.warning(

--- a/tests/unit/test_run_all_trades_warning.py
+++ b/tests/unit/test_run_all_trades_warning.py
@@ -6,6 +6,8 @@ import types
 import sys
 from unittest.mock import Mock
 
+import pytest
+
 sklearn_stub = types.ModuleType("sklearn")
 ensemble_stub = types.ModuleType("sklearn.ensemble")
 
@@ -30,6 +32,94 @@ sys.modules.setdefault("sklearn.model_selection", model_selection_stub)
 preproc_stub = types.ModuleType("sklearn.preprocessing")
 preproc_stub.StandardScaler = type("StandardScaler", (), {})
 sys.modules.setdefault("sklearn.preprocessing", preproc_stub)
+
+numpy_stub = types.ModuleType("numpy")
+numpy_stub.nan = float("nan")
+numpy_stub.NaN = float("nan")
+numpy_stub.isfinite = lambda *_a, **_k: True
+numpy_stub.asarray = lambda value, *a, **k: value
+numpy_stub.array = lambda value, *a, **k: value
+numpy_stub.stack = lambda seq, *a, **k: list(seq)
+numpy_stub.std = lambda *_a, **_k: 0.0
+numpy_stub.mean = lambda *_a, **_k: 0.0
+numpy_stub.clip = lambda arr, *a, **k: arr
+numpy_stub.argmax = lambda *_a, **_k: 0
+numpy_stub.where = lambda cond, x, y: x if cond else y
+numpy_stub.float32 = float
+numpy_stub.float64 = float
+numpy_stub.eye = lambda n, dtype=None: [
+    [1 if i == j else 0 for j in range(n)] for i in range(n)
+]
+numpy_stub.zeros = lambda shape, dtype=None: [0] * shape if isinstance(shape, int) else [
+    [0 for _ in range(shape[1])] for _ in range(shape[0])
+]
+numpy_stub.ones = lambda shape, dtype=None: [1] * shape if isinstance(shape, int) else [
+    [1 for _ in range(shape[1])] for _ in range(shape[0])
+]
+numpy_stub.random = types.SimpleNamespace(seed=lambda *_a, **_k: None)
+numpy_stub.polyfit = lambda *_a, **_k: [0.0]
+numpy_stub.where = lambda cond, x, y: x if cond else y
+numpy_stub.isnan = lambda *_a, **_k: False
+numpy_stub.isscalar = lambda obj: not isinstance(obj, (list, tuple, dict, set))
+numpy_stub.bool_ = bool
+sys.modules.setdefault("numpy", numpy_stub)
+
+portalocker_stub = types.ModuleType("portalocker")
+portalocker_stub.LOCK_EX = 1
+portalocker_stub.lock = lambda *_a, **_k: None
+portalocker_stub.unlock = lambda *_a, **_k: None
+sys.modules.setdefault("portalocker", portalocker_stub)
+
+bs4_stub = types.ModuleType("bs4")
+bs4_stub.BeautifulSoup = type("BeautifulSoup", (), {})
+sys.modules.setdefault("bs4", bs4_stub)
+
+class _Flask:
+    def __init__(self, *_a, **_k):
+        pass
+
+    def route(self, *args, **kwargs):  # noqa: D401
+        """Return a no-op decorator."""
+
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    def run(self, *args, **kwargs):  # noqa: D401
+        """No-op run."""
+
+        return None
+
+
+flask_stub = types.ModuleType("flask")
+flask_stub.Flask = _Flask
+flask_stub.jsonify = lambda obj=None, *a, **k: obj
+sys.modules.setdefault("flask", flask_stub)
+
+cachetools_stub = types.ModuleType("cachetools")
+
+
+class _TTLCache(dict):
+    def __init__(self, maxsize=128, ttl=600):
+        super().__init__()
+        self.maxsize = maxsize
+        self.ttl = ttl
+
+    def __setitem__(self, key, value):  # noqa: D401
+        """Insert while enforcing a crude max size."""
+
+        if len(self) >= self.maxsize:
+            try:
+                first_key = next(iter(self))
+                super().__delitem__(first_key)
+            except StopIteration:  # pragma: no cover - defensive
+                pass
+        super().__setitem__(key, value)
+
+
+cachetools_stub.TTLCache = _TTLCache
+sys.modules.setdefault("cachetools", cachetools_stub)
 
 import ai_trading.core.bot_engine as eng
 
@@ -86,6 +176,11 @@ def test_run_all_trades_no_warning_with_valid_api(monkeypatch):
 
     monkeypatch.setattr(eng, "_prepare_run", _raise_df)
     monkeypatch.setattr(eng.CFG, "log_market_fetch", False, raising=False)
+    stub_fetcher = types.SimpleNamespace()
+    monkeypatch.setattr(
+        eng.data_fetcher_module, "build_fetcher", lambda *_a, **_k: stub_fetcher
+    )
+    monkeypatch.setattr(eng, "data_fetcher", stub_fetcher, raising=False)
 
     class DummyLock:
         def acquire(self, blocking: bool = False) -> bool:  # noqa: D401
@@ -151,6 +246,11 @@ def test_run_all_trades_creates_trade_log(tmp_path, monkeypatch):
     monkeypatch.setattr(eng, "get_strategies", lambda: [])
     monkeypatch.setattr(eng, "get_verbose_logging", lambda: False)
     monkeypatch.setattr(eng.CFG, "log_market_fetch", False, raising=False)
+    stub_fetcher = types.SimpleNamespace()
+    monkeypatch.setattr(
+        eng.data_fetcher_module, "build_fetcher", lambda *_a, **_k: stub_fetcher
+    )
+    monkeypatch.setattr(eng, "data_fetcher", stub_fetcher, raising=False)
 
     class DummyLock:
         def acquire(self, blocking: bool = False) -> bool:
@@ -180,3 +280,135 @@ def test_run_all_trades_creates_trade_log(tmp_path, monkeypatch):
         trade_log.read_text().splitlines()[0]
         == "symbol,entry_time,entry_price,exit_time,exit_price,qty,side,strategy,classification,signal_tags,confidence,reward"
     )
+
+
+def test_run_multi_strategy_forwards_price_to_execution(monkeypatch):
+    """Ensure sizing price is forwarded to execute_order."""
+
+    expected_price = 123.45
+
+    class DummyExecutionEngine:
+        def __init__(self):
+            self.calls: list[dict] = []
+            self.end_cycle_called = 0
+
+        def execute_order(self, symbol, side, qty, *, price, asset_class):  # noqa: D401
+            """Capture the order payload."""
+
+            self.calls.append(
+                {
+                    "symbol": symbol,
+                    "side": side,
+                    "qty": qty,
+                    "price": price,
+                    "asset_class": asset_class,
+                }
+            )
+
+        def end_cycle(self) -> None:
+            self.end_cycle_called += 1
+
+    class DummyRiskEngine:
+        def __init__(self):
+            self.last_price: float | None = None
+            self.registered: list = []
+
+        def position_exists(self, api, symbol):  # noqa: D401
+            """Always allow new positions."""
+
+            return False
+
+        def position_size(self, sig, cash, price):  # noqa: D401
+            """Record the price used for sizing and return a fixed qty."""
+
+            self.last_price = price
+            return 7
+
+        def register_fill(self, sig):  # noqa: D401
+            """Track registered fills."""
+
+            self.registered.append(sig)
+
+    class DummyStrategy:
+        name = "stub"
+
+        def generate(self, ctx):  # noqa: D401
+            """Return a single long signal."""
+
+            return [
+                types.SimpleNamespace(
+                    symbol="AAPL",
+                    side="buy",
+                    confidence=0.9,
+                    strategy="stub",
+                    weight=1.0,
+                    asset_class="equity",
+                )
+            ]
+
+    class DummyAllocator:
+        def allocate(self, signals_by_strategy):  # noqa: D401
+            """Flatten strategy outputs."""
+
+            return [
+                sig for signals in signals_by_strategy.values() for sig in signals
+            ]
+
+    class DummyAPI:
+        def list_positions(self):  # noqa: D401
+            """Return an empty portfolio."""
+
+            return []
+
+        def get_account(self):  # noqa: D401
+            """Return a cash-only account."""
+
+            return types.SimpleNamespace(cash=10_000)
+
+    class DummyDataClient:
+        def __init__(self):
+            self.requests: list = []
+
+        def get_stock_latest_quote(self, req):  # noqa: D401
+            """Record the request and return a static quote."""
+
+            self.requests.append(req)
+            return types.SimpleNamespace(ask_price=expected_price)
+
+    dummy_exec = DummyExecutionEngine()
+    dummy_risk = DummyRiskEngine()
+    dummy_api = DummyAPI()
+    dummy_data_client = DummyDataClient()
+
+    ctx = types.SimpleNamespace(
+        strategies=[DummyStrategy()],
+        allocator=DummyAllocator(),
+        api=dummy_api,
+        data_client=dummy_data_client,
+        execution_engine=dummy_exec,
+        risk_engine=dummy_risk,
+        data_fetcher=object(),
+    )
+
+    class DummyQuoteRequest:
+        def __init__(self, symbol_or_symbols):
+            self.symbol_or_symbols = symbol_or_symbols
+
+    signals_mod = types.ModuleType("ai_trading.signals")
+    signals_mod.enhance_signals_with_position_logic = (
+        lambda signals, _ctx, _hold: signals
+    )
+    signals_mod.generate_position_hold_signals = lambda _ctx, _pos: []
+
+    monkeypatch.setitem(sys.modules, "ai_trading.signals", signals_mod)
+    monkeypatch.setattr(eng, "StockLatestQuoteRequest", DummyQuoteRequest)
+    monkeypatch.setattr(eng, "to_trade_signal", lambda sig: sig)
+    monkeypatch.setattr(eng, "fetch_minute_df_safe", lambda symbol: pytest.fail("unexpected fallback"))
+
+    eng.run_multi_strategy(ctx)
+
+    assert dummy_exec.calls, "execute_order should be invoked"
+    call = dummy_exec.calls[0]
+    assert call["price"] == pytest.approx(expected_price)
+    assert call["asset_class"] == "equity"
+    assert dummy_risk.last_price == pytest.approx(expected_price)


### PR DESCRIPTION
## Summary
- include the calculated quote price when calling `ctx.execution_engine.execute_order` so sizing and execution share the same value
- extend the unit test suite with a scenario that verifies the forwarded price and provide lightweight stubs for optional dependencies needed to run it in isolation

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/unit/test_run_all_trades_warning.py tests/test_submit_order_fix.py

------
https://chatgpt.com/codex/tasks/task_e_68c9bbc1a6288330b65618f96b305766