### PR TITLE
Handle sentiment rate limits without backoff

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1005,7 +1005,8 @@ def fetch_sentiment(
                 )
                 # fmt: on
                 if resp.status_code in {429, 500, 502, 503, 504}:
-                    raise RequestException(f"status {resp.status_code}")
+                    _SENTIMENT_CACHE[symbol] = (time.time(), 0.0)
+                    return 0.0
                 resp.raise_for_status()
                 data = resp.json()
                 score = float(data.get("sentiment", 0.0))


### PR DESCRIPTION
## Summary
- return a neutral sentiment score immediately when the upstream API responds with rate limit and related transient errors
- update the sentiment caching test to assert the neutral score is cached without triggering retries, failure counters, or sleep

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_critical_datetime_fixes.py::TestSentimentCaching::test_sentiment_cache_rate_limit_handling -q

------
https://chatgpt.com/codex/tasks/task_e_68cb3e0f1a008330ac8d3a89ae6e897d