### PR TITLE
Ensure sys import is grouped correctly in safe_submit_order tests

### DIFF
--- a/tests/test_safe_submit_order.py
+++ b/tests/test_safe_submit_order.py
@@ -1,5 +1,6 @@
 import sys
 import types
+
 import pytest
 
 


### PR DESCRIPTION
## Summary
- adjust the import block in tests/test_safe_submit_order.py so the sys import appears before third-party imports

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_safe_submit_order.py

------
https://chatgpt.com/codex/tasks/task_e_68ccc43c3cd48330bec624c16150296c