### PR TITLE
Add market regime detection output and tests

### DIFF
--- a/ai_trading/position/market_regime.py
+++ b/ai_trading/position/market_regime.py
@@ -26,8 +26,10 @@ class MarketRegime(Enum):
 
 @dataclass
 class RegimeMetrics:
-    """Placeholder metrics container."""
+    """Lightweight metrics summary for detected market regimes."""
 
+    regime: MarketRegime = MarketRegime.RANGE_BOUND
+    confidence: float = 0.0
     trend_strength: float = 0.0
     volatility_percentile: float = 0.0
 
@@ -35,9 +37,17 @@ class RegimeMetrics:
 class MarketRegimeDetector:
     """Very small regime detector used in tests."""
 
+    _DEFAULT_CONFIDENCE = 0.2
+
     def __init__(self, ctx: Any | None = None) -> None:
         self.ctx = ctx
         self.logger = get_logger(self.__class__.__name__)
+
+    @staticmethod
+    def _clamp(value: float, lower: float = 0.0, upper: float = 1.0) -> float:
+        """Clamp a float to the provided bounds."""
+
+        return max(lower, min(upper, value))
 
     def _classify_regime(
         self,
@@ -57,6 +67,76 @@ class MarketRegimeDetector:
         if strength >= 0.6:
             return MarketRegime.TRENDING_BULL if direction >= 0 else MarketRegime.TRENDING_BEAR
         return MarketRegime.RANGE_BOUND
+
+    def detect_regime(
+        self,
+        trend_metrics: dict[str, float] | None = None,
+        vol_metrics: dict[str, float] | None = None,
+        momentum_metrics: dict[str, float] | None = None,
+        mean_reversion_metrics: dict[str, float] | None = None,
+    ) -> RegimeMetrics:
+        """Produce a lightweight regime assessment for the position manager."""
+
+        trend_metrics = trend_metrics or {}
+        vol_metrics = vol_metrics or {}
+        momentum_metrics = momentum_metrics or {}
+        mean_reversion_metrics = mean_reversion_metrics or {}
+
+        trend_strength = float(trend_metrics.get("strength", 0.0) or 0.0)
+        volatility_percentile = float(vol_metrics.get("percentile", 0.0) or 0.0)
+
+        has_signal = any((trend_metrics, vol_metrics, momentum_metrics, mean_reversion_metrics))
+        if not has_signal:
+            self.logger.debug("detect_regime called without metrics; returning defaults")
+            return RegimeMetrics(
+                regime=MarketRegime.RANGE_BOUND,
+                confidence=self._DEFAULT_CONFIDENCE,
+                trend_strength=0.0,
+                volatility_percentile=0.0,
+            )
+
+        regime = self._classify_regime(
+            trend_metrics, vol_metrics, momentum_metrics, mean_reversion_metrics
+        )
+
+        confidence_components: list[float] = []
+        if "strength" in trend_metrics:
+            confidence_components.append(self._clamp(abs(trend_strength)))
+        if "percentile" in vol_metrics:
+            confidence_components.append(self._clamp(volatility_percentile / 100.0))
+        if "score" in momentum_metrics:
+            momentum_score = float(momentum_metrics.get("score", 0.0) or 0.0)
+            confidence_components.append(self._clamp(abs(momentum_score)))
+        if "score" in mean_reversion_metrics:
+            mean_rev_score = float(mean_reversion_metrics.get("score", 0.0) or 0.0)
+            # Scores close to 0.5 imply balanced mean-reversion; favor extremes less.
+            balance = 1.0 - min(abs(mean_rev_score - 0.5) * 2.0, 1.0)
+            confidence_components.append(self._clamp(balance))
+
+        if confidence_components:
+            confidence = sum(confidence_components) / len(confidence_components)
+        else:
+            confidence = self._DEFAULT_CONFIDENCE
+
+        if regime in (MarketRegime.TRENDING_BULL, MarketRegime.TRENDING_BEAR):
+            confidence = max(confidence, self._clamp(trend_strength))
+        elif regime is MarketRegime.HIGH_VOLATILITY:
+            high_vol_conf = (volatility_percentile - 50.0) / 50.0
+            confidence = max(confidence, self._clamp(high_vol_conf))
+
+        confidence = self._clamp(confidence)
+
+        regime_metrics = RegimeMetrics(
+            regime=regime,
+            confidence=confidence,
+            trend_strength=trend_strength,
+            volatility_percentile=volatility_percentile,
+        )
+
+        self.logger.debug(
+            "detect_regime classified %s with confidence %.2f", regime_metrics.regime, regime_metrics.confidence
+        )
+        return regime_metrics
 
     def get_regime_parameters(self, regime: MarketRegime) -> dict[str, float]:
         """Return heuristic parameters for a regime."""

--- a/tests/test_market_regime_detector_unit.py
+++ b/tests/test_market_regime_detector_unit.py
@@ -1,0 +1,36 @@
+"""Unit tests for the lightweight MarketRegimeDetector utilities."""
+
+import pytest
+
+from ai_trading.position.market_regime import MarketRegime, MarketRegimeDetector, RegimeMetrics
+
+
+def test_detect_regime_happy_path():
+    """detect_regime should return a populated metrics container when data is provided."""
+
+    detector = MarketRegimeDetector()
+    metrics = detector.detect_regime(
+        trend_metrics={'strength': 0.7, 'direction': 0.3},
+        vol_metrics={'percentile': 40.0},
+        momentum_metrics={'score': 0.6},
+        mean_reversion_metrics={'score': 0.2},
+    )
+
+    assert isinstance(metrics, RegimeMetrics)
+    assert metrics.regime == MarketRegime.TRENDING_BULL
+    assert 0.6 <= metrics.confidence <= 1.0
+    assert metrics.trend_strength == 0.7
+    assert metrics.volatility_percentile == 40.0
+
+
+def test_detect_regime_fallback_defaults():
+    """detect_regime should return safe defaults when no metrics are supplied."""
+
+    detector = MarketRegimeDetector()
+    metrics = detector.detect_regime()
+
+    assert isinstance(metrics, RegimeMetrics)
+    assert metrics.regime == MarketRegime.RANGE_BOUND
+    assert metrics.confidence == pytest.approx(0.2)
+    assert metrics.trend_strength == 0.0
+    assert metrics.volatility_percentile == 0.0


### PR DESCRIPTION
## Summary
- extend the lightweight regime metrics container with regime and confidence fields
- implement MarketRegimeDetector.detect_regime to return a classified regime with derived confidence
- add focused unit tests covering happy path and default fallback behaviour

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_market_regime_detector_unit.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d2db8daff883308615d926a95fc65f