### PR TITLE
Use datetime objects for Alpaca bar windows

### DIFF
--- a/tests/test_alpaca_time_params.py
+++ b/tests/test_alpaca_time_params.py
@@ -28,6 +28,8 @@ def test_daily_uses_date_only(mock_rest_cls):
     (req,), kwargs = mock_rest.get_stock_bars.call_args
     assert isinstance(req.start, dt.datetime) and req.start.tzinfo is None
     assert isinstance(req.end, dt.datetime) and req.end.tzinfo is None
+    assert req.start.time() == dt.time(0)
+    assert req.end.time() == dt.time(0)
     assert getattr(req.timeframe, "amount", None) == 1
     assert getattr(req.timeframe.unit, "name", "") == "Day"
 
@@ -48,6 +50,8 @@ def test_intraday_uses_rfc3339z(mock_rest_cls):
     (req,), kwargs = mock_rest.get_stock_bars.call_args
     assert isinstance(req.start, dt.datetime) and req.start.tzinfo == dt.UTC
     assert isinstance(req.end, dt.datetime) and req.end.tzinfo == dt.UTC
+    assert req.start == start.astimezone(dt.UTC)
+    assert req.end == end.astimezone(dt.UTC)
     assert getattr(req.timeframe, "amount", None) == 5
     assert getattr(req.timeframe.unit, "name", "") in {"Minute", "Min"}
 

--- a/tests/test_alpaca_timeframe_mapping.py
+++ b/tests/test_alpaca_timeframe_mapping.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import sys
 import types
 from unittest.mock import MagicMock, patch
@@ -47,6 +48,8 @@ def test_day_timeframe_normalized(mock_rest_cls):
     (req,), kwargs = mock_rest.get_stock_bars.call_args
     assert getattr(req.timeframe, "amount", None) == 1
     assert getattr(req.timeframe.unit, "name", "") == "Day"
+    assert isinstance(req.start, dt.datetime) and req.start.tzinfo is None
+    assert isinstance(req.end, dt.datetime) and req.end.tzinfo is None
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
 
 
@@ -63,6 +66,8 @@ def test_tf_zero_arg_normalized(mock_rest_cls):
     (req,), kwargs = mock_rest.get_stock_bars.call_args
     assert getattr(req.timeframe, "amount", None) == 1
     assert getattr(req.timeframe.unit, "name", "") == "Day"
+    assert isinstance(req.start, dt.datetime) and req.start.tzinfo is None
+    assert isinstance(req.end, dt.datetime) and req.end.tzinfo is None
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
 
 
@@ -79,6 +84,8 @@ def test_minute_normalized(mock_rest_cls):
     (req,), kwargs = mock_rest.get_stock_bars.call_args
     assert getattr(req.timeframe, "amount", None) == 1
     assert getattr(req.timeframe.unit, "name", "") in {"Minute", "Min"}
+    assert isinstance(req.start, dt.datetime) and req.start.tzinfo == dt.UTC
+    assert isinstance(req.end, dt.datetime) and req.end.tzinfo == dt.UTC
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode
 
 
@@ -95,4 +102,6 @@ def test_week_normalized(mock_rest_cls):
     (req,), kwargs = mock_rest.get_stock_bars.call_args
     assert getattr(req.timeframe, "amount", None) == 1
     assert getattr(req.timeframe.unit, "name", "").lower() == "week"
+    assert isinstance(req.start, dt.datetime)
+    assert isinstance(req.end, dt.datetime)
     assert_df_like(df)  # AI-AGENT-REF: allow empty in offline mode


### PR DESCRIPTION
## Summary
- return timezone-aware datetimes from `_bars_time_window` and normalize daily windows to naive midnights
- pass datetime objects into `StockBarsRequest` while preserving string forms for logging
- extend bar request tests to assert naive daily dates and UTC intraday datetimes

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_time_params.py tests/test_alpaca_timeframe_mapping.py -q *(skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ca1c1915d48330bb9b0e22ad532f4d