### PR TITLE
Support inline comments for numeric config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ config.reload_env()
 
 `.env` at the repo root is reloaded at startup with `override=True`; if configuration
 cannot be loaded, the bot exits early with a critical log.
-Float environment values ignore inline comments after `#`, allowing declarations like
-`MAX_DRAWDOWN_THRESHOLD="0.08  # 8% limit"`.
+Numeric and boolean environment values ignore inline comments after `#`, allowing
+declarations like `MAX_DRAWDOWN_THRESHOLD="0.08  # 8% limit"` or
+`ALLOW_AFTER_HOURS="true  # testing"`. CSV-based numeric sequences (e.g.
+`0.25, 0.5, 0.75  # thresholds`) are trimmed before parsing.
 Rebalance frequency defaults to 60 minutes; override with `AI_TRADING_REBALANCE_INTERVAL_MIN`
 (minutes) or `AI_TRADING_REBALANCE_INTERVAL_HOURS` (hours). The smallest positive value
 is used when multiple sources are set.

--- a/ai_trading/data/finnhub.py
+++ b/ai_trading/data/finnhub.py
@@ -35,7 +35,11 @@ class _FinnhubFetcherStub:
 
 
 def _build_fetcher() -> Any:
-    enable = config.get_env("ENABLE_FINNHUB", "1").lower() not in ("0", "false")
+    raw_enable = config.get_env("ENABLE_FINNHUB", "1")
+    if isinstance(raw_enable, str):
+        enable = raw_enable.strip().lower() not in {"0", "false", "off", "no"}
+    else:
+        enable = bool(raw_enable)
     if not enable:
         if "finnhub" not in _SENT_DEPS_LOGGED:
             log_finnhub_disabled("GLOBAL")

--- a/ai_trading/logging/setup.py
+++ b/ai_trading/logging/setup.py
@@ -33,7 +33,13 @@ def _apply_library_filters() -> None:
         "peewee": logging.WARNING,
     }
     raw = config.get_env("LOG_QUIET_LIBRARIES", "")
-    for item in raw.split(","):
+    if isinstance(raw, (tuple, list)):
+        items = raw
+    else:
+        items = tuple(part.strip() for part in str(raw).split(","))
+    for item in items:
+        if not item:
+            continue
         name, _, level = item.partition("=")
         if name.strip() and level.strip():
             filters[name.strip()] = getattr(logging, level.strip().upper(), logging.INFO)

--- a/tests/config/test_env_comment_handling.py
+++ b/tests/config/test_env_comment_handling.py
@@ -4,6 +4,12 @@ import sys
 import pytest
 
 from ai_trading.config.management import TradingConfig
+from ai_trading.config.runtime import (
+    ConfigSpec,
+    _cast_value,
+    _parse_numeric_sequence,
+    _strip_inline_comment,
+)
 
 
 def _reload_config(monkeypatch, **env):
@@ -30,8 +36,9 @@ def _cleanup():
 
 
 def test_comment_stripped_from_float_env(monkeypatch):
-    cfg = _reload_config(monkeypatch, MAX_DRAWDOWN_THRESHOLD="0.08  # comment")
-    assert cfg.get_max_drawdown_threshold() == pytest.approx(0.08)
+    monkeypatch.delenv("MAX_DRAWDOWN_THRESHOLD", raising=False)
+    cfg = TradingConfig.from_env({"MAX_DRAWDOWN_THRESHOLD": "0.08  # comment"})
+    assert cfg.max_drawdown_threshold == pytest.approx(0.08)
 
 
 def test_inline_comments_ignored_for_all_numeric_fields(monkeypatch):
@@ -41,36 +48,37 @@ def test_inline_comments_ignored_for_all_numeric_fields(monkeypatch):
         "DAILY_LOSS_LIMIT": "0.05  # comment",
         "MAX_POSITION_SIZE": "9000  # comment",
         "MAX_POSITION_EQUITY_FALLBACK": "210000  # comment",
