### PR TITLE
Mark heuristic fallback model as placeholder

### DIFF
--- a/ai_trading/simple_models.py
+++ b/ai_trading/simple_models.py
@@ -19,6 +19,10 @@ import numpy as np
 
 
 class HeuristicModel:
+    """Lightweight heuristic classifier acting as a placeholder model."""
+
+    is_placeholder_model = True
+    classes_ = np.array([0, 1], dtype=int)
     feature_names_in_ = np.array(["rsi", "macd", "atr", "vwap", "sma_50", "sma_200"])  # type: ignore[attr-defined]
 
     def _score_row(self, x: np.ndarray) -> float:

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -122,3 +122,25 @@ def test_missing_model_warns_when_flag_set(monkeypatch, tmp_path, caplog):
     reload_bot_engine()
     assert "ML_MODEL_MISSING" in caplog.text
 
+
+def test_heuristic_fallback_marked_placeholder(monkeypatch, tmp_path):
+    external = tmp_path / "ext"
+    internal = tmp_path / "int"
+    external.mkdir()
+    internal.mkdir()
+
+    monkeypatch.setenv("AI_TRADING_MODELS_DIR", str(external))
+
+    import ai_trading.paths as paths
+    import ai_trading.model_loader as model_loader
+
+    importlib.reload(paths)
+    ml = importlib.reload(model_loader)
+    monkeypatch.setattr(ml, "INTERNAL_MODELS_DIR", internal)
+    ml.ML_MODELS.clear()
+
+    model = ml.load_model("MISSING_PLACEHOLDER")
+
+    assert getattr(model, "is_placeholder_model", False) is True
+    assert tuple(getattr(model, "classes_", ())) == (0, 1)
+


### PR DESCRIPTION
## Summary
- mark `HeuristicModel` as a placeholder and expose light metadata for downstream checks
- add a regression test to ensure the heuristic fallback is detected as a placeholder model

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_model_loading.py::test_heuristic_fallback_marked_placeholder


------
https://chatgpt.com/codex/tasks/task_e_68cb8363e4a88330bc10b5c8e7f531ab