### PR TITLE
Allow ALPACA_API_URL in env validation

### DIFF
--- a/ai_trading/tools/env_validate.py
+++ b/ai_trading/tools/env_validate.py
@@ -10,12 +10,24 @@ REQUIRED_KEYS: tuple[str, ...] = (
     'ALPACA_SECRET_KEY',
     'ALPACA_BASE_URL',
 )
+
+INTERCHANGEABLE_URL_KEYS: tuple[str, ...] = (
+    'ALPACA_BASE_URL',
+    'ALPACA_API_URL',
+)
 REQUIRED_PACKAGES: tuple[str, ...] = ('hmmlearn',)
 
 def validate_env(env: Mapping[str, str] | None=None) -> list[str]:
     """Return list of missing required environment keys or packages."""
     env = env or os.environ
-    missing = [k for k in REQUIRED_KEYS if not env.get(k)]
+    missing: list[str] = []
+    for key in REQUIRED_KEYS:
+        if key == 'ALPACA_BASE_URL':
+            if not any(env.get(url_key) for url_key in INTERCHANGEABLE_URL_KEYS):
+                missing.append(key)
+            continue
+        if not env.get(key):
+            missing.append(key)
     for pkg in REQUIRED_PACKAGES:
         if importlib.util.find_spec(pkg) is None:
             missing.append(pkg)

--- a/tests/test_env_validate_tool.py
+++ b/tests/test_env_validate_tool.py
@@ -1,0 +1,49 @@
+"""Tests for ai_trading.tools.env_validate."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from ai_trading.tools.env_validate import validate_env
+
+
+@pytest.fixture(autouse=True)
+def mock_required_package(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure required package checks pass during tests."""
+
+    monkeypatch.setattr(importlib.util, 'find_spec', lambda pkg: object())
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        'ALPACA_API_KEY': 'key',
+        'ALPACA_SECRET_KEY': 'secret',
+    }
+
+
+def test_validate_env_accepts_base_url_only() -> None:
+    env = {
+        **_base_env(),
+        'ALPACA_BASE_URL': 'https://paper-api.alpaca.markets',
+    }
+
+    assert validate_env(env) == []
+
+
+def test_validate_env_accepts_api_url_only() -> None:
+    env = {
+        **_base_env(),
+        'ALPACA_API_URL': 'https://paper-api.alpaca.markets',
+    }
+
+    assert validate_env(env) == []
+
+
+def test_validate_env_requires_some_url() -> None:
+    env = _base_env()
+
+    missing = validate_env(env)
+
+    assert 'ALPACA_BASE_URL' in missing


### PR DESCRIPTION
## Summary
- allow ai_trading.tools.env_validate to accept either ALPACA_BASE_URL or ALPACA_API_URL when checking credentials
- add regression tests covering both environment variable options and missing URL detection

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_env_validate_tool.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cec902356483309c593bbbc6d0fd8c