### PR TITLE
Fix pending order cleanup persistence and startup reconcile

### DIFF
--- a/ai_trading/core/runtime.py
+++ b/ai_trading/core/runtime.py
@@ -69,6 +69,7 @@ class BotRuntime:
     drawdown_circuit_breaker: Any = None
     model: Any = None
     allocator: AllocatorProtocol | None = None
+    state: dict[str, Any] = field(default_factory=dict)
 
 def build_runtime(cfg: TradingConfig, **kwargs: Any) -> BotRuntime:
     """


### PR DESCRIPTION
## Summary
- persist pending-order tracking on the runtime with richer log metadata and rate limiting
- add a startup reconciliation pass that cancels stale pending orders once and logs outcomes
- extend pending-order cleanup tests to cover runtime state handling and guard behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d2f0d877e4833082f9505fc18f9b3a