### PR TITLE
Handle RL stack import errors gracefully

### DIFF
--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -28,8 +28,8 @@ def _load_rl_stack() -> dict[str, Any] | None:
         sb3 = importlib.import_module("stable_baselines3")
         gym = importlib.import_module("gymnasium")
         importlib.import_module("torch")
-    except ImportError as exc:
-        logger.debug("RL stack unavailable: %s", exc)
+    except Exception as exc:
+        logger.exception("RL stack unavailable: %s", exc)
         return None
     global PPO, DummyVecEnv
     try:

--- a/tests/test_rl_stack_imports.py
+++ b/tests/test_rl_stack_imports.py
@@ -1,0 +1,39 @@
+"""Tests for RL stack optional dependency handling."""
+
+from __future__ import annotations
+
+import types
+
+import ai_trading.rl_trading as rl
+
+
+def test_is_rl_unavailable_when_torch_raises_name_error(monkeypatch):
+    """Torch import errors should keep the RL facade in stub mode."""
+
+    rl._load_rl_stack.cache_clear()
+
+    dummy_vec_env = object()
+    dummy_sb3 = types.SimpleNamespace(
+        PPO=object(),
+        common=types.SimpleNamespace(
+            vec_env=types.SimpleNamespace(DummyVecEnv=dummy_vec_env)
+        ),
+    )
+    dummy_gym = types.ModuleType("gymnasium")
+
+    def fake_import(name: str, package: str | None = None):
+        if name == "stable_baselines3":
+            return dummy_sb3
+        if name == "gymnasium":
+            return dummy_gym
+        if name == "torch":
+            raise NameError("_C")
+        raise AssertionError(f"unexpected import request: {name}")
+
+    monkeypatch.setattr(rl.importlib, "import_module", fake_import)
+
+    try:
+        assert rl._load_rl_stack() is None
+        assert rl.is_rl_available() is False
+    finally:
+        rl._load_rl_stack.cache_clear()


### PR DESCRIPTION
## Motivation
- Torch can raise `NameError("_C")` during import on partially installed environments, which previously propagated past the RL optional dependency loader and broke the stubbed interface.

## Summary
- Treat any exception raised while importing `stable_baselines3`, `gymnasium`, or `torch` as a signal that the RL stack is unavailable and log the failure for diagnostics.
- Preserve the stubbed RL facade by returning `None` from `_load_rl_stack` when imports fail so `is_rl_available()` remains `False`.
- Add a regression test that simulates `torch` raising `NameError("_C")` and asserts the RL layer stays disabled.

## Before/After
- **Before:** Non-`ImportError` exceptions from the RL stack bubbled up and could crash callers expecting graceful degradation.
- **After:** All import exceptions are logged, the RL stack remains disabled, and callers continue to interact with the stubbed API safely.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rl_stack_imports.py -q`

## Rollback Plan
- Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68cc1de19bb083308f214ce603418eea