### PR TITLE
Add compatibility alias for data_validation

### DIFF
--- a/data_validation/__init__.py
+++ b/data_validation/__init__.py
@@ -1,0 +1,11 @@
+"""Compatibility alias for :mod:`ai_trading.data_validation`.
+
+This lightweight module re-exports the public API from
+``ai_trading.data_validation`` so that both ``import data_validation`` and
+``from data_validation import ...`` remain supported.
+"""
+
+from ai_trading.data_validation import *  # noqa: F401,F403
+from ai_trading.data_validation import __all__  # noqa: F401
+
+__all__ = list(__all__)


### PR DESCRIPTION
## Summary
- add a lightweight root-level data_validation package that re-exports the ai_trading.data_validation API
- ensure __all__ is forwarded so both import styles remain fully supported

## Testing
- not run (not required for this change)


------
https://chatgpt.com/codex/tasks/task_e_68cb3d938bf48330bae8d8283c3bcccf