### PR TITLE
Add urllib3 test stub with disable_warnings

### DIFF
--- a/tests/stubs/urllib3/__init__.py
+++ b/tests/stubs/urllib3/__init__.py
@@ -1,0 +1,44 @@
+"""Lightweight urllib3 stub for tests."""
+
+from __future__ import annotations
+
+import types
+import warnings
+
+try:
+    from .util.retry import Retry  # noqa: F401  # re-export for import parity
+except Exception:  # pragma: no cover - missing util stub
+    Retry = None  # type: ignore[assignment]
+
+
+class HTTPWarning(Warning):
+    """Base warning type for HTTP issues."""
+
+
+class SystemTimeWarning(HTTPWarning):
+    """Warning for TLS clock skew issues."""
+
+
+exceptions = types.SimpleNamespace(
+    HTTPWarning=HTTPWarning,
+    SystemTimeWarning=SystemTimeWarning,
+)
+
+
+def disable_warnings(category: type[Warning] | None = HTTPWarning) -> None:
+    """Mimic urllib3.disable_warnings by silencing the provided warning."""
+
+    if category is None:
+        category = HTTPWarning
+    try:
+        warnings.filterwarnings("ignore", category=category)
+    except Exception:
+        # In line with urllib3's behavior, failures should not raise.
+        pass
+
+
+__all__ = [
+    "Retry",
+    "exceptions",
+    "disable_warnings",
+]


### PR DESCRIPTION
## Summary
- add a lightweight urllib3 stub that exposes disable_warnings and warning classes used in tests
- re-export the existing Retry stub so imports stay compatible

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_and_screen.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb825fe17483309d39fb1620507dd4