### PR TITLE
Update coverage recovery logging to reflect resolved feed

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -150,6 +150,20 @@ def _alpaca_available() -> bool:
 
 from ai_trading.data import bars
 
+
+def _coverage_recovery_event(resolved_feed: str | None) -> str:
+    """Return a log event name that reflects the resolved recovery feed."""
+
+    if not resolved_feed:
+        return "COVERAGE_RECOVERY"
+    feed_token = "".join(
+        ch if ch.isalnum() else "_"
+        for ch in str(resolved_feed).upper()
+    ).strip("_")
+    if not feed_token:
+        return "COVERAGE_RECOVERY"
+    return f"COVERAGE_RECOVERY_{feed_token}"
+
 try:  # pragma: no cover
     from alpaca.data.historical.stock import StockHistoricalDataClient  # type: ignore
 except ImportError:  # pragma: no cover
@@ -3933,8 +3947,9 @@ def fetch_minute_df_safe(symbol: str) -> pd.DataFrame:
                         resolved_provider = f"alpaca_{resolved_feed}"
                     else:
                         resolved_provider = resolved_feed
+                event_name = _coverage_recovery_event(resolved_feed)
                 logger.warning(
-                    "COVERAGE_RECOVERY_SIP",
+                    event_name,
                     extra={
                         "symbol": symbol,
                         "prev_feed": current_feed,
@@ -6845,8 +6860,9 @@ def _try_sip_recovery(
 
     new_cov = round(new_bars / max(expected_bars, 1), 4)
     prev_cov = round(primary_actual_bars / max(expected_bars, 1), 4)
+    event_name = _coverage_recovery_event("sip")
     logger.warning(
-        "COVERAGE_RECOVERY_SIP",
+        event_name,
         extra={
             "symbol": symbol,
             "prev_feed": "iex",

--- a/tests/core/bot_engine/test_coverage_recovery_provider.py
+++ b/tests/core/bot_engine/test_coverage_recovery_provider.py
@@ -126,8 +126,9 @@ def test_coverage_recovery_uses_backup_provider_annotation(monkeypatch, caplog):
     assert isinstance(result, pd.DataFrame)
     assert call_history.count("sip") >= 1
     assert result.attrs.get("data_provider") == "yahoo"
+    expected_event = "COVERAGE_RECOVERY_YAHOO"
     assert any(
-        record.message == "COVERAGE_RECOVERY_SIP" and getattr(record, "new_feed", None) == "yahoo"
+        record.message == expected_event and getattr(record, "new_feed", None) == "yahoo"
         for record in caplog.records
     )
     assert cached_feeds == ["yahoo"]


### PR DESCRIPTION
## Summary
- add a helper to derive coverage recovery log event names from the resolved data feed
- log feed-specific recovery events for fallback data so non-SIP sources are reflected in the message
- update the coverage recovery provider test to assert the new feed-specific event name

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/core/bot_engine/test_coverage_recovery_provider.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d2d94f568c83308e0a0942524b05d7