### PR TITLE
Preserve canonical dollar risk limit when aliases present

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -475,12 +475,19 @@ class TradingConfig:
             "AI_TRADING_BUY_THRESHOLD": "BUY_THRESHOLD",
             "AI_TRADING_CONF_THRESHOLD": "CONF_THRESHOLD",
             "AI_TRADING_MAX_DRAWDOWN_THRESHOLD": "MAX_DRAWDOWN_THRESHOLD",
-            # Ensure legacy daily loss limit inputs override canonical dollar risk limits
+            # Legacy daily loss limit alias: backfills ``DOLLAR_RISK_LIMIT`` when absent.
             "DAILY_LOSS_LIMIT": "DOLLAR_RISK_LIMIT",
         }
+        # Aliases are a legacy backfill mechanism: only populate canonicals when
+        # the operator did not provide an explicit canonical value.
         for alias, canon in alias_map.items():
-            if alias in env_map:
-                env_map[canon] = env_map[alias]
+            alias_value = env_map.get(alias)
+            if alias_value in (None, ""):
+                continue
+            canonical_value = env_map.get(canon)
+            if canonical_value is not None and str(canonical_value).strip() != "":
+                continue
+            env_map[canon] = alias_value
 
         from .aliases import resolve_trading_mode
 

--- a/tests/unit/test_trading_config_aliases.py
+++ b/tests/unit/test_trading_config_aliases.py
@@ -1,12 +1,28 @@
 import logging
 
+import pytest
+
 from ai_trading.config.management import TradingConfig
 from ai_trading.main import _fail_fast_env
 
 
-def test_trading_config_env_aliases():
+@pytest.mark.parametrize(
+    ("env_updates", "expected_limit"),
+    [
+        pytest.param(
+            {"DOLLAR_RISK_LIMIT": "0.06", "DAILY_LOSS_LIMIT": "0.02"},
+            0.06,
+            id="canonical_only",
+        ),
+        pytest.param(
+            {"DOLLAR_RISK_LIMIT": "", "DAILY_LOSS_LIMIT": "0.07"},
+            0.07,
+            id="alias_only",
+        ),
+    ],
+)
+def test_trading_config_env_aliases(env_updates, expected_limit):
     env = {
-        "DAILY_LOSS_LIMIT": "0.06",
         "CAPITAL_CAP": "0.05",
         "MAX_POSITION_MODE": "STATIC",
         "DATA_FEED": "iex",
@@ -17,13 +33,20 @@ def test_trading_config_env_aliases():
         "MIN_SAMPLE_SIZE": "50",
         "CONFIDENCE_LEVEL": "0.9",
     }
+    env.update(env_updates)
+
     cfg = TradingConfig.from_env(env)
-    assert cfg.dollar_risk_limit == 0.06
+
+    assert cfg.dollar_risk_limit == pytest.approx(expected_limit)
     assert cfg.capital_cap == 0.05
     assert cfg.max_position_mode == "STATIC"
     assert cfg.kelly_fraction_max == 0.2
     assert cfg.min_sample_size == 50
     assert cfg.confidence_level == 0.9
+    if "DAILY_LOSS_LIMIT" in env_updates:
+        assert cfg.daily_loss_limit == pytest.approx(
+            float(env_updates["DAILY_LOSS_LIMIT"])
+        )
     snap = cfg.snapshot_sanitized()
     assert snap["data"]["feed"] == "iex"
     assert snap["data"]["provider"] == "alpaca"
@@ -48,26 +71,39 @@ def test_paper_false_when_live_prod():
     assert cfg.paper is False
 
 
-def test_fail_fast_env_warns_on_alias_override(monkeypatch, caplog):
+def test_fail_fast_env_alias_override_logging(monkeypatch, caplog):
     caplog.set_level(logging.INFO, logger="ai_trading.main")
-    monkeypatch.setenv("ALPACA_API_KEY", "key")
-    monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
-    monkeypatch.setenv("ALPACA_DATA_FEED", "iex")
-    monkeypatch.setenv("WEBHOOK_SECRET", "hook")
-    monkeypatch.setenv("CAPITAL_CAP", "0.25")
-    monkeypatch.setenv("ALPACA_API_URL", "https://paper-api.alpaca.markets")
-    monkeypatch.setenv("DOLLAR_RISK_LIMIT", "0.10")
+    base_env = {
+        "ALPACA_API_KEY": "key",
+        "ALPACA_SECRET_KEY": "secret",
+        "ALPACA_DATA_FEED": "iex",
+        "WEBHOOK_SECRET": "hook",
+        "CAPITAL_CAP": "0.25",
+        "ALPACA_API_URL": "https://paper-api.alpaca.markets",
+    }
+    for key, value in base_env.items():
+        monkeypatch.setenv(key, value)
     monkeypatch.setenv("DAILY_LOSS_LIMIT", "0.02")
 
+    def _alias_override_records():
+        return [
+            record
+            for record in caplog.records
+            if record.name == "ai_trading.main"
+            and record.message == "DOLLAR_RISK_LIMIT_ALIAS_OVERRIDE"
+        ]
+
+    caplog.clear()
+    monkeypatch.setenv("DOLLAR_RISK_LIMIT", "0.10")
+    _fail_fast_env()
+    assert not _alias_override_records()
+
+    caplog.clear()
+    monkeypatch.delenv("DOLLAR_RISK_LIMIT", raising=False)
     _fail_fast_env()
 
-    records = [
-        record
-        for record in caplog.records
-        if record.name == "ai_trading.main" and record.message == "DOLLAR_RISK_LIMIT_ALIAS_OVERRIDE"
-    ]
-    assert records, "Expected DOLLAR_RISK_LIMIT_ALIAS_OVERRIDE warning"
+    records = _alias_override_records()
+    assert records, "Expected DOLLAR_RISK_LIMIT_ALIAS_OVERRIDE warning when alias backfills"
     record = records[0]
-    assert getattr(record, "env_value", None) == "0.10"
+    assert getattr(record, "env_value", None) == "0.02"
     assert getattr(record, "trading_config_value", None) == 0.02
-


### PR DESCRIPTION
## Summary
- ensure TradingConfig.from_env only backfills canonical env keys from aliases when the canonical value is missing
- keep fail-fast environment validation from overwriting operator-provided dollar risk limits while warning when legacy aliases backfill the value
- expand the trading config alias tests to cover canonical/alias combinations and the adjusted warning behaviour

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_trading_config_aliases.py


------
https://chatgpt.com/codex/tasks/task_e_68c9ebc37b148330b7bd9a9c40af0aca