### PR TITLE
Use centralized trading config in order monitor

### DIFF
--- a/tests/test_order_health_monitor_import.py
+++ b/tests/test_order_health_monitor_import.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_order_health_monitor_importable_and_singleton_config():
+    module = importlib.import_module("ai_trading.monitoring.order_health_monitor")
+    monitor = module.OrderHealthMonitor()
+
+    assert module.OrderHealthMonitor is not None
+    assert monitor._config is module.CONFIG


### PR DESCRIPTION
## Summary
- switch the order health monitor to use the centralized trading config loader instead of instantiating TradingConfig directly
- cache the resolved config on the monitor so a single instance is reused across its lifecycle
- add a regression test to ensure the monitor module imports successfully and retains the shared config instance

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_order_health_monitor_import.py -q


------
https://chatgpt.com/codex/tasks/task_e_68cec34f7e7083308ef5133dc220f559