### PR TITLE
Handle Alpaca auth failures gracefully

### DIFF
--- a/tests/test_run_cycle_after_hours.py
+++ b/tests/test_run_cycle_after_hours.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 
 from ai_trading import main
+from ai_trading.alpaca_api import AlpacaAuthenticationError, is_alpaca_service_available
 
 
 def test_run_cycle_skips_when_market_closed(monkeypatch):
@@ -14,3 +15,26 @@ def test_run_cycle_skips_when_market_closed(monkeypatch):
     main.run_cycle()
 
     assert "ai_trading.core.bot_engine" not in sys.modules
+
+
+def test_run_cycle_aborts_on_alpaca_auth_failure(monkeypatch, caplog):
+    sys.modules.pop("ai_trading.core.bot_engine", None)
+    monkeypatch.setenv("ALLOW_AFTER_HOURS", "1")
+    monkeypatch.setattr(main, "_is_market_open_base", lambda: True)
+
+    import ai_trading.alpaca_api as alpaca_api
+
+    monkeypatch.setattr(alpaca_api, "_ALPACA_SERVICE_AVAILABLE", True)
+
+    def raise_auth(*_a, **_k):
+        monkeypatch.setattr(alpaca_api, "_ALPACA_SERVICE_AVAILABLE", False)
+        raise AlpacaAuthenticationError("Unauthorized")
+
+    monkeypatch.setattr(alpaca_api, "alpaca_get", raise_auth)
+
+    with caplog.at_level("CRITICAL"):
+        main.run_cycle()
+
+    assert "ALPACA_AUTH_PREFLIGHT_FAILED" in caplog.text
+    assert "ai_trading.core.bot_engine" not in sys.modules
+    assert not is_alpaca_service_available()


### PR DESCRIPTION
## Summary
- add dedicated AlpacaAuthenticationError handling for HTTP 401 responses and track service availability in the Alpaca API client
- guard bot_engine trade entry helpers against authentication failures and record skipped symbols instead of raising
- run a credential preflight in run_cycle and cover the new behaviour with targeted tests

## Testing
- pytest tests/test_alpaca_get.py tests/test_get_latest_price_fallback.py tests/test_run_cycle_after_hours.py tests/test_bot_engine.py -k "auth" -q

------
https://chatgpt.com/codex/tasks/task_e_68cb0a596a3c8330917b23d3a5f6c2a3