### PR TITLE
Trigger meta-learning conversion after trade exits

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -5886,6 +5886,7 @@ class TradeLogger:
             logger.debug("TradeLogger entry log skipped; path not writable")
 
     def log_exit(self, state: BotState, symbol: str, exit_price: float) -> None:
+        updated_row: list[str] | None = None
         try:
             with open(self.path, "r+") as f:
                 _has_lock = hasattr(portalocker, "lock")
@@ -5935,6 +5936,7 @@ class TradeLogger:
                             else:
                                 row.append(conf)
                                 row.append(pnl * conf)
+                            updated_row = list(row)
                             break
                     f.seek(0)
                     f.truncate()
@@ -5947,6 +5949,10 @@ class TradeLogger:
         except PermissionError:
             logger.debug("TradeLogger exit log skipped; path not writable")
             return
+
+        trade_record: dict[str, Any] = (
+            dict(zip(header, updated_row)) if updated_row else {"symbol": symbol}
+        )
 
         # log reward
         try:
@@ -5997,6 +6003,7 @@ class TradeLogger:
         settings = get_settings()
         if settings.enable_sklearn:  # Meta-learning requires sklearn
             from ai_trading.meta_learning import (
+                trigger_meta_learning_conversion,
                 validate_trade_data_quality,
             )
             # from meta_learning import validate_trade_data_quality  # Legacy trigger reference
@@ -6008,7 +6015,14 @@ class TradeLogger:
                 logger.info(
                     "METALEARN_TRIGGER_CONVERSION: Converting audit format to meta-learning format"
                 )
-                # The conversion will be handled by the meta-learning system when it reads the log
+                try:
+                    trigger_meta_learning_conversion(trade_record)
+                except Exception as exc:  # noqa: BLE001
+                    logger.exception(
+                        "METALEARN_CONVERSION_FAILED",
+                        exc_info=exc,
+                        extra={"symbol": trade_record.get("symbol", symbol)},
+                    )
         else:
             logger.debug("Meta-learning disabled, skipping conversion")
 

--- a/tests/test_trade_logger_meta_conversion.py
+++ b/tests/test_trade_logger_meta_conversion.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import ai_trading.meta_learning as meta_learning
+from ai_trading.core import bot_engine
+
+
+def test_trade_logger_triggers_conversion_on_audit_rows(monkeypatch, tmp_path):
+    reward_log = tmp_path / "reward_log.csv"
+    trade_log = tmp_path / "trades.csv"
+
+    monkeypatch.setattr(bot_engine, "REWARD_LOG_FILE", str(reward_log))
+
+    trade_logger = bot_engine.TradeLogger(path=trade_log)
+    state = bot_engine.BotState()
+    state.capital_band = "small"
+
+    trade_logger.log_entry(
+        "AAPL",
+        price=100.0,
+        qty=1,
+        side="buy",
+        strategy="test_strategy",
+        confidence=0.6,
+    )
+
+    monkeypatch.setattr(
+        bot_engine,
+        "get_settings",
+        lambda: SimpleNamespace(enable_sklearn=True),
+    )
+    monkeypatch.setattr(
+        "ai_trading.config.get_settings",
+        lambda: SimpleNamespace(enable_sklearn=True),
+    )
+
+    conversion_calls: list[dict[str, object]] = []
+
+    def fake_trigger(trade_data: dict[str, object]) -> bool:
+        conversion_calls.append(trade_data)
+        return True
+
+    def fake_quality_report(_path: str) -> dict[str, int]:
+        return {"audit_format_rows": 2, "meta_format_rows": 0}
+
+    monkeypatch.setattr(meta_learning, "trigger_meta_learning_conversion", fake_trigger)
+    monkeypatch.setattr(meta_learning, "validate_trade_data_quality", fake_quality_report)
+
+    trade_logger.log_exit(state, "AAPL", 105.0)
+
+    assert len(conversion_calls) == 1
+    trade_data = conversion_calls[0]
+    assert trade_data.get("symbol") == "AAPL"
+    assert trade_data.get("exit_price") == 105.0


### PR DESCRIPTION
## Summary
- invoke `trigger_meta_learning_conversion` immediately after recording trade exits when audit-format rows are detected
- capture the updated trade record so the conversion helper receives the latest trade details
- add a regression test that patches the conversion helpers and asserts they are called during `TradeLogger.log_exit`

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_trade_logger_meta_conversion.py


------
https://chatgpt.com/codex/tasks/task_e_68cc2ccb58608330a613deda5f956466