### PR TITLE
Raise EmptyBarsError for Alpaca retry limits

### DIFF
--- a/tests/test_empty_bar_backoff.py
+++ b/tests/test_empty_bar_backoff.py
@@ -111,8 +111,10 @@ def test_backoff_skips_when_alternate_empty(monkeypatch, caplog):
     monkeypatch.setattr(fetch, "_yahoo_get_bars", lambda *a, **k: pd.DataFrame())
 
     with caplog.at_level(logging.WARNING):
-        with pytest.raises(fetch.EmptyBarsError):
+        with pytest.raises(fetch.EmptyBarsError) as exc:
             fetch.get_minute_df(symbol, start, end)
+
+    assert str(exc.value).startswith("empty_bars")
 
     assert key in fetch._SKIPPED_SYMBOLS
     assert fetch._EMPTY_BAR_COUNTS[key] == fetch._EMPTY_BAR_THRESHOLD


### PR DESCRIPTION
## Summary
- raise `EmptyBarsError` when Alpaca empty responses hit retry limits or market closures instead of silently returning `None`
- extend empty bar handling tests to exercise the new error path and make helper sessions resilient to extra retry attempts
- add a regression test covering the Alpaca retry-limit log path

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_empty_handling.py tests/test_empty_bar_backoff.py tests/test_fetch_empty_retry_exhausted.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68cc24a25aec83308fbbd91f936cd6fe