### PR TITLE
Expose retrain joblib alias

### DIFF
--- a/retrain/__init__.py
+++ b/retrain/__init__.py
@@ -1,6 +1,11 @@
 """Compatibility wrapper exposing the public retraining helpers."""
 
+from types import SimpleNamespace
+
 from ai_trading.retrain import *  # noqa: F401,F403 - re-export public API
 from ai_trading.retrain import main
 
-__all__ = ["atomic_joblib_dump", "detect_regime", "build_parser", "main"]
+
+joblib = SimpleNamespace(dump=atomic_joblib_dump)
+
+__all__ = ["atomic_joblib_dump", "detect_regime", "build_parser", "main", "joblib"]

--- a/tests/test_retrain_joblib_alias.py
+++ b/tests/test_retrain_joblib_alias.py
@@ -1,0 +1,8 @@
+import importlib
+
+
+def test_retrain_joblib_dump_aliases_cli():
+    retrain_pkg = importlib.import_module("retrain")
+    cli_pkg = importlib.import_module("ai_trading.retrain")
+
+    assert retrain_pkg.joblib.dump is cli_pkg.atomic_joblib_dump


### PR DESCRIPTION
## Summary
- expose the `retrain.joblib.dump` helper so callers share the CLI dump implementation
- add a regression test covering the alias to the CLI's atomic joblib dump helper

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_retrain_joblib_alias.py

------
https://chatgpt.com/codex/tasks/task_e_68cb8362e91c8330916aada64e3dfc2d