### PR TITLE
Make MAX_DRAWDOWN_THRESHOLD dynamic

### DIFF
--- a/risk_parameter_audit_report.md
+++ b/risk_parameter_audit_report.md
@@ -34,10 +34,10 @@
   Line: print(f"  • MAX_POSITION_SIZE: 10.0% → {RISK_PARAMETERS['MAX_POSITION_SIZE']*100:.1f}% (+150% increase)")
 - demo_drawdown_protection.py:20 - MAX_DRAWDOWN_THRESHOLD
   Found: 0.1 | Expected: 0.15
-  Line: print(f"Configuration: Max Drawdown = {config.MAX_DRAWDOWN_THRESHOLD:.1%}")
+  Line: print(f"Configuration: Max Drawdown = {config.get_max_drawdown_threshold():.1%}")
 - demo_drawdown_protection.py:63 - MAX_DRAWDOWN_THRESHOLD
   Found: 0.1 | Expected: 0.15
-  Line: print(f"      💥 CIRCUIT BREAKER TRIGGERED: {status['current_drawdown']:.1%} > {config.MAX_DRAWDOWN_THRESHOLD:.1%}")
+  Line: print(f"      💥 CIRCUIT BREAKER TRIGGERED: {status['current_drawdown']:.1%} > {config.get_max_drawdown_threshold():.1%}")
 - demonstrate_optimization_simple.py:43 - MAX_POSITION_SIZE
   Found: 10.0 | Expected: 8000
   Line: print(f"  • MAX_POSITION_SIZE: 10.0% → 25.0% (+150% increase)")

--- a/scripts/demo_drawdown_protection.py
+++ b/scripts/demo_drawdown_protection.py
@@ -2,6 +2,7 @@ import logging
 '\nDemonstration of DrawdownCircuitBreaker with centralized configuration.\n\nThis script simulates how the circuit breaker would protect a portfolio\nduring a volatile trading session using parameters from the centralized\nTradingConfig system.\n'
 import os
 os.environ['TESTING'] = '1'
+from ai_trading.config import get_max_drawdown_threshold
 from ai_trading.config import management as config
 from ai_trading.config.management import TradingConfig
 from ai_trading.risk.circuit_breakers import DrawdownCircuitBreaker
@@ -39,8 +40,9 @@ def simulate_trading_session():
         trading_status = '🟢 TRADING' if trading_allowed else '🔴 HALTED'
         drawdown_pct = status['current_drawdown'] * 100
         logging.info(f'{time}: ${equity:>8,.0f} {change:<15} | {trading_status:<12} | Drawdown: {drawdown_pct:>4.1f}% | {description}')
-        if not trading_allowed and status['current_drawdown'] > config.MAX_DRAWDOWN_THRESHOLD:
-            logging.info(str(f"      💥 CIRCUIT BREAKER TRIGGERED: {status['current_drawdown']:.1%} > {config.MAX_DRAWDOWN_THRESHOLD:.1%}"))
+        threshold = get_max_drawdown_threshold()
+        if not trading_allowed and status['current_drawdown'] > threshold:
+            logging.info(str(f"      💥 CIRCUIT BREAKER TRIGGERED: {status['current_drawdown']:.1%} > {threshold:.1%}"))
         elif trading_allowed and status['current_drawdown'] > 0:
             recovery_ratio = equity / status['peak_equity'] if status['peak_equity'] > 0 else 0
             if recovery_ratio >= breaker.recovery_threshold:

--- a/tests/config/test_env_comment_handling.py
+++ b/tests/config/test_env_comment_handling.py
@@ -9,6 +9,7 @@ def _reload_config(monkeypatch, **env):
     sys.modules.pop(module_name, None)
     for key in [
         "MAX_DRAWDOWN_THRESHOLD",
+        "AI_TRADING_MAX_DRAWDOWN_THRESHOLD",
         "TRADING_MODE",
         "KELLY_FRACTION",
         "CONF_THRESHOLD",
@@ -28,5 +29,5 @@ def _cleanup():
 
 def test_comment_stripped_from_float_env(monkeypatch):
     cfg = _reload_config(monkeypatch, MAX_DRAWDOWN_THRESHOLD="0.08  # comment")
-    assert cfg.MAX_DRAWDOWN_THRESHOLD == pytest.approx(0.08)
+    assert cfg.get_max_drawdown_threshold() == pytest.approx(0.08)
 

--- a/tests/public_api/test_exports.py
+++ b/tests/public_api/test_exports.py
@@ -35,7 +35,7 @@ EXPECTED = {
     'ai_trading.config': sorted([
         '_require_env_vars',
         'AlpacaConfig',
-        'MAX_DRAWDOWN_THRESHOLD',
+        'get_max_drawdown_threshold',
         'META_LEARNING_BOOTSTRAP_ENABLED',
         'META_LEARNING_BOOTSTRAP_WIN_RATE',
         'META_LEARNING_MIN_TRADES_REDUCED',

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -8,7 +8,14 @@ def _reload_config(monkeypatch, **env):
     module_name = "ai_trading.config"
     if module_name in list(importlib.sys.modules):
         del importlib.sys.modules[module_name]
-    for k in ["MAX_DRAWDOWN_THRESHOLD", "TRADING_MODE", "KELLY_FRACTION", "CONF_THRESHOLD", "MAX_POSITION_SIZE"]:
+    for k in [
+        "MAX_DRAWDOWN_THRESHOLD",
+        "AI_TRADING_MAX_DRAWDOWN_THRESHOLD",
+        "TRADING_MODE",
+        "KELLY_FRACTION",
+        "CONF_THRESHOLD",
+        "MAX_POSITION_SIZE",
+    ]:
         monkeypatch.delenv(k, raising=False)
     for k, v in env.items():
         monkeypatch.setenv(k, str(v))
@@ -23,8 +30,9 @@ def _cleanup():
 
 
 def test_missing_drawdown_threshold(monkeypatch):
+    module = _reload_config(monkeypatch)
     with pytest.raises(RuntimeError):
-        _reload_config(monkeypatch)
+        module.get_max_drawdown_threshold()
 
 
 def test_mode_presets(monkeypatch):

--- a/tests/test_integration_simple.py
+++ b/tests/test_integration_simple.py
@@ -21,7 +21,7 @@ def test_integration():
     # Test 1: Configuration loading
 
     # Test 2: Circuit breaker creation
-    breaker = DrawdownCircuitBreaker(max_drawdown=config.MAX_DRAWDOWN_THRESHOLD)
+    breaker = DrawdownCircuitBreaker(max_drawdown=config.get_max_drawdown_threshold())
 
     # Test 3: Normal operation
     initial_equity = 10000.0


### PR DESCRIPTION
## Summary
- replace the eager MAX_DRAWDOWN_THRESHOLD constant with a get_max_drawdown_threshold accessor that sanitizes environment input and reloads TradingConfig on demand
- update scripts, docs, and tests to use the accessor so monkeypatched environment values are honored immediately

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_centralized_config.py tests/config/ -q


------
https://chatgpt.com/codex/tasks/task_e_68cb3145cbe0833090261d36836cd426