### PR TITLE
Enforce drawdown threshold presence in TradingConfig

### DIFF
--- a/tests/test_centralized_config.py
+++ b/tests/test_centralized_config.py
@@ -56,6 +56,13 @@ class TestCentralizedConfig:
             TradingConfig.from_env({})
         monkeypatch.setenv("MAX_DRAWDOWN_THRESHOLD", "0.2")
 
+    def test_missing_drawdown_threshold_allowed_when_opted_in(self, monkeypatch):
+        """Legacy relaxed path still defaults the drawdown threshold."""
+        monkeypatch.delenv("MAX_DRAWDOWN_THRESHOLD", raising=False)
+        cfg = TradingConfig.from_env({}, allow_missing_drawdown=True)
+        assert cfg.max_drawdown_threshold == pytest.approx(0.08)
+        monkeypatch.setenv("MAX_DRAWDOWN_THRESHOLD", "0.2")
+
     def test_mode_specific_configurations(self):
         """Test that each mode has appropriate parameter values."""
         conservative = TradingConfig.from_env("conservative")


### PR DESCRIPTION
## Summary
- ensure `TradingConfig.from_env` detects when the drawdown threshold is absent and raises unless the relaxed mode is enabled
- preserve the legacy relaxed path by defaulting to 0.08 when `allow_missing_drawdown=True`
- extend centralized config tests to cover both strict and relaxed drawdown handling

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_centralized_config.py::TestCentralizedConfig::test_missing_drawdown_threshold_raises -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_centralized_config.py::TestCentralizedConfig::test_missing_drawdown_threshold_allowed_when_opted_in -q

------
https://chatgpt.com/codex/tasks/task_e_68ca1b21e8048330afd9b4480e49b98f