### PR TITLE
Add urllib3 disable_warnings shim with monkeypatch test

### DIFF
--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -29,6 +29,15 @@ try:  # handle TLS validation clock skew warnings gracefully
         if _warning_category is Warning:
             _warning_category = getattr(_exceptions, "HTTPWarning", Warning)
     _disable_warnings = getattr(urllib3, "disable_warnings", None)
+    if _disable_warnings is None:
+        def _noop_disable_warnings(*args, **kwargs):
+            return None
+
+        _disable_warnings = _noop_disable_warnings
+        try:
+            setattr(urllib3, "disable_warnings", _disable_warnings)
+        except Exception:  # pragma: no cover - attribute assignment failed
+            pass
     if callable(_disable_warnings):
         _disable_warnings(_warning_category)
 except Exception:  # pragma: no cover - urllib3 missing or misbehaving


### PR DESCRIPTION
## Summary
- add a noop fallback for urllib3.disable_warnings when the attribute is absent so warning suppression still executes safely
- keep the callable guard and verify that monkeypatching works when the shim is installed

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_net_http_warning_guard.py


------
https://chatgpt.com/codex/tasks/task_e_68cb7c92b25883309ecd214b3f605448