### PR TITLE
Refine SoftBudget timing precision

### DIFF
--- a/ai_trading/utils/prof.py
+++ b/ai_trading/utils/prof.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import time
 from contextlib import contextmanager
 
@@ -20,7 +19,7 @@ class SoftBudget:
 
     def __init__(self, millis: int):
         self.budget_ms = max(0, int(millis))
-        self._start = time.perf_counter()
+        self._start = time.perf_counter_ns()
 
     def __enter__(self) -> "SoftBudget":
         self.reset()
@@ -30,23 +29,25 @@ class SoftBudget:
         return False
 
     def reset(self) -> None:
-        self._start = time.perf_counter()
+        self._start = time.perf_counter_ns()
 
     def elapsed_ms(self) -> int:
-        elapsed = time.perf_counter() - self._start
-        if elapsed <= 0:
+        elapsed_ns = time.perf_counter_ns() - self._start
+        if elapsed_ns <= 0:
             return 0
-        return math.ceil(elapsed * 1000)
+        elapsed_ms = (elapsed_ns + 999_999) // 1_000_000
+        return max(1, int(elapsed_ms))
 
     def over_budget(self) -> bool:
         return self.elapsed_ms() >= self.budget_ms
 
     def remaining(self) -> float:
-        elapsed = time.perf_counter() - self._start
-        remaining_ms = self.budget_ms - (elapsed * 1000)
-        if remaining_ms <= 0:
+        elapsed_ns = max(time.perf_counter_ns() - self._start, 0)
+        remaining_ns = (self.budget_ms * 1_000_000) - elapsed_ns
+        if remaining_ns <= 0:
             return 0.0
-        return math.ceil(remaining_ms) / 1000.0
+        remaining_ms = (remaining_ns + 999_999) // 1_000_000
+        return int(remaining_ms) / 1000.0
 
     def over(self) -> bool:  # Backward compatibility
         return self.over_budget()


### PR DESCRIPTION
## Summary
- switch SoftBudget to track timing with perf_counter_ns and integer math for elapsed milliseconds
- clamp negative timing deltas and ensure positive intervals round up to at least one millisecond
- base remaining budget calculations on nanosecond precision to align with the updated elapsed math

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_prof_budget.py

------
https://chatgpt.com/codex/tasks/task_e_68d1666c87bc83308c5c30b940121baa