### PR TITLE
Align balanced presets and runtime sizing fallbacks

### DIFF
--- a/ai_trading/config/runtime.py
+++ b/ai_trading/config/runtime.py
@@ -267,7 +267,7 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
         field="daily_loss_limit",
         env=("DAILY_LOSS_LIMIT", "AI_TRADING_DAILY_LOSS_LIMIT"),
         cast="float",
-        default=0.03,
+        default=0.05,
         description="Maximum tolerated realised drawdown over a single trading day.",
         min_value=0.0,
         max_value=1.0,
@@ -1093,6 +1093,11 @@ class TradingConfig:
                 if spec is None:
                     continue
                 provided = any(env_map.get(env_key) not in (None, "") for env_key in spec.env)
+                if not provided and spec.deprecated_env:
+                    provided = any(
+                        env_map.get(alias) not in (None, "")
+                        for alias in spec.deprecated_env
+                    )
                 if not provided:
                     values[field] = default_value
 


### PR DESCRIPTION
## Summary
- align the balanced trading preset defaults with the documented values and ensure mode hydration respects deprecated env aliases
- derive config module risk constants from the resolved TradingConfig so module reloads see the correct per-mode values
- guard runtime sizing to fall back to required defaults when max_position_size is explicitly None instead of reusing the legacy AI_TRADING_MAX_POSITION_SIZE override

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_config_module.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_params_hydration.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runtime_max_position_size.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/runtime/test_max_position_size_consistency.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot_engine_position_size_consistency.py

------
https://chatgpt.com/codex/tasks/task_e_68d0c0a560d0833082ac1f12e4cbca5e