### PR TITLE
Refactor strategy allocator config initialization

### DIFF
--- a/ai_trading/strategy_allocator.py
+++ b/ai_trading/strategy_allocator.py
@@ -7,9 +7,7 @@ from dataclasses import replace
 import logging
 from typing import Any
 
-from ai_trading.config.management import TradingConfig
-
-CONFIG = TradingConfig()
+from ai_trading.config.management import TradingConfig, get_trading_config
 logger = logging.getLogger(__name__)
 _missing_attr_warned: set[str] = set()
 _invalid_value_warned: set[str] = set()
@@ -28,7 +26,8 @@ class StrategyAllocator:
     """Allocator implementing signal confirmation and confidence gating."""
 
     def __init__(self, config: Any | None = None) -> None:
-        self.config = copy.deepcopy(config or CONFIG)
+        base_config = config if config is not None else get_trading_config()
+        self.config = copy.deepcopy(base_config)
         self._ensure_config_attributes()
         self.signal_history: dict[str, list[float]] = {}
         self.last_direction: dict[str, str] = {}

--- a/tests/test_strategy_allocator_import.py
+++ b/tests/test_strategy_allocator_import.py
@@ -1,0 +1,28 @@
+from importlib import import_module
+import sys
+
+from ai_trading.config.management import get_trading_config
+
+
+def test_strategy_allocator_module_import_does_not_raise():
+    module_name = "ai_trading.strategy_allocator"
+    sys.modules.pop(module_name, None)
+    module = import_module(module_name)
+    assert hasattr(module, "StrategyAllocator")
+    allocator = module.StrategyAllocator()
+    assert hasattr(allocator, "config")
+
+
+def test_strategy_allocator_config_isolation():
+    from ai_trading import strategy_allocator
+
+    base_cfg = get_trading_config()
+    allocator = strategy_allocator.StrategyAllocator()
+
+    assert allocator.config is not base_cfg
+    assert allocator.config.signal_confirmation_bars == base_cfg.signal_confirmation_bars
+
+    bumped = base_cfg.signal_confirmation_bars + 1
+    allocator.replace_config(signal_confirmation_bars=bumped)
+
+    assert get_trading_config().signal_confirmation_bars == base_cfg.signal_confirmation_bars


### PR DESCRIPTION
## Summary
- defer creation of the trading configuration in `StrategyAllocator` to use `get_trading_config()` instead of instantiating `TradingConfig` at import time
- add regression tests covering safe module import and verifying allocator config isolation from the shared runtime config

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_strategy_allocator_import.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_strategy_allocator_smoke.py::test_allocator


------
https://chatgpt.com/codex/tasks/task_e_68cec3505b9c8330b2884e725572f5b7