### PR TITLE
Ensure SIP overrides persist and empty minute fallbacks raise

### DIFF
--- a/tests/test_finnhub_disabled.py
+++ b/tests/test_finnhub_disabled.py
@@ -12,7 +12,9 @@ def _force_window(monkeypatch):
     monkeypatch.setattr(data_fetcher, "_window_has_trading_session", lambda *a, **k: True)
 
 
-def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch, caplog):
+def test_get_minute_df_raises_when_finnhub_disabled(monkeypatch, caplog):
+    data_fetcher._SKIPPED_SYMBOLS.clear()
+    data_fetcher._EMPTY_BAR_COUNTS.clear()
     monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
     monkeypatch.setenv("ENABLE_FINNHUB", "0")
 
@@ -24,19 +26,24 @@ def test_get_minute_df_returns_empty_when_finnhub_disabled(monkeypatch, caplog):
     monkeypatch.setattr(data_fetcher, "_yahoo_get_bars", lambda *a, **k: pd.DataFrame())
 
     with caplog.at_level(logging.INFO):
-        df = data_fetcher.get_minute_df(
-            "AAPL",
-            dt.datetime(2023, 1, 1, tzinfo=dt.UTC),
-            dt.datetime(2023, 1, 2, tzinfo=dt.UTC),
-        )
-    assert df.empty
+        with pytest.raises(data_fetcher.EmptyBarsError):
+            data_fetcher.get_minute_df(
+                "AAPL",
+                dt.datetime(2023, 1, 1, tzinfo=dt.UTC),
+                dt.datetime(2023, 1, 2, tzinfo=dt.UTC),
+            )
     assert any(r.message == "FINNHUB_DISABLED_NO_DATA" for r in caplog.records)
+    key = ("AAPL", "1Min")
+    assert key in data_fetcher._SKIPPED_SYMBOLS
+    assert data_fetcher._EMPTY_BAR_COUNTS.get(key, 0) >= 1
 
 
 def test_duplicate_info_suppressed(monkeypatch, caplog):
     from ai_trading.logging import logger_once
 
     monkeypatch.setattr(logger_once, "_emitted_keys", {})
+    data_fetcher._SKIPPED_SYMBOLS.clear()
+    data_fetcher._EMPTY_BAR_COUNTS.clear()
     monkeypatch.delenv("FINNHUB_API_KEY", raising=False)
     monkeypatch.setenv("ENABLE_FINNHUB", "0")
     monkeypatch.setattr(data_fetcher, "_fetch_bars", lambda *a, **k: pd.DataFrame())
@@ -44,7 +51,9 @@ def test_duplicate_info_suppressed(monkeypatch, caplog):
     start = dt.datetime(2023, 1, 1, tzinfo=dt.UTC)
     end = dt.datetime(2023, 1, 2, tzinfo=dt.UTC)
     with caplog.at_level(logging.INFO):
-        data_fetcher.get_minute_df("MSFT", start, end)
-        data_fetcher.get_minute_df("MSFT", start, end)
+        with pytest.raises(data_fetcher.EmptyBarsError):
+            data_fetcher.get_minute_df("MSFT", start, end)
+        with pytest.raises(data_fetcher.EmptyBarsError):
+            data_fetcher.get_minute_df("MSFT", start, end)
     infos = [r for r in caplog.records if r.message == "FINNHUB_DISABLED_NO_DATA"]
     assert len(infos) == 1


### PR DESCRIPTION
## Summary
- fix the SIP failover bookkeeping to use the tracked current feed when recording a switch
- tighten get_minute_df so exhausted backups raise EmptyBarsError while leaving skip counters intact
- extend regression coverage for SIP overrides and empty backup scenarios

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_feed_failover.py tests/test_finnhub_disabled.py`


------
https://chatgpt.com/codex/tasks/task_e_68d16665be448330ace64df88305a82b