### PR TITLE
Add instantiable base strategy implementation

### DIFF
--- a/ai_trading/strategies/base.py
+++ b/ai_trading/strategies/base.py
@@ -262,6 +262,17 @@ class BaseStrategy(ABC):
         """Convert strategy to dictionary representation."""
         return {'strategy_id': self.strategy_id, 'name': self.name, 'risk_level': self.risk_level.value, 'is_active': self.is_active, 'parameters': self.parameters, 'symbols': self.symbols, 'timeframes': self.timeframes, 'performance': self.get_performance_summary(), 'created_at': self.created_at.isoformat()}
 
+class Strategy(BaseStrategy):
+    """Minimal concrete strategy used for tests and fallbacks."""
+
+    def __init__(self) -> None:
+        super().__init__(strategy_id="base", name="Base Strategy")
+
+    def generate_signals(self, market_data: dict) -> list[StrategySignal]:
+        """Return an empty signal list for any market data."""
+        return []
+
+
 class StrategyRegistry:
     """
     Registry for managing multiple trading strategies.
@@ -410,4 +421,3 @@ class StrategyRegistry:
     def get_registry_summary(self) -> dict:
         """Get summary of strategy registry."""
         return {'total_strategies': len(self.strategies), 'active_strategies': len(self.active_strategies), 'strategy_list': [{'id': strategy.strategy_id, 'name': strategy.name, 'is_active': strategy.is_active, 'signals_generated': strategy.signals_generated, 'trades_executed': strategy.trades_executed} for strategy in self.strategies.values()]}
-Strategy = BaseStrategy

--- a/tests/test_strategies_base_extra.py
+++ b/tests/test_strategies_base_extra.py
@@ -8,5 +8,6 @@ def test_asset_class_for_crypto():
 
 
 def test_strategy_generate_base():
-    """Base Strategy.generate returns empty list."""
-    assert Strategy().generate(None) == []
+    """Default Strategy implementation returns no signals and does not raise."""
+    strategy = Strategy()
+    assert strategy.generate(None) == []


### PR DESCRIPTION
## Summary
- add a minimal `Strategy` subclass so callers can instantiate a default strategy without parameters
- ensure the default implementation returns no signals and update the regression test accordingly

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_strategies_base_extra.py -q *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68ca1da71bec83308132f789589acbb7