### PR TITLE
Ensure Alpaca clients respect paper mode

### DIFF
--- a/ai_trading/core/alpaca_client.py
+++ b/ai_trading/core/alpaca_client.py
@@ -222,7 +222,12 @@ def _initialize_alpaca_clients() -> bool:
             be.data_client = None
             return False
         try:
-            be.trading_client = AlpacaREST(api_key=key, secret_key=secret, url_override=base_url)
+            be.trading_client = AlpacaREST(
+                api_key=key,
+                secret_key=secret,
+                paper="paper" in str(base_url).lower(),
+                url_override=base_url,
+            )
             be.data_client = stock_client_cls(api_key=key, secret_key=secret)
         except (APIError, TypeError, ValueError, OSError) as e:
             logger.error("ALPACA_CLIENT_INIT_FAILED", extra={"error": str(e)})

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8441,6 +8441,7 @@ def _initialize_alpaca_clients() -> bool:
             trading_client = AlpacaREST(
                 api_key=key,
                 secret_key=secret,
+                paper="paper" in str(base_url).lower(),
                 url_override=base_url,
             )
             data_client = stock_client_cls(

--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -221,6 +221,7 @@ class ExecutionEngine:
             raw_client = AlpacaREST(
                 api_key=key,
                 secret_key=secret,
+                paper=paper,
                 url_override=base_url,
             )
             config_paper = paper if self.config is None else bool(self.config.use_paper)


### PR DESCRIPTION
## Summary
- forward the resolved paper/live mode when building Alpaca trading clients in live trading and core engine helpers
- cover the paper flag propagation with a regression test that exercises both paper and live execution modes

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/institutional/test_live_trading.py::test_initialize_sets_paper_flag -q` *(skipped: requires optional requests/alpaca packages during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bc77b9cc83308bb716bd10cb214d