### PR TITLE
Handle AUTO max position mode

### DIFF
--- a/ai_trading/config/runtime.py
+++ b/ai_trading/config/runtime.py
@@ -51,6 +51,17 @@ def _parse_numeric_sequence(value: str) -> tuple[float, ...]:
     return tuple(float(chunk) for chunk in cleaned)
 
 
+def _parse_max_position_mode(raw: str) -> str:
+    value = _strip_inline_comment(raw).strip().upper()
+    if value in {"", "STATIC"}:
+        return "STATIC"
+    if value == "AUTO":
+        return "AUTO"
+    raise ValueError(
+        "MAX_POSITION_MODE must be one of: STATIC, AUTO"
+    )
+
+
 CastFn = Callable[[str], Any]
 
 
@@ -292,6 +303,13 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
         min_value=0.0,
         max_value=1.0,
         deprecated_env={"AI_TRADING_MAX_DRAWDOWN_THRESHOLD": "Use MAX_DRAWDOWN_THRESHOLD instead."},
+    ),
+    ConfigSpec(
+        field="max_position_mode",
+        env=("MAX_POSITION_MODE", "AI_TRADING_MAX_POSITION_MODE"),
+        cast=_parse_max_position_mode,
+        default="STATIC",
+        description="Controls whether max_position_size is STATIC or AUTO sized.",
     ),
     ConfigSpec(
         field="max_position_size",

--- a/ai_trading/core/runtime.py
+++ b/ai_trading/core/runtime.py
@@ -127,43 +127,57 @@ def build_runtime(cfg: TradingConfig, **kwargs: Any) -> BotRuntime:
             except Exception:  # pragma: no cover - defensive
                 pass
 
-    # Resolve max_position_size consistently with position_sizing helper.
+    mode = str(getattr(cfg, "max_position_mode", "STATIC")).upper()
     raw_cfg_value = getattr(cfg, "max_position_size", object())
     explicit_none = raw_cfg_value is None
     val = _cfg_coalesce(cfg, "MAX_POSITION_SIZE", None)
     sizing_meta: dict[str, Any] = {}
-    if val is None and not explicit_none:
-        try:
-            from ai_trading.config.management import get_env
-
-            env_val = get_env("MAX_POSITION_SIZE", cast=float)
-        except (ImportError, RuntimeError):
-            env_val = None
-        if env_val is not None:
-            val = env_val
-
-    if val is None and explicit_none:
-        resolved = float(REQUIRED_PARAM_DEFAULTS["MAX_POSITION_SIZE"])
-        sizing_meta = {
-            "mode": str(getattr(cfg, "max_position_mode", "STATIC")).upper(),
-            "source": "required_default",
-            "capital_cap": getattr(cfg, "capital_cap", 0.0),
-        }
-    elif val is None:
+    if mode == "AUTO":
         resolved, sizing_meta = resolve_max_position_size(cfg, cfg, force_refresh=True)
     else:
-        resolved = float(val)
-        sizing_meta = {
-            "mode": str(getattr(cfg, "max_position_mode", "STATIC")).upper(),
-            "source": "provided",
-            "capital_cap": getattr(cfg, "capital_cap", 0.0),
-        }
+        if val is None and not explicit_none:
+            try:
+                from ai_trading.config.management import get_env
 
+                env_val = get_env("MAX_POSITION_SIZE", cast=float)
+            except (ImportError, RuntimeError):
+                env_val = None
+            if env_val is not None:
+                val = env_val
+
+        if val is None and explicit_none:
+            resolved = float(REQUIRED_PARAM_DEFAULTS["MAX_POSITION_SIZE"])
+            sizing_meta = {
+                "mode": mode,
+                "source": "required_default",
+                "capital_cap": getattr(cfg, "capital_cap", 0.0),
+            }
+        elif val is None:
+            resolved, sizing_meta = resolve_max_position_size(cfg, cfg, force_refresh=True)
+        else:
+            resolved = float(val)
+            sizing_meta = {
+                "mode": mode,
+                "source": "provided",
+                "capital_cap": getattr(cfg, "capital_cap", 0.0),
+            }
+
+    if not sizing_meta:
+        sizing_meta = {"mode": mode, "capital_cap": getattr(cfg, "capital_cap", 0.0)}
+
+    storage = getattr(cfg, "_values", None)
+    if isinstance(storage, dict):
+        storage["max_position_size"] = float(resolved)
+        if sizing_meta:
+            storage["max_position_size_meta"] = dict(sizing_meta)
     if getattr(cfg, "max_position_size", None) != resolved:
         try:
             object.__setattr__(cfg, "max_position_size", float(resolved))
         except Exception:
-            pass
+            try:
+                setattr(cfg, "max_position_size", float(resolved))
+            except Exception:
+                pass
     if resolved <= 0:
         raise ValueError("MAX_POSITION_SIZE must be positive")
     params["MAX_POSITION_SIZE"] = float(resolved)


### PR DESCRIPTION
## Summary
- add a ConfigSpec for MAX_POSITION_MODE that normalizes allowed values
- refresh runtime max position sizing when AUTO mode is requested and persist metadata onto the TradingConfig
- add a regression test covering AUTO mode resolution and logging

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/runtime/test_max_position_size_consistency.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d179c60fcc833090941bd2ce46391e