### PR TITLE
Add mapping protocol support to ExecutionResult

### DIFF
--- a/ai_trading/execution/classes.py
+++ b/ai_trading/execution/classes.py
@@ -13,16 +13,17 @@ returns that complicate caller logic.
 
 from __future__ import annotations
 
+from collections.abc import ItemsView, KeysView, Mapping, ValuesView
 from dataclasses import dataclass, field, replace, fields
 from datetime import UTC, datetime
 import time
-from typing import Any
+from typing import Any, Iterator
 
 from ..core.enums import OrderSide, OrderType
 
 
 @dataclass
-class ExecutionResult:
+class ExecutionResult(Mapping[str, Any]):
     """Represents the outcome of an order execution."""
 
     status: str
@@ -86,6 +87,35 @@ class ExecutionResult:
             "is_failed": self.is_failed,
             "is_partial": self.is_partial,
         }
+
+    # Mapping protocol -------------------------------------------------
+    def __getitem__(self, key: str) -> Any:
+        """Allow dictionary-style access, delegating to :meth:`to_dict`."""
+
+        data = self.to_dict()
+        try:
+            return data[key]
+        except KeyError as exc:  # pragma: no cover - defensive re-raise
+            raise KeyError(key) from exc
+
+    def __iter__(self) -> Iterator[str]:
+        """Iterate over keys from :meth:`to_dict`."""
+
+        return iter(self.to_dict())
+
+    def __len__(self) -> int:
+        """Return the number of items in :meth:`to_dict`."""
+
+        return len(self.to_dict())
+
+    def keys(self) -> KeysView[str]:
+        return self.to_dict().keys()
+
+    def items(self) -> ItemsView[str, Any]:
+        return self.to_dict().items()
+
+    def values(self) -> ValuesView[Any]:
+        return self.to_dict().values()
 
     def with_updates(self, **updates: Any) -> "ExecutionResult":
         """Return a copy of the result with ``updates`` applied."""

--- a/tests/test_production_system.py
+++ b/tests/test_production_system.py
@@ -198,7 +198,13 @@ async def test_production_execution_coordinator():
             strategy="test_strategy"
         )
 
-        assert result["status"] in ["success", "rejected"], f"Unexpected status: {result['status']}"
+        # Ensure ExecutionResult maintains attribute access for existing callers
+        assert result.status in ["success", "rejected"], f"Unexpected status: {result.status}"
+
+        # Mapping compatibility keeps dictionary-style access working for integrations
+        assert result["status"] == result.status
+        assert result["symbol"] == "AAPL"
+        assert result["is_successful"] == result.is_successful
 
         # Test execution summary
         summary = coordinator.get_execution_summary()


### PR DESCRIPTION
## Summary
- update `ExecutionResult` to implement the mapping protocol so dictionary-style access forwards to `to_dict`
- ensure production execution coordinator tests validate both attribute and bracket usage on execution results

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_production_system.py -q` *(fails: async def functions require pytest-asyncio or similar plugin in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb567f0ca4833088cc29dc7d3e4854