### PR TITLE
Ensure urllib3 disable warnings helper is resilient

### DIFF
--- a/tests/test_net_http_warning_guard.py
+++ b/tests/test_net_http_warning_guard.py
@@ -67,3 +67,26 @@ def test_disable_warnings_missing_attribute_can_be_monkeypatched():
         else:
             sys.modules.pop("urllib3", None)
         importlib.reload(http)
+
+
+def test_helper_restores_deleted_disable_warnings():
+    import ai_trading.net.http as http
+
+    urllib3 = importlib.import_module("urllib3")
+    original = getattr(urllib3, "disable_warnings", None)
+
+    if hasattr(urllib3, "disable_warnings"):
+        delattr(urllib3, "disable_warnings")
+
+    try:
+        http.ensure_urllib3_disable_warnings()
+        refreshed = importlib.import_module("urllib3")
+        assert hasattr(refreshed, "disable_warnings")
+        assert callable(refreshed.disable_warnings)
+    finally:
+        if original is not None:
+            setattr(urllib3, "disable_warnings", original)
+        else:
+            if hasattr(urllib3, "disable_warnings"):
+                delattr(urllib3, "disable_warnings")
+        importlib.reload(http)


### PR DESCRIPTION
## Summary
- add a reusable helper that re-imports urllib3, injects a callable disable_warnings shim when missing, and invoke it from every HTTP session accessor
- expose the helper for external callers and ensure TimeoutSession revalidates urllib3 safeguards on construction
- extend the urllib3 warning guard tests with a regression that verifies disable_warnings restoration after deletion

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_net_http_warning_guard.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc1fe1d8b88330ab29ca60dd9ada32