### PR TITLE
Enable SIP fallback and skip invalid price symbols

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -1269,8 +1269,19 @@ def fetch_daily_data_async(
 _FETCHER_SINGLETON: Any | None = None
 
 
-def build_fetcher(config: Any):
+def build_fetcher(
+    config: Any | None = None,
+    *,
+    prefer: str | None = None,
+    force_feed: str | None = None,
+):
     """Return a market data fetcher with safe fallbacks."""
+
+    if prefer or force_feed:
+        fetcher = DataFetcher(prefer=prefer, force_feed=force_feed)
+        setattr(fetcher, "source", "alpaca")
+        return fetcher
+
     global _FETCHER_SINGLETON
     if _FETCHER_SINGLETON is not None:
         return _FETCHER_SINGLETON

--- a/ai_trading/data/fetch/sip_disallowed.py
+++ b/ai_trading/data/fetch/sip_disallowed.py
@@ -1,76 +1,21 @@
+"""Helpers for deciding whether the SIP feed may be used."""
+
 from __future__ import annotations
 
-"""Lightweight helpers for handling disallowed SIP feed requests.
-
-This module mirrors a minimal subset of :mod:`ai_trading.data.fetch` to allow
-isolated testing.  When the SIP feed is disabled, requests should fall back to
-IEX while still recording that ``sip`` was originally requested.
-"""
-
-from datetime import datetime
-from typing import Any
-
-from ai_trading.utils.lazy_imports import load_pandas
-
-# Re-use shared state from the package's ``__init__`` module.
-from . import _HTTP_SESSION, _ALLOW_SIP
-
-pd = load_pandas()
+from ai_trading.utils.environment import env
 
 
-def _to_df(payload: dict[str, Any]):
-    """Return a pandas DataFrame for ``payload`` bars."""
-    bars = payload.get("bars", [])
-    if pd is None:  # pragma: no cover - defensive
-        return bars
-    try:  # pragma: no cover - optional pandas
-        return pd.DataFrame(bars)
-    except Exception:
-        return bars
+def sip_disallowed() -> bool:
+    """Return ``True`` when the SIP feed should not be used."""
+
+    if not env.ALPACA_ALLOW_SIP:
+        return True
+
+    has_creds = bool(env.ALPACA_KEY) and bool(env.ALPACA_SECRET)
+    if hasattr(env, "ALPACA_HAS_SIP") and (env.ALPACA_HAS_SIP is not None):
+        return not (has_creds and bool(env.ALPACA_HAS_SIP))
+    return not has_creds
 
 
-def fetch_bars(
-    symbol: str,
-    start: datetime,
-    end: datetime,
-    timeframe: str,
-    *,
-    feed: str = "sip",
-    session=None,
-    feeds_used: list[str] | None = None,
-) -> Any:
-    """Fetch market bars honouring SIP disallow rules.
+__all__ = ["sip_disallowed"]
 
-    Parameters
-    ----------
-    feeds_used:
-        Optional list extended with the actual feed used.  When a fallback from
-        SIP to IEX occurs, the originally requested ``sip`` feed is appended as
-        well so callers can introspect both feeds.
-    """
-
-    session = session or _HTTP_SESSION
-    tf = str(timeframe)
-    requested = str(feed)
-    actual = requested
-    if requested == "sip" and not _ALLOW_SIP:
-        actual = "iex"
-
-    params = {
-        "symbol": symbol,
-        "start": start,
-        "end": end,
-        "feed": actual,
-        "timeframe": tf,
-    }
-    resp = session.get("https://data.alpaca.markets/v2/stocks/bars", params=params)
-
-    if feeds_used is not None:
-        feeds_used.append(actual)
-        if actual != requested:
-            feeds_used.append(requested)
-
-    return _to_df(resp.json())
-
-
-__all__ = ["fetch_bars"]

--- a/ai_trading/utils/environment.py
+++ b/ai_trading/utils/environment.py
@@ -1,0 +1,39 @@
+"""Environment helpers exposed as attribute-style access."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+_BOOL_TRUE = {"1", "true", "yes", "on", "enable", "enabled"}
+_BOOL_FALSE = {"0", "false", "no", "off", "disable", "disabled"}
+_ALIASES = {
+    "ALPACA_KEY": "ALPACA_API_KEY",
+    "ALPACA_SECRET": "ALPACA_SECRET_KEY",
+}
+_BOOL_KEYS = {"ALPACA_ALLOW_SIP", "ALPACA_HAS_SIP"}
+
+
+class _EnvProxy:
+    """Proxy object exposing ``os.environ`` via attributes."""
+
+    def __getattr__(self, name: str) -> Any:
+        key = _ALIASES.get(name, name)
+        value = os.getenv(key)
+        if value is None:
+            return None
+        if key in _BOOL_KEYS:
+            value_lower = value.strip().lower()
+            if value_lower in _BOOL_TRUE:
+                return True
+            if value_lower in _BOOL_FALSE:
+                return False
+        return value
+
+
+env = _EnvProxy()
+
+
+__all__ = ["env"]
+


### PR DESCRIPTION
## Summary
- add an environment proxy and use it for sip_disallowed() so SIP is only blocked when credentials or entitlements are missing
- teach DataFetcher/build_fetcher to honour forced feeds, add a SIP recovery pass, and resolve execution prices with a graceful skip path
- refresh the SIP disallowed tests for the new behaviour

## Testing
- pytest tests/test_sip_disallowed.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb1c890a8833089a40cac9848cc2d