### PR TITLE
Extend minute fetch window for long indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to this project will be documented in this file.
 - Meta-learning: WeightOptimizer now warns when provided an empty DataFrame.
 - Core: gate `ML_MODEL_MISSING` warning behind `AI_TRADING_WARN_IF_MODEL_MISSING` flag.
 - Data fetch: enforce rate limiter in `fetch.core` to comply with Alpaca quotas.
+- Minute data: `fetch_minute_df_safe` now stitches the prior RTH session into
+  morning windows so long-horizon intraday indicators (e.g., SMA-200) remain
+  populated during early trading.
 - Utils: `safe_subprocess_run` now returns a result object exposing `stdout`, `returncode`, and `timeout` flag.
 - Execution: convert market orders exceeding slippage threshold to limits with adjusted price and proportionally reduce quantity; record adjustments in trade log.
 


### PR DESCRIPTION
## Summary
- ensure `fetch_minute_df_safe` backfills prior RTH sessions until the window covers long intraday indicators
- add regression coverage verifying early session requests request at least 200 minutes of data
- document the behavior change in the changelog

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py -k extends --maxfail=1 *(skipped: pandas not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2cc447b483309afc87940461561a