### PR TITLE
Ensure fallback concurrency scans nested dataclasses

### DIFF
--- a/ai_trading/data/fallback/concurrency.py
+++ b/ai_trading/data/fallback/concurrency.py
@@ -119,6 +119,13 @@ async def run_with_concurrency(
                 except AttributeError:
                     continue
                 _scan(value, seen)
+            try:
+                extra_attrs = vars(obj)
+            except TypeError:
+                extra_attrs = None
+            if extra_attrs:
+                for value in extra_attrs.values():
+                    _scan(value, seen)
             return
         if isinstance(obj, SimpleNamespace):
             for value in vars(obj).values():


### PR DESCRIPTION
## Summary
- extend the fallback concurrency scanner to walk attributes referenced through dataclass __dict__ entries while still deduplicating visits
- add a regression test that exercises nested dataclass lock holders to ensure foreign loop locks are rebound and execution completes

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/data/test_fallback_concurrency.py

------
https://chatgpt.com/codex/tasks/task_e_68cc834a7e1c83308ceeed009a53439f