### PR TITLE
Guard IEX rate-limit retries when SIP unauthorized

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -1635,6 +1635,16 @@ def _fetch_bars(
                     return _backup_get_bars(symbol, _start, _end, interval=fb_int)
                 return pd.DataFrame()
             attempt = _state["retries"] + 1
+            if _feed == "iex" and _SIP_UNAUTHORIZED:
+                fallback_viable = False
+                if fallback:
+                    _, fb_feed, _, _ = fallback
+                    if fb_feed != "sip":
+                        fallback_viable = True
+                    elif _sip_configured() and not _SIP_UNAUTHORIZED:
+                        fallback_viable = True
+                if not fallback_viable:
+                    raise ValueError("rate_limited")
             if attempt >= max_retries:
                 if fallback:
                     result = _attempt_fallback(fallback)


### PR DESCRIPTION
## Summary
- stop scheduling additional Alpaca IEX retries when SIP access is unauthorized and no fallback feed is viable
- add regression coverage to ensure only one IEX attempt occurs after SIP authorization failures
- extend metrics tests to cover the no-fallback rate-limit path and patch HTTP session usage in unit tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_data_fetcher_http.py tests/unit/test_data_fetcher_metrics.py -q *(skipped: pandas not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1c1983908330bf4028958fb310ce