### PR TITLE
Fix indicator NaN handling and add regression test

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -11764,11 +11764,19 @@ def prepare_indicators(frame: pd.DataFrame) -> pd.DataFrame:
 
     # Stochastic RSI using single rolling aggregation
     rsi_bounds = rsi.rolling(14).agg(["min", "max"])
-    frame["stochrsi"] = (rsi - rsi_bounds["min"]) / (
-        rsi_bounds["max"] - rsi_bounds["min"]
-    )
+    stoch_denominator = (rsi_bounds["max"] - rsi_bounds["min"]).astype(float)
+    stoch_denominator = stoch_denominator.mask(stoch_denominator == 0.0, np.nan)
+    frame["stochrsi"] = (rsi - rsi_bounds["min"]) / stoch_denominator
 
-    frame.dropna(inplace=True)
+    indicator_cols = [
+        "rsi",
+        "rsi_14",
+        "ichimoku_conv",
+        "ichimoku_base",
+        "stochrsi",
+    ]
+    subset = [col for col in indicator_cols if col in frame.columns]
+    frame.dropna(subset=subset, inplace=True)
     if frame.empty:
         logger.warning(
             "prepare_indicators produced empty dataframe after dropping NaNs.",


### PR DESCRIPTION
## Summary
- guard the stochastic RSI denominator and only drop rows missing required indicators in `prepare_indicators`
- extend the bot engine test harness with an Alpaca stub and add a regression test covering dataframes with unrelated NaN columns

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot_engine.py::test_prepare_indicators_creates_required_columns tests/test_bot_engine.py::test_prepare_indicators_ignores_non_indicator_nans


------
https://chatgpt.com/codex/tasks/task_e_68cad42255f48330a6806845e6c4799a