### PR TITLE
Adjust fallback price logging for Alpaca sources

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -10981,7 +10981,8 @@ def _enter_long(
             extra={"symbol": symbol, "price_source": price_source},
         )
         return True
-    if price_source != "alpaca":
+    is_alpaca_source = isinstance(price_source, str) and price_source.lower().startswith("alpaca")
+    if not is_alpaca_source:
         logger.info(
             "ORDER_USING_FALLBACK_PRICE",
             extra={"symbol": symbol, "price_source": price_source},
@@ -11198,7 +11199,8 @@ def _enter_short(
             extra={"symbol": symbol, "price_source": price_source},
         )
         return True
-    if price_source != "alpaca":
+    is_alpaca_source = isinstance(price_source, str) and price_source.lower().startswith("alpaca")
+    if not is_alpaca_source:
         logger.info(
             "ORDER_USING_FALLBACK_PRICE",
             extra={"symbol": symbol, "price_source": price_source},

--- a/tests/bot_engine/test_bot_engine.py
+++ b/tests/bot_engine/test_bot_engine.py
@@ -365,3 +365,193 @@ def test_enter_long_uses_feature_close_when_quote_invalid(monkeypatch, caplog):
     assert any("FALLBACK_TO_FEATURE_CLOSE" in rec.message for rec in caplog.records)
     assert not any("computed qty <= 0" in rec.message for rec in caplog.records)
     assert bot_engine._PRICE_SOURCE[symbol] == "feature_close"
+
+
+def test_enter_long_logs_fallback_only_for_non_alpaca(monkeypatch, caplog):
+    pd = pytest.importorskip("pandas")
+
+    symbol = "AAPL"
+    orders: list[tuple[str, int, str, float | None]] = []
+
+    class _DummyAPI:
+        def list_positions(self):  # noqa: D401, ANN001 - minimal stub
+            return []
+
+        def get_account(self):  # noqa: D401 - minimal stub
+            return types.SimpleNamespace(equity=100000.0, portfolio_value=100000.0)
+
+    class _Logger:
+        def log_entry(self, *args, **kwargs):  # noqa: D401 - capture call
+            return (args, kwargs)
+
+        def log_exit(self, *args, **kwargs):  # noqa: D401 - unused in test
+            return None
+
+    feat_df = pd.DataFrame(
+        {
+            "close": [100.0, 101.0],
+            "open": [99.5, 100.5],
+            "high": [101.0, 102.0],
+            "low": [99.0, 100.0],
+            "volume": [1_000, 1_200],
+            "macd": [0.1, 0.2],
+            "atr": [1.0, 1.0],
+            "vwap": [100.2, 100.6],
+            "macds": [0.05, 0.05],
+            "sma_50": [99.0, 99.5],
+            "sma_200": [95.0, 95.5],
+        }
+    )
+
+    ctx = types.SimpleNamespace(
+        portfolio_weights={symbol: 0.02},
+        api=_DummyAPI(),
+        trade_logger=_Logger(),
+        take_profit_targets={},
+        stop_targets={},
+        market_open=time(6, 30),
+        market_close=time(13, 0),
+        config=types.SimpleNamespace(exposure_cap_aggressive=0.9),
+    )
+
+    monkeypatch.delenv("PYTEST_RUNNING", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    monkeypatch.setattr(bot_engine, "_apply_sector_cap_qty", lambda _ctx, _sym, qty, _price: qty)
+    monkeypatch.setattr(bot_engine, "scaled_atr_stop", lambda **_k: (95.95, 106.05))
+    monkeypatch.setattr(bot_engine, "is_high_vol_regime", lambda: False)
+    monkeypatch.setattr(bot_engine, "get_take_profit_factor", lambda: 1.0)
+    monkeypatch.setattr(bot_engine, "_record_trade_in_frequency_tracker", lambda *a, **k: None)
+    monkeypatch.setattr(
+        bot_engine,
+        "submit_order",
+        lambda _ctx, sym, qty, side, price=None: orders.append((sym, qty, side, price))
+        or types.SimpleNamespace(id="order-1"),
+    )
+    monkeypatch.setattr(bot_engine, "get_latest_price", lambda _symbol: 101.0)
+    monkeypatch.setattr(bot_engine, "_PRICE_SOURCE", {}, raising=False)
+
+    def _run_with_source(price_source: str) -> list[str]:
+        caplog.clear()
+        ctx.stop_targets.clear()
+        ctx.take_profit_targets.clear()
+        bot_engine._PRICE_SOURCE.clear()
+        bot_engine._PRICE_SOURCE[symbol] = price_source
+        state = bot_engine.BotState()
+        with caplog.at_level("INFO"):
+            assert (
+                bot_engine._enter_long(
+                    ctx,
+                    state,
+                    symbol,
+                    balance=100000.0,
+                    feat_df=feat_df,
+                    final_score=1.0,
+                    conf=0.8,
+                    strat="fallback_source_test",
+                )
+                is True
+            )
+        return [rec.message for rec in caplog.records if rec.message == "ORDER_USING_FALLBACK_PRICE"]
+
+    fallback_logs = _run_with_source("feature_close")
+    assert fallback_logs
+
+    fallback_logs_alpaca_variant = _run_with_source("alpaca_stream")
+    assert not fallback_logs_alpaca_variant
+
+
+def test_enter_short_logs_fallback_only_for_non_alpaca(monkeypatch, caplog):
+    pd = pytest.importorskip("pandas")
+
+    symbol = "AAPL"
+    orders: list[tuple[str, int, str, float | None]] = []
+
+    class _DummyAPI:
+        def get_asset(self, _symbol):  # noqa: D401, ANN001 - minimal stub
+            return types.SimpleNamespace(shortable=True, shortable_shares=500)
+
+        def get_account(self):  # noqa: D401 - minimal stub
+            return types.SimpleNamespace(equity=100000.0)
+
+    class _Logger:
+        def log_entry(self, *args, **kwargs):  # noqa: D401 - capture call
+            return (args, kwargs)
+
+        def log_exit(self, *args, **kwargs):  # noqa: D401 - unused in test
+            return None
+
+    feat_df = pd.DataFrame(
+        {
+            "close": [100.0, 101.0],
+            "open": [99.5, 100.5],
+            "high": [101.0, 102.0],
+            "low": [99.0, 100.0],
+            "volume": [1_000, 1_200],
+            "macd": [0.1, 0.2],
+            "atr": [1.0, 1.0],
+            "vwap": [100.2, 100.6],
+            "macds": [0.05, 0.05],
+            "sma_50": [99.0, 99.5],
+            "sma_200": [95.0, 95.5],
+        }
+    )
+
+    ctx = types.SimpleNamespace(
+        api=_DummyAPI(),
+        trade_logger=_Logger(),
+        take_profit_targets={},
+        stop_targets={},
+        market_open=time(6, 30),
+        market_close=time(13, 0),
+    )
+
+    monkeypatch.delenv("PYTEST_RUNNING", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    monkeypatch.setattr(bot_engine, "_apply_sector_cap_qty", lambda _ctx, _sym, qty, _price: qty)
+    monkeypatch.setattr(bot_engine, "scaled_atr_stop", lambda **_k: (95.95, 106.05))
+    monkeypatch.setattr(bot_engine, "is_high_vol_regime", lambda: False)
+    monkeypatch.setattr(bot_engine, "get_take_profit_factor", lambda: 1.0)
+    monkeypatch.setattr(bot_engine, "_record_trade_in_frequency_tracker", lambda *a, **k: None)
+    monkeypatch.setattr(bot_engine, "calculate_entry_size", lambda *_a, **_k: 10)
+    monkeypatch.setattr(
+        bot_engine,
+        "submit_order",
+        lambda _ctx, sym, qty, side, price=None: orders.append((sym, qty, side, price))
+        or types.SimpleNamespace(id="order-1"),
+    )
+    monkeypatch.setattr(bot_engine, "get_latest_price", lambda _symbol: 101.0)
+    monkeypatch.setattr(bot_engine, "_PRICE_SOURCE", {}, raising=False)
+
+    def _run_with_source(price_source: str) -> list[str]:
+        caplog.clear()
+        ctx.stop_targets.clear()
+        ctx.take_profit_targets.clear()
+        bot_engine._PRICE_SOURCE.clear()
+        bot_engine._PRICE_SOURCE[symbol] = price_source
+        state = bot_engine.BotState()
+        with caplog.at_level("INFO"):
+            assert (
+                bot_engine._enter_short(
+                    ctx,
+                    state,
+                    symbol,
+                    feat_df=feat_df,
+                    final_score=-1.0,
+                    conf=0.8,
+                    strat="fallback_source_test",
+                )
+                is True
+            )
+        return [rec.message for rec in caplog.records if rec.message == "ORDER_USING_FALLBACK_PRICE"]
+
+    fallback_logs = _run_with_source("feature_close")
+    assert fallback_logs
+
+    fallback_logs_alpaca_variant = _run_with_source("alpaca_secondary")
+    assert not fallback_logs_alpaca_variant
+
+


### PR DESCRIPTION
## Summary
- treat any price source starting with "alpaca" as primary so fallback price logging only fires for true non-Alpaca sources
- extend bot engine tests to cover the updated logging behavior for long and short entries

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_bot_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68cd76d114fc83308fb47a4bd88d759f