### PR TITLE
Adjust sentiment retry defaults

### DIFF
--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -51,13 +51,13 @@ def alpaca_empty_to_backup(s: Settings | None = None) -> bool:
 
 
 def sentiment_retry_max(s: Settings | None = None) -> int:
-    """Return maximum sentiment fetch retry count."""
+    """Return maximum sentiment fetch retry count (defaults to 5 attempts)."""
     s = s or get_settings()
     return int(getattr(s, 'sentiment_max_retries', 5))
 
 
 def sentiment_backoff_base(s: Settings | None = None) -> float:
-    """Return base delay for sentiment fetch backoff."""
+    """Return base delay for sentiment fetch backoff (defaults to 5 seconds)."""
     s = s or get_settings()
     return float(getattr(s, 'sentiment_backoff_base', 5.0))
 

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -186,8 +186,8 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices('SENTIMENT_API_KEY', 'NEWS_API_KEY'),
     )
     sentiment_api_url: str | None = Field(default=None, alias='SENTIMENT_API_URL')
-    sentiment_max_retries: int = Field(3, alias='SENTIMENT_MAX_RETRIES')
-    sentiment_backoff_base: float = Field(1.0, alias='SENTIMENT_BACKOFF_BASE')
+    sentiment_max_retries: int = Field(5, alias='SENTIMENT_MAX_RETRIES')
+    sentiment_backoff_base: float = Field(5.0, alias='SENTIMENT_BACKOFF_BASE')
     sentiment_backoff_strategy: str = Field('exponential', alias='SENTIMENT_BACKOFF_STRATEGY')
     rebalance_interval_min: int = Field(60, ge=1, description='Minutes between portfolio rebalances', alias='REBALANCE_INTERVAL_MIN')
     # HTTP client/session tuning (used by main._init_http_session)


### PR DESCRIPTION
## Summary
- set the default sentiment retry count to 5 attempts and the base backoff delay to 5 seconds in the settings model
- clarify the config accessors to mention the updated default values so helper documentation stays accurate

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_critical_trading_fixes.py -q` *(skipped: pandas not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0c728a7c8330888f90e05c5bb5c6