### PR TITLE
Handle missing broker before PDT rule check

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8315,6 +8315,14 @@ def check_pdt_rule(runtime) -> bool:
     Returns False when Alpaca is unavailable, allowing the bot to continue
     operating in simulation mode.
     """
+    if getattr(runtime, "api", None) is None:
+        initialized = _initialize_alpaca_clients()
+        if not initialized and getattr(runtime, "api", None) is None:
+            logger_once.info(
+                "PDT_CHECK_SKIPPED - Alpaca unavailable, assuming no PDT restrictions",
+                key="pdt_check_skipped",
+            )
+            return False
     ensure_alpaca_attached(runtime)
     acct = safe_alpaca_get_account(runtime)
 


### PR DESCRIPTION
## Summary
- short-circuit `check_pdt_rule` when no Alpaca client can be initialized so that missing brokers skip PDT evaluation without raising

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_broker_unavailable_paths.py::test_safe_account_none tests/test_broker_unavailable_paths.py::test_pdt_rule_skips_without_false_fail -q`
- `ALPACA_API_KEY=testkey ALPACA_SECRET_KEY=testsecret ALPACA_API_URL=https://paper-api.alpaca.markets CAPITAL_CAP=100000 DOLLAR_RISK_LIMIT=1000 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_broker_unavailable_paths.py -q` *(fails: repeated upstream HTTP attempts emit ERROR logs under the constrained environment)*


------
https://chatgpt.com/codex/tasks/task_e_68cb31455f408330b60c8f58c7eebb11