### PR TITLE
Cache HTTP host semaphore per event loop

### DIFF
--- a/ai_trading/http/__init__.py
+++ b/ai_trading/http/__init__.py
@@ -1,9 +1,9 @@
-from .pooling import HOST_SEMAPHORE, get_host_semaphore
+from .pooling import get_host_semaphore, refresh_host_semaphore
 from .timeouts import SESSION_TIMEOUT, get_session_timeout
 
 __all__ = [
-    "HOST_SEMAPHORE",
     "get_host_semaphore",
+    "refresh_host_semaphore",
     "SESSION_TIMEOUT",
     "get_session_timeout",
 ]

--- a/ai_trading/http/pooling.py
+++ b/ai_trading/http/pooling.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 import asyncio
 from typing import Final
+from weakref import WeakKeyDictionary
 
 from ai_trading.config import management as config
 
 _DEFAULT_LIMIT: Final[int] = 8
+
+_SemaphoreRecord = tuple[asyncio.Semaphore, int]
+_HOST_SEMAPHORES: WeakKeyDictionary[
+    asyncio.AbstractEventLoop, _SemaphoreRecord
+] = WeakKeyDictionary()
 
 
 def _resolve_limit() -> int:
@@ -16,9 +22,37 @@ def _resolve_limit() -> int:
         return _DEFAULT_LIMIT
 
 
-HOST_SEMAPHORE: asyncio.Semaphore = asyncio.Semaphore(_resolve_limit())
+def _get_or_create_loop_semaphore(
+    loop: asyncio.AbstractEventLoop, limit: int
+) -> asyncio.Semaphore:
+    record = _HOST_SEMAPHORES.get(loop)
+    if record is not None:
+        semaphore, cached_limit = record
+        if cached_limit == limit:
+            return semaphore
+
+    semaphore = asyncio.Semaphore(limit)
+    _HOST_SEMAPHORES[loop] = (semaphore, limit)
+    return semaphore
 
 
 def get_host_semaphore() -> asyncio.Semaphore:
-    """Return the global semaphore limiting concurrent host requests."""
-    return HOST_SEMAPHORE
+    """Return the semaphore limiting concurrent host requests for the current loop."""
+
+    loop = asyncio.get_running_loop()
+    limit = _resolve_limit()
+    return _get_or_create_loop_semaphore(loop, limit)
+
+
+def refresh_host_semaphore() -> asyncio.Semaphore:
+    """Force the cached semaphore for the current loop to refresh using the latest limit."""
+
+    loop = asyncio.get_running_loop()
+    limit = _resolve_limit()
+    record = _HOST_SEMAPHORES.get(loop)
+    if record is not None and record[1] == limit:
+        return record[0]
+
+    semaphore = asyncio.Semaphore(limit)
+    _HOST_SEMAPHORES[loop] = (semaphore, limit)
+    return semaphore

--- a/tests/test_http_host_limit.py
+++ b/tests/test_http_host_limit.py
@@ -1,28 +1,98 @@
 import asyncio
+
 from tests.conftest import reload_module
 
 
-def test_host_limit_enforced(monkeypatch):
-    monkeypatch.setenv("AI_TRADING_HOST_LIMIT", "2")
-    pooling = reload_module("ai_trading.http.pooling")
-    sem = pooling.get_host_semaphore()
-
+async def _max_concurrency(pooling, worker_count: int) -> int:
+    semaphore = pooling.get_host_semaphore()
     current = 0
     max_seen = 0
 
-    async def worker():
+    async def worker() -> None:
         nonlocal current, max_seen
-        async with sem:
+        async with semaphore:
             current += 1
             max_seen = max(max_seen, current)
             await asyncio.sleep(0.01)
             current -= 1
 
-    async def main():
-        await asyncio.gather(*(worker() for _ in range(5)))
+    await asyncio.gather(*(worker() for _ in range(worker_count)))
+    return max_seen
 
