### PR TITLE
Track fills before updating exposure

### DIFF
--- a/tests/execution/test_execution_engine.py
+++ b/tests/execution/test_execution_engine.py
@@ -1,0 +1,81 @@
+import pytest
+from types import SimpleNamespace
+
+from ai_trading.execution.engine import ExecutionEngine, ExecutionResult, OrderManager
+from ai_trading.core.enums import OrderSide
+from ai_trading.risk.engine import TradeSignal
+
+
+class DummyRiskEngine:
+    def __init__(self):
+        self.fills = []
+
+    def register_fill(self, signal):
+        self.fills.append(signal)
+
+
+def _accepting_submit(order_manager, order):
+    order_manager.orders[order.id] = order
+    order_manager.active_orders[order.id] = order
+    return SimpleNamespace(id=order.id)
+
+
+def test_execute_order_returns_execution_result(monkeypatch):
+    engine = ExecutionEngine()
+
+    def submit_and_fill(self, order):
+        self.orders[order.id] = order
+        self.active_orders[order.id] = order
+        order.add_fill(order.quantity, 101.0)
+        return SimpleNamespace(id=order.id)
+
+    monkeypatch.setattr(OrderManager, "submit_order", submit_and_fill, raising=False)
+    monkeypatch.setattr(ExecutionEngine, "_simulate_market_execution", lambda self, order: None, raising=False)
+
+    result = engine.execute_order("AAPL", OrderSide.BUY, 5)
+    assert isinstance(result, ExecutionResult)
+    assert isinstance(result, str)
+    assert result.has_fill
+    assert result.filled_quantity == 5
+    assert result.fill_ratio == pytest.approx(1.0)
+
+
+def test_async_fill_triggers_risk_engine(monkeypatch):
+    risk = DummyRiskEngine()
+    ctx = SimpleNamespace(risk_engine=risk)
+    engine = ExecutionEngine(ctx=ctx)
+
+    monkeypatch.setattr(OrderManager, "submit_order", _accepting_submit, raising=False)
+    monkeypatch.setattr(ExecutionEngine, "_simulate_market_execution", lambda self, order: None, raising=False)
+
+    signal = TradeSignal(
+        symbol="AAPL",
+        side="buy",
+        confidence=1.0,
+        strategy="s",
+        weight=0.5,
+        asset_class="equity",
+    )
+
+    result = engine.execute_order(
+        "AAPL",
+        OrderSide.BUY,
+        10,
+        signal=signal,
+        signal_weight=signal.weight,
+    )
+    assert isinstance(result, ExecutionResult)
+    assert result.filled_quantity == 0
+    assert risk.fills == []
+
+    order = engine.order_manager.orders[str(result)]
+    order.add_fill(4, 100.0)
+    engine._handle_execution_event(order, "completed")
+    assert len(risk.fills) == 1
+    assert pytest.approx(risk.fills[0].weight, rel=1e-6) == 0.2
+
+    remaining = order.remaining_quantity
+    order.add_fill(remaining, 100.0)
+    engine._handle_execution_event(order, "completed")
+    assert len(risk.fills) == 2
+    assert pytest.approx(sum(sig.weight for sig in risk.fills), rel=1e-6) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- return an ExecutionResult from the execution engine with fill metadata and track order signal context for late fills
- update the bot engine to only register fills with the risk engine when quantities actually fill and handle partial fills
- wire execution callbacks and document the exposure workflow, adding tests covering aborted orders and delayed fills

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_execution_engine.py tests/test_risk_engine_module.py tests/test_bot_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68caf839ed4c833091d7b4711baef5a7