### PR TITLE
Normalize Finnhub minute bars in fallback

### DIFF
--- a/tests/test_finnhub_symbol_processing.py
+++ b/tests/test_finnhub_symbol_processing.py
@@ -15,8 +15,18 @@ def test_get_minute_df_uses_finnhub_when_key(monkeypatch):
         is_stub = False
         def fetch(self, symbol, start, end, resolution="1"):
             called["called"] = True
-            return pd.DataFrame({"t": [1, 2], "c": [1.0, 2.0]})
+            return pd.DataFrame(
+                {
+                    "t": [1, 2],
+                    "o": [1.0, 1.5],
+                    "h": [1.2, 2.1],
+                    "l": [0.9, 1.8],
+                    "c": [1.0, 2.0],
+                    "v": [100, 150],
+                }
+            )
     monkeypatch.setattr(fetch, "fh_fetcher", DummyFetcher())
     df = fetch.get_minute_df("AAPL", "2024-01-01", "2024-01-02")
     assert called.get("called") is True
-    assert list(df["c"]) == [1.0, 2.0]
+    assert list(df["close"]) == [1.0, 2.0]
+    assert set(df.columns) >= {"timestamp", "open", "high", "low", "close", "volume"}


### PR DESCRIPTION
## Summary
- route Finnhub minute fallback through the shared normalization helper so OHLCV columns are canonical
- tolerate AttributeError from Alpaca fetch attempts when requests is unavailable so backup providers engage
- update Finnhub symbol processing test fixtures to mimic full OHLCV payloads and assert canonical columns
- silence pandas FutureWarning during timestamp normalization to keep Finnhub frames populated under warnings-as-errors

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_finnhub_*

------
https://chatgpt.com/codex/tasks/task_e_68cccde745f48330bea3fb1b360dda9e