### PR TITLE
Add 2023 year-end fallback trading sessions

### DIFF
--- a/ai_trading/utils/market_calendar.py
+++ b/ai_trading/utils/market_calendar.py
@@ -48,6 +48,15 @@ class Session:
 # Known session overrides when :mod:`pandas_market_calendars` is missing.
 # Times are defined in ET then converted to UTC for accuracy.
 _FALLBACK_SESSIONS: dict[date, Session] = {
+    # Final trading days for 2023 used by previous-session fallbacks
+    date(2023, 12, 28): Session(
+        datetime(2023, 12, 28, 9, 30, tzinfo=_ET).astimezone(UTC),
+        datetime(2023, 12, 28, 16, 0, tzinfo=_ET).astimezone(UTC),
+    ),
+    date(2023, 12, 29): Session(
+        datetime(2023, 12, 29, 9, 30, tzinfo=_ET).astimezone(UTC),
+        datetime(2023, 12, 29, 16, 0, tzinfo=_ET).astimezone(UTC),
+    ),
     # Dummy sessions for early January 2024 to keep tests deterministic
     date(2024, 1, 1): Session(
         datetime(2024, 1, 1, 9, 30, tzinfo=_ET).astimezone(UTC),


### PR DESCRIPTION
## Summary
- add NYSE fallback sessions for December 28-29, 2023 to cover year-end lookups
- ensure the new entries mirror standard 09:30-16:00 ET trading hours in UTC

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_daily_bars_datetime_sanitization.py -q` *(skipped: pandas not installed)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_price_snapshot_minute_fallback.py -q` *(skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68cb60f872a88330adaa307513fbd9be