### PR TITLE
Fix ValueError raised for missing OHLCV columns

### DIFF
--- a/ai_trading/signals/__init__.py
+++ b/ai_trading/signals/__init__.py
@@ -328,7 +328,7 @@ def _validate_input_df(data) -> None:
     if hasattr(data, "columns"):
         missing = [col for col in required if col not in data.columns]
         if missing:
-            raise KeyError(f"Input data missing required column(s): {missing}")
+            raise ValueError(f"Input data missing required column(s): {missing}")
 
 
 def _apply_macd(data) -> Any | None:


### PR DESCRIPTION
## Summary
- raise ValueError instead of KeyError when required OHLCV columns are missing during indicator preparation

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_signals.py::test_prepare_indicators_requires_ohlcv


------
https://chatgpt.com/codex/tasks/task_e_68ca1e56ee7c83309c93e20d3a1a1e94