### PR TITLE
Ensure trade log initialization runs once

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -491,9 +491,17 @@ def validate_environment() -> None:
         os.makedirs(logs_dir, exist_ok=True)
 
 
+_TRADE_LOG_INITIALIZED = False
+
+
 def ensure_trade_log_path() -> None:
     """Initialize trade log and verify the path is writable."""
     from ai_trading.core.bot_engine import get_trade_logger
+
+    global _TRADE_LOG_INITIALIZED
+
+    if _TRADE_LOG_INITIALIZED:
+        return
 
     tl = get_trade_logger()
     path = Path(tl.path)
@@ -512,6 +520,7 @@ def ensure_trade_log_path() -> None:
             "TRADE_LOG_PATH_READY",
             extra={"path": str(path)},
         )
+        _TRADE_LOG_INITIALIZED = True
 
 
 def run_bot(*_a, **_k) -> int:
@@ -545,7 +554,8 @@ def run_bot(*_a, **_k) -> int:
             logger.info("Memory optimization enabled")
         logger.info("Bot startup complete - entering main loop")
         preflight_import_health()
-        ensure_trade_log_path()
+        if not _TRADE_LOG_INITIALIZED:
+            ensure_trade_log_path()
         run_cycle()
         return 0
     except (ValueError, TypeError, RuntimeError) as e:

--- a/tests/test_main_extended2.py
+++ b/tests/test_main_extended2.py
@@ -88,10 +88,20 @@ def test_run_flask_app_skips_ipv6_port(monkeypatch):
 def test_run_bot_calls_cycle(monkeypatch):
     """run_bot executes a trading cycle in-process."""
     called = {}
+    trade_log_calls = {"count": 0}
+
+    def _fake_ensure():
+        trade_log_calls["count"] += 1
+        main._TRADE_LOG_INITIALIZED = True
 
     monkeypatch.setattr(main, "run_cycle", lambda: called.setdefault("ran", True))
+    monkeypatch.setattr(main, "ensure_trade_log_path", _fake_ensure)
+    monkeypatch.setenv("IMPORT_PREFLIGHT_DISABLED", "1")
+    main._TRADE_LOG_INITIALIZED = False
+
     assert main.run_bot() == 0
     assert called["ran"]
+    assert trade_log_calls["count"] == 1
 
 
 def test_validate_environment_missing(monkeypatch):


### PR DESCRIPTION
## Summary
- guard trade log initialization behind a module-level flag so run_bot only triggers it when needed
- update the run bot cycle test to assert trade log initialization is called exactly once

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_main_extended2.py::test_run_bot_calls_cycle

------
https://chatgpt.com/codex/tasks/task_e_68d179c5214083308d76302573b69724