### PR TITLE
Ensure RL train module assignment overwrites placeholder

### DIFF
--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -153,7 +153,7 @@ def _load_train_module() -> Any:
         raise AttributeError(
             f"module {__name__!r} has no attribute 'train'"
         ) from exc
-    sys.modules.setdefault("ai_trading.rl_trading.train", module)
+    sys.modules["ai_trading.rl_trading.train"] = module
     globals()["train"] = module
     return module
 


### PR DESCRIPTION
## Summary
- replace the lazy train module registration to always assign the imported module into sys.modules so placeholders are overwritten

## Motivation & Context
- ensure `_load_train_module` always returns the fresh module even if a placeholder already exists in `sys.modules`

## Before & After
- before: `sys.modules.setdefault` kept any existing placeholder module
- after: the imported module always overwrites the registry entry

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rl_module.py

## Rollback Plan
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68ccc952629c8330ab2cff77bd137ad5