### PR TITLE
Use monotonic clock for SoftBudget timing

### DIFF
--- a/ai_trading/utils/prof.py
+++ b/ai_trading/utils/prof.py
@@ -21,10 +21,10 @@ class SoftBudget:
     def __init__(self, interval_sec: float, fraction: float):
         now = time.monotonic()
         self._deadline = now + max(0.0, interval_sec) * max(0.1, min(1.0, fraction))
-        self._start = time.perf_counter()
+        self._start = now
 
     def __enter__(self) -> "SoftBudget":
-        self._start = time.perf_counter()
+        self._start = time.monotonic()
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
@@ -35,7 +35,10 @@ class SoftBudget:
         return max(0.0, self._deadline - time.monotonic())
 
     def elapsed_ms(self) -> int:
-        return math.ceil((time.perf_counter() - self._start) * 1000)
+        elapsed = time.monotonic() - self._start
+        if elapsed <= 0:
+            return 0
+        return max(1, round(elapsed * 1000))
 
     def over(self) -> bool:
         return time.monotonic() >= self._deadline

--- a/tests/test_prof_budget.py
+++ b/tests/test_prof_budget.py
@@ -3,9 +3,34 @@ import time
 from ai_trading.utils.prof import SoftBudget
 
 
-def test_soft_budget_elapsed_and_over():
-    b = SoftBudget(interval_sec=0.1, fraction=0.5)
-    time.sleep(0.02)
-    assert b.elapsed_ms() >= 20
-    time.sleep(0.05)
-    assert b.over() is True or b.remaining() == 0.0
+def test_soft_budget_direct_usage_elapsed_and_over():
+    budget = SoftBudget(interval_sec=0.05, fraction=1.0)
+
+    initial_elapsed = budget.elapsed_ms()
+    assert initial_elapsed <= 1
+
+    time.sleep(0.005)
+    assert budget.elapsed_ms() >= 1
+    assert budget.remaining() > 0.0
+
+    time.sleep(0.07)
+    assert budget.over() is True
+    assert budget.remaining() == 0.0
+
+
+def test_soft_budget_context_manager_resets_start():
+    budget = SoftBudget(interval_sec=0.05, fraction=1.0)
+    time.sleep(0.005)
+    assert budget.elapsed_ms() >= 1
+
+    with budget as managed_budget:
+        assert managed_budget is budget
+        elapsed_on_enter = managed_budget.elapsed_ms()
+        assert elapsed_on_enter <= 1
+
+        time.sleep(0.005)
+        assert managed_budget.elapsed_ms() >= 1
+        assert managed_budget.remaining() > 0.0
+
+    time.sleep(0.07)
+    assert budget.over() is True


### PR DESCRIPTION
## Summary
- align `SoftBudget` timing to a single monotonic clock and guarantee a minimum 1 ms elapsed result after time advances
- extend the `SoftBudget` unit tests to cover direct and context manager usage under the corrected semantics

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_prof_budget.py -q


------
https://chatgpt.com/codex/tasks/task_e_68cb836440788330ae2119dd569753bf