-        "POSITION_SIZE_MIN_USD": "125  # comment",
-        "SECTOR_EXPOSURE_CAP": "0.4  # comment",
+        "AI_TRADING_POSITION_SIZE_MIN_USD": "125  # comment",
+        "AI_TRADING_SECTOR_EXPOSURE_CAP": "0.4  # comment",
         "MAX_DRAWDOWN_THRESHOLD": "0.11  # comment",
         "TRAILING_FACTOR": "0.25  # comment",
         "TAKE_PROFIT_FACTOR": "1.9  # comment",
-        "MAX_POSITION_SIZE_PCT": "0.15  # comment",
-        "MAX_VAR_95": "0.05  # comment",
-        "MIN_PROFIT_FACTOR": "1.5  # comment",
-        "MIN_SHARPE_RATIO": "1.2  # comment",
-        "MIN_WIN_RATE": "0.55  # comment",
         "KELLY_FRACTION": "0.65  # comment",
         "KELLY_FRACTION_MAX": "0.3  # comment",
+        "MIN_CONFIDENCE": "0.7  # comment",
+        "CONF_THRESHOLD": "0.77  # comment",
         "MIN_SAMPLE_SIZE": "12  # comment",
         "CONFIDENCE_LEVEL": "0.91  # comment",
-        "CONF_THRESHOLD": "0.77  # comment",
-        "LOOKBACK_PERIODS": "45  # comment",
-        "SCORE_CONFIDENCE_MIN": "0.5  # comment",
         "SIGNAL_CONFIRMATION_BARS": "4  # comment",
         "DELTA_THRESHOLD": "0.03  # comment",
-        "MIN_CONFIDENCE": "0.7  # comment",
+        "AI_TRADING_VOLUME_THRESHOLD": "1200  # comment",
         "MINUTE_DATA_FRESHNESS_TOLERANCE_SECONDS": "600  # comment",
-        "BUY_THRESHOLD": "0.61  # comment",
-        "SIGNAL_PERIOD": "25  # comment",
-        "FAST_PERIOD": "12  # comment",
-        "SLOW_PERIOD": "30  # comment",
-        "LIMIT_ORDER_SLIPPAGE": "0.02  # comment",
-        "MAX_SLIPPAGE_BPS": "35  # comment",
-        "PARTICIPATION_RATE": "0.6  # comment",
-        "POV_SLICE_PCT": "0.2  # comment",
-        "ORDER_TIMEOUT_SECONDS": "120  # comment",
+        "MAX_DATA_FALLBACKS": "3  # comment",
+        "DATA_PROVIDER_BACKOFF_FACTOR": "1.25  # comment",
+        "DATA_PROVIDER_MAX_COOLDOWN": "120  # comment",
+        "AI_TRADING_HTTP_TIMEOUT": "8.5  # comment",
+        "AI_TRADING_HOST_LIMIT": "4  # comment",
+        "MAX_EMPTY_RETRIES": "5  # comment",
+        "SYMBOL_PROCESS_BUDGET": "120  # comment",
+        "CYCLE_BUDGET_FRACTION": "0.6  # comment",
+        "CYCLE_COMPUTE_BUDGET": "0.5  # comment",
+        "AI_TRADING_SIGNAL_HOLD_EPS": "0.02  # comment",
+        "MAX_SYMBOLS_PER_CYCLE": "250  # comment",
+        "HEALTH_TICK_SECONDS": "240  # comment",
+        "HARD_STOP_COOLDOWN_MIN": "25  # comment",
+        "SLIPPAGE_LIMIT_TOLERANCE_BPS": "15.5  # comment",
+        "SENTIMENT_BACKOFF_BASE": "7.5  # comment",
+        "SENTIMENT_MAX_RETRIES": "8  # comment",
     }
     for key in numeric_env:
         monkeypatch.delenv(key, raising=False)
@@ -89,37 +97,67 @@ def test_inline_comments_ignored_for_all_numeric_fields(monkeypatch):
         "max_drawdown_threshold": 0.11,
         "trailing_factor": 0.25,
         "take_profit_factor": 1.9,
