### PR TITLE
Handle pending orders with cleanup and tests

### DIFF
--- a/ai_trading/config/runtime.py
+++ b/ai_trading/config/runtime.py
@@ -779,9 +779,10 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
         field="order_stale_cleanup_interval",
         env=("ORDER_STALE_CLEANUP_INTERVAL",),
         cast="int",
-        default=60,
-        description="Interval in seconds between stale order cleanup sweeps.",
-        min_value=1,
+        default=120,
+        description="Seconds to wait before auto-canceling pending/new orders to unstick the trade loop.",
+        min_value=10,
+        max_value=3600,
     ),
     ConfigSpec(
         field="order_fill_rate_target",

--- a/tests/bot_engine/test_pending_orders_cleanup.py
+++ b/tests/bot_engine/test_pending_orders_cleanup.py
@@ -1,0 +1,130 @@
+"""Tests for pending-order reconciliation logic in the bot engine."""
+
+import logging
+import sys
+import types
+from unittest.mock import MagicMock
+
+if "ai_trading.indicators" not in sys.modules:
+    indicators_stub = types.ModuleType("ai_trading.indicators")
+
+    def _unavailable_indicator(*_args, **_kwargs):  # pragma: no cover - safety stub
+        raise RuntimeError("Indicator module unavailable in tests")
+
+    indicators_stub.compute_atr = _unavailable_indicator
+    indicators_stub.atr = _unavailable_indicator
+    indicators_stub.mean_reversion_zscore = _unavailable_indicator
+    indicators_stub.rsi = _unavailable_indicator
+    sys.modules["ai_trading.indicators"] = indicators_stub
+
+if "ai_trading.signals" not in sys.modules:
+    signals_stub = types.ModuleType("ai_trading.signals")
+    signals_indicators_stub = types.ModuleType("ai_trading.signals.indicators")
+
+    def _composite_confidence_stub(*_args, **_kwargs):  # pragma: no cover - safety stub
+        return {}
+
+    signals_indicators_stub.composite_signal_confidence = _composite_confidence_stub
+    sys.modules["ai_trading.signals"] = signals_stub
+    sys.modules["ai_trading.signals.indicators"] = signals_indicators_stub
+    signals_stub.indicators = signals_indicators_stub
+
+if "ai_trading.features" not in sys.modules:
+    features_stub = types.ModuleType("ai_trading.features")
+    features_indicators_stub = types.ModuleType("ai_trading.features.indicators")
+
+    def _feature_passthrough(df, **_kwargs):  # pragma: no cover - safety stub
+        return df
+
+    features_indicators_stub.compute_macd = _feature_passthrough
+    features_indicators_stub.compute_macds = _feature_passthrough
+    features_indicators_stub.compute_vwap = _feature_passthrough
+    features_indicators_stub.compute_atr = _feature_passthrough
+    features_indicators_stub.compute_sma = _feature_passthrough
+    features_indicators_stub.ensure_columns = _feature_passthrough
+    sys.modules["ai_trading.features"] = features_stub
+    sys.modules["ai_trading.features.indicators"] = features_indicators_stub
+    features_stub.indicators = features_indicators_stub
+
+if "portalocker" not in sys.modules:
+    portalocker_stub = types.ModuleType("portalocker")
+    portalocker_stub.LOCK_EX = 1
+
+    def _noop_lock(*_args, **_kwargs):  # pragma: no cover - safety stub
+        return None
+
+    portalocker_stub.lock = _noop_lock
+    portalocker_stub.unlock = _noop_lock
+    sys.modules["portalocker"] = portalocker_stub
+
+if "bs4" not in sys.modules:
+    bs4_stub = types.ModuleType("bs4")
+
+    class _BeautifulSoup:  # pragma: no cover - safety stub
+        def __init__(self, *_args, **_kwargs):
+            self.text = ""
+
+        def find(self, *_args, **_kwargs):
+            return None
+
+    bs4_stub.BeautifulSoup = _BeautifulSoup
+    sys.modules["bs4"] = bs4_stub
+
+from ai_trading.core import bot_engine as be
+
+
+def _order(status: str, oid: str = "order-1"):
+    return types.SimpleNamespace(id=oid, status=status)
+
+
+def test_handle_pending_orders_grace_then_cleanup(monkeypatch, caplog):
+    runtime = types.SimpleNamespace()
+    cancel_mock = MagicMock()
+    monkeypatch.setattr(be, "cancel_all_open_orders", cancel_mock)
+    monkeypatch.setattr(
+        be,
+        "get_trading_config",
+        lambda: types.SimpleNamespace(order_stale_cleanup_interval=12),
+    )
+    clock = types.SimpleNamespace(value=100.0)
+    monkeypatch.setattr(be.time, "time", lambda: clock.value)
+    be._pending_orders_since = None
+    be._pending_orders_last_log = None
+
+    caplog.set_level(logging.INFO)
+    orders = [_order("pending_new", "o-1")]
+
+    assert be._handle_pending_orders(orders, runtime) is True
+    first_record = caplog.records[0]
+    assert first_record.message == "PENDING_ORDERS_DETECTED"
+    assert first_record.pending_ids == ["o-1"]
+    assert first_record.cleanup_after_s == 12
+    assert cancel_mock.call_count == 0
+
+    clock.value = 105.0
+    caplog.clear()
+    assert be._handle_pending_orders(orders, runtime) is True
+    assert cancel_mock.call_count == 0
+    assert all(record.message != "PENDING_ORDERS_CANCELED" for record in caplog.records)
+
+    clock.value = 120.0
+    caplog.clear()
+    assert be._handle_pending_orders(orders, runtime) is False
+    cancel_mock.assert_called_once_with(runtime)
+    messages = [record.message for record in caplog.records]
+    assert "PENDING_ORDERS_CANCELED" in messages
+    assert be._pending_orders_since is None
+    assert be._pending_orders_last_log is None
+
+
+def test_handle_pending_orders_clears_tracker(monkeypatch, caplog):
+    be._pending_orders_since = 95.0
+    be._pending_orders_last_log = 95.0
+    monkeypatch.setattr(be.time, "time", lambda: 150.0)
+    caplog.set_level(logging.INFO)
+
+    runtime = types.SimpleNamespace()
+    assert be._handle_pending_orders([], runtime) is False
+    assert be._pending_orders_since is None
+    assert be._pending_orders_last_log is None
+    assert any(record.message == "PENDING_ORDERS_CLEARED" for record in caplog.records)

--- a/tests/test_critical_trading_fixes.py
+++ b/tests/test_critical_trading_fixes.py
@@ -308,7 +308,7 @@ class TestOrderManagementFixes(unittest.TestCase):
     def test_order_timeout_configuration(self):
         """Test that order timeout is properly configured."""
         self.assertEqual(config.ORDER_TIMEOUT_SECONDS, 300)  # 5 minutes
-        self.assertEqual(config.ORDER_STALE_CLEANUP_INTERVAL, 60)  # 1 minute
+        self.assertEqual(config.ORDER_STALE_CLEANUP_INTERVAL, 120)  # 2 minutes
         self.assertEqual(config.ORDER_FILL_RATE_TARGET, 0.80)  # 80%
 
     @patch('time.time')


### PR DESCRIPTION
## Summary
- add a reusable pending-order handler that enforces a grace window, cancels stale orders, and emits structured logs
- raise the default ORDER_STALE_CLEANUP_INTERVAL to 120s and update the existing configuration test
- add unit coverage for the new logic with lightweight dependency stubs to isolate bot_engine

## Testing
- ruff check ai_trading/core/bot_engine.py tests/bot_engine/test_pending_orders_cleanup.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_pending_orders_cleanup.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d2ecf8aae08330b966426ee5d984b0