### PR TITLE
Respect direct max position size env override

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -495,11 +495,13 @@ class TradingConfig:
             if alias_value in (None, ""):
                 continue
 
+            canonical_value = env_map.get(canon)
+
             if alias.startswith("AI_TRADING_"):
-                env_map[canon] = alias_value
+                if canonical_value is None or str(canonical_value).strip() == "":
+                    env_map[canon] = alias_value
                 continue
 
-            canonical_value = env_map.get(canon)
             if canonical_value is None or str(canonical_value).strip() == "":
                 env_map[canon] = alias_value
 

--- a/tests/test_runtime_params_hydration.py
+++ b/tests/test_runtime_params_hydration.py
@@ -50,6 +50,18 @@ def test_trading_config_from_env_loads_parameters():
         assert cfg.position_size_min_usd == 25.0
 
 
+def test_alias_does_not_override_direct_max_position_size(monkeypatch):
+    """MAX_POSITION_SIZE should win over AI_TRADING_MAX_POSITION_SIZE."""
+    from ai_trading.config.management import TradingConfig
+
+    monkeypatch.setenv("MAX_POSITION_SIZE", "1234")
+    monkeypatch.setenv("AI_TRADING_MAX_POSITION_SIZE", "5678")
+
+    cfg = TradingConfig.from_env()
+
+    assert cfg.max_position_size == 1234.0
+
+
 def test_trading_config_from_env_market_calendar(monkeypatch):
     """TradingConfig.from_env picks up MARKET_CALENDAR."""  # AI-AGENT-REF
     from ai_trading.config.management import TradingConfig


### PR DESCRIPTION
## Summary
- ensure AI_TRADING_* aliases only backfill canonical keys when they are unset
- add a regression test to confirm MAX_POSITION_SIZE beats AI_TRADING_MAX_POSITION_SIZE when both are provided

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_params_hydration.py tests/test_config_validation_max_position_size.py


------
https://chatgpt.com/codex/tasks/task_e_68cb6ad64fa0833081fe81f537445795