### PR TITLE
Ensure systemd unit pins API port to 9001

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -147,6 +147,7 @@ User=ai-trading
 Group=ai-trading
 WorkingDirectory=/opt/ai-trading-bot
 Environment=PATH=/opt/ai-trading-bot/venv/bin
+Environment=API_PORT=9001
 ExecStart=/opt/ai-trading-bot/venv/bin/python -m ai_trading
 Restart=on-failure
 RestartSec=10

--- a/README.md
+++ b/README.md
@@ -1154,6 +1154,7 @@ Environment=AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot
 Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
 Environment=AI_TRADING_MODELS_DIR=/var/lib/ai-trading-bot/models
 Environment=AI_TRADING_OUTPUT_DIR=/var/lib/ai-trading-bot/output
+Environment=API_PORT=9001
 ExecStart=/opt/ai-trading-bot/venv/bin/python -m ai_trading
 Restart=on-failure
 RestartSec=10

--- a/packaging/systemd/ai-trading.service
+++ b/packaging/systemd/ai-trading.service
@@ -15,6 +15,7 @@ Environment=AI_TRADING_CACHE_DIR=/var/cache/ai-trading-bot
 Environment=AI_TRADING_LOG_DIR=/var/log/ai-trading-bot
 Environment=AI_TRADING_MODELS_DIR=/var/lib/ai-trading-bot/models
 Environment=AI_TRADING_OUTPUT_DIR=/var/lib/ai-trading-bot/output
+Environment=API_PORT=9001
 Environment=TRADE_LOG_PATH=/home/aiuser/ai-trading-bot/logs/trades.jsonl
 Environment=ALPACA_API_URL=https://paper-api.alpaca.markets
 EnvironmentFile=-/home/aiuser/ai-trading-bot/.env


### PR DESCRIPTION
## Summary
- set API_PORT=9001 in the packaged ai-trading systemd unit so deployments align with ai_trading.settings
- document the explicit API_PORT=9001 expectation in the README and deployment guide

## Testing
- pytest tests/config/test_env_aliases_unified.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d2deb45f848330a0866b7b9c6a86db