### PR TITLE
Handle directional slippage in execution engine

### DIFF
--- a/tests/execution/test_manual_price_slippage.py
+++ b/tests/execution/test_manual_price_slippage.py
@@ -19,16 +19,21 @@ from ai_trading.core.enums import OrderSide, OrderType
 from ai_trading.execution import ExecutionEngine
 
 
-def test_manual_price_slippage_adjustment(monkeypatch, caplog):
-    """Manual price orders should adjust without raising assertion errors."""
-
+def _make_engine(monkeypatch, hash_value):
     os.environ["TESTING"] = "true"
     monkeypatch.setenv("MAX_SLIPPAGE_BPS", "10")
     monkeypatch.setenv("SLIPPAGE_LIMIT_TOLERANCE_BPS", "5")
-    monkeypatch.setattr("ai_trading.execution.engine.hash", lambda _: 99, raising=False)
-
+    monkeypatch.setattr("ai_trading.execution.engine.hash", lambda _: hash_value, raising=False)
     engine = ExecutionEngine()
     monkeypatch.setattr(engine, "_guess_price", lambda symbol: 100.0)
+    monkeypatch.setattr(engine, "get_available_qty", lambda: 100)
+    return engine
+
+
+def test_manual_price_slippage_adjustment(monkeypatch, caplog):
+    """Manual price orders should adjust without raising assertion errors."""
+
+    engine = _make_engine(monkeypatch, 99)
 
     caplog.set_level("WARNING")
 
@@ -40,11 +45,78 @@ def test_manual_price_slippage_adjustment(monkeypatch, caplog):
         price=100.0,
     )
 
+    assert order_id is not None
     order = engine.order_manager.orders[order_id]
 
     assert order.order_type == OrderType.LIMIT
     assert order.quantity < 10
 
+    warn_messages = [record.getMessage() for record in caplog.records]
+    assert "SLIPPAGE_LIMIT_CONVERSION" in warn_messages
+    assert "SLIPPAGE_QTY_REDUCED" in warn_messages
+
+
+def test_predicted_slippage_improvement_buy_does_not_mitigate(monkeypatch, caplog):
+    engine = _make_engine(monkeypatch, 0)
+
+    caplog.set_level("WARNING")
+
+    order_id = engine.execute_order(
+        "AAPL",
+        OrderSide.BUY,
+        10,
+        order_type=OrderType.MARKET,
+        price=100.0,
+    )
+
+    assert order_id is not None
+    order = engine.order_manager.orders[order_id]
+    assert order.order_type == OrderType.MARKET
+    assert order.quantity == 10
+    warn_messages = [record.getMessage() for record in caplog.records]
+    assert "SLIPPAGE_LIMIT_CONVERSION" not in warn_messages
+    assert "SLIPPAGE_QTY_REDUCED" not in warn_messages
+
+
+def test_predicted_slippage_improvement_sell_does_not_mitigate(monkeypatch, caplog):
+    engine = _make_engine(monkeypatch, 99)
+
+    caplog.set_level("WARNING")
+
+    order_id = engine.execute_order(
+        "AAPL",
+        OrderSide.SELL,
+        10,
+        order_type=OrderType.MARKET,
+        price=100.0,
+    )
+
+    assert order_id is not None
+    order = engine.order_manager.orders[order_id]
+    assert order.order_type == OrderType.MARKET
+    assert order.quantity == 10
+    warn_messages = [record.getMessage() for record in caplog.records]
+    assert "SLIPPAGE_LIMIT_CONVERSION" not in warn_messages
+    assert "SLIPPAGE_QTY_REDUCED" not in warn_messages
+
+
+def test_predicted_slippage_adverse_sell_still_mitigates(monkeypatch, caplog):
+    engine = _make_engine(monkeypatch, 0)
+
+    caplog.set_level("WARNING")
+
+    order_id = engine.execute_order(
+        "AAPL",
+        OrderSide.SELL,
+        10,
+        order_type=OrderType.MARKET,
+        price=100.0,
+    )
+
+    assert order_id is not None
+    order = engine.order_manager.orders[order_id]
+    assert order.order_type == OrderType.LIMIT
+    assert order.quantity < 10
     warn_messages = [record.getMessage() for record in caplog.records]
     assert "SLIPPAGE_LIMIT_CONVERSION" in warn_messages
     assert "SLIPPAGE_QTY_REDUCED" in warn_messages


### PR DESCRIPTION
## Summary
- respect order direction when validating slippage and only trigger mitigation for adverse price moves, while logging directional deltas that caused action
- surface directional slippage data in pre-check, conversion, reduction, rejection, and post-trade warnings
- extend execution-engine tests to cover directional slippage scenarios for buys and sells, ensuring favorable moves pass and adverse ones still mitigate

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_manual_price_slippage.py -q

------
https://chatgpt.com/codex/tasks/task_e_68caf741c2048330b510a2a9e9f62b9b