### PR TITLE
Handle logging defaults when settings missing

### DIFF
--- a/tests/test_logging_setup_idempotent.py
+++ b/tests/test_logging_setup_idempotent.py
@@ -1,4 +1,6 @@
+import importlib
 import logging
+from unittest import mock
 
 import ai_trading.logging as L
 
@@ -39,4 +41,49 @@ def test_setup_logging_idempotent():
                     pass
             L._listener = None
             L._log_queue = None
+
+
+def test_logging_reload_with_null_settings(monkeypatch):
+    """Reload module when settings resolve to ``None`` without error."""
+
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+
+    root = logging.getLogger()
+    original_handlers = root.handlers.copy()
+
+    try:
+        root.handlers.clear()
+        with L._LOGGING_LOCK:
+            L._LOGGING_CONFIGURED = False
+            L._configured = False
+            if L._listener is not None:
+                try:
+                    L._listener.stop()
+                except Exception:
+                    pass
+            L._listener = None
+            L._log_queue = None
+
+        with mock.patch("ai_trading.config.get_settings", return_value=None):
+            reloaded = importlib.reload(L)
+            logger = reloaded.setup_logging()
+            assert isinstance(logger, logging.Logger)
+
+            handlers = [h for h in logging.getLogger().handlers if getattr(h, "formatter", None)]
+            assert handlers, "expected at least one configured handler"
+            assert any(isinstance(h.formatter, reloaded.JSONFormatter) for h in handlers)
+
+    finally:
+        root.handlers = original_handlers
+        with L._LOGGING_LOCK:
+            L._LOGGING_CONFIGURED = False
+            L._configured = False
+            if L._listener is not None:
+                try:
+                    L._listener.stop()
+                except Exception:
+                    pass
+            L._listener = None
+            L._log_queue = None
+        importlib.reload(L)
 


### PR DESCRIPTION
## Motivation
- `ai_trading.logging` assumed `get_settings()` always returned an object, so returning `None` during early startup caused attribute errors and missing defaults.

## Summary
- Guard all settings access with `getattr` fallbacks so JSON formatting and log levels fall back to the existing environment defaults when settings are absent.
- Ensure the HTTP log level also reuses the environment/config defaults without assuming a truthy settings object.
- Add a regression test that reloads the logging module with `get_settings()` returning `None` to verify graceful configuration.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_logging_setup_idempotent.py -q`

## Rollback Plan
- Revert this commit.


------
https://chatgpt.com/codex/tasks/task_e_68cc7c01c5888330a7595b8e47219747