### PR TITLE
Handle frozen clock in worker threads

### DIFF
--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -24,6 +24,7 @@ except Exception:  # ImportError
 from ai_trading.logging.emit_once import emit_once
 from ai_trading.metrics import get_counter
 from ai_trading.config.management import get_env
+from ai_trading.utils.time import safe_utcnow
 
 logger = get_logger(__name__)
 ORDER_STALE_AFTER_S = 8 * 60
@@ -443,7 +444,7 @@ class OrderManager:
         """Monitor active orders for timeouts and updates."""
         while self._monitor_running:
             try:
-                current_time = datetime.now(UTC)
+                current_time = safe_utcnow()
                 expired_orders = []
                 for order_id, order in list(self.active_orders.items()):
                     age_seconds = (current_time - order.created_at).total_seconds()

--- a/ai_trading/rebalancer.py
+++ b/ai_trading/rebalancer.py
@@ -14,6 +14,7 @@ except Exception:  # ImportError
 from ai_trading.config import get_settings
 from ai_trading.portfolio import compute_portfolio_weights
 from ai_trading.settings import get_rebalance_interval_min
+from ai_trading.utils.time import safe_utcnow
 
 logger = get_logger(__name__)
 
@@ -39,7 +40,7 @@ from ai_trading.strategies.regime_detector import create_regime_detector
 def rebalance_interval_min() -> int:
     return get_rebalance_interval_min()
 
-_last_rebalance = datetime.now(UTC)
+_last_rebalance = safe_utcnow()
 _rebalancer: "TaxAwareRebalancer | None" = None
 
 
@@ -351,7 +352,7 @@ def rebalance_portfolio(ctx) -> None:
 def enhanced_maybe_rebalance(ctx) -> None:
     """Enhanced rebalance check with tax optimization and market conditions."""
     global _last_rebalance
-    now = datetime.now(UTC)
+    now = safe_utcnow()
     if now - _last_rebalance >= timedelta(minutes=rebalance_interval_min()):
         try:
             portfolio = getattr(ctx, 'portfolio_weights', {})
@@ -554,7 +555,7 @@ def _prepare_rebalancing_market_data(ctx) -> dict:
 def maybe_rebalance(ctx) -> None:
     """Rebalance when interval has elapsed."""
     global _last_rebalance
-    now = datetime.now(UTC)
+    now = safe_utcnow()
     if now - _last_rebalance >= timedelta(minutes=rebalance_interval_min()):
         settings = get_settings()
         portfolio = getattr(ctx, 'portfolio_weights', {})

--- a/tests/test_safe_utcnow_freezegun.py
+++ b/tests/test_safe_utcnow_freezegun.py
@@ -1,0 +1,20 @@
+import time
+
+from freezegun import freeze_time
+
+from ai_trading.core.enums import OrderSide, OrderType
+from ai_trading.execution.engine import Order, OrderManager
+
+
+@freeze_time("2024-01-01 09:30:00", tz_offset=0)
+def test_order_monitor_thread_survives_frozen_time():
+    manager = OrderManager()
+    manager.start_monitoring()
+    try:
+        order = Order("SPY", OrderSide.BUY, 10, order_type=OrderType.MARKET)
+        manager.submit_order(order)
+        time.sleep(0.2)
+        assert manager._monitor_thread is not None
+        assert manager._monitor_thread.is_alive()
+    finally:
+        manager.stop_monitoring()


### PR DESCRIPTION
## Summary
- add a safe_utcnow helper so datetime.now calls survive Freezegun's frozen clock IndexError
- switch background monitoring loops to use the helper across execution, safety, and alerting threads
- add a regression test that freezes time and ensures the order monitor thread keeps running

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ca1da63b488330be8d6565c05ba8bd