### PR TITLE
Reuse cached minute data in safe trade

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -9546,6 +9546,8 @@ def _safe_trade(
     model: Any,
     regime_ok: bool,
     side: OrderSide | None = None,
+    *,
+    price_df: pd.DataFrame | None = None,
 ) -> bool:
     try:
         # Real-time position check to prevent buy/sell flip-flops
@@ -9573,7 +9575,15 @@ def _safe_trade(
                         "detail": str(e),
                     },
                 )
-        return trade_logic(ctx, state, symbol, balance, model, regime_ok)
+        return trade_logic(
+            ctx,
+            state,
+            symbol,
+            balance,
+            model,
+            regime_ok,
+            price_df=price_df,
+        )
     except RetryError as e:
         logger.warning(
             f"[trade_logic] retries exhausted for {symbol}: {e}",
@@ -9610,12 +9620,16 @@ def _fetch_feature_data(
     ctx: BotContext,
     state: BotState,
     symbol: str,
+    price_df: pd.DataFrame | None = None,
 ) -> tuple[pd.DataFrame | None, pd.DataFrame | None, bool | None]:
     """Fetch raw price data and compute indicators.
 
     Returns ``(raw_df, feat_df, skip_flag)``. When data is missing returns
     ``(None, None, False)``; when indicators are insufficient returns
     ``(raw_df, None, True)``.
+
+    When ``price_df`` is provided, it is treated as the raw minute-bar data and
+    no additional fetch is attempted.
     """
     def _halt(reason: str) -> None:
         logger.error("DATA_FETCH_EMPTY", extra={"symbol": symbol, "reason": reason})
@@ -9626,30 +9640,32 @@ def _fetch_feature_data(
             except (AttributeError, RuntimeError) as hm_exc:  # noqa: BLE001
                 logger.error("HALT_MANAGER_ERROR", extra={"cause": str(hm_exc)})
 
-    try:
-        raw_df = fetch_minute_df_safe(symbol)
-    except DataFetchError as exc:
-        reason = getattr(exc, "fetch_reason", "")
-        if reason in {
-            "close_column_all_nan",
-            "close_column_missing",
-            "ohlcv_columns_missing",
-        }:
-            _halt("empty_frame")
-        else:
-            _halt("minute_data_unavailable")
-        return None, None, False
-    except APIError as e:
-        msg = str(e).lower()
-        if "subscription does not permit querying recent sip data" in msg:
-            logger.debug(f"{symbol}: minute fetch failed, falling back to daily.")
-            raw_df = ctx.data_fetcher.get_daily_df(ctx, symbol)
-            if raw_df is None or raw_df.empty:
-                logger.debug(f"{symbol}: no daily data either; skipping.")
-                _halt("daily_data_unavailable")
-                return None, None, False
-        else:
-            raise
+    raw_df = price_df
+    if raw_df is None:
+        try:
+            raw_df = fetch_minute_df_safe(symbol)
+        except DataFetchError as exc:
+            reason = getattr(exc, "fetch_reason", "")
+            if reason in {
+                "close_column_all_nan",
+                "close_column_missing",
+                "ohlcv_columns_missing",
+            }:
+                _halt("empty_frame")
+            else:
+                _halt("minute_data_unavailable")
+            return None, None, False
+        except APIError as e:
+            msg = str(e).lower()
+            if "subscription does not permit querying recent sip data" in msg:
+                logger.debug(f"{symbol}: minute fetch failed, falling back to daily.")
+                raw_df = ctx.data_fetcher.get_daily_df(ctx, symbol)
+                if raw_df is None or raw_df.empty:
+                    logger.debug(f"{symbol}: no daily data either; skipping.")
+                    _halt("daily_data_unavailable")
+                    return None, None, False
+            else:
+                raise
     if raw_df is None or raw_df.empty:
         _halt("empty_frame")
         return None, None, False
@@ -10310,6 +10326,8 @@ def trade_logic(
     balance: float,
     model: Any,
     regime_ok: bool,
+    *,
+    price_df: pd.DataFrame | None = None,
     now_provider: Callable[[], datetime] | None = None,
 ) -> bool:
     """
@@ -10329,7 +10347,9 @@ def trade_logic(
         return False
 
     with StageTimer(logger, "FETCH_FEATURE_DATA", symbol=symbol):
-        raw_df, feat_df, skip_flag = _fetch_feature_data(ctx, state, symbol)
+        raw_df, feat_df, skip_flag = _fetch_feature_data(
+            ctx, state, symbol, price_df=price_df
+        )
     if feat_df is None:
         return skip_flag if skip_flag is not None else False
 
@@ -13492,7 +13512,15 @@ def _process_symbols(
             if symbol in state.position_cache:
                 return  # AI-AGENT-REF: skip symbol with open position
             processed.append(symbol)
-            _safe_trade(ctx, state, symbol, current_cash, model, regime_ok)
+            _safe_trade(
+                ctx,
+                state,
+                symbol,
+                current_cash,
+                model,
+                regime_ok,
+                price_df=price_df,
+            )
         except (
             KeyError,
             ValueError,

--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -1,5 +1,28 @@
+import sys
+import types
+
 import pytest
 from ai_trading.utils.lazy_imports import load_pandas
+
+sys.modules.setdefault(
+    "portalocker",
+    types.SimpleNamespace(lock=lambda *a, **k: None, unlock=lambda *a, **k: None, LOCK_EX=1),
+)
+sys.modules.setdefault("bs4", types.SimpleNamespace(BeautifulSoup=object))
+sys.modules.setdefault(
+    "flask",
+    types.SimpleNamespace(
+        Flask=type(
+            "Flask",
+            (),
+            {
+                "__init__": lambda self, *a, **k: None,
+                "route": lambda self, *a, **k: (lambda fn: fn),
+                "after_request": lambda self, fn: fn,
+            },
+        )
+    ),
+)
 
 from ai_trading.core import bot_engine
 from ai_trading.guards import staleness
@@ -25,4 +48,89 @@ def test_fetch_minute_df_safe_raises_on_empty(monkeypatch):
     monkeypatch.setattr(staleness, "_ensure_data_fresh", lambda df, max_age_seconds, *, symbol=None, now=None, tz=None: None)
     with pytest.raises(bot_engine.DataFetchError):
         bot_engine.fetch_minute_df_safe("AAPL")
+
+
+def test_process_symbol_reuses_prefetched_minute_data(monkeypatch):
+    pd = load_pandas()
+    sample = _sample_df()
+
+    fetch_calls: list[str] = []
+
+    def fake_fetch(symbol: str):
+        fetch_calls.append(symbol)
+        return sample
+
+    monkeypatch.setattr(bot_engine, "fetch_minute_df_safe", fake_fetch)
+
+    observed: list = []
+    fallback_calls: list[str] = []
+
+    def fake_fetch_feature_data(ctx, state, symbol, price_df=None):
+        observed.append(price_df)
+        if price_df is None:
+            fallback_calls.append(symbol)
+            local_df = bot_engine.fetch_minute_df_safe(symbol)
+        else:
+            local_df = price_df
+        return local_df, local_df, False
+
+    monkeypatch.setattr(bot_engine, "_fetch_feature_data", fake_fetch_feature_data)
+
+    def fake_trade_logic(
+        ctx,
+        state,
+        symbol,
+        balance,
+        model,
+        regime_ok,
+        *,
+        price_df=None,
+        now_provider=None,
+    ):
+        bot_engine._fetch_feature_data(ctx, state, symbol, price_df=price_df)
+        return True
+
+    monkeypatch.setattr(bot_engine, "trade_logic", fake_trade_logic)
+
+    state = bot_engine.BotState()
+    state.position_cache = {}
+    bot_engine.state = state
+
+    monkeypatch.setattr(bot_engine, "is_market_open", lambda: True)
+    monkeypatch.setattr(bot_engine, "ensure_final_bar", lambda symbol, timeframe: True)
+    monkeypatch.setattr(bot_engine, "log_skip_cooldown", lambda *a, **k: None)
+    monkeypatch.setattr(
+        bot_engine,
+        "skipped_duplicates",
+        types.SimpleNamespace(inc=lambda: None),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        bot_engine,
+        "skipped_cooldown",
+        types.SimpleNamespace(inc=lambda: None),
+        raising=False,
+    )
+
+    ctx = types.SimpleNamespace(
+        halt_manager=None,
+        data_fetcher=types.SimpleNamespace(get_daily_df=lambda *_: sample),
+        api=types.SimpleNamespace(list_positions=lambda: []),
+    )
+    monkeypatch.setattr(bot_engine, "get_ctx", lambda: ctx)
+
+    prediction_executor = types.SimpleNamespace(
+        submit=lambda fn, sym: types.SimpleNamespace(result=lambda: fn(sym))
+    )
+    monkeypatch.setattr(bot_engine, "prediction_executor", prediction_executor, raising=False)
+    monkeypatch.setattr(bot_engine.executors, "_ensure_executors", lambda: None)
+
+    processed, _ = bot_engine._process_symbols(["AAPL"], 1000.0, None, True)
+
+    assert processed == ["AAPL"]
+    assert fetch_calls == ["AAPL"]
+    assert fallback_calls == []
+    assert len(observed) == 1
+    assert observed[0] is not None
+    pd.testing.assert_frame_equal(observed[0], sample)
 


### PR DESCRIPTION
## Summary
- allow the core trade path to accept a cached minute-bar DataFrame so repeated fetches are avoided
- pass the prefetched data from `_process_symbols` through `_safe_trade` into `_fetch_feature_data`
- cover the behaviour with a unit test that confirms the fetcher is called only once per symbol

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9c4b63d4c8330ad14c2b50b825f08