### PR TITLE
Fix fallback price logging for Alpaca sources

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -654,7 +654,14 @@ _PRIMARY_PRICE_SOURCES = frozenset(
 def _is_primary_price_source(source: str) -> bool:
     """Return ``True`` when *source* represents Alpaca-provided pricing."""
 
-    return source in _PRIMARY_PRICE_SOURCES
+    if not source:
+        return False
+    normalized = source.strip().lower()
+    if not normalized:
+        return False
+    if normalized.startswith("alpaca"):
+        return True
+    return normalized in _PRIMARY_PRICE_SOURCES
 logger = get_logger(__name__)
 
 def _alpaca_diag_info() -> dict[str, object]:


### PR DESCRIPTION
## Summary
- treat any price source beginning with "alpaca" as a primary source when deciding whether to log fallback pricing usage
- add focused unit tests for long and short entries to ensure Alpaca-prefixed price sources do not emit fallback logs while other providers still do

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_bot_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68cd7b9784748330a96322f6a1cfacda