### PR TITLE
Add data feed alias propagation and tests

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -1685,7 +1685,11 @@ if getattr(S, "use_rl_agent", False) and RL_MODEL_PATH:
             extra={"hint": "ai_trading.rl_trading import failed"},
         )
 
-_DEFAULT_FEED = getattr(CFG, "alpaca_data_feed", "iex") or "iex"
+_DEFAULT_FEED = (
+    getattr(CFG, "data_feed", None)
+    or getattr(CFG, "alpaca_data_feed", "iex")
+    or "iex"
+)
 
 # Ensure numpy.NaN exists for pandas_ta compatibility
 # AI-AGENT-REF: guard numpy.NaN assignment for test environments
@@ -4707,7 +4711,11 @@ class DataFetcher:
         logger.debug(
             "ALPACA_DATA_CONFIG",
             extra={
-                "feed": getattr(self.settings, "alpaca_data_feed", None),
+                "feed": getattr(
+                    self.settings,
+                    "data_feed",
+                    getattr(self.settings, "alpaca_data_feed", None),
+                ),
                 "adjustment": getattr(self.settings, "alpaca_adjustment", None),
             },
         )
@@ -4943,7 +4951,14 @@ class DataFetcher:
                 return None
 
         try:
-            feed = getattr(self.settings, "alpaca_data_feed", None) or "iex"
+            feed = (
+                getattr(
+                    self.settings,
+                    "data_feed",
+                    getattr(self.settings, "alpaca_data_feed", None),
+                )
+                or "iex"
+            )
             req = bars.StockBarsRequest(
                 symbol_or_symbols=[symbol],
                 timeframe=bars.TimeFrame.Day,
@@ -5269,7 +5284,14 @@ class DataFetcher:
         df: pd.DataFrame | None = None
 
         try:
-            feed = (getattr(self.settings, "alpaca_data_feed", None) or "iex").lower()
+            feed = (
+                getattr(
+                    self.settings,
+                    "data_feed",
+                    getattr(self.settings, "alpaca_data_feed", None),
+                )
+                or "iex"
+            ).lower()
             req = bars.StockBarsRequest(
                 symbol_or_symbols=[symbol],
                 timeframe=bars.TimeFrame.Minute,
@@ -5449,7 +5471,14 @@ class DataFetcher:
         """
         all_days: list[pd.DataFrame] = []
         current_day = start_date
-        feed = getattr(self.settings, "alpaca_data_feed", None) or "iex"
+        feed = (
+            getattr(
+                self.settings,
+                "data_feed",
+                getattr(self.settings, "alpaca_data_feed", None),
+            )
+            or "iex"
+        )
 
         while current_day <= end_date:
             day_start = datetime.combine(current_day, dt_time.min, UTC)

--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -517,7 +517,15 @@ def last_minute_bar_age_seconds(symbol: str) -> int | None:
     return max(0, now_s - int(ts))
 
 
-_DEFAULT_FEED = "iex"
+try:
+    _cfg_default = get_settings()
+    _DEFAULT_FEED = (
+        getattr(_cfg_default, "data_feed", None)
+        or getattr(_cfg_default, "alpaca_data_feed", "iex")
+        or "iex"
+    )
+except Exception:  # pragma: no cover - defensive default
+    _DEFAULT_FEED = "iex"
 def _env_flag(key: str, default: bool = False) -> bool:
     """Return truthy flag for ``key`` honouring ``default`` when unset."""
 
@@ -2672,7 +2680,7 @@ def get_bars(
             if prov.startswith("alpaca_"):
                 feed = prov.split("_", 1)[1]
                 break
-        feed = feed or S.alpaca_data_feed
+        feed = feed or getattr(S, 'data_feed', getattr(S, 'alpaca_data_feed', 'iex'))
     adjustment = adjustment or S.alpaca_adjustment
     # If Alpaca credentials are missing, skip direct Alpaca HTTP calls and
     # fall back to the Yahoo helper to avoid noisy empty/unauthorized logs.


### PR DESCRIPTION
## Summary
- expose a `data_feed` alias in the runtime settings that updates Alpaca feed defaults in dependent modules
- teach the data fetcher and bot engine to resolve their default feeds via the alias-aware settings values
- extend the settings test suite to cover runtime mutations of `CFG.data_feed` and property-based fallbacks

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_settings_config.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb567dae7c8330b1fb874c8434ffff