### PR TITLE
Tighten meta-learning price validation filters

### DIFF
--- a/tests/test_validate_trade_data_quality_decimal_format.py
+++ b/tests/test_validate_trade_data_quality_decimal_format.py
@@ -1,0 +1,22 @@
+import pytest
+
+from ai_trading.meta_learning import validate_trade_data_quality
+
+
+def test_validate_trade_data_quality_enforces_decimal_strings(tmp_path):
+    """Rows with exponential price strings are rejected by validation."""
+
+    path = tmp_path / "strict_prices.csv"
+    content = """symbol,entry_time,entry_price,exit_time,exit_price,qty,side,strategy,classification,signal_tags,confidence,reward
+AAA,2025-01-01T00:00:00Z,100.50,2025-01-01T00:05:00Z,105.75,1,buy,strat,test,momentum,0.5,1
+BBB,2025-01-01T01:00:00Z,1e2,2025-01-01T01:05:00Z,195.00,1,sell,strat,test,mean_revert,0.4,-1
+CCC,2025-01-01T02:00:00Z,invalid,2025-01-01T02:05:00Z,210.00,1,buy,strat,test,momentum,0.6,1
+DDD,2025-01-01T03:00:00Z,50.25,2025-01-01T03:05:00Z,55.00,1,sell,strat,test,trend,0.3,1
+""".strip()
+    path.write_text(content + "\n")
+
+    report = validate_trade_data_quality(str(path))
+
+    assert report["row_count"] == 4
+    assert report["valid_price_rows"] == 2
+    assert report["data_quality_score"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- enforce strict decimal validation in trade log audits and meta-learning retraining so malformed price strings are dropped
- ensure retrain_meta_learner only trains on rows that satisfy the stricter decimal mask and log filtered counts
- add regression tests covering the stricter price filtering for validation and retraining workflows

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_validate_trade_data_quality_decimal_format.py -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_meta_learning_additional.py -k non_decimal -q # skips when numpy is unavailable


------
https://chatgpt.com/codex/tasks/task_e_68cb4461489c8330b652b45c4641aa85