### PR TITLE
Ensure modern env aliases override canonical entries

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -498,8 +498,7 @@ class TradingConfig:
             canonical_value = env_map.get(canon)
 
             if alias.startswith("AI_TRADING_"):
-                if canonical_value is None or str(canonical_value).strip() == "":
-                    env_map[canon] = alias_value
+                env_map[canon] = alias_value
                 continue
 
             if canonical_value is None or str(canonical_value).strip() == "":

--- a/tests/config/test_env_aliases_unified.py
+++ b/tests/config/test_env_aliases_unified.py
@@ -27,3 +27,30 @@ def test_modern_env_keys_satisfy_tradingconfig(monkeypatch):
     assert cfg.confidence_level == 0.85
     assert cfg.kelly_fraction_max == 0.20
     assert cfg.min_sample_size == 12
+
+
+def test_ai_trading_alias_overrides_existing_canonical(monkeypatch):
+    monkeypatch.setenv("CONF_THRESHOLD", "0.6")
+    monkeypatch.setenv("AI_TRADING_CONF_THRESHOLD", "0.9")
+
+    cfg = TradingConfig.from_env({})
+
+    assert cfg.conf_threshold == 0.9
+
+
+def test_legacy_alias_backfills_only_when_missing(monkeypatch):
+    monkeypatch.delenv("DOLLAR_RISK_LIMIT", raising=False)
+    monkeypatch.setenv("DAILY_LOSS_LIMIT", "0.25")
+
+    cfg = TradingConfig.from_env({})
+
+    assert cfg.dollar_risk_limit == 0.25
+
+
+def test_legacy_alias_does_not_override_existing_canonical(monkeypatch):
+    monkeypatch.setenv("DOLLAR_RISK_LIMIT", "0.42")
+    monkeypatch.setenv("DAILY_LOSS_LIMIT", "0.25")
+
+    cfg = TradingConfig.from_env({})
+
+    assert cfg.dollar_risk_limit == 0.42


### PR DESCRIPTION
## Summary
- ensure AI_TRADING_* environment aliases always replace their canonical counterparts when building TradingConfig
- retain legacy aliases as backfills that only populate missing canonical keys
- extend env alias tests to cover modern overrides and legacy backfill behavior

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/config/test_env_aliases_unified.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb7c907cd88330ac14aab4a23f97c7