### PR TITLE
Improve minute coverage fallback detection

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -3013,13 +3013,16 @@ def fetch_minute_df_safe(symbol: str) -> pd.DataFrame:
         except Exception:
             actual_bars = 0
 
-    low_coverage = (
-        expected_bars >= intraday_lookback
-        and (
-            actual_bars < max(1, int(expected_bars * 0.5))
-            or actual_bars < intraday_lookback
-        )
+    coverage_threshold = (
+        max(1, int(expected_bars * 0.5)) if expected_bars > 0 else 0
     )
+    materially_short = (
+        expected_bars > 0 and actual_bars < coverage_threshold
+    )
+    insufficient_intraday = (
+        expected_bars >= intraday_lookback and actual_bars < intraday_lookback
+    )
+    low_coverage = materially_short or insufficient_intraday
 
     if low_coverage:
         fallback_feed, fallback_provider = _determine_fallback_feed(current_feed)

--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -461,6 +461,87 @@ def test_fetch_minute_df_safe_sparse_minute_data_triggers_sip_fallback(
     assert any(rec.message == "MINUTE_DATA_COVERAGE_WARNING" for rec in caplog.records)
 
 
+def test_fetch_minute_df_safe_early_session_sparse_data_triggers_sip_fallback(
+    monkeypatch, caplog
+):
+    pd = load_pandas()
+
+    base_now = datetime(2024, 1, 3, 15, 0, tzinfo=UTC)
+    session_start = datetime(2024, 1, 3, 14, 30, tzinfo=UTC)
+
+    class FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return base_now.replace(tzinfo=None)
+            return base_now.astimezone(tz)
+
+    expected = int((base_now - session_start).total_seconds() // 60)
+
+    calls: list[tuple[str, object, object, object]] = []
+
+    def fake_get_minute_df(symbol: str, start, end, feed=None, **_):
+        calls.append((symbol, start, end, feed))
+        if feed == "sip":
+            idx = pd.date_range(
+                end=end - timedelta(minutes=1),
+                periods=expected,
+                freq="min",
+                tz="UTC",
+            )
+            return pd.DataFrame(
+                {
+                    "close": list(range(len(idx))),
+                    "volume": [100] * len(idx),
+                },
+                index=idx,
+            )
+        idx = pd.date_range(start=start, periods=5, freq="min", tz="UTC")
+        return pd.DataFrame(
+            {
+                "close": [1.0] * len(idx),
+                "volume": [100] * len(idx),
+            },
+            index=idx,
+        )
+
+    from ai_trading.data import market_calendar
+    from ai_trading.utils import base as base_utils
+
+    monkeypatch.setattr(bot_engine, "datetime", FrozenDatetime, raising=False)
+    monkeypatch.setattr(base_utils, "is_market_open", lambda: True)
+    monkeypatch.setattr(bot_engine, "get_minute_df", fake_get_minute_df)
+    monkeypatch.setattr(
+        staleness,
+        "_ensure_data_fresh",
+        lambda df, max_age_seconds, *, symbol=None, now=None, tz=None: None,
+    )
+    monkeypatch.setattr(bot_engine.CFG, "data_feed", "iex", raising=False)
+    monkeypatch.setattr(
+        bot_engine.data_fetcher_module,
+        "_sip_configured",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        market_calendar,
+        "rth_session_utc",
+        lambda *_: (session_start, base_now + timedelta(hours=4)),
+    )
+    monkeypatch.setattr(
+        market_calendar,
+        "previous_trading_session",
+        lambda current_date: current_date,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = bot_engine.fetch_minute_df_safe("AAPL")
+
+    assert len(calls) == 2
+    assert calls[1][3] == "sip"
+    assert len(result) == expected
+    assert any(rec.message == "MINUTE_DATA_COVERAGE_WARNING" for rec in caplog.records)
+
+
 def test_data_fetcher_stale_iex_retries_realtime_feed(monkeypatch):
     pd = load_pandas()
 


### PR DESCRIPTION
## Summary
- update the minute coverage fallback logic so a material shortfall always triggers recovery while keeping the existing telemetry path
- add a regression test that simulates an early-session sparse window and verifies that the SIP feed is attempted

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py -k sparse -q *(skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3e0e47c08330803ca25ea0b57710