### PR TITLE
Route config autofix log through startup config logger

### DIFF
--- a/ai_trading/core/config_autofix.py
+++ b/ai_trading/core/config_autofix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ai_trading.logging import get_logger
 
-_log = get_logger(__name__)
+_log = get_logger("ai_trading.startup.config")
 
 
 def ensure_max_position_size(cfg, tcfg) -> float:


### PR DESCRIPTION
## Summary
- use the `ai_trading.startup.config` logger for configuration autofix log messages so downstream capture uses the expected channel

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_startup_missing_max_position_size.py

------
https://chatgpt.com/codex/tasks/task_e_68ca1da933bc8330852d890ed56afb84