### PR TITLE
Update systemd service restart policy

### DIFF
--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -28,12 +28,13 @@ ExecStartPre=/usr/bin/install -d -m 700 -o aiuser -g aiuser \
 ExecStart=/home/aiuser/ai-trading-bot/venv/bin/python -m ai_trading
 # Allow long-lived process; systemd will supervise restarts
 RuntimeMaxSec=0
-Restart=on-failure
+Restart=always
 RestartSec=10
 RestartPreventExitStatus=98
 StandardOutput=journal
 StandardError=journal
 NoNewPrivileges=true
+ProtectSystem=strict
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- set the systemd unit to always restart the AI trading service
- harden the service by enabling strict system protection

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_critical_fixes_validation.py::TestCriticalFixes::test_systemd_service_configuration

------
https://chatgpt.com/codex/tasks/task_e_68cb445b9d988330ac605d73197e073f