### PR TITLE
fix(exec): implement ExecutionEngine.execute_order + stop hook; sanitize Alpaca feed usage

### DIFF
--- a/tests/unit/test_price_quote_feed.py
+++ b/tests/unit/test_price_quote_feed.py
@@ -49,6 +49,8 @@ if "bs4" not in sys.modules:  # pragma: no cover - optional dependency stub
 
 from ai_trading.alpaca_api import AlpacaOrderHTTPError
 from ai_trading.core import bot_engine
+from ai_trading.core.enums import OrderSide as CoreOrderSide
+from ai_trading.execution import live_trading
 from ai_trading.utils import base as utils_base
 
 
@@ -60,7 +62,12 @@ def _clear_price_source(monkeypatch):
 
 def test_get_latest_price_uses_configured_feed(monkeypatch):
     symbol = "AAPL"
+    bot_engine._reset_cycle_cache()
     monkeypatch.setenv("ALPACA_DATA_FEED", "sip")
+    monkeypatch.setenv("ALPACA_ALLOW_SIP", "1")
+    monkeypatch.setenv("ALPACA_API_KEY", "test-key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "test-secret")
+    monkeypatch.setattr(bot_engine, "_INTRADAY_FEED_CACHE", "sip", raising=False)
     monkeypatch.setattr(
         "ai_trading.core.bot_engine.is_alpaca_service_available",
         lambda: True,
@@ -115,6 +122,9 @@ def test_get_latest_price_http_error_falls_back(monkeypatch):
 
 def test_get_current_price_uses_configured_feed(monkeypatch):
     symbol = "TSLA"
+    monkeypatch.setenv("ALPACA_ALLOW_SIP", "1")
+    monkeypatch.setenv("ALPACA_API_KEY", "test-key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "test-secret")
     monkeypatch.setenv("ALPACA_DATA_FEED", "sip")
 
     captured: dict[str, object] = {}
@@ -149,4 +159,119 @@ def test_get_current_price_http_error_uses_fallback(monkeypatch):
     price = utils_base.get_current_price(symbol)
 
     assert price == pytest.approx(33.0)
+
+
+def test_get_latest_price_invalid_feed_skips_alpaca(monkeypatch, caplog):
+    symbol = "AAPL"
+    bot_engine._reset_cycle_cache()
+    caplog.set_level("WARNING")
+    monkeypatch.setattr(bot_engine, "_get_intraday_feed", lambda: "yahoo")
+    monkeypatch.setattr(bot_engine, "_prefer_feed_this_cycle", lambda: None)
+    monkeypatch.setattr(
+        bot_engine,
+        "_get_price_provider_order",
+        lambda: ("alpaca_trade", "alpaca_quote", "yahoo"),
+    )
+
+    def _fail_alpaca_symbols():  # pragma: no cover - ensure sanitized skip
+        raise AssertionError("alpaca should not be called with invalid feed")
+
+    monkeypatch.setattr(bot_engine, "_alpaca_symbols", _fail_alpaca_symbols)
+    sentinel = 12.34
+    monkeypatch.setattr(bot_engine, "_attempt_yahoo_price", lambda _s: (sentinel, "yahoo"))
+    monkeypatch.setattr(bot_engine, "_attempt_bars_price", lambda _s: (None, "bars_invalid"))
+    monkeypatch.setattr(
+        "ai_trading.core.bot_engine.is_alpaca_service_available", lambda: True
+    )
+
+    price = bot_engine.get_latest_price(symbol)
+
+    assert price == pytest.approx(sentinel)
+    assert bot_engine._PRICE_SOURCE[symbol] == "yahoo"
+    invalid_logs = [
+        (getattr(record, "provider", None), getattr(record, "requested_feed", None))
+        for record in caplog.records
+        if record.message == "ALPACA_INVALID_FEED_SKIPPED"
+    ]
+    assert invalid_logs
+    assert any(provider == "alpaca_trade" for provider, _ in invalid_logs)
+    assert any(feed == "yahoo" for _, feed in invalid_logs)
+
+
+def test_execute_order_routes_market(monkeypatch):
+    engine = live_trading.ExecutionEngine.__new__(live_trading.ExecutionEngine)
+    calls: dict[str, dict[str, object]] = {}
+
+    def fake_market(self, symbol, side, quantity, **kwargs):
+        calls["market"] = {
+            "symbol": symbol,
+            "side": side,
+            "qty": quantity,
+            "kwargs": kwargs,
+        }
+        return types.SimpleNamespace(id="OID-MARKET", client_order_id="CID-MARKET")
+
+    def fake_limit(self, symbol, side, quantity, **kwargs):  # pragma: no cover - ensure unused
+        calls["limit"] = {
+            "symbol": symbol,
+            "side": side,
+            "qty": quantity,
+            "kwargs": kwargs,
+        }
+        return {"id": "OID-LIMIT", "client_order_id": "CID-LIMIT"}
+
+    monkeypatch.setattr(engine, "submit_market_order", types.MethodType(fake_market, engine))
+    monkeypatch.setattr(engine, "submit_limit_order", types.MethodType(fake_limit, engine))
+
+    order_id = engine.execute_order("AAPL", CoreOrderSide.BUY, 10)
+
+    assert order_id == "OID-MARKET"
+    assert "market" in calls and "limit" not in calls
+    assert calls["market"]["side"] == "buy"
+    assert calls["market"]["kwargs"] == {}
+
+
+def test_execute_order_routes_limit(monkeypatch):
+    engine = live_trading.ExecutionEngine.__new__(live_trading.ExecutionEngine)
+    calls: dict[str, dict[str, object]] = {}
+
+    def fake_market(self, symbol, side, quantity, **kwargs):  # pragma: no cover - ensure unused
+        calls["market"] = {
+            "symbol": symbol,
+            "side": side,
+            "qty": quantity,
+            "kwargs": kwargs,
+        }
+        return types.SimpleNamespace(id="OID-MARKET")
+
+    def fake_limit(self, symbol, side, quantity, **kwargs):
+        calls["limit"] = {
+            "symbol": symbol,
+            "side": side,
+            "qty": quantity,
+            "kwargs": kwargs,
+        }
+        return {"id": "OID-LIMIT"}
+
+    monkeypatch.setattr(engine, "submit_market_order", types.MethodType(fake_market, engine))
+    monkeypatch.setattr(engine, "submit_limit_order", types.MethodType(fake_limit, engine))
+
+    order_id = engine.execute_order(
+        "MSFT",
+        CoreOrderSide.SELL,
+        7,
+        price=123.45,
+        tif="ioc",
+        extended_hours=True,
+    )
+
+    assert order_id == "OID-LIMIT"
+    assert "limit" in calls
+    limit_call = calls["limit"]
+    assert limit_call["side"] == "sell"
+    assert limit_call["qty"] == 7
+    assert limit_call["kwargs"]["limit_price"] == 123.45
+    assert limit_call["kwargs"]["time_in_force"] == "ioc"
+    assert limit_call["kwargs"]["extended_hours"] is True
+    assert "market" not in calls
 


### PR DESCRIPTION
## Summary
- add the missing execute_order adapter and stop-check hook to the live trading execution engine, returning Alpaca order ids with structured logging
- sanitize Alpaca feed handling so non-Alpaca feeds short-circuit to fallbacks and propagate AlpacaOrderHTTPError through submit_order
- extend unit coverage to ensure invalid feeds skip Alpaca calls and the execution adapter dispatches market vs limit submissions

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_price_quote_feed.py

------
https://chatgpt.com/codex/tasks/task_e_68d19883a32c8330ae33973dc1435bfe