### PR TITLE
Guard urllib3.disable_warnings invocation

### DIFF
--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -28,7 +28,9 @@ try:  # handle TLS validation clock skew warnings gracefully
         _warning_category = getattr(_exceptions, "SystemTimeWarning", Warning)
         if _warning_category is Warning:
             _warning_category = getattr(_exceptions, "HTTPWarning", Warning)
-    urllib3.disable_warnings(_warning_category)
+    _disable_warnings = getattr(urllib3, "disable_warnings", None)
+    if callable(_disable_warnings):
+        _disable_warnings(_warning_category)
 except Exception:  # pragma: no cover - urllib3 missing or misbehaving
     pass
 

--- a/tests/test_net_http_warning_guard.py
+++ b/tests/test_net_http_warning_guard.py
@@ -33,3 +33,24 @@ def test_disable_warnings_handles_missing_httpwarning():
         else:
             sys.modules.pop("urllib3", None)
         importlib.reload(http)
+
+
+def test_disable_warnings_missing_attribute_is_ignored():
+    import ai_trading.net.http as http
+
+    original_urllib3 = sys.modules.get("urllib3")
+
+    stub = types.ModuleType("urllib3")
+    stub.exceptions = types.SimpleNamespace(SystemTimeWarning=Warning)
+    # Explicitly omit disable_warnings to simulate an older/broken urllib3.
+
+    sys.modules["urllib3"] = stub
+    try:
+        # Should not raise even though disable_warnings is absent.
+        importlib.reload(http)
+    finally:
+        if original_urllib3 is not None:
+            sys.modules["urllib3"] = original_urllib3
+        else:
+            sys.modules.pop("urllib3", None)
+        importlib.reload(http)


### PR DESCRIPTION
## Summary
- guard the urllib3.disable_warnings call so it only runs when available and callable
- add regression test covering urllib3 modules without disable_warnings

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_net_http_warning_guard.py tests/test_fetch_and_screen.py

------
https://chatgpt.com/codex/tasks/task_e_68cb6ad69d788330bc22589ed1e10fa6