### PR TITLE
Adjust sentiment circuit breaker thresholds per audit

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -316,7 +316,7 @@ from ai_trading.config.settings import (
 from ai_trading.data.provider_monitor import provider_monitor
 
 # Sentiment knobs used by tests
-SENTIMENT_FAILURE_THRESHOLD: int = 25
+SENTIMENT_FAILURE_THRESHOLD: int = 8  # Audit: trip circuit after 8 consecutive failures
 _SENTIMENT_FAILURES: int = 0
 _SENTIMENT_CACHE: dict[str, tuple[float, float]] = {}
 SENTIMENT_SUCCESS_TTL_SEC: int = int(os.getenv("SENTIMENT_SUCCESS_TTL_SEC", "900"))
@@ -5752,7 +5752,7 @@ _SENTIMENT_CIRCUIT_BREAKER = {
 }  # closed, open, half-open
 # AI-AGENT-REF: Enhanced sentiment circuit breaker thresholds for better resilience
 SENTIMENT_RECOVERY_TIMEOUT = (
-    1800  # Extended to 30 minutes (1800s) for better recovery per problem statement
+    900  # Audit: 15-minute (900s) recovery window for sentiment circuit breaker
 )
 if SENTIMENT_BACKOFF_STRATEGY.lower() == "fixed":
     _SENTIMENT_WAIT = wait_random(SENTIMENT_BACKOFF_BASE, SENTIMENT_BACKOFF_BASE * 2)
@@ -5760,7 +5760,7 @@ else:
     _SENTIMENT_WAIT = wait_exponential(
         multiplier=SENTIMENT_BACKOFF_BASE,
         min=SENTIMENT_BACKOFF_BASE,
-        max=SENTIMENT_RECOVERY_TIMEOUT,
+        max=SENTIMENT_RECOVERY_TIMEOUT,  # capped by updated recovery timeout
     ) + wait_random(0, SENTIMENT_BACKOFF_BASE)
 
 


### PR DESCRIPTION
## Summary
- update the sentiment failure threshold to 8 consecutive errors per the latest audit
- reduce the sentiment recovery timeout to 900 seconds and ensure retry backoff respects the new cap

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -k sentiment -q

------
https://chatgpt.com/codex/tasks/task_e_68ca0ae4029c8330bd03324dbb9a83e3