-    asyncio.run(main())
+
+async def _semaphore_id(pooling) -> int:
+    return id(pooling.get_host_semaphore())
+
+
+async def _refresh_and_get_id(pooling) -> int:
+    return id(pooling.refresh_host_semaphore())
+
+
+def test_host_limit_enforced(monkeypatch):
+    monkeypatch.setenv("AI_TRADING_HOST_LIMIT", "2")
+    pooling = reload_module("ai_trading.http.pooling")
+
+    max_seen = asyncio.run(_max_concurrency(pooling, worker_count=5))
     assert max_seen == 2
+
+    monkeypatch.delenv("AI_TRADING_HOST_LIMIT", raising=False)
+    reload_module(pooling)
+
+
+def test_host_limit_updates_when_env_changes(monkeypatch):
+    monkeypatch.setenv("AI_TRADING_HOST_LIMIT", "2")
+    pooling = reload_module("ai_trading.http.pooling")
+
+    loop = asyncio.new_event_loop()
+    try:
+        first_id = loop.run_until_complete(_semaphore_id(pooling))
+        assert loop.run_until_complete(_max_concurrency(pooling, worker_count=5)) == 2
+
+        monkeypatch.setenv("AI_TRADING_HOST_LIMIT", "3")
+        second_id = loop.run_until_complete(_semaphore_id(pooling))
+        assert second_id != first_id
+        assert loop.run_until_complete(_max_concurrency(pooling, worker_count=6)) == 3
+
+        monkeypatch.setenv("AI_TRADING_HOST_LIMIT", "4")
+        refreshed_id = loop.run_until_complete(_refresh_and_get_id(pooling))
+        assert refreshed_id != second_id
+        assert loop.run_until_complete(_max_concurrency(pooling, worker_count=7)) == 4
+    finally:
+        loop.close()
+
+    monkeypatch.delenv("AI_TRADING_HOST_LIMIT", raising=False)
+    reload_module(pooling)
+
+
+def test_host_semaphore_is_scoped_per_event_loop(monkeypatch):
+    monkeypatch.setenv("AI_TRADING_HOST_LIMIT", "3")
+    pooling = reload_module("ai_trading.http.pooling")
+
+    loop_a = asyncio.new_event_loop()
+    loop_b = asyncio.new_event_loop()
+    try:
+        first_a = loop_a.run_until_complete(_semaphore_id(pooling))
+        again_a = loop_a.run_until_complete(_semaphore_id(pooling))
+        assert first_a == again_a
+
+        first_b = loop_b.run_until_complete(_semaphore_id(pooling))
+        assert first_b != first_a
+
+        assert loop_a.run_until_complete(_max_concurrency(pooling, worker_count=6)) == 3
+        assert loop_b.run_until_complete(_max_concurrency(pooling, worker_count=6)) == 3
+
+        monkeypatch.setenv("AI_TRADING_HOST_LIMIT", "5")
+        refreshed_a = loop_a.run_until_complete(_semaphore_id(pooling))
+        refreshed_b = loop_b.run_until_complete(_semaphore_id(pooling))
+        assert refreshed_a != first_a
+        assert refreshed_b != first_b
+        assert refreshed_a != refreshed_b
+
+        assert loop_a.run_until_complete(_max_concurrency(pooling, worker_count=7)) == 5
+        assert loop_b.run_until_complete(_max_concurrency(pooling, worker_count=7)) == 5
+    finally:
+        loop_a.close()
+        loop_b.close()
 
     monkeypatch.delenv("AI_TRADING_HOST_LIMIT", raising=False)
     reload_module(pooling)


### PR DESCRIPTION
## Summary
- cache the HTTP host semaphore per event loop and add a refresh helper
- update the package exports to expose the new utility
- extend the host limit unit tests to cover limit changes and multiple event loops

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_http_host_limit.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca18c4a880833096ec7a17d949408d