### PR TITLE
Use Alpaca request objects when submitting orders

### DIFF
--- a/tests/test_alpaca_api_module.py
+++ b/tests/test_alpaca_api_module.py
@@ -40,3 +40,69 @@ def test_submit_order_rate_limit(monkeypatch):
         alpaca_api.submit_order("AAPL", "buy", qty=1, client=api)
     assert getattr(e.value, "status", None) == 429
     assert api.calls == 1
+
+
+def test_submit_order_uses_request_object(monkeypatch):
+    monkeypatch.delenv("SHADOW_MODE", raising=False)
+
+    class _BaseRequest:
+        def __init__(self, **kwargs):
+            self._kwargs = kwargs
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    class _MarketReq(_BaseRequest):
+        pass
+
+    class _LimitReq(_BaseRequest):
+        pass
+
+    class _StopReq(_BaseRequest):
+        pass
+
+    class _StopLimitReq(_BaseRequest):
+        pass
+
+    monkeypatch.setattr(alpaca_api, "MarketOrderRequest", _MarketReq)
+    monkeypatch.setattr(alpaca_api, "LimitOrderRequest", _LimitReq)
+    monkeypatch.setattr(alpaca_api, "StopOrderRequest", _StopReq)
+    monkeypatch.setattr(alpaca_api, "StopLimitOrderRequest", _StopLimitReq)
+
+    class RequestClient:
+        def __init__(self):
+            self.calls = 0
+            self.last = None
+
+        def submit_order(self, *, order_data, idempotency_key=None):
+            if isinstance(order_data, dict):  # pragma: no cover - defensive
+                raise AssertionError("request object should not be a dict")
+            self.calls += 1
+            self.last = (order_data, idempotency_key)
+            payload = {
+                "id": "abc123",
+                "client_order_id": getattr(order_data, "client_order_id", None),
+                "symbol": getattr(order_data, "symbol", None),
+                "qty": getattr(order_data, "qty", None),
+                "side": getattr(order_data, "side", None),
+                "time_in_force": getattr(order_data, "time_in_force", None),
+            }
+            return types.SimpleNamespace(id="abc123", _raw=payload)
+
+    client = RequestClient()
+    result = alpaca_api.submit_order(
+        "AAPL",
+        "buy",
+        qty=1,
+        client=client,
+        idempotency_key="idem-1",
+        timeout=5,
+    )
+
+    assert client.calls == 1
+    request_obj, idem = client.last
+    assert isinstance(request_obj, _MarketReq)
+    assert request_obj.symbol == "AAPL"
+    assert request_obj.qty == "1"
+    assert request_obj.side == "buy"
+    assert idem == "idem-1"
+    assert result["client_order_id"] == "idem-1"


### PR DESCRIPTION
## Summary
- build Alpaca order requests before calling `TradingClient.submit_order` and detect request-style signatures
- retain the keyword-based fallback path for legacy clients so retries and idempotency tracking still function
- add unit coverage with a fake TradingClient enforcing the new interface to ensure compatibility

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_api_module.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d2c2d85ef88330867434421059610d