### PR TITLE
Honor alias overrides for max position size presets

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -653,9 +653,16 @@ class TradingConfig:
                     max_position_size=12000.0,
                 ),
             }
+            preset_aliases = {
+                "MAX_POSITION_SIZE": ("AI_TRADING_MAX_POSITION_SIZE",),
+            }
             for k, v in presets[mode].items():
                 env_key = k.upper()
-                if env_key in env_map and env_map[env_key] != "":
+                override_keys = (env_key, *preset_aliases.get(env_key, ()))
+                if any(
+                    key in env_map and env_map[key] not in (None, "")
+                    for key in override_keys
+                ):
                     continue
                 try:
                     object.__setattr__(cfg, k, v)

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -39,3 +39,16 @@ def test_mode_presets(monkeypatch):
     cfg = _reload_config(monkeypatch, MAX_DRAWDOWN_THRESHOLD=0.2, TRADING_MODE="aggressive")
     assert cfg.CONF_THRESHOLD == pytest.approx(0.65)
     assert cfg.MAX_POSITION_SIZE == pytest.approx(12000.0)
+
+
+def test_balanced_mode_max_position_alias(monkeypatch):
+    monkeypatch.setenv("TRADING_MODE", "balanced")
+    monkeypatch.setenv("MAX_DRAWDOWN_THRESHOLD", "0.2")
+    monkeypatch.delenv("MAX_POSITION_SIZE", raising=False)
+    alias_value = "4321.5"
+    monkeypatch.setenv("AI_TRADING_MAX_POSITION_SIZE", alias_value)
+
+    from ai_trading.config.management import TradingConfig
+
+    cfg = TradingConfig.from_env()
+    assert cfg.max_position_size == pytest.approx(float(alias_value))


### PR DESCRIPTION
## Summary
- skip applying mode preset max position sizes when AI_TRADING_MAX_POSITION_SIZE is provided
- cover the regression with a balanced mode alias test in `tests/test_config_module.py`

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_config_module.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9f973aa488330ad7849ddcf58a277