-        "max_position_size_pct": 0.15,
-        "max_var_95": 0.05,
-        "min_profit_factor": 1.5,
-        "min_sharpe_ratio": 1.2,
-        "min_win_rate": 0.55,
         "kelly_fraction": 0.65,
         "kelly_fraction_max": 0.3,
-        "confidence_level": 0.91,
-        "conf_threshold": 0.77,
-        "score_confidence_min": 0.5,
-        "delta_threshold": 0.03,
         "min_confidence": 0.7,
-        "buy_threshold": 0.61,
-        "limit_order_slippage": 0.02,
-        "participation_rate": 0.6,
-        "pov_slice_pct": 0.2,
+        "conf_threshold": 0.77,
+        "confidence_level": 0.91,
+        "delta_threshold": 0.03,
+        "allow_after_hours_volume_threshold": 1200.0,
+        "data_provider_backoff_factor": 1.25,
+        "http_timeout_seconds": 8.5,
+        "symbol_process_budget_seconds": 120.0,
+        "cycle_budget_fraction": 0.6,
+        "cycle_compute_budget_factor": 0.5,
+        "signal_hold_epsilon": 0.02,
+        "health_tick_seconds": 240.0,
+        "slippage_limit_tolerance_bps": 15.5,
+        "sentiment_backoff_base": 7.5,
     }
     int_expectations = {
         "min_sample_size": 12,
-        "lookback_periods": 45,
         "signal_confirmation_bars": 4,
         "minute_data_freshness_tolerance_seconds": 600,
-        "signal_period": 25,
-        "fast_period": 12,
-        "slow_period": 30,
-        "max_slippage_bps": 35,
-        "order_timeout_seconds": 120,
+        "max_data_fallbacks": 3,
+        "data_provider_max_cooldown": 120,
+        "host_concurrency_limit": 4,
+        "max_empty_retries": 5,
+        "max_symbols_per_cycle": 250,
+        "hard_stop_cooldown_min": 25,
+        "sentiment_retry_max": 8,
     }
 
     for attr, expected in float_expectations.items():
         assert getattr(cfg, attr) == pytest.approx(expected), attr
     for attr, expected in int_expectations.items():
         assert getattr(cfg, attr) == expected, attr
+
+
+def test_strip_inline_comment_helper_behaviour():
+    assert _strip_inline_comment("42  # answer") == "42"
+    assert _strip_inline_comment("true  # enabled") == "true"
+    assert _strip_inline_comment("1.0, 2.0  # range") == "1.0, 2.0"
+    assert _strip_inline_comment("value#notacomment") == "value#notacomment"
+    assert _strip_inline_comment("   # full comment") == ""
+
+    tuple_value = _parse_numeric_sequence("0.1, 0.9  # thresholds")
+    assert tuple_value == pytest.approx((0.1, 0.9))
+
+    tuple_spec = ConfigSpec(
+        field="demo_tuple",
+        env=("DEMO_TUPLE",),
+        cast="tuple[float]",
+        default=(),
+        description="demo",
+    )
+    assert _cast_value(tuple_spec, "0.2, 0.4  # inline") == pytest.approx((0.2, 0.4))
+
+
+def test_bool_cast_handles_inline_comments(monkeypatch):
+    monkeypatch.delenv("ALLOW_AFTER_HOURS", raising=False)
+    cfg = TradingConfig.from_env({
+        "ALLOW_AFTER_HOURS": "true  # enable after hours",
+    })
+
+    assert cfg.allow_after_hours is True
 


### PR DESCRIPTION
## Summary
- add a runtime helper that strips inline comments before casting numeric, tuple, and boolean config values
- update dependent modules to operate on typed config outputs and document inline comment support for numeric settings
- expand environment comment handling tests to cover the helper, boolean parsing, and tuple casting

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/config/test_env_comment_handling.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ceb828b29c8330a89dc027da3ea66e