### PR TITLE
Remove legacy APCA base URL alias

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -69,7 +69,7 @@ def _select_alpaca_base_url(
     env_map = env or os.environ
     invalid_entries: list[tuple[str, str, str]] = []
 
-    for env_key in ("ALPACA_BASE_URL", "ALPACA_API_URL", "APCA_API_BASE_URL"):
+    for env_key in ("ALPACA_BASE_URL", "ALPACA_API_URL"):
         raw = env_map.get(env_key)
         normalized, message = _normalize_alpaca_base_url(raw, source_key=env_key)
         if normalized:
@@ -80,7 +80,6 @@ def _select_alpaca_base_url(
     fallback_raw = (
         env_map.get("ALPACA_BASE_URL")
         or env_map.get("ALPACA_API_URL")
-        or env_map.get("APCA_API_BASE_URL")
     )
     return None, fallback_raw, invalid_entries
 

--- a/ai_trading/env/config_redaction.py
+++ b/ai_trading/env/config_redaction.py
@@ -8,7 +8,6 @@ from ai_trading.logging.redact import redact_env
 # Mapping of environment variable aliases to their canonical names.
 _ALIAS_MAP: Dict[str, str] = {
     "ALPACA_BASE_URL": "ALPACA_API_URL",
-    "APCA_API_BASE_URL": "ALPACA_API_URL",
 }
 
 

--- a/tests/test_alpaca_credentials_env.py
+++ b/tests/test_alpaca_credentials_env.py
@@ -35,6 +35,16 @@ class TestAlpacaCredentials:
             assert secret_key == "alias_secret"
             assert base_url == "https://alias-api.alpaca.markets"
 
+    def test_legacy_apca_base_url_ignored(self) -> None:
+        env_vars = {
+            "ALPACA_API_KEY": "legacy_key",
+            "ALPACA_SECRET_KEY": "legacy_secret",
+            "APCA_API_BASE_URL": "https://legacy-api.alpaca.markets",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            _, _, base_url = _resolve_alpaca_env()
+            assert base_url == "https://paper-api.alpaca.markets"
+
     def test_default_base_url_when_missing(self) -> None:
         env_vars = {
             "ALPACA_API_KEY": "key",

--- a/tests/unit/test_env_config_redaction.py
+++ b/tests/unit/test_env_config_redaction.py
@@ -48,6 +48,13 @@ def test_redact_config_env_alias_mapped():
     assert "ALPACA_BASE_URL" not in redacted
 
 
+def test_redact_config_env_does_not_alias_apca():
+    payload = {"APCA_API_BASE_URL": "https://legacy-api.alpaca.markets"}
+    redacted = redact_config_env(payload)
+    assert "ALPACA_API_URL" not in redacted
+    assert redacted["APCA_API_BASE_URL"] == "https://legacy-api.alpaca.markets"
+
+
 def test_base_url_alias_logged(caplog, monkeypatch):
     monkeypatch.setenv("ALPACA_API_KEY", "AK123456789")
     monkeypatch.setenv("ALPACA_SECRET_KEY", "SK987654321")


### PR DESCRIPTION
## Summary
- remove the legacy APCA_API_BASE_URL alias from config redaction and Alpaca base URL selection logic
- ensure Alpaca environment resolution ignores the legacy base URL and document the behavior through tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_env_config_redaction.py tests/test_alpaca_credentials_env.py -q


------
https://chatgpt.com/codex/tasks/task_e_68ca0f51bf3c833091b2af88d92e09ac