### PR TITLE
Guard MACD computation against non-finite closes

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -9708,6 +9708,12 @@ def _fetch_feature_data(
         ) as e:  # AI-AGENT-REF: narrow exception
             logger.warning("Corp actions adjust failed: %s", e)
 
+    close_numeric = pd.to_numeric(df["close"], errors="coerce")
+    finite_close = close_numeric.replace([np.inf, -np.inf], np.nan).dropna()
+    if finite_close.empty:
+        logger.debug("SKIP_FEATURES_NO_FINITE_CLOSES", extra={"symbol": symbol})
+        return raw_df, None, True
+
     # AI-AGENT-REF: log initial dataframe and monitor row drops
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug("Initial tail data for %s: %s", symbol, df.tail(5).to_dict(orient="list"))

--- a/ai_trading/features/indicators.py
+++ b/ai_trading/features/indicators.py
@@ -29,9 +29,16 @@ def compute_macd(df: pd.DataFrame) -> pd.DataFrame:
             logger.debug("Skipping MACD computation: close column has no numeric values")
             return df
 
-        valid_close = close_numeric.dropna()
-        valid_index = valid_close.index
-        close_tuple = tuple(valid_close.astype(float))
+        close_series = close_numeric.dropna()
+        if close_series.empty:
+            logger.debug("Skipping MACD computation: close column has no finite values after dropping NaNs")
+            return df
+
+        valid_index = close_series.index
+        close_tuple = tuple(close_series.astype(float))
+        if not close_tuple:
+            logger.debug("Skipping MACD computation: close column has no usable samples")
+            return df
 
         ema12_raw = ema(close_tuple, 12)
         ema26_raw = ema(close_tuple, 26)
@@ -51,11 +58,20 @@ def compute_macd(df: pd.DataFrame) -> pd.DataFrame:
 
         macd_valid = macd_aligned.loc[valid_index].dropna()
         signal_aligned = pd.Series(index=df.index, dtype=float)
-        if not macd_valid.empty:
-            macd_tuple = tuple(macd_valid.astype(float))
-            signal_raw = ema(macd_tuple, 9)
-            signal_series = pd.Series(signal_raw.to_numpy(), index=macd_valid.index, dtype=float)
-            signal_aligned.loc[signal_series.index] = signal_series
+        if macd_valid.empty:
+            df["signal"] = signal_aligned
+            df["histogram"] = df["macd"] - df["signal"]
+            return df
+
+        macd_tuple = tuple(macd_valid.astype(float))
+        if not macd_tuple:
+            df["signal"] = signal_aligned
+            df["histogram"] = df["macd"] - df["signal"]
+            return df
+
+        signal_raw = ema(macd_tuple, 9)
+        signal_series = pd.Series(signal_raw.to_numpy(), index=macd_valid.index, dtype=float)
+        signal_aligned.loc[signal_series.index] = signal_series
         df["signal"] = signal_aligned
         df["histogram"] = df["macd"] - df["signal"]
         return df

--- a/tests/features/test_indicators.py
+++ b/tests/features/test_indicators.py
@@ -1,0 +1,77 @@
+import types
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading.features import compute_macd
+from ai_trading.core import bot_engine
+
+
+def test_compute_macd_skips_all_nan_close(monkeypatch, caplog):
+    df = pd.DataFrame({"close": [float("nan"), float("nan"), float("nan")]})
+
+    called = {"ema": False}
+
+    def _guarded_ema(values, period):  # pragma: no cover - ensure guard trips before EMA
+        called["ema"] = True
+        raise AssertionError("EMA should not be invoked for all-NaN input")
+
+    monkeypatch.setattr("ai_trading.features.indicators.ema", _guarded_ema)
+    caplog.set_level("ERROR", logger="ai_trading.features.indicators")
+
+    result = compute_macd(df.copy())
+
+    assert not called["ema"], "EMA helper should not be invoked when input is all NaN"
+    assert "MACD computation failed" not in [record.getMessage() for record in caplog.records]
+    pd.testing.assert_frame_equal(result, df)
+
+
+def test_fetch_feature_data_skips_without_finite_closes(monkeypatch, caplog):
+    index = pd.date_range("2024-01-01", periods=5, freq="T", tz="UTC")
+    inf_df = pd.DataFrame(
+        {
+            "open": [100.0] * len(index),
+            "high": [101.0] * len(index),
+            "low": [99.0] * len(index),
+            "close": [float("inf")] * len(index),
+            "volume": [1_000] * len(index),
+        },
+        index=index,
+    )
+
+    monkeypatch.setattr(bot_engine, "fetch_minute_df_safe", lambda symbol: inf_df.copy())
+
+    if hasattr(bot_engine.CFG, "data_sanitize_enabled"):
+        monkeypatch.setattr(bot_engine.CFG, "data_sanitize_enabled", False)
+    if hasattr(bot_engine.S, "data_sanitize_enabled"):
+        monkeypatch.setattr(bot_engine.S, "data_sanitize_enabled", False)
+    if hasattr(bot_engine.CFG, "corp_actions_enabled"):
+        monkeypatch.setattr(bot_engine.CFG, "corp_actions_enabled", False)
+    if hasattr(bot_engine.S, "corp_actions_enabled"):
+        monkeypatch.setattr(bot_engine.S, "corp_actions_enabled", False)
+
+    caplog.set_level("DEBUG", logger="ai_trading.core.bot_engine")
+
+    called = {"prepare": False}
+
+    def _marker(frame):  # pragma: no cover - guard path
+        called["prepare"] = True
+        return frame
+
+    monkeypatch.setattr(bot_engine, "prepare_indicators", _marker)
+
+    ctx = types.SimpleNamespace(
+        data_fetcher=types.SimpleNamespace(get_daily_df=lambda *_a, **_k: inf_df.copy()),
+        halt_manager=None,
+    )
+
+    raw_df, feat_df, skip_flag = bot_engine._fetch_feature_data(ctx, None, "TEST")
+
+    assert raw_df is not None
+    pd.testing.assert_frame_equal(raw_df, inf_df)
+    assert feat_df is None
+    assert skip_flag is True
+    assert not called["prepare"], "prepare_indicators should not be invoked when data is skipped"
+    assert not any("MACD computation failed" in record.getMessage() for record in caplog.records)
+


### PR DESCRIPTION
## Summary
- ensure `compute_macd` drops non-finite closes before invoking EMA helpers
- skip indicator generation when sanitized minute data lacks any usable close values
- add regression coverage verifying MACD and feature fetching guard these paths

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/features/test_macd_alignment.py tests/features/test_indicators.py tests/test_bot_engine_edge_cases.py tests/test_sma_features.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9c552acbc833098f42abf6a90d5f6