### PR TITLE
Handle sparse minute coverage by retrying with SIP feed

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -52,6 +52,12 @@ Daily price requests now log their parameters and outcome:
 - `DAILY_FETCH_CACHE_HIT` emits once on first cache use; subsequent hits appear only when debug logging is enabled
 - `DAILY_FETCH_RESULT` reports the number of rows returned and whether the
   response came from cache
+- `MINUTE_DATA_COVERAGE_WARNING` fires when intraday data covers less than half
+  of the expected regular-session window or drops below the configured
+  indicator lookback. The bot immediately re-requests the same window from an
+  alternate feed (SIP when entitled, otherwise the next provider in
+  `provider_priority`) so on-call operators can correlate coverage gaps with
+  upstream providers.
 - Unauthorized feed responses trigger a quick entitlement check and switch to a
   permitted feed when available. If no alternative exists, operators are
   notified once.


### PR DESCRIPTION
## Summary
- detect sparse minute-bar coverage and warn before retrying the session window with an alternate feed
- exercise the SIP retry path with a simulated low-coverage IEX response
- document the new MINUTE_DATA_COVERAGE_WARNING troubleshooting signal

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68caf0df28a08330953ff9b56d908766