### PR TITLE
Include retry metadata in fetch attempt logs

### DIFF
--- a/tests/test_fetch_empty_retry_once.py
+++ b/tests/test_fetch_empty_retry_once.py
@@ -5,6 +5,8 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+pytest.importorskip("pandas")
+
 from ai_trading.data import fetch
 
 
@@ -92,6 +94,7 @@ def test_single_retry_and_warning(monkeypatch, caplog):
     assert calls[0][1] == "empty"
     assert calls[0][2]["correlation_id"] == "id1"
     assert "previous_correlation_id" not in calls[0][2]
+    assert calls[0][2]["delay"] == sleep_called["delay"]
     assert calls[1][1] is None
     assert calls[1][2]["correlation_id"] == "id2"
     assert calls[1][2]["previous_correlation_id"] == "id1"


### PR DESCRIPTION
## Summary
- coerce retry metadata for empty bar fetches into JSON primitives when scheduling a retry
- merge the retry metadata into the structured log payload so the upcoming delay is captured
- adjust the empty-fetch retry test to require pandas and assert the delay field appears in the logged extra

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_empty_retry_once.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc1de294848330a9e3b5f98a456bff