### PR TITLE
Improve SIP fallback coverage and execution guardrails

### DIFF
--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -280,7 +280,7 @@ class Settings(BaseSettings):
     @classmethod
     def _enforce_allowed_feed(cls, v: str) -> str:
         """Force IEX feed unless SIP explicitly allowed."""
-        allow_sip = os.getenv('ALPACA_ALLOW_SIP', '').strip().lower() in {
+        allow_sip = str(os.getenv('ALPACA_ALLOW_SIP', '0')).strip().lower() in {
             '1',
             'true',
             'yes',
@@ -304,7 +304,7 @@ class Settings(BaseSettings):
     @field_validator('alpaca_feed_failover', mode='after')
     @classmethod
     def _normalize_feed_failover(cls, v: tuple[str, ...]) -> tuple[str, ...]:
-        allow_sip = os.getenv('ALPACA_ALLOW_SIP', '').strip().lower() in {
+        allow_sip = str(os.getenv('ALPACA_ALLOW_SIP', '0')).strip().lower() in {
             '1',
             'true',
             'yes',


### PR DESCRIPTION
## Summary
- add a targeted SIP recovery attempt when IEX minute coverage is thin so Alpaca consolidated tape is reused instead of falling back to Yahoo
- fail fast when live execution is requested without Alpaca credentials and tighten ALPACA_ALLOW_SIP parsing
- only expose the live execution engine when credentials are present, otherwise retain the simulator implementation

## Testing
- pytest tests/execution/test_execution_imports.py
- pytest tests/bot_engine/test_bot_engine.py


------
https://chatgpt.com/codex/tasks/task_e_68cdac25b76c8330ad92bacb89e09b92