### PR TITLE
Update host semaphore cache management

### DIFF
--- a/ai_trading/http/pooling.py
+++ b/ai_trading/http/pooling.py
@@ -16,6 +16,15 @@ _HOST_SEMAPHORES: WeakKeyDictionary[
 ] = WeakKeyDictionary()
 
 
+def reset_host_semaphores() -> None:
+    """Clear cached host semaphores.
+
+    Useful for ensuring a clean slate when the module is reloaded in tests.
+    """
+
+    _HOST_SEMAPHORES.clear()
+
+
 def _resolve_limit() -> int:
     raw = os.getenv("AI_TRADING_HOST_LIMIT")
     if raw not in (None, ""):


### PR DESCRIPTION
## Summary
- add a helper to clear cached host semaphores when the pooling module is reloaded
- reuse the async helpers in the host limit tests to validate semaphore replacement on limit changes and per-loop isolation

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_http_host_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68d0c29f6dac833082a4d8ff1cf6e786