### PR TITLE
Extend urllib3 stub warnings

### DIFF
--- a/tests/test_bot_extended.py
+++ b/tests/test_bot_extended.py
@@ -69,7 +69,21 @@ if "pandas_ta" in sys.modules:
 sys.modules["pipeline"].model_pipeline = lambda *a, **k: None
 sys.modules.setdefault("requests", types.ModuleType("requests"))
 sys.modules.setdefault("urllib3", types.ModuleType("urllib3"))
-sys.modules["urllib3"].exceptions = types.SimpleNamespace(HTTPError=Exception)
+
+
+class _HTTPWarning(Warning):
+    pass
+
+
+class _SystemTimeWarning(Warning):
+    pass
+
+
+sys.modules["urllib3"].exceptions = types.SimpleNamespace(
+    HTTPError=Exception,
+    HTTPWarning=_HTTPWarning,
+    SystemTimeWarning=_SystemTimeWarning,
+)
 sys.modules.setdefault("bs4", types.ModuleType("bs4"))
 sys.modules["bs4"].BeautifulSoup = lambda *a, **k: None
 sys.modules.setdefault("flask", types.ModuleType("flask"))


### PR DESCRIPTION
## Summary
- extend the urllib3 exceptions stub in tests to expose HTTPWarning and SystemTimeWarning
- provide lightweight warning subclasses so tests referencing urllib3 warning helpers can import them

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_and_screen.py

------
https://chatgpt.com/codex/tasks/task_e_68cb60f93068833091597e9be0e9d69e