### PR TITLE
Cap closed-market sleep interval and add regression coverage

### DIFF
--- a/tests/test_market_closed_logging.py
+++ b/tests/test_market_closed_logging.py
@@ -1,19 +1,25 @@
-"""Tests for market closed logging once per date."""
-from __future__ import annotations
+"""Tests for market closed logging behaviors."""
 
 import logging
 import sys
 import types
-from datetime import datetime
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-import pandas as pd
+import pytest
+
+try:
+    import pandas as pd
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    pd = None
 
 from ai_trading.utils import base as utils
 
 
 class DummyCalendar:
-    def schedule(self, start_date, end_date):
+    def schedule(self, start_date, end_date):  # noqa: D401 - short helper
+        """Return an empty schedule DataFrame for tests."""
+
         return pd.DataFrame()
 
 
@@ -24,6 +30,9 @@ def _install_dummy_calendar(monkeypatch):
 
 def test_logs_closed_once_per_date(monkeypatch, caplog):
     """is_market_open should log closed only once per day."""
+
+    if pd is None:  # pragma: no cover - depends on optional pandas
+        pytest.skip("pandas is required for calendar schedule stubs")
     _install_dummy_calendar(monkeypatch)
     monkeypatch.setattr(utils, "_LAST_MARKET_CLOSED_DATE", None)
     monkeypatch.setattr(utils, "_LAST_MARKET_HOURS_LOG", 0.0)
@@ -38,3 +47,45 @@ def test_logs_closed_once_per_date(monkeypatch, caplog):
 
     msgs = [r.getMessage() for r in caplog.records if "Detected Market Hours today: CLOSED" in r.getMessage()]
     assert len(msgs) == 2
+
+
+def test_market_closed_sleep_is_capped(monkeypatch, caplog):
+    from ai_trading import main as main_module
+
+    caplog.set_level(logging.WARNING, logger=main_module.logger.name)
+
+    stub_settings = types.SimpleNamespace(
+        interval_when_closed=120,
+        alpaca_data_feed="sip",
+        alpaca_adjustment="raw",
+    )
+
+    monkeypatch.setattr(main_module, "ensure_dotenv_loaded", lambda: None)
+    monkeypatch.setattr(main_module, "_check_alpaca_sdk", lambda: None)
+    monkeypatch.setattr(main_module, "_fail_fast_env", lambda: None)
+    monkeypatch.setattr(main_module, "_validate_runtime_config", lambda *args, **kwargs: None)
+    monkeypatch.setattr(main_module, "_init_http_session", lambda *args, **kwargs: False)
+    monkeypatch.setattr(main_module, "get_settings", lambda: stub_settings)
+    monkeypatch.setattr(main_module, "_is_market_open_base", lambda: False)
+
+    sleep_calls = []
+
+    def fake_sleep(duration):
+        sleep_calls.append(duration)
+
+    monkeypatch.setattr(main_module.time, "sleep", fake_sleep)
+    monkeypatch.setattr(main_module, "config", None, raising=False)
+
+    delta = timedelta(hours=10)
+    monkeypatch.setattr(main_module, "next_market_open", lambda now: now + delta)
+
+    main_module.main([])
+
+    assert sleep_calls == [pytest.approx(120.0)]
+
+    records = [r for r in caplog.records if r.msg == "MARKET_CLOSED_SLEEP"]
+    assert records, "expected MARKET_CLOSED_SLEEP warning"
+    record = records[-1]
+    assert record.sleep_original_s == int(delta.total_seconds())
+    assert record.sleep_s == 120
+    assert record.sleep_cap_s == 120


### PR DESCRIPTION
## Summary
- cap the market-closed sleep duration in `ai_trading.main` using the configured `interval_when_closed` and log both the original and applied waits
- extend `tests/test_market_closed_logging.py` to keep the existing calendar logging check while adding a regression that verifies the capped sleep duration

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_market_closed_logging.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9ff7ee3648330a3c164dc236571d1