### PR TITLE
Improve Alpaca price fallback handling

### DIFF
--- a/tests/test_get_latest_price_fallback.py
+++ b/tests/test_get_latest_price_fallback.py
@@ -2,16 +2,95 @@
 
 from __future__ import annotations
 
-import pandas as pd
+import sys
+import types
+
+try:  # pragma: no cover - optional dependency in test env
+    import pandas as pd  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - provide minimal stub
+    pd = None
+
+    class _FakeILoc:
+        def __init__(self, value: float) -> None:
+            self._value = value
+
+        def __getitem__(self, idx: int) -> float:
+            if idx == -1:
+                return self._value
+            raise IndexError(idx)
+
+    class _FakeSeries:
+        def __init__(self, value: float) -> None:
+            self._value = value
+            self.iloc = _FakeILoc(value)
+
+    class _FakeDataFrame:
+        def __init__(self, value: float) -> None:
+            self._value = value
+            self.empty = False
+
+        def __getitem__(self, key: str) -> _FakeSeries:
+            if key != "close":
+                raise KeyError(key)
+            return _FakeSeries(self._value)
+
+
+def _df(price: float):
+    if pd is not None:
+        return pd.DataFrame({"close": [price]})
+    return _FakeDataFrame(price)
+
+
+if "numpy" not in sys.modules:  # pragma: no cover - optional dependency stub
+    class _NumpyStub(types.ModuleType):
+        def __init__(self) -> None:
+            super().__init__("numpy")
+            self.ndarray = object
+            self.nan = float("nan")
+            self.NAN = self.nan
+            self.float64 = float
+            self.random = types.SimpleNamespace(seed=lambda *_, **__: None)
+            self.isscalar = lambda _v: True
+            self.bool_ = bool
+
+        def __getattr__(self, name: str):  # noqa: D401 - stub fallback
+            def _stub(*args, **kwargs):  # noqa: ANN001, ANN002
+                raise NotImplementedError(f"numpy stub invoked for {name}")
+
+            return _stub
+
+    sys.modules["numpy"] = _NumpyStub()
+
+
+if "portalocker" not in sys.modules:  # pragma: no cover - optional dependency stub
+    portalocker_stub = types.ModuleType("portalocker")
+    portalocker_stub.LOCK_EX = 1
+    portalocker_stub.LockException = RuntimeError
+    portalocker_stub.AlreadyLocked = RuntimeError
+
+    def _noop_lock(*args, **kwargs):  # noqa: D401 - stub
+        return None
+
+    portalocker_stub.lock = _noop_lock
+    portalocker_stub.unlock = _noop_lock
+    sys.modules["portalocker"] = portalocker_stub
+
+
+if "bs4" not in sys.modules:  # pragma: no cover - optional dependency stub
+    bs4_stub = types.ModuleType("bs4")
+
+    class _BeautifulSoup:  # noqa: D401 - minimal stub
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - stub
+            raise NotImplementedError("BeautifulSoup stub invoked")
+
+    bs4_stub.BeautifulSoup = _BeautifulSoup
+    sys.modules["bs4"] = bs4_stub
+
 
 import ai_trading.alpaca_api as alpaca_api
 from ai_trading.alpaca_api import AlpacaAuthenticationError, is_alpaca_service_available
 from ai_trading.core import bot_engine
 import ai_trading.data.fetch as data_fetcher
-
-
-def _df(price: float) -> pd.DataFrame:
-    return pd.DataFrame({"close": [price]})
 
 
 def test_get_latest_price_uses_yahoo_when_alpaca_none(monkeypatch):
@@ -36,6 +115,36 @@ def test_get_latest_price_uses_yahoo_when_alpaca_none(monkeypatch):
 
     assert called["yahoo"]
     assert price == 101.0
+
+
+def test_get_latest_price_uses_alpaca_bid_when_ask_invalid(monkeypatch):
+    """Positive bid/last data should prevent Yahoo fallback when ask is invalid."""
+
+    monkeypatch.setattr(bot_engine, "_PRICE_SOURCE", {})
+    monkeypatch.setattr(
+        "ai_trading.core.bot_engine.is_alpaca_service_available",
+        lambda: True,
+    )
+
+    def fake_alpaca_get(*_a, **_k):
+        return {
+            "ap": 0.0,
+            "bp": 94.5,
+            "last": {"price": 95.1},
+            "midpoint": 94.8,
+        }
+
+    monkeypatch.setattr(bot_engine, "_alpaca_symbols", lambda: (fake_alpaca_get, None))
+
+    def yahoo_fail(*_a, **_k):  # pragma: no cover - defensive
+        raise AssertionError("Yahoo fallback should not run when Alpaca provides prices")
+
+    monkeypatch.setattr(data_fetcher, "_backup_get_bars", yahoo_fail)
+
+    price = bot_engine.get_latest_price("AAPL")
+
+    assert price == 94.5
+    assert bot_engine._PRICE_SOURCE["AAPL"] == "alpaca_bid"
 
 
 def test_get_latest_price_uses_latest_close_when_providers_fail(monkeypatch):

--- a/tests/unit/test_price_quote_feed.py
+++ b/tests/unit/test_price_quote_feed.py
@@ -86,7 +86,7 @@ def test_get_latest_price_uses_configured_feed(monkeypatch):
         == f"https://data.alpaca.markets/v2/stocks/{symbol}/quotes/latest"
     )
     assert captured["params"] == {"feed": "sip"}
-    assert bot_engine._PRICE_SOURCE[symbol] == "alpaca"
+    assert bot_engine._PRICE_SOURCE[symbol] == "alpaca_ask"
 
 
 def test_get_latest_price_http_error_falls_back(monkeypatch):


### PR DESCRIPTION
## Summary
- expand `get_latest_price` to consider Alpaca ask, bid, last, and midpoint quotes before falling back
- adjust `_PRICE_SOURCE` tracking and unit tests to reflect the specific Alpaca price field used
- add regression coverage ensuring Yahoo fallback is skipped when Alpaca provides a positive bid and stub optional deps for isolated tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_get_latest_price_fallback.py tests/unit/test_price_quote_feed.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc62e5a054833083b89711098bc36c