### PR TITLE
Log minute gap continuity issues

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -985,7 +985,11 @@ def _verify_minute_continuity(
     if missing.empty:
         return df
 
-    warnings.warn(f"{symbol} minute data has {len(missing)} gaps", RuntimeWarning)
+    gap_count = int(len(missing))
+    logger.warning(
+        "MINUTE_GAPS_DETECTED",
+        extra=_norm_extra({"symbol": symbol, "gap_count": gap_count}),
+    )
     if not backfill:
         return df
 


### PR DESCRIPTION
## Summary
- switch minute continuity gap detection from warnings to structured logging with symbol and gap count metadata
- update the continuity test to assert logging behavior while ensuring no Python warnings are emitted

## Testing
- pytest tests/test_minute_gap_backfill.py

------
https://chatgpt.com/codex/tasks/task_e_68cb3c819a6883308a82b0cc47845690