### PR TITLE
Defer trading config hydration until runtime

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -781,6 +781,13 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_cli(argv)
     global config
     config = S = get_settings()
+    # Initialize TradingConfig-backed overrides (import-safe)
+    try:
+        from ai_trading.core import bot_engine as _be
+
+        _be.initialize_runtime_config()
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("RUNTIME_CONFIG_INIT_SKIPPED", exc_info=True)
     try:
         _assert_singleton_api(S)
     except PortInUseError as exc:


### PR DESCRIPTION
## Summary
- keep `ai_trading.core.bot_engine` import-safe by deferring TradingConfig overrides to a runtime initializer
- invoke the initializer from `ai_trading.main` once settings are loaded so sizing limits stay in sync
- lazily resolve TradingConfig in `scripts/predict.py` to avoid import-time environment coupling

## Motivation
- **Before:** importing `ai_trading.core.bot_engine` or `scripts.predict` attempted to hydrate `TradingConfig.from_env()` immediately, which crashed when `.env` had not been loaded yet and prevented safe module preflights.
- **After:** both modules import without side effects; runtime code explicitly calls an initializer after configuration is ready, so overrides like `MAX_POSITION_SIZE` and `DOLLAR_RISK_LIMIT` are still applied.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_import_side_effects.py::test_module_imports_without_heavy_stacks` *(fails: `ai_trading.__main__` consumes pytest argv and exits 2; pre-existing behavior)*

## Rollback Plan
- Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68cd914823cc83308d21407e241085c2