### PR TITLE
Handle recoverable equity fetch errors with zero cache

### DIFF
--- a/ai_trading/core/runtime.py
+++ b/ai_trading/core/runtime.py
@@ -100,7 +100,7 @@ def build_runtime(cfg: TradingConfig, **kwargs: Any) -> BotRuntime:
     eq = getattr(cfg, "equity", None)
     if eq in (None, 0.0):
         fetched = _get_equity_from_alpaca(cfg, force_refresh=True)
-        eq = fetched if fetched > 0 else None
+        eq = fetched if (fetched is not None and fetched > 0) else None
         try:
             object.__setattr__(cfg, "equity", eq)
         except Exception:

--- a/ai_trading/exc.py
+++ b/ai_trading/exc.py
@@ -11,7 +11,13 @@ except ImportError:
 
     class RequestException(Exception):
         pass
-    HTTPError = Exception
+
+    class HTTPError(Exception):
+        """Fallback HTTPError with optional response attribute."""
+
+        def __init__(self, *args, response=None, **kwargs):  # noqa: D401 - simple passthrough
+            super().__init__(*args)
+            self.response = response
 COMMON_EXC = (TypeError, ValueError, KeyError, JSONDecodeError, RequestException, TimeoutError, ImportError)
 TRANSIENT_HTTP_EXC = (RequestException, HTTPError, TimeoutError, OSError, ConnectionError)
 


### PR DESCRIPTION
## Summary
- return 0.0 for recoverable Alpaca equity fetch failures and clear cached values on unexpected errors
- guard runtime equity refresh to ignore zero-valued fetches and add a fallback HTTPError class response attribute for testing

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_max_position_size.py -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_position_sizing_error_handling.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc7c02a35c8330a1a837f4a8b507cc