### PR TITLE
Improve SIP fallback resilience and add Finnhub backup option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,7 @@ DOLLAR_RISK_LIMIT=0.05
 
 # ---- Market Data ----
 # Alpaca data feed: iex (free) or sip (subscription). Default: iex
+# When ALPACA_HAS_SIP=1 the SIP feed is automatically enabled unless explicitly disabled.
 ALPACA_DATA_FEED=iex
 
 # Adjustments for bars: all | raw. Default: all

--- a/README.md
+++ b/README.md
@@ -759,7 +759,7 @@ exits early with a clear error message when these values are invalid.
    # Set the following only if your Alpaca account has SIP permissions
   # ALPACA_DATA_FEED=sip
   # ALPACA_HAS_SIP=1      # set to 1 if your Alpaca account has SIP access
-  # ALPACA_ALLOW_SIP=1    # enable SIP feed and SIP fallback
+  # ALPACA_ALLOW_SIP=1    # enable SIP feed and SIP fallback (auto-enabled when HAS_SIP=1)
   # ALPACA_FEED_FAILOVER=sip,iex  # retry SIP first when Alpaca returns an empty payload
   # ALPACA_EMPTY_TO_BACKUP=1      # hop straight to the backup provider after empty Alpaca responses
   # Without ALPACA_HAS_SIP, the fetcher uses the backup provider instead of SIP
@@ -837,7 +837,7 @@ connectivity.
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `PRIMARY_DATA_PROVIDER` | `alpaca` | Primary data source |
-| `BACKUP_DATA_PROVIDER` | `yahoo` | Fallback data source |
+| `BACKUP_DATA_PROVIDER` | `yahoo` | Fallback data source (`yahoo`, `finnhub`, or `none`) |
 | `MARKET_DATA_TIMEOUT` | `30` | API timeout in seconds |
 | `CACHE_MARKET_DATA` | `true` | Enable data caching |
 | `TRADING_HOURS_ONLY` | `true` | Trade only during market hours |
@@ -847,7 +847,7 @@ and queries the backup source. Configure additional fallbacks with:
 
 - Set `ENABLE_FINNHUB=1` and supply `FINNHUB_API_KEY` to enable a Finnhub
   retry before using the backup provider.
-- `BACKUP_DATA_PROVIDER` to override the default Yahoo Finance fallback (`yahoo` or `none`).
+- `BACKUP_DATA_PROVIDER` to override the default Yahoo Finance fallback (`yahoo`, `finnhub`, or `none`).
 
 When the configured fallback is used, a `USING_BACKUP_PROVIDER` log entry is emitted with the provider name.
 See [docs/provider_configuration.md](docs/provider_configuration.md) for environment-specific examples.

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -75,7 +75,7 @@ class Settings(BaseSettings):
     redis_url: str | None = Field(default=None, alias='REDIS_URL')
     enable_finnhub: bool = Field(True, alias='ENABLE_FINNHUB')
     finnhub_api_key: str | None = Field(default=None, alias='FINNHUB_API_KEY')
-    backup_data_provider: Literal['yahoo', 'none'] = Field(
+    backup_data_provider: Literal['yahoo', 'none', 'finnhub', 'finnhub_low_latency'] = Field(
         'yahoo', alias='BACKUP_DATA_PROVIDER'
     )
     alpaca_base_url: str = Field(

--- a/docs/provider_configuration.md
+++ b/docs/provider_configuration.md
@@ -28,7 +28,7 @@ once. Future requests for the same pair use the working feed immediately, elimin
 
 ## Backup Provider
 
-- `BACKUP_DATA_PROVIDER`: fallback source when the primary feed returns empty data. The default is `yahoo`. Set to `none` to disable backup queries.
+- `BACKUP_DATA_PROVIDER`: fallback source when the primary feed returns empty data. The default is `yahoo`. Set to `finnhub` to use the Finnhub low-latency candles API when an API key is configured, or to `none` to disable backup queries.
 - When a fallback is used, the bot logs `USING_BACKUP_PROVIDER` with the chosen provider. If disabled or unknown, `BACKUP_PROVIDER_DISABLED` or `UNKNOWN_BACKUP_PROVIDER` is logged.
 
 ## Provider Priority and Fallbacks


### PR DESCRIPTION
## Summary
- default SIP access to on when HAS_SIP or SIP failover are configured and document the behavior
- add a Finnhub-backed low latency backup path and accept new BACKUP_DATA_PROVIDER values
- soften provider switchover disables by tracking streaks per provider and add regression tests for partial coverage scenarios

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_provider_monitor_backoff.py tests/test_backup_provider_switch.py

------
https://chatgpt.com/codex/tasks/task_e_68cb0a5a9a8c83308259d424b4d41a1d