### PR TITLE
Handle non-list client order id containers

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -9947,9 +9947,27 @@ def safe_submit_order(api: Any, req, *, bypass_market_check: bool = False) -> Or
             cid = _gen_id("ai")
             order_args["client_order_id"] = cid
             ids = getattr(api, "client_order_ids", None)
-            if ids is None:
-                setattr(api, "client_order_ids", [])
-                ids = api.client_order_ids
+            if isinstance(ids, list):
+                ids_list = ids
+            else:
+                if ids is None:
+                    ids_list: list[Any] = []
+                elif isinstance(ids, (tuple, set)):
+                    ids_list = list(ids)
+                else:
+                    ids_list = []
+                assigned = False
+                try:
+                    setattr(api, "client_order_ids", ids_list)
+                except (AttributeError, TypeError):
+                    assigned = False
+                else:
+                    assigned = True
+                if assigned:
+                    refreshed = getattr(api, "client_order_ids", ids_list)
+                    if isinstance(refreshed, list):
+                        ids_list = refreshed
+                ids = ids_list
             ids.append(cid)
         except (ImportError, AttributeError):
             pass


### PR DESCRIPTION
## Summary
- update `safe_submit_order` to normalize `api.client_order_ids` to a mutable list before appending
- allow tuple/set client ID stores to be converted without silent append failures

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_safe_submit_order.py -k "test_safe_submit_order_pending_new or test_safe_submit_order_generates_id"


------
https://chatgpt.com/codex/tasks/task_e_68cc96e0b8e88330aa0475f706e35f14