### PR TITLE
Ensure Alpaca API lazy wrapper reinstalls after real import

### DIFF
--- a/tests/test_shadow_mode_runtime.py
+++ b/tests/test_shadow_mode_runtime.py
@@ -31,3 +31,23 @@ def test_lazy_alpaca_api_behavior_switch(monkeypatch):
 
     with pytest.raises(AssertionError):
         sys.modules["ai_trading.alpaca_api"].submit_order("AAPL", "buy", qty=1, client=Dummy())
+
+
+def test_lazy_alpaca_api_placeholder_reinstated_after_real_import(monkeypatch):
+    monkeypatch.delenv("SHADOW_MODE", raising=False)
+
+    import importlib
+
+    sys.modules.pop("ai_trading.alpaca_api", None)
+    sys.modules.pop("ai_trading.shadow_mode.runtime", None)
+
+    real_api = importlib.import_module("ai_trading.alpaca_api")
+    assert sys.modules["ai_trading.alpaca_api"] is real_api
+
+    # Importing the runtime should re-register the lazy placeholder even though the
+    # real module is already loaded in ``sys.modules``.
+    runtime = importlib.import_module("ai_trading.shadow_mode.runtime")
+
+    placeholder = sys.modules["ai_trading.alpaca_api"]
+    assert isinstance(placeholder, runtime._LazyModule)
+    assert placeholder._real is real_api


### PR DESCRIPTION
## Summary
- update the shadow-mode lazy module so it wraps a previously loaded `ai_trading.alpaca_api` while preserving the original module reference
- ensure the lazy loader always updates `sys.modules` with the loaded module for subsequent imports
- add a regression test that verifies importing `ai_trading.shadow_mode.runtime` reinstalls the placeholder after the real Alpaca API was imported

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_shadow_mode_runtime.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca1e57e8a88330839e6bf201fab082