### PR TITLE
Fix circuit breaker reset on successful execution

### DIFF
--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -617,7 +617,9 @@ class ExecutionEngine:
         while attempt < self.retry_config['max_attempts']:
             try:
                 result = func(*args, **kwargs)
-                self.circuit_breaker['failure_count'] = min(self.circuit_breaker['failure_count'], 0)
+                self.circuit_breaker['failure_count'] = 0
+                self.circuit_breaker['is_open'] = False
+                self.circuit_breaker['last_failure'] = None
                 return result
             except (APIError, TimeoutError, ConnectionError) as e:
                 attempt += 1

--- a/tests/unit/test_live_trading_circuit_breaker.py
+++ b/tests/unit/test_live_trading_circuit_breaker.py
@@ -1,0 +1,44 @@
+"""Tests for the live trading execution engine circuit breaker behaviour."""
+
+from ai_trading.execution import live_trading
+
+
+def _make_engine():
+    engine = live_trading.ExecutionEngine.__new__(live_trading.ExecutionEngine)
+    engine.retry_config = {
+        'max_attempts': 3,
+        'base_delay': 0,
+        'max_delay': 0,
+        'exponential_base': 1,
+    }
+    engine.circuit_breaker = {
+        'failure_count': 0,
+        'max_failures': 1,
+        'reset_time': 300,
+        'last_failure': None,
+        'is_open': False,
+    }
+    engine.stats = {
+        'retry_count': 0,
+        'circuit_breaker_trips': 0,
+    }
+    engine.is_initialized = True
+    engine.trading_client = None
+    return engine
+
+
+def test_circuit_breaker_closes_after_success():
+    engine = _make_engine()
+
+    # Trip the breaker on failure and ensure it blocks subsequent work.
+    engine._handle_execution_failure(RuntimeError('forced failure'))
+    assert engine.circuit_breaker['is_open'] is True
+    assert not engine._pre_execution_checks()
+
+    # Successful execution should immediately clear breaker state.
+    result = engine._execute_with_retry(lambda: 'ok')
+    assert result == 'ok'
+    assert engine.circuit_breaker['failure_count'] == 0
+    assert engine.circuit_breaker['is_open'] is False
+    assert engine.circuit_breaker['last_failure'] is None
+    assert engine._pre_execution_checks()


### PR DESCRIPTION
## Summary
- ensure successful executions clear the circuit breaker state so new orders can flow immediately
- add a unit test covering the breaker trip followed by a successful retry to verify _pre_execution_checks reopens trading

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_live_trading_circuit_breaker.py


------
https://chatgpt.com/codex/tasks/task_e_68d2b9d3a01483308ca049f681bc25ac