### PR TITLE
Round SoftBudget elapsed milliseconds

### DIFF
--- a/ai_trading/utils/prof.py
+++ b/ai_trading/utils/prof.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+
+import math
 import time
 from contextlib import contextmanager
 
@@ -33,7 +35,7 @@ class SoftBudget:
         return max(0.0, self._deadline - time.monotonic())
 
     def elapsed_ms(self) -> int:
-        return int((time.perf_counter() - self._start) * 1000)
+        return math.ceil((time.perf_counter() - self._start) * 1000)
 
     def over(self) -> bool:
         return time.monotonic() >= self._deadline


### PR DESCRIPTION
## Summary
- use math.ceil to compute SoftBudget elapsed milliseconds so we no longer truncate sub-millisecond durations while keeping monotonic behavior
- import math in the profiling utility module to support the rounded elapsed time calculation

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_prof_budget.py tests/performance/test_run_cycle_budget.py -q *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68cb3d928d68833083567b07c2bb622e