### PR TITLE
Handle invalid sizing inputs in calculate_entry_size

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -10068,6 +10068,13 @@ def calculate_entry_size(
         logger.warning("Failed to get cash for entry size calculation: %s", exc)
         return 1
 
+    if price <= 0:
+        logger.info(
+            "SKIP_INVALID_PRICE",
+            extra={"symbol": symbol, "price": price},
+        )
+        return 0
+
     cap_pct = ctx.params.get("get_capital_cap()", get_capital_cap())
     cap_sz = int(round((cash * cap_pct) / price)) if price > 0 else 0
     df = ctx.data_fetcher.get_daily_df(ctx, symbol)
@@ -10077,8 +10084,26 @@ def calculate_entry_size(
         else np.array([0.0])
     )
     kelly_sz = fractional_kelly_size(ctx, cash, price, atr, win_prob)
+    if kelly_sz <= 0:
+        logger.info(
+            "SKIP_INVALID_KELLY_SIZE",
+            extra={"symbol": symbol, "kelly_sz": kelly_sz},
+        )
+        return 0
     vol_sz = vol_target_position_size(cash, price, rets, target_vol=0.02)
     dollar_cap = ctx.max_position_dollars / price if price > 0 else kelly_sz
+    if cap_sz <= 0:
+        logger.info(
+            "SKIP_CAP_SIZE_ZERO",
+            extra={"symbol": symbol, "cap_sz": cap_sz, "cash": cash, "cap_pct": cap_pct},
+        )
+        return 0
+    if dollar_cap <= 0:
+        logger.info(
+            "SKIP_DOLLAR_CAP_ZERO",
+            extra={"symbol": symbol, "dollar_cap": dollar_cap, "price": price},
+        )
+        return 0
     base = int(round(min(kelly_sz, vol_sz, cap_sz, dollar_cap, MAX_POSITION_SIZE)))
     factor = max(0.5, min(1.5, 1 + (win_prob - 0.5)))
     liq = liquidity_factor(ctx, symbol)

--- a/tests/test_kelly_confidence_fix.py
+++ b/tests/test_kelly_confidence_fix.py
@@ -5,6 +5,48 @@ This module tests that confidence values > 1.0 are properly normalized
 to valid probability ranges in the Kelly calculation.
 """
 import math
+import sys
+import types
+from types import SimpleNamespace
+
+if "numpy" not in sys.modules:  # pragma: no cover - lightweight stub for tests
+    numpy_stub = types.ModuleType("numpy")
+    numpy_stub.nan = float("nan")
+    numpy_stub.NaN = numpy_stub.nan
+    numpy_stub.array = lambda data, *_, **__: list(data)
+    numpy_stub.asarray = lambda data, *_, **__: list(data)
+    numpy_stub.std = lambda data, *_, **__: 1.0
+    numpy_stub.diff = lambda arr: [b - a for a, b in zip(arr, arr[1:])]
+    numpy_stub.where = lambda cond, x, y: [
+        (xi if bool(ci) else yi) for ci, xi, yi in zip(cond, x, y)
+    ]
+    numpy_stub.zeros_like = lambda arr: [0 for _ in arr]
+    numpy_stub.zeros = lambda shape, dtype=None: [0.0] * shape if isinstance(shape, int) else []
+    numpy_stub.mean = lambda data: (sum(data) / len(data)) if data else 0.0
+    numpy_stub.exp = math.exp
+    numpy_stub.float64 = float
+    numpy_stub.ndarray = list
+    numpy_stub.random = types.SimpleNamespace(seed=lambda *_a, **_k: None)
+    sys.modules["numpy"] = numpy_stub
+
+if "portalocker" not in sys.modules:  # pragma: no cover - lightweight stub for tests
+    portalocker_stub = types.ModuleType("portalocker")
+    portalocker_stub.LOCK_EX = 1
+    portalocker_stub.LOCK_SH = 0
+    portalocker_stub.lock = lambda *_a, **_k: None
+    portalocker_stub.unlock = lambda *_a, **_k: None
+    sys.modules["portalocker"] = portalocker_stub
+
+if "bs4" not in sys.modules:  # pragma: no cover - lightweight stub for tests
+    bs4_stub = types.ModuleType("bs4")
+
+    class _BeautifulSoup:  # pragma: no cover - minimal placeholder
+        def __init__(self, *args, **kwargs) -> None:
+            self.args = args
+            self.kwargs = kwargs
+
+    bs4_stub.BeautifulSoup = _BeautifulSoup
+    sys.modules["bs4"] = bs4_stub
 
 # Test the actual import and function from bot_engine
 import pytest
@@ -85,6 +127,89 @@ def test_kelly_input_validation():
     except ImportError:
         # Skip if we can't import the actual function
         pytest.skip("Cannot import fractional_kelly_size function")
+
+
+def test_calculate_entry_size_zero_price(monkeypatch, caplog):
+    """Ensure calculate_entry_size skips symbols with invalid pricing data."""
+
+    from ai_trading.core.bot_engine import calculate_entry_size
+
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+
+    class _DummySeries:
+        def __init__(self, values):
+            self._values = list(values)
+
+        def pct_change(self, fill_method=None):  # noqa: D401 - minimal stub
+            changes = []
+            for idx in range(1, len(self._values)):
+                prev = self._values[idx - 1]
+                curr = self._values[idx]
+                changes.append(((curr - prev) / prev) if prev else 0.0)
+            return _DummySeries(changes or [0.0])
+
+        def dropna(self):  # noqa: D401 - minimal stub
+            return self
+
+        @property
+        def values(self):  # noqa: D401 - minimal stub
+            return self._values
+
+    class _DummyDataFrame:
+        empty = False
+
+        def __init__(self, close_values):
+            self._close = _DummySeries(close_values)
+
+        def __getitem__(self, key):  # noqa: D401 - minimal stub
+            if key != "close":
+                raise KeyError(key)
+            return self._close
+
+    daily_df = _DummyDataFrame([100.0, 101.0, 102.0])
+
+    class _DummyAPI:
+        def get_account(self):
+            return SimpleNamespace(cash="10000")
+
+    class _DummyFetcher:
+        def get_daily_df(self, *_args, **_kwargs):
+            return daily_df
+
+    class _DummyQuote:
+        ask_price = 100.5
+        bid_price = 100.0
+
+    class _DummyDataClient:
+        def get_stock_latest_quote(self, *_args, **_kwargs):
+            return _DummyQuote()
+
+    ctx = SimpleNamespace(
+        api=_DummyAPI(),
+        data_fetcher=_DummyFetcher(),
+        data_client=_DummyDataClient(),
+        volume_threshold=100_000,
+        params={},
+        max_position_dollars=10_000.0,
+    )
+
+    caplog.set_level("INFO")
+    size = calculate_entry_size(ctx, "TEST", price=0.0, atr=1.0, win_prob=0.6)
+
+    assert size == 0
+    assert any("SKIP_INVALID_PRICE" in rec.message for rec in caplog.records)
+
+    caplog.clear()
+
+    monkeypatch.setattr(
+        "ai_trading.core.bot_engine.fractional_kelly_size",
+        lambda *args, **kwargs: 0,
+    )
+
+    size = calculate_entry_size(ctx, "TEST", price=100.0, atr=1.0, win_prob=0.6)
+
+    assert size == 0
+    assert any("SKIP_INVALID_KELLY_SIZE" in rec.message for rec in caplog.records)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- skip entry sizing when the upstream inputs (price, capital cap, dollar cap, Kelly) are non-positive so symbols get marked as skips
- emit explicit SKIP_* log messages for each invalid sizing condition so operators can see why a symbol was ignored
- extend the Kelly confidence test module with lightweight dependency stubs and new coverage for zero-price and invalid Kelly sizing scenarios

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_kelly_confidence_fix.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc4d4842e083308aabf7d286f3db01