### PR TITLE
Handle string NaNs in MACD computation

### DIFF
--- a/ai_trading/features/indicators.py
+++ b/ai_trading/features/indicators.py
@@ -24,25 +24,39 @@ def compute_macd(df: pd.DataFrame) -> pd.DataFrame:
         if "close" not in df.columns:
             logger.error("Missing 'close' column for MACD calculation")
             return df
-        close_series = df["close"]
-        if close_series.count() == 0:
-            logger.debug("Skipping MACD computation: close column has no valid values")
+        close_numeric = pd.to_numeric(df["close"], errors="coerce")
+        if close_numeric.count() == 0:
+            logger.debug("Skipping MACD computation: close column has no numeric values")
             return df
-        close = tuple(close_series.astype(float))
 
-        def _aligned(values: pd.Series | pd.Index | tuple[float, ...] | list[float]) -> pd.Series:
-            if isinstance(values, pd.Series):
-                raw = values.to_numpy()
-            else:
-                raw = pd.Series(values).to_numpy()
-            if len(raw) != len(df.index):
-                return pd.Series([float("nan")] * len(df.index), index=df.index, dtype=float)
-            return pd.Series(raw, index=df.index)
+        valid_close = close_numeric.dropna()
+        valid_index = valid_close.index
+        close_tuple = tuple(valid_close.astype(float))
 
-        df["ema12"] = _aligned(ema(close, 12))
-        df["ema26"] = _aligned(ema(close, 26))
-        df["macd"] = df["ema12"] - df["ema26"]
-        df["signal"] = _aligned(ema(tuple(df["macd"].astype(float)), 9))
+        ema12_raw = ema(close_tuple, 12)
+        ema26_raw = ema(close_tuple, 26)
+
+        ema12_series = pd.Series(ema12_raw.to_numpy(), index=valid_index, dtype=float)
+        ema26_series = pd.Series(ema26_raw.to_numpy(), index=valid_index, dtype=float)
+
+        ema12_aligned = pd.Series(index=df.index, dtype=float)
+        ema26_aligned = pd.Series(index=df.index, dtype=float)
+        ema12_aligned.loc[ema12_series.index] = ema12_series
+        ema26_aligned.loc[ema26_series.index] = ema26_series
+        df["ema12"] = ema12_aligned
+        df["ema26"] = ema26_aligned
+
+        macd_aligned = df["ema12"] - df["ema26"]
+        df["macd"] = macd_aligned
+
+        macd_valid = macd_aligned.loc[valid_index].dropna()
+        signal_aligned = pd.Series(index=df.index, dtype=float)
+        if not macd_valid.empty:
+            macd_tuple = tuple(macd_valid.astype(float))
+            signal_raw = ema(macd_tuple, 9)
+            signal_series = pd.Series(signal_raw.to_numpy(), index=macd_valid.index, dtype=float)
+            signal_aligned.loc[signal_series.index] = signal_series
+        df["signal"] = signal_aligned
         df["histogram"] = df["macd"] - df["signal"]
         return df
     except (KeyError, ValueError, TypeError):

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -20,6 +20,16 @@ def test_macd_pipeline_produces_macds():
     assert df["macds"].notna().any()
 
 
+def test_compute_macd_ignores_string_nan(caplog):
+    df = pd.DataFrame({"close": ["nan", "nan", "nan"]})
+
+    with caplog.at_level("ERROR"):
+        result = compute_macd(df.copy())
+
+    assert not any("Error calculating EMA" in message for message in caplog.messages)
+    assert list(result.columns) == ["close"]
+
+
 def test_position_none_safe(monkeypatch):
     class Dummy:
         def get_position(self, symbol):


### PR DESCRIPTION
## Summary
- sanitize MACD close series by coercing to numeric and skipping rows that remain NaN
- align EMA, MACD, signal, and histogram outputs with the original index after dropping invalid rows
- add regression test covering string "nan" closes to ensure MACD skips logging EMA errors

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_data_pipeline.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9c36266308330ae81cbab0ff6ca3d