### PR TITLE
Handle missing _C alias in RL module train

### DIFF
--- a/ai_trading/rl/module.py
+++ b/ai_trading/rl/module.py
@@ -46,7 +46,9 @@ def train(data: Any, model_path: str | Path, cfg: RLConfig | None = None):
         Optional :class:`RLConfig` overriding the legacy ``_C`` defaults.
     """
 
-    cfg = cfg or _C
+    # ``_C`` may be removed by callers to avoid the legacy alias.  Fall back to
+    # a fresh configuration if the global alias is absent.
+    cfg = cfg or globals().get("_C") or RLConfig()
     logger.debug("RL train invoked", extra={"timesteps": cfg.timesteps})
     return _train_mod.train(data, model_path, timesteps=cfg.timesteps)
 

--- a/tests/test_rl_module.py
+++ b/tests/test_rl_module.py
@@ -58,3 +58,34 @@ def test_rl_wrapper_without_c(monkeypatch, tmp_path):
     agent = rl_mod.load(path)
     sig = rl_mod.predict(agent, data[0])
     assert sig and sig.side == "buy"
+
+
+def test_rl_wrapper_without_c_defaults(monkeypatch, tmp_path):
+    data = np.random.rand(20, 4)
+
+    class DummyPPO:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def learn(self, *a, **k):
+            return None
+
+        def save(self, path):
+            open(path, "wb").write(b"0")
+
+        def predict(self, state, deterministic=True):
+            return (1, None)
+
+        @classmethod
+        def load(cls, path):
+            return cls()
+
+    monkeypatch.setattr(train_mod, "PPO", DummyPPO)
+    monkeypatch.setattr(rl_mod._rl, "PPO", DummyPPO)
+    monkeypatch.setattr(rl_mod._rl, "is_rl_available", lambda: True)
+    monkeypatch.delattr(rl_mod, "_C", raising=False)
+    path = tmp_path / "model.zip"
+    rl_mod.train(data, path)
+    agent = rl_mod.load(path)
+    sig = rl_mod.predict(agent, data[0])
+    assert sig and sig.side == "buy"


### PR DESCRIPTION
## Summary
- ensure the RL module's train helper falls back to a fresh RLConfig when the legacy _C alias is missing
- add a regression test verifying train succeeds after deleting the _C alias

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rl_module.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb6e84bfb48330a9cc26f1e853df98