### PR TITLE
Ensure rl train module registered for reload

### DIFF
--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -147,13 +147,15 @@ def _load_train_module() -> Any:
     """Dynamically import :mod:`ai_trading.rl_trading.train` when requested."""
 
     module_name = f"{__name__}.train"
-    try:
-        module = importlib.import_module(module_name)
-    except ModuleNotFoundError as exc:  # pragma: no cover - defensive guard
-        raise AttributeError(
-            f"module {__name__!r} has no attribute 'train'"
-        ) from exc
-    sys.modules["ai_trading.rl_trading.train"] = module
+    module = sys.modules.get(module_name)
+    if module is None:
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:  # pragma: no cover - defensive guard
+            raise AttributeError(
+                f"module {__name__!r} has no attribute 'train'"
+            ) from exc
+    module = sys.modules.setdefault(module_name, module)
     globals()["train"] = module
     return module
 


### PR DESCRIPTION
## Summary
- ensure the rl training module loader reuses the concrete module object and registers it in `sys.modules` via `setdefault`
- keep the global `train` attribute pointing at the real module while eagerly loading during package import to support `importlib.reload`

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rl_module.py

------
https://chatgpt.com/codex/tasks/task_e_68d0c441d7648330b8342c23bb713b32