### PR TITLE
Prefer AI_TRADING env aliases in TradingConfig

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -474,20 +474,30 @@ class TradingConfig:
         alias_map = {
             "AI_TRADING_BUY_THRESHOLD": "BUY_THRESHOLD",
             "AI_TRADING_CONF_THRESHOLD": "CONF_THRESHOLD",
+            "AI_TRADING_CONFIDENCE_LEVEL": "CONFIDENCE_LEVEL",
+            "AI_TRADING_KELLY_FRACTION_MAX": "KELLY_FRACTION_MAX",
             "AI_TRADING_MAX_DRAWDOWN_THRESHOLD": "MAX_DRAWDOWN_THRESHOLD",
+            "AI_TRADING_MAX_POSITION_SIZE": "MAX_POSITION_SIZE",
+            "AI_TRADING_MIN_SAMPLE_SIZE": "MIN_SAMPLE_SIZE",
+            "AI_TRADING_POSITION_SIZE_MIN_USD": "POSITION_SIZE_MIN_USD",
             # Legacy daily loss limit alias: backfills ``DOLLAR_RISK_LIMIT`` when absent.
             "DAILY_LOSS_LIMIT": "DOLLAR_RISK_LIMIT",
         }
-        # Aliases are a legacy backfill mechanism: only populate canonicals when
-        # the operator did not provide an explicit canonical value.
+        # AI_TRADING_* aliases are the canonical spellings going forward and always
+        # override their legacy counterparts. Other aliases continue to act as
+        # backfills when the canonical key is missing.
         for alias, canon in alias_map.items():
             alias_value = env_map.get(alias)
             if alias_value in (None, ""):
                 continue
-            canonical_value = env_map.get(canon)
-            if canonical_value is not None and str(canonical_value).strip() != "":
+
+            if alias.startswith("AI_TRADING_"):
+                env_map[canon] = alias_value
                 continue
-            env_map[canon] = alias_value
+
+            canonical_value = env_map.get(canon)
+            if canonical_value is None or str(canonical_value).strip() == "":
+                env_map[canon] = alias_value
 
         from .aliases import resolve_trading_mode
 

--- a/tests/config/test_env_aliases_unified.py
+++ b/tests/config/test_env_aliases_unified.py
@@ -2,10 +2,28 @@ from ai_trading.config.management import TradingConfig
 
 
 def test_modern_env_keys_satisfy_tradingconfig(monkeypatch):
+    monkeypatch.setenv("BUY_THRESHOLD", "0.1")
+    monkeypatch.setenv("CONF_THRESHOLD", "0.6")
+    monkeypatch.setenv("MAX_DRAWDOWN_THRESHOLD", "0.2")
+    monkeypatch.setenv("MAX_POSITION_SIZE", "5000")
+    monkeypatch.setenv("POSITION_SIZE_MIN_USD", "150")
+    monkeypatch.setenv("CONFIDENCE_LEVEL", "0.5")
+    monkeypatch.setenv("KELLY_FRACTION_MAX", "0.15")
+    monkeypatch.setenv("MIN_SAMPLE_SIZE", "3")
     monkeypatch.setenv("AI_TRADING_BUY_THRESHOLD", "0.4")
     monkeypatch.setenv("AI_TRADING_CONF_THRESHOLD", "0.8")
     monkeypatch.setenv("AI_TRADING_MAX_DRAWDOWN_THRESHOLD", "0.08")
+    monkeypatch.setenv("AI_TRADING_MAX_POSITION_SIZE", "9000")
+    monkeypatch.setenv("AI_TRADING_POSITION_SIZE_MIN_USD", "25")
+    monkeypatch.setenv("AI_TRADING_CONFIDENCE_LEVEL", "0.85")
+    monkeypatch.setenv("AI_TRADING_KELLY_FRACTION_MAX", "0.20")
+    monkeypatch.setenv("AI_TRADING_MIN_SAMPLE_SIZE", "12")
     cfg = TradingConfig.from_env({})
     assert cfg.buy_threshold == 0.4
     assert cfg.conf_threshold == 0.8
     assert cfg.max_drawdown_threshold == 0.08
+    assert cfg.max_position_size == 9000
+    assert cfg.position_size_min_usd == 25
+    assert cfg.confidence_level == 0.85
+    assert cfg.kelly_fraction_max == 0.20
+    assert cfg.min_sample_size == 12


### PR DESCRIPTION
## Summary
- update TradingConfig.from_env to always let AI_TRADING_* aliases override legacy keys
- expand the alias mapping to cover sizing and risk configuration fields
- extend the env alias test to cover conflicting legacy and AI_TRADING values so the modern keys win

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/config/test_env_aliases_unified.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca079150d88330b629b0a783db3680