### PR TITLE
Make minute data staleness tolerance configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ Rebalance frequency defaults to 60 minutes; override with `AI_TRADING_REBALANCE_
 is used when multiple sources are set.
 Production code paths must avoid shim helpers like `optional_import(...)`; use direct `try`/`except ImportError` blocks or `importlib.util.find_spec` to guard optional dependencies and gate heavy imports inside function scope when possible.
 
+### Minute data freshness
+
+Real-time trading tolerates minute bars that are up to **15 minutes** old by default (900 seconds).
+Operators can tighten or relax this guard by exporting
+`AI_TRADING_MINUTE_DATA_MAX_STALENESS_SECONDS=<seconds>` in the environment. For feed-specific
+controls, set `AI_TRADING_MINUTE_DATA_STALENESS_OVERRIDES` to a JSON object such as
+`{"sip": 300, "iex": 900}`. The bot applies the override for the active feed and falls back to the
+global limit when no feed match is provided. Overrides outside JSON (for example YAML) are ignored.
+
 ### HTTP client tuning (performance)
 
 The global HTTP session used for data/broker calls can be tuned via env to balance latency, throughput, and resiliency:

--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -78,4 +78,34 @@ __all__ = [
     'sentiment_retry_max',
     'sentiment_backoff_base',
     'sentiment_backoff_strategy',
+    'minute_data_staleness_seconds',
 ]
+
+
+def minute_data_staleness_seconds(
+    feed: str | None = None, s: Settings | None = None
+) -> int:
+    """Return maximum allowed age (seconds) for minute data, honoring overrides."""
+
+    s = s or get_settings()
+    try:
+        default = int(getattr(s, 'minute_data_max_staleness_seconds', 900))
+    except (TypeError, ValueError):
+        default = 900
+    overrides = getattr(s, 'minute_data_staleness_overrides', None)
+    if overrides and feed:
+        try:
+            normalized = str(feed).strip().lower()
+        except Exception:
+            normalized = ''
+        if normalized:
+            try:
+                candidate = overrides.get(normalized)
+            except AttributeError:
+                candidate = None
+            if candidate is not None:
+                try:
+                    return int(candidate)
+                except (TypeError, ValueError):
+                    return default
+    return default

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -138,6 +138,22 @@ class Settings(BaseSettings):
     alpaca_data_feed: Literal['iex', 'sip'] = Field('iex', env='ALPACA_DATA_FEED')
     alpaca_feed_failover: tuple[str, ...] = Field(('sip',), env='ALPACA_FEED_FAILOVER')
     alpaca_empty_to_backup: bool = Field(True, env='ALPACA_EMPTY_TO_BACKUP')
+    minute_data_max_staleness_seconds: int = Field(
+        900,
+        validation_alias=AliasChoices(
+            'AI_TRADING_MINUTE_DATA_MAX_STALENESS_SECONDS',
+            'MINUTE_DATA_MAX_STALENESS_SECONDS',
+        ),
+        description='Maximum age (seconds) minute bars may be before considered stale.',
+    )
+    minute_data_staleness_overrides: dict[str, int] = Field(
+        default_factory=dict,
+        validation_alias=AliasChoices(
+            'AI_TRADING_MINUTE_DATA_STALENESS_OVERRIDES',
+            'MINUTE_DATA_STALENESS_OVERRIDES',
+        ),
+        description='Optional JSON mapping of feed name to per-feed stale thresholds in seconds.',
+    )
     alpaca_adjustment: Literal['all', 'raw'] = Field('all', env='ALPACA_ADJUSTMENT')
     data_provider_priority: tuple[str, ...] = Field(
         ('alpaca_iex', 'alpaca_sip', 'yahoo'), env='DATA_PROVIDER_PRIORITY'


### PR DESCRIPTION
## Summary
- replace the hard-coded 10 minute freshness guard in `fetch_minute_df_safe` with a configurable threshold sourced from settings
- add settings accessors and documentation for `AI_TRADING_MINUTE_DATA_MAX_STALENESS_SECONDS` and per-feed overrides
- extend the minute-data tests to cover configurable tolerances and ensure stale payloads still raise

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py` *(skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68caf83290ec8330b224fe422051c50e