### PR TITLE
Ensure safe_get_stock_bars preserves sanitized datetimes

### DIFF
--- a/tests/test_daily_bars_datetime_sanitization.py
+++ b/tests/test_daily_bars_datetime_sanitization.py
@@ -6,6 +6,7 @@ import pytest
 
 pd = pytest.importorskip("pandas")
 
+from ai_trading.data import bars as bars_mod
 from ai_trading.data.bars import StockBarsRequest, TimeFrame, safe_get_stock_bars
 
 
@@ -67,3 +68,77 @@ def test_request_timestamps_sanitized_for_get_stock_bars():
     expected_end = end.replace(hour=23, minute=59, second=59, microsecond=999999)
     assert captured["start"] == start
     assert captured["end"] == expected_end
+
+
+def test_safe_get_stock_bars_sets_datetimes_on_plain_request():
+    start = datetime(2024, 1, 7, 13, tzinfo=UTC)
+    end = datetime(2024, 1, 8, 12, tzinfo=UTC)
+
+    class PlainRequest:
+        symbol_or_symbols = "SPY"
+        timeframe = "1Day"
+        feed = "sip"
+
+        def __init__(self):
+            self.start = start
+            self.end = end
+
+    captured: dict[str, datetime] = {}
+
+    class DummyClient:
+        def get_stock_bars(self, request):
+            captured["start"] = request.start
+            captured["end"] = request.end
+            return pd.DataFrame({"open": [1], "high": [1], "low": [1], "close": [1]})
+
+    req = PlainRequest()
+
+    safe_get_stock_bars(DummyClient(), req, symbol="SPY", context="TEST")
+
+    expected_start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+    expected_end = end.replace(hour=23, minute=59, second=59, microsecond=999999)
+
+    assert isinstance(req.start, datetime)
+    assert req.start == expected_start
+    assert req.start.tzinfo == UTC
+    assert isinstance(req.end, datetime)
+    assert req.end == expected_end
+    assert req.end.tzinfo == UTC
+    assert captured["start"] == req.start
+    assert captured["end"] == expected_end
+
+
+def test_http_fallback_receives_iso_timestamps(monkeypatch):
+    start = datetime(2024, 1, 9, tzinfo=UTC)
+    end = datetime(2024, 1, 10, tzinfo=UTC)
+    req = StockBarsRequest(
+        symbol_or_symbols="SPY",
+        timeframe=TimeFrame.Hour,
+        start=start,
+        end=end,
+        feed="sip",
+    )
+
+    captured_http: dict[str, str] = {}
+
+    def fake_http_get_bars(symbol, timeframe, start, end, *, feed=None):
+        captured_http["start"] = start
+        captured_http["end"] = end
+        return pd.DataFrame()
+
+    class DummyClient:
+        class Resp:
+            df = pd.DataFrame()
+
+        def get_stock_bars(self, request):
+            return self.Resp()
+
+    monkeypatch.setattr(bars_mod, "http_get_bars", fake_http_get_bars)
+    monkeypatch.setattr(bars_mod.time, "sleep", lambda *_: None)
+
+    safe_get_stock_bars(DummyClient(), req, symbol="SPY", context="TEST")
+
+    assert isinstance(req.start, datetime)
+    assert isinstance(req.end, datetime)
+    assert captured_http["start"] == req.start.isoformat()
+    assert captured_http["end"] == req.end.isoformat()


### PR DESCRIPTION
## Summary
- update `safe_get_stock_bars` to retain timezone-aware datetimes on the request while formatting ISO strings for HTTP fallbacks
- route minute and HTTP fallback helpers through ISO strings and extend coverage for plain requests and fallback handling

## Testing
- pytest tests/test_daily_bars_datetime_sanitization.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca0c771c2083309d88c399ea9eb4c9