### PR TITLE
Narrow ATR fallback exception handling

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -166,11 +166,11 @@ def safe_get_stock_bars(client: Any, request: "StockBarsRequest", symbol: str, c
     iso_end = end_dt.isoformat()
     try:
         request.start = start_dt
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         pass
     try:
         request.end = end_dt
-    except Exception:
+    except (AttributeError, TypeError, ValueError):
         pass
     feed_req = _canon_feed(getattr(request, 'feed', None))
     if feed_req:

--- a/ai_trading/risk/engine.py
+++ b/ai_trading/risk/engine.py
@@ -192,7 +192,14 @@ class RiskEngine:
                                 df = bars_df.copy()
                         elif bars_df is not None and pd is not None:
                             df = pd.DataFrame(bars_df)
-                    except Exception as exc:  # pragma: no cover - provider variance
+                    except (
+                        APIError,
+                        TimeoutError,
+                        ConnectionError,
+                        ValueError,
+                        TypeError,
+                        OSError,
+                    ) as exc:  # pragma: no cover - provider variance
                         logger.warning('ATR client fetch failed for %s: %s', symbol, exc)
                         simple_get = getattr(client, 'get_bars', None)
                         if callable(simple_get):
@@ -200,7 +207,13 @@ class RiskEngine:
                                 candidate = simple_get(symbol, limit)
                             except TypeError:
                                 candidate = None
-                            except Exception as fallback_exc:  # pragma: no cover - provider variance
+                            except (
+                                APIError,
+                                TimeoutError,
+                                ConnectionError,
+                                ValueError,
+                                OSError,
+                            ) as fallback_exc:  # pragma: no cover - provider variance
                                 logger.debug('ATR simple get_bars failed for %s: %s', symbol, fallback_exc)
                                 candidate = None
                             if candidate:
@@ -237,7 +250,7 @@ class RiskEngine:
                         df_local = pd.DataFrame(df_in)
                     else:
                         df_local = df_in.copy() if isinstance(df_in, pd.DataFrame) else df_in
-                except Exception:
+                except (ValueError, TypeError, AttributeError):
                     return (None, None, None)
                 if getattr(df_local, 'empty', True):
                     return (None, None, None)
@@ -280,7 +293,15 @@ class RiskEngine:
                                     records.append(record)
                         if records:
                             df_from_seq = pd.DataFrame(records)
-                    except Exception as exc:  # pragma: no cover - defensive
+                    except (
+                        APIError,
+                        TimeoutError,
+                        ConnectionError,
+                        ValueError,
+                        TypeError,
+                        OSError,
+                        AttributeError,
+                    ) as exc:  # pragma: no cover - defensive
                         logger.debug('ATR bars sequence conversion failed for %s: %s', symbol, exc)
                 if df_from_seq is not None and getattr(df_from_seq, 'empty', True) is False:
                     high, low, close = _extract_arrays(df_from_seq)
@@ -315,7 +336,15 @@ class RiskEngine:
                     if fetcher is not None and hasattr(fetcher, 'get_daily_df'):
                         try:
                             df_fallback = fetcher.get_daily_df(ctx, symbol)
-                        except Exception as exc:  # pragma: no cover - defensive
+                        except (
+                            APIError,
+                            TimeoutError,
+                            ConnectionError,
+                            ValueError,
+                            TypeError,
+                            OSError,
+                            AttributeError,
+                        ) as exc:  # pragma: no cover - defensive
                             logger.debug('ATR fetcher fallback failed for %s: %s', symbol, exc)
                             df_fallback = None
                 if df_fallback is not None and getattr(df_fallback, 'empty', False) is False:


### PR DESCRIPTION
## Summary
- narrow ATR data fetch fallback handlers in risk engine to specific API and network errors
- tighten pandas conversion and fallback guards to avoid swallowing unexpected exceptions in ATR processing
- constrain stock bars request attribute assignment to expected attribute/type/value errors

## Testing
- pytest tests/runtime/test_no_broad_in_stage2.py

------
https://chatgpt.com/codex/tasks/task_e_68ca1f268a888330a073bcfae0573d2f