### PR TITLE
Handle Alpaca outages in long entries

### DIFF
--- a/tests/bot_engine/test_bot_engine.py
+++ b/tests/bot_engine/test_bot_engine.py
@@ -309,7 +309,7 @@ def test_get_latest_price_skips_primary_during_cooldown(monkeypatch):
     assert bot_engine._PRICE_SOURCE["AAPL"] == bot_engine._ALPACA_DISABLED_SENTINEL
 
 
-def test_enter_long_uses_feature_close_when_primary_disabled(monkeypatch, caplog):
+def test_enter_long_skips_when_primary_disabled(monkeypatch, caplog):
     pd = pytest.importorskip("pandas")
 
     symbol = "AAPL"
@@ -395,10 +395,59 @@ def test_enter_long_uses_feature_close_when_primary_disabled(monkeypatch, caplog
     )
 
     assert result is True
-    assert orders and orders[0][3] == pytest.approx(feat_df["close"].iloc[-1])
-    assert any("FALLBACK_TO_FEATURE_CLOSE" in rec.message for rec in caplog.records)
-    assert not any("computed qty <= 0" in rec.message for rec in caplog.records)
-    assert bot_engine._PRICE_SOURCE[symbol] == "feature_close"
+    assert orders == []
+    assert any(
+        record.message == "SKIP_ORDER_ALPACA_UNAVAILABLE" for record in caplog.records
+    )
+    assert not any(
+        record.message == "FALLBACK_TO_FEATURE_CLOSE" for record in caplog.records
+    )
+
+
+def test_enter_long_skips_when_alpaca_auth_failed(monkeypatch, caplog):
+    pd = pytest.importorskip("pandas")
+
+    symbol = "AAPL"
+    orders: list[tuple[str, int, str, float | None]] = []
+    ctx, state, feat_df = _build_dummy_long_context(pd, symbol)
+
+    monkeypatch.delenv("PYTEST_RUNNING", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    monkeypatch.setattr(
+        bot_engine,
+        "submit_order",
+        lambda _ctx, sym, qty, side, price=None: orders.append(
+            (sym, qty, side, price)
+        )
+        or types.SimpleNamespace(id="order-1"),
+    )
+    monkeypatch.setattr(
+        bot_engine,
+        "_resolve_order_quote",
+        lambda *_a, **_k: (None, "alpaca_auth_failed"),
+    )
+
+    caplog.set_level("WARNING")
+
+    result = bot_engine._enter_long(
+        ctx,
+        state,
+        symbol,
+        balance=100000.0,
+        feat_df=feat_df,
+        final_score=1.0,
+        conf=0.8,
+        strat="auth_failed_test",
+    )
+
+    assert result is True
+    assert orders == []
+    assert symbol in state.auth_skipped_symbols
+    assert any(
+        record.message == "SKIP_ORDER_ALPACA_UNAVAILABLE" for record in caplog.records
+    )
 
 
 def _build_dummy_long_context(pd, symbol):


### PR DESCRIPTION
## Summary
- ensure long entry flow skips order placement when Alpaca quotes are unavailable, sharing sentinel handling with the short path
- add regression coverage for long-entry Alpaca outage scenarios

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_bot_engine.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d16cfcf3a48330b46be3b68c449101