### PR TITLE
Handle degraded quotes when entering longs

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -11544,6 +11544,26 @@ def _enter_long(
             return True
 
     if quote_price is None:
+        price_source_label = str(price_source or "unknown")
+        source_degraded = prefer_backup_quote or price_source_label.endswith(
+            ("_invalid", "_degraded")
+        )
+        if source_degraded:
+            degraded = getattr(state, "degraded_providers", None)
+            if degraded is None:
+                degraded = set()
+                setattr(state, "degraded_providers", degraded)
+            degraded.add("alpaca")
+            degraded.add(symbol)
+            logger.warning(
+                "SKIP_ORDER_DEGRADED_QUOTE",
+                extra={
+                    "symbol": symbol,
+                    "price_source": price_source_label,
+                    "prefer_backup": prefer_backup_quote,
+                },
+            )
+            return True
         fallback_price = current_price if np.isfinite(current_price) and current_price > 0 else None
         if fallback_price is not None:
             logger.warning(


### PR DESCRIPTION
## Summary
- skip long entries when the resolved quote is missing while a degraded provider is active
- keep degraded provider tracking for the affected symbol to retry once quotes recover
- add coverage ensuring the degraded quote path avoids falling back to feature close pricing

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_bot_engine.py


------
https://chatgpt.com/codex/tasks/task_e_68d173d4573c8330940d319b47933736