### PR TITLE
Log trade path when meta-learning data is missing

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -10970,7 +10970,10 @@ def run_meta_learning_weight_optimizer(
             usecols=["entry_price", "exit_price", "signal_tags", "side", "confidence"],
         )
         if df is None:
-            logger.warning("METALEARN_NO_TRADES")
+            logger.warning(
+                "METALEARN_NO_TRADES",
+                extra={"trade_log_path": trade_log_path},
+            )
             return
         df = df.dropna(subset=["entry_price", "exit_price", "signal_tags"])
         if df.empty:


### PR DESCRIPTION
## Summary
- add the trade log path to the METALEARN_NO_TRADES warning for run_meta_learning_weight_optimizer
- extend the empty trade log test to verify the warning carries file context and exits without writing weights

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_empty_dataframe_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68ca0f5158188330bf67dadf0c493812