### PR TITLE
Handle stale minute data with retry

### DIFF
--- a/LOGGING_README.md
+++ b/LOGGING_README.md
@@ -58,6 +58,12 @@ Daily price requests now log their parameters and outcome:
   alternate feed (SIP when entitled, otherwise the next provider in
   `provider_priority`) so on-call operators can correlate coverage gaps with
   upstream providers.
+- `FETCH_MINUTE_STALE_DATA` warns when the most recent minute bar is outside the
+  freshness SLA. The bot now re-fetches the window using the current clock,
+  tries configured feed promotions, and logs `FETCH_MINUTE_STALE_RECOVERED`
+  once fresher data arrives. Operators only see a `DataFetchError` after all
+  retry attempts still return stale payloads, with the aggregated staleness
+  reasons recorded in the exception detail for post-mortem analysis.
 - Unauthorized feed responses trigger a quick entitlement check and switch to a
   permitted feed when available. If no alternative exists, operators are
   notified once.


### PR DESCRIPTION
## Summary
- add retry and provider promotion logic to `fetch_minute_df_safe` so stale minute data is re-fetched before surfacing an error
- extend the unit tests to cover stale-first/fresh-second recovery and exhausted stale retries
- document the new `FETCH_MINUTE_STALE_RECOVERED` log flow for operators

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py (skipped: pandas not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68caf83ab9308330ab7d383fbf3df529