### PR TITLE
Ensure Alpaca shadow submissions record client IDs

### DIFF
--- a/tests/test_safe_submit_order.py
+++ b/tests/test_safe_submit_order.py
@@ -1,5 +1,65 @@
+import sys
 import types
 import pytest
+
+
+if "numpy" not in sys.modules:
+    class _RandomStub:
+        def seed(self, *_args, **_kwargs):
+            return None
+
+    class _NumpyStub(types.ModuleType):
+        def __init__(self):
+            super().__init__("numpy")
+            self.random = _RandomStub()
+            self.nan = float("nan")
+            self.NaN = self.nan
+            self.ndarray = object
+
+        def __getattr__(self, _name):  # type: ignore[override]
+            def _stub(*_args, **_kwargs):
+                return 0
+
+            return _stub
+
+    sys.modules["numpy"] = _NumpyStub()
+
+
+if "ai_trading.indicators" not in sys.modules:
+    indicators_stub = types.ModuleType("ai_trading.indicators")
+    _zero = lambda *args, **kwargs: 0
+    indicators_stub.atr = _zero
+    indicators_stub.compute_atr = _zero
+    indicators_stub.mean_reversion_zscore = _zero
+    indicators_stub.rsi = _zero
+    indicators_stub.__getattr__ = lambda _name: _zero  # type: ignore[attr-defined]
+    sys.modules["ai_trading.indicators"] = indicators_stub
+
+if "portalocker" not in sys.modules:
+    portalocker_stub = types.ModuleType("portalocker")
+    portalocker_stub.LOCK_EX = 1
+    portalocker_stub.lock = lambda *args, **kwargs: None
+    portalocker_stub.unlock = lambda *args, **kwargs: None
+    sys.modules["portalocker"] = portalocker_stub
+
+if "bs4" not in sys.modules:
+    bs4_stub = types.ModuleType("bs4")
+
+    class _Soup:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def find_all(self, *_args, **_kwargs):
+            return []
+
+        def find_parent(self, *_args, **_kwargs):
+            return None
+
+        def get_text(self, *_args, **_kwargs):
+            return ""
+
+    bs4_stub.BeautifulSoup = lambda *_args, **_kwargs: _Soup()
+    sys.modules["bs4"] = bs4_stub
 
 
 class DummyAPI:


### PR DESCRIPTION
## Summary
- ensure `alpaca_api.submit_order` records generated idempotency keys on both `client.ids` and `client.client_order_ids`, even when shadow submissions short-circuit
- extend client order ID coverage to assert ID lists stay aligned across normal and shadow submissions
- stub optional broker dependencies in `test_safe_submit_order` so the suite runs without heavyweight packages

## Testing
- pytest tests/test_client_order_id.py tests/test_safe_submit_order.py

------
https://chatgpt.com/codex/tasks/task_e_68cb72e192e08330b3c99f0c316b18fe