### PR TITLE
Implement trailing stops, allocator caps, and meta-learning persistence

### DIFF
--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -4,6 +4,7 @@ Core execution engine for institutional order management.
 Provides order lifecycle management, execution algorithms,
 and real-time execution monitoring with institutional controls.
 """
+
 from __future__ import annotations
 from ai_trading.logging import get_logger
 import math
@@ -17,15 +18,20 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, TYPE_CHECKING
 from types import SimpleNamespace
+
 try:  # pragma: no cover - Alpaca SDK optional in tests
     from alpaca.common.exceptions import APIError
 except Exception:  # ImportError
+
     class APIError(Exception):
         """Fallback when Alpaca SDK is unavailable."""
+
+
 from ai_trading.logging.emit_once import emit_once
 from ai_trading.metrics import get_counter
 from ai_trading.config.management import get_env
 from ai_trading.utils.time import safe_utcnow
+from ai_trading.meta_learning.persistence import record_trade_fill
 
 logger = get_logger(__name__)
 ORDER_STALE_AFTER_S = 8 * 60
@@ -40,12 +46,14 @@ from ai_trading.monitoring.order_health_monitor import (
     _active_orders as _mon_active,
     _order_tracking_lock as _mon_lock,
 )
+
 _active_orders = _mon_active
 _order_tracking_lock = _mon_lock
 
 _PRIMARY_FALLBACK_SOURCE = "unknown"
 
-def _cleanup_stale_orders(now: float | None=None, max_age_s: int | None=None) -> int:
+
+def _cleanup_stale_orders(now: float | None = None, max_age_s: int | None = None) -> int:
     """Remove orders older than ``max_age_s`` and return count."""
     max_age = max_age_s if max_age_s is not None else ORDER_STALE_AFTER_S
     now_s = now if now is not None else time.time()
@@ -56,6 +64,8 @@ def _cleanup_stale_orders(now: float | None=None, max_age_s: int | None=None) ->
                 _active_orders.pop(oid, None)
                 removed += 1
     return removed
+
+
 from ai_trading.market.symbol_specs import TICK_BY_SYMBOL, get_lot_size, get_tick_size
 from ai_trading.math.money import Money, round_to_lot, round_to_tick
 from ..core.constants import EXECUTION_PARAMETERS
@@ -65,21 +75,24 @@ from .idempotency import OrderIdempotencyCache
 if TYPE_CHECKING:  # pragma: no cover - type checking only
     from ai_trading.risk.engine import TradeSignal
 
+
 def _ensure_positive_qty(qty: float) -> float:
     if qty is None:
-        raise ValueError('qty_none')
+        raise ValueError("qty_none")
     q = float(qty)
     if not math.isfinite(q) or q <= 0.0:
-        raise ValueError(f'invalid_qty:{qty}')
+        raise ValueError(f"invalid_qty:{qty}")
     return q
+
 
 def _ensure_valid_price(price: float | None) -> float | None:
     if price is None:
         return None
     p = float(price)
     if not math.isfinite(p) or p <= 0.0:
-        raise ValueError(f'invalid_price:{price}')
+        raise ValueError(f"invalid_price:{price}")
     return p
+
 
 def _normalize_order_side(side: OrderSide | str | None) -> OrderSide | None:
     """Best-effort normalization of ``side`` to :class:`OrderSide`."""
@@ -93,14 +106,17 @@ def _normalize_order_side(side: OrderSide | str | None) -> OrderSide | None:
     except Exception:
         return None
 
+
 class ExecutionAlgorithm(Enum):
     """Execution algorithm types."""
-    MARKET = 'market'
-    LIMIT = 'limit'
-    VWAP = 'vwap'
-    TWAP = 'twap'
-    IMPLEMENTATION_SHORTFALL = 'implementation_shortfall'
-    ICEBERG = 'iceberg'
+
+    MARKET = "market"
+    LIMIT = "limit"
+    VWAP = "vwap"
+    TWAP = "twap"
+    IMPLEMENTATION_SHORTFALL = "implementation_shortfall"
+    ICEBERG = "iceberg"
+
 
 class Order:
     """
@@ -110,16 +126,24 @@ class Order:
     partial fills, and institutional metadata.
     """
 
-    def __init__(self, symbol: str, side: OrderSide, quantity: int, order_type: OrderType=OrderType.MARKET, price: Money=None, **kwargs):
+    def __init__(
+        self,
+        symbol: str,
+        side: OrderSide,
+        quantity: int,
+        order_type: OrderType = OrderType.MARKET,
+        price: Money = None,
+        **kwargs,
+    ):
         """Initialize order with institutional parameters."""
-        self.id = kwargs.get('id', str(uuid.uuid4()))
+        self.id = kwargs.get("id", str(uuid.uuid4()))
         self.symbol = symbol
         self.side = side
         self.quantity = quantity
         self.order_type = order_type
         tick = TICK_BY_SYMBOL.get(symbol)
         self.price = Money(price, tick) if price is not None else None
-        exp = kwargs.get('expected_price')
+        exp = kwargs.get("expected_price")
         self.expected_price = Money(exp, tick) if exp is not None else None
         self.status = OrderStatus.PENDING
         self.filled_quantity = 0
@@ -128,24 +152,23 @@ class Order:
         self.created_at = datetime.now(UTC)
         self.updated_at = self.created_at
         self.executed_at = None
-        self.client_order_id = kwargs.get('client_order_id', f'ord_{int(time.time())}')
-        self.strategy_id = kwargs.get('strategy_id')
-        self.execution_algorithm = kwargs.get('execution_algorithm', ExecutionAlgorithm.MARKET)
-        self.time_in_force = kwargs.get('time_in_force', 'DAY')
-        self.min_quantity = kwargs.get('min_quantity', 0)
-        self.stop_price = kwargs.get('stop_price')
-        self.target_price = kwargs.get('target_price')
-        self.price_source = kwargs.get('price_source', 'unknown')
-        self.expected_price_source = kwargs.get('expected_price_source', self.price_source)
-        self.max_participation_rate = kwargs.get('max_participation_rate', 0.1)
-        self.max_slippage_bps = kwargs.get('max_slippage_bps', EXECUTION_PARAMETERS['MAX_SLIPPAGE_BPS'])
-        self.urgency_level = kwargs.get('urgency_level', 'normal')
-        self.notes = kwargs.get('notes', '')
-        self.source_system = kwargs.get('source_system', 'ai_trading')
-        self.parent_order_id = kwargs.get('parent_order_id')
+        self.client_order_id = kwargs.get("client_order_id", f"ord_{int(time.time())}")
+        self.strategy_id = kwargs.get("strategy_id")
+        self.execution_algorithm = kwargs.get("execution_algorithm", ExecutionAlgorithm.MARKET)
+        self.time_in_force = kwargs.get("time_in_force", "DAY")
+        self.min_quantity = kwargs.get("min_quantity", 0)
+        self.stop_price = kwargs.get("stop_price")
+        self.target_price = kwargs.get("target_price")
+        self.price_source = kwargs.get("price_source", "unknown")
+        self.expected_price_source = kwargs.get("expected_price_source", self.price_source)
+        self.max_participation_rate = kwargs.get("max_participation_rate", 0.1)
+        self.max_slippage_bps = kwargs.get("max_slippage_bps", EXECUTION_PARAMETERS["MAX_SLIPPAGE_BPS"])
+        self.urgency_level = kwargs.get("urgency_level", "normal")
+        self.notes = kwargs.get("notes", "")
+        self.source_system = kwargs.get("source_system", "ai_trading")
+        self.parent_order_id = kwargs.get("parent_order_id")
         self.slippage_bps = 0.0
-        logger.debug(f'Order created: {self.id} {self.side} {self.quantity} {self.symbol}')
-
+        logger.debug(f"Order created: {self.id} {self.side} {self.quantity} {self.symbol}")
 
     @property
     def remaining_quantity(self) -> int:
@@ -173,17 +196,17 @@ class Order:
         price = self.price or self.average_fill_price or Money(0)
         return Money(abs(self.quantity)) * price
 
-    def add_fill(self, quantity: int, price: Money, timestamp: datetime=None):
+    def add_fill(self, quantity: int, price: Money, timestamp: datetime = None):
         """Add a fill to the order with precise money math."""
         if timestamp is None:
             timestamp = datetime.now(UTC)
         tick = TICK_BY_SYMBOL.get(self.symbol)
         if not isinstance(price, Money):
             price = Money(price, tick)
-        fill = {'quantity': quantity, 'price': price, 'timestamp': timestamp, 'fill_id': str(uuid.uuid4())}
+        fill = {"quantity": quantity, "price": price, "timestamp": timestamp, "fill_id": str(uuid.uuid4())}
         self.fills.append(fill)
         self.filled_quantity += quantity
-        total_value = sum((Money(f['quantity']) * f['price'] for f in self.fills))
+        total_value = sum((Money(f["quantity"]) * f["price"] for f in self.fills))
         self.average_fill_price = total_value / Money(self.filled_quantity) if self.filled_quantity > 0 else Money(0)
         if self.is_filled:
             self.status = OrderStatus.FILLED
@@ -191,41 +214,41 @@ class Order:
         elif self.is_partially_filled:
             self.status = OrderStatus.PARTIALLY_FILLED
         self.updated_at = timestamp
-        logger.debug(f'Fill added to order {self.id}: {quantity}@{price} ({self.fill_percentage:.1f}% filled)')
+        logger.debug(f"Fill added to order {self.id}: {quantity}@{price} ({self.fill_percentage:.1f}% filled)")
 
-    def cancel(self, reason: str='User cancelled'):
+    def cancel(self, reason: str = "User cancelled"):
         """Cancel the order."""
         if self.status in [OrderStatus.FILLED, OrderStatus.CANCELED, OrderStatus.REJECTED]:
-            logger.warning(f'Cannot cancel order {self.id} in status {self.status}')
+            logger.warning(f"Cannot cancel order {self.id} in status {self.status}")
             return False
         self.status = OrderStatus.CANCELED
         self.updated_at = datetime.now(UTC)
-        self.notes += f' | Cancelled: {reason}'
-        logger.info(f'Order {self.id} cancelled: {reason}')
+        self.notes += f" | Cancelled: {reason}"
+        logger.info(f"Order {self.id} cancelled: {reason}")
         return True
 
     def to_dict(self) -> dict:
         """Convert order to dictionary representation."""
         return {
-            'id': self.id,
-            'symbol': self.symbol,
-            'side': self.side.value if isinstance(self.side, OrderSide) else self.side,
-            'quantity': self.quantity,
-            'order_type': self.order_type.value if isinstance(self.order_type, OrderType) else self.order_type,
-            'price': self.price,
-            'expected_price': self.expected_price,
-            'status': self.status.value if isinstance(self.status, OrderStatus) else self.status,
-            'filled_quantity': self.filled_quantity,
-            'average_fill_price': self.average_fill_price,
-            'slippage_bps': self.slippage_bps,
-            'created_at': self.created_at.isoformat(),
-            'updated_at': self.updated_at.isoformat(),
-            'executed_at': self.executed_at.isoformat() if self.executed_at else None,
-            'client_order_id': self.client_order_id,
-            'strategy_id': self.strategy_id,
-            'fills': self.fills,
-            'notional_value': self.notional_value,
-            'fill_percentage': self.fill_percentage,
+            "id": self.id,
+            "symbol": self.symbol,
+            "side": self.side.value if isinstance(self.side, OrderSide) else self.side,
+            "quantity": self.quantity,
+            "order_type": self.order_type.value if isinstance(self.order_type, OrderType) else self.order_type,
+            "price": self.price,
+            "expected_price": self.expected_price,
+            "status": self.status.value if isinstance(self.status, OrderStatus) else self.status,
+            "filled_quantity": self.filled_quantity,
+            "average_fill_price": self.average_fill_price,
+            "slippage_bps": self.slippage_bps,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "executed_at": self.executed_at.isoformat() if self.executed_at else None,
+            "client_order_id": self.client_order_id,
+            "strategy_id": self.strategy_id,
+            "fills": self.fills,
+            "notional_value": self.notional_value,
+            "fill_percentage": self.fill_percentage,
         }
 
 
@@ -301,6 +324,7 @@ class ExecutionResult(str):
         except (TypeError, ValueError):
             return None
 
+
 class OrderManager:
     """
     Order lifecycle management for institutional execution.
@@ -314,13 +338,13 @@ class OrderManager:
         self.orders: dict[str, Order] = {}
         self.active_orders: dict[str, Order] = {}
         self.execution_callbacks: list[Callable] = []
-        self.max_concurrent_orders = EXECUTION_PARAMETERS.get('MAX_CONCURRENT_ORDERS', 100)
-        self.order_timeout = EXECUTION_PARAMETERS.get('ORDER_TIMEOUT_SECONDS', 300)
-        self.retry_attempts = EXECUTION_PARAMETERS.get('RETRY_ATTEMPTS', 3)
+        self.max_concurrent_orders = EXECUTION_PARAMETERS.get("MAX_CONCURRENT_ORDERS", 100)
+        self.order_timeout = EXECUTION_PARAMETERS.get("ORDER_TIMEOUT_SECONDS", 300)
+        self.retry_attempts = EXECUTION_PARAMETERS.get("RETRY_ATTEMPTS", 3)
         self._monitor_thread = None
         self._monitor_running = False
         self._idempotency_cache: OrderIdempotencyCache | None = None
-        emit_once(logger, 'ORDER_MANAGER_INIT', 'info', 'OrderManager initialized')
+        emit_once(logger, "ORDER_MANAGER_INIT", "info", "OrderManager initialized")
 
     def _ensure_idempotency_cache(self) -> OrderIdempotencyCache:
         """Ensure idempotency cache is instantiated."""
@@ -328,7 +352,7 @@ class OrderManager:
             try:
                 self._idempotency_cache = OrderIdempotencyCache()
             except (KeyError, ValueError, TypeError, RuntimeError) as e:
-                logger.error('IDEMPOTENCY_CACHE_FAILED', extra={'cause': e.__class__.__name__, 'detail': str(e)})
+                logger.error("IDEMPOTENCY_CACHE_FAILED", extra={"cause": e.__class__.__name__, "detail": str(e)})
                 raise
         return self._idempotency_cache
 
@@ -353,6 +377,7 @@ class OrderManager:
             if getattr(order, "order_type", None) == OrderType.MARKET:
                 try:
                     import importlib
+
                     be = importlib.import_module("ai_trading.core.bot_engine")
                     quote_info: SimpleNamespace | None = None
                     if hasattr(be, "resolve_trade_quote"):
@@ -398,9 +423,9 @@ class OrderManager:
             cache = self._ensure_idempotency_cache()
             key = cache.generate_key(order.symbol, order.side, order.quantity, datetime.now(UTC))
             if cache.is_duplicate(key):
-                logger.warning(f'ORDER_DUPLICATE_SKIPPED: {order.symbol} {order.side} {order.quantity}')
+                logger.warning(f"ORDER_DUPLICATE_SKIPPED: {order.symbol} {order.side} {order.quantity}")
                 order.status = OrderStatus.REJECTED
-                order.notes += ' | Rejected: Duplicate order detected'
+                order.notes += " | Rejected: Duplicate order detected"
                 try:
                     _orders_duplicate_total.inc()
                     _orders_rejected_total.inc()
@@ -408,9 +433,9 @@ class OrderManager:
                     pass
                 return None
             if len(self.active_orders) >= self.max_concurrent_orders:
-                logger.error(f'Cannot submit order: max concurrent orders reached ({self.max_concurrent_orders})')
+                logger.error(f"Cannot submit order: max concurrent orders reached ({self.max_concurrent_orders})")
                 order.status = OrderStatus.REJECTED
-                order.notes += ' | Rejected: Max concurrent orders reached'
+                order.notes += " | Rejected: Max concurrent orders reached"
                 try:
                     _orders_rejected_total.inc()
                 except Exception:
@@ -421,17 +446,17 @@ class OrderManager:
             cache.mark_submitted(key, order.id)
             if not self._monitor_running:
                 self.start_monitoring()
-            logger.info(f'Order submitted: {order.id} {order.side} {order.quantity} {order.symbol}')
-            if getattr(order, 'expected_price', None) is not None:
+            logger.info(f"Order submitted: {order.id} {order.side} {order.quantity} {order.symbol}")
+            if getattr(order, "expected_price", None) is not None:
                 logger.debug(
-                    'ORDER_EXPECTED_PRICE',
+                    "ORDER_EXPECTED_PRICE",
                     extra={
-                        'order_id': order.id,
-                        'symbol': order.symbol,
-                        'expected_price': float(order.expected_price),
+                        "order_id": order.id,
+                        "symbol": order.symbol,
+                        "expected_price": float(order.expected_price),
                     },
                 )
-            self._notify_callbacks(order, 'submitted')
+            self._notify_callbacks(order, "submitted")
 
             # Mimic a broker-style response object even when running without a
             # real broker (dry‑run).  ``filled_qty`` mirrors Alpaca's string
@@ -442,40 +467,54 @@ class OrderManager:
                 pass
             return SimpleNamespace(
                 id=order.id,
-                status='pending_new',
+                status="pending_new",
                 symbol=order.symbol,
-                side=getattr(order.side, 'value', order.side),
+                side=getattr(order.side, "value", order.side),
                 qty=order.quantity,
-                filled_qty='0',
+                filled_qty="0",
                 filled_avg_price=None,
             )
         except (APIError, TimeoutError, ConnectionError) as e:
-            logger.error('ORDER_API_FAILED', extra={'cause': e.__class__.__name__, 'detail': str(e), 'op': 'submit', 'symbol': order.symbol, 'qty': order.quantity, 'side': getattr(order.side, 'value', order.side), 'type': getattr(order.order_type, 'value', order.order_type)})
+            logger.error(
+                "ORDER_API_FAILED",
+                extra={
+                    "cause": e.__class__.__name__,
+                    "detail": str(e),
+                    "op": "submit",
+                    "symbol": order.symbol,
+                    "qty": order.quantity,
+                    "side": getattr(order.side, "value", order.side),
+                    "type": getattr(order.order_type, "value", order.order_type),
+                },
+            )
             order.status = OrderStatus.REJECTED
-            order.notes += f' | Error: {e}'
+            order.notes += f" | Error: {e}"
             try:
                 _orders_rejected_total.inc()
             except Exception:
                 pass
             return None
 
-    def cancel_order(self, order_id: str, reason: str='User request') -> bool:
+    def cancel_order(self, order_id: str, reason: str = "User request") -> bool:
         """Cancel an active order."""
         if not order_id:
-            logger.warning('CANCEL_SKIPPED', extra={'reason': 'empty_order_id'})
+            logger.warning("CANCEL_SKIPPED", extra={"reason": "empty_order_id"})
             return False
         try:
             order = self.active_orders.get(order_id)
             if not order:
-                logger.warning(f'Cannot cancel order {order_id}: not found in active orders')
+                logger.warning(f"Cannot cancel order {order_id}: not found in active orders")
                 return False
             success = order.cancel(reason)
             if success:
                 self.active_orders.pop(order_id, None)
-                self._notify_callbacks(order, 'cancelled')
+                self._notify_callbacks(order, "cancelled")
             return success
         except (APIError, TimeoutError, ConnectionError) as e:
-            logger.error('ORDER_API_FAILED', extra={'cause': e.__class__.__name__, 'detail': str(e), 'op': 'cancel', 'order_id': order_id})
+            logger.error(
+                "ORDER_API_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "op": "cancel", "order_id": order_id},
+            )
             return False
 
     def get_order_status(self, order_id: str) -> dict | None:
@@ -489,7 +528,7 @@ class OrderManager:
         """Get all active orders."""
         return [order.to_dict() for order in self.active_orders.values()]
 
-    def get_order_history(self, symbol: str=None, limit: int=100) -> list[dict]:
+    def get_order_history(self, symbol: str = None, limit: int = 100) -> list[dict]:
         """Get order history with optional filtering."""
         orders = list(self.orders.values())
         if symbol:
@@ -508,43 +547,45 @@ class OrderManager:
         self._monitor_running = True
         self._monitor_thread = threading.Thread(target=self._monitor_orders, daemon=True)
         self._monitor_thread.start()
-        logger.info('Order monitoring started')
+        logger.info("Order monitoring started")
 
     def stop_monitoring(self):
         """Stop order monitoring thread."""
         self._monitor_running = False
         if self._monitor_thread:
             self._monitor_thread.join(timeout=5)
-        logger.info('Order monitoring stopped')
+        logger.info("Order monitoring stopped")
 
     def _validate_order(self, order: Order) -> bool:
         """Validate order before submission."""
         try:
             if not order.symbol or order.quantity <= 0:
-                logger.error(f'Invalid order parameters: symbol={order.symbol}, quantity={order.quantity}')
+                logger.error(f"Invalid order parameters: symbol={order.symbol}, quantity={order.quantity}")
                 return False
             tick = get_tick_size(order.symbol)
             lot = get_lot_size(order.symbol)
             original_quantity = order.quantity
             order.quantity = round_to_lot(order.quantity, lot)
             if original_quantity != order.quantity:
-                logger.debug(f'Quantity adjusted for {order.symbol}: {original_quantity} -> {order.quantity} (lot={lot})')
+                logger.debug(
+                    f"Quantity adjusted for {order.symbol}: {original_quantity} -> {order.quantity} (lot={lot})"
+                )
             if order.order_type == OrderType.LIMIT:
                 if not order.price or order.price <= 0:
-                    logger.error(f'Limit order requires valid price: {order.price}')
+                    logger.error(f"Limit order requires valid price: {order.price}")
                     return False
                 if not isinstance(order.price, Money):
                     order.price = Money(order.price)
                 original_price = order.price
                 order.price = round_to_tick(order.price, tick)
                 if float(original_price) != float(order.price):
-                    logger.debug(f'Price adjusted for {order.symbol}: {original_price} -> {order.price} (tick={tick})')
+                    logger.debug(f"Price adjusted for {order.symbol}: {original_price} -> {order.price} (tick={tick})")
             if order.side not in [OrderSide.BUY, OrderSide.SELL, OrderSide.SELL_SHORT]:
-                logger.error(f'Invalid order side: {order.side}')
+                logger.error(f"Invalid order side: {order.side}")
                 return False
             return True
         except (KeyError, ValueError, TypeError, RuntimeError) as e:
-            logger.error('ORDER_VALIDATION_FAILED', extra={'cause': e.__class__.__name__, 'detail': str(e)})
+            logger.error("ORDER_VALIDATION_FAILED", extra={"cause": e.__class__.__name__, "detail": str(e)})
             return False
 
     def _monitor_orders(self):
@@ -559,20 +600,21 @@ class OrderManager:
                         expired_orders.append(order_id)
                     if order.status in [OrderStatus.FILLED, OrderStatus.CANCELED, OrderStatus.REJECTED]:
                         self.active_orders.pop(order_id, None)
-                        self._notify_callbacks(order, 'completed')
+                        self._notify_callbacks(order, "completed")
                 for order_id in expired_orders:
                     order = self.active_orders.get(order_id)
                     if order:
                         order.status = OrderStatus.EXPIRED
                         order.updated_at = current_time
                         self.active_orders.pop(order_id, None)
-                        logger.warning(f'Order {order_id} expired after {self.order_timeout} seconds')
-                        self._notify_callbacks(order, 'expired')
+                        logger.warning(f"Order {order_id} expired after {self.order_timeout} seconds")
+                        self._notify_callbacks(order, "expired")
                 from .reconcile import reconcile_positions_and_orders
+
                 reconcile_positions_and_orders()
                 time.sleep(1)
             except (APIError, TimeoutError, ConnectionError) as e:
-                logger.error('ORDER_MONITOR_FAILED', extra={'cause': e.__class__.__name__, 'detail': str(e)})
+                logger.error("ORDER_MONITOR_FAILED", extra={"cause": e.__class__.__name__, "detail": str(e)})
                 time.sleep(5)
 
     def _notify_callbacks(self, order: Order, event_type: str):
@@ -582,9 +624,15 @@ class OrderManager:
                 try:
                     callback(order, event_type)
                 except (KeyError, ValueError, TypeError, RuntimeError) as e:
-                    logger.error('CALLBACK_FAILED', extra={'cause': e.__class__.__name__, 'detail': str(e), 'order_id': order.id})
+                    logger.error(
+                        "CALLBACK_FAILED", extra={"cause": e.__class__.__name__, "detail": str(e), "order_id": order.id}
+                    )
         except (KeyError, ValueError, TypeError, RuntimeError) as e:
-            logger.error('CALLBACK_NOTIFICATION_FAILED', extra={'cause': e.__class__.__name__, 'detail': str(e), 'order_id': order.id})
+            logger.error(
+                "CALLBACK_NOTIFICATION_FAILED",
+                extra={"cause": e.__class__.__name__, "detail": str(e), "order_id": order.id},
+            )
+
 
 class ExecutionEngine:
     """
@@ -593,6 +641,7 @@ class ExecutionEngine:
     Coordinates order management, execution algorithms,
     and provides unified execution interface.
     """
+
     _minute_stats: dict[str, float] = {}
     _latest_quote: dict[str, float] = {}
 
@@ -609,22 +658,22 @@ class ExecutionEngine:
         # In-memory fallback for position tracking when broker data is unavailable
         self._position_ledger: dict[str, int] = {}
         self.execution_stats = {
-            'total_orders': 0,
-            'filled_orders': 0,
-            'cancelled_orders': 0,
-            'rejected_orders': 0,
-            'total_volume': 0.0,
-            'average_fill_time': 0.0,
+            "total_orders": 0,
+            "filled_orders": 0,
+            "cancelled_orders": 0,
+            "rejected_orders": 0,
+            "total_volume": 0.0,
+            "average_fill_time": 0.0,
         }
-        emit_once(logger, 'EXECUTION_ENGINE_INIT', 'info', 'ExecutionEngine initialized')
+        emit_once(logger, "EXECUTION_ENGINE_INIT", "info", "ExecutionEngine initialized")
         try:
             self.order_manager.add_execution_callback(self._handle_execution_event)
         except Exception:  # pragma: no cover - defensive, callbacks optional in some tests
-            logger.debug('EXECUTION_CALLBACK_REGISTRATION_FAILED', exc_info=True)
+            logger.debug("EXECUTION_CALLBACK_REGISTRATION_FAILED", exc_info=True)
 
     def _select_api(self):
         """Return the active broker API interface."""
-        ctx_api = getattr(getattr(self, 'ctx', None), 'api', None)
+        ctx_api = getattr(getattr(self, "ctx", None), "api", None)
         return ctx_api or self.broker_interface
 
     @property
@@ -690,10 +739,10 @@ class ExecutionEngine:
         info = OrderInfo(
             order_id=order.id,
             symbol=order.symbol,
-            side=getattr(order.side, 'value', order.side),
-            qty=getattr(order, 'quantity', getattr(order, 'qty', 0)),
+            side=getattr(order.side, "value", order.side),
+            qty=getattr(order, "quantity", getattr(order, "qty", 0)),
             submitted_time=time.time(),
-            last_status=getattr(order.status, 'value', getattr(order, 'status', 'new')),
+            last_status=getattr(order.status, "value", getattr(order, "status", "new")),
         )
         with _order_tracking_lock:
             _active_orders[order.id] = info
@@ -704,7 +753,7 @@ class ExecutionEngine:
 
     def _update_order_status(self, order_id: str, status: str) -> None:
         """Update tracked order status and remove if terminal."""
-        terminal = {'filled', 'canceled', 'cancelled', 'rejected'}
+        terminal = {"filled", "canceled", "cancelled", "rejected"}
         with _order_tracking_lock:
             info = _active_orders.get(order_id)
             if info:
@@ -723,11 +772,11 @@ class ExecutionEngine:
             return False
         try:
             ord_obj = self.broker_interface.get_order(order_id)
-            if getattr(ord_obj, 'status', '').lower() == 'new':
+            if getattr(ord_obj, "status", "").lower() == "new":
                 self.broker_interface.cancel_order(order_id)
             return True
         except Exception as exc:  # pragma: no cover - broker interface may vary
-            logger.debug('Failed to cancel stale order %s: %s', order_id, exc)
+            logger.debug("Failed to cancel stale order %s: %s", order_id, exc)
             return False
 
     def _assess_liquidity(self, symbol: str, quantity: int) -> tuple[int, bool]:
@@ -742,7 +791,7 @@ class ExecutionEngine:
             return (int(quantity * 0.75), False)
         return (quantity, False)
 
-    def cleanup_stale_orders(self, now: float | None=None, max_age_seconds: int | None=None) -> int:
+    def cleanup_stale_orders(self, now: float | None = None, max_age_seconds: int | None = None) -> int:
         """Remove stale orders and attempt cancelation via broker."""
         now_s = now if now is not None else time.time()
         max_age = max_age_seconds if max_age_seconds is not None else ORDER_STALE_AFTER_S
@@ -758,15 +807,15 @@ class ExecutionEngine:
         For now: best-effort inspection of open positions; no-op if unsupported.
         """
         try:
-            broker = getattr(self, 'broker', None) or getattr(self, 'broker_interface', None)
-            if broker is not None and hasattr(broker, 'list_positions'):
+            broker = getattr(self, "broker", None) or getattr(self, "broker_interface", None)
+            if broker is not None and hasattr(broker, "list_positions"):
                 positions = broker.list_positions() or []
-                logger.debug('check_stops: inspected %d positions', len(positions))
+                logger.debug("check_stops: inspected %d positions", len(positions))
             else:
                 positions = [SimpleNamespace(symbol=s, qty=q) for s, q in self._position_ledger.items()]
-                logger.debug('check_stops: inspected %d positions (ledger)', len(positions))
+                logger.debug("check_stops: inspected %d positions (ledger)", len(positions))
         except (ValueError, TypeError) as e:
-            logger.info('check_stops: suppressed exception: %s', e)
+            logger.info("check_stops: suppressed exception: %s", e)
 
     def check_trailing_stops(self) -> None:
         """Evaluate any active trailing-stop handlers.
@@ -778,25 +827,25 @@ class ExecutionEngine:
         unconditionally.
         """
         try:
-            handler = getattr(self, 'trailing_stop_handler', None)
+            handler = getattr(self, "trailing_stop_handler", None)
             if handler is None:
                 return
-            check_fn = getattr(handler, 'check', None)
+            check_fn = getattr(handler, "check", None)
             if callable(check_fn):
                 check_fn()
         except Exception as e:  # pragma: no cover - defensive
-            logger.debug('check_trailing_stops: suppressed exception: %s', e)
+            logger.debug("check_trailing_stops: suppressed exception: %s", e)
 
-    def _validate_short_selling(
-        self, _api, symbol: str, qty: float, price: float | None = None
-    ) -> bool:
+    def _validate_short_selling(self, _api, symbol: str, qty: float, price: float | None = None) -> bool:
         """Run short selling validation and return True on success."""
 
         from ai_trading.risk.short_selling import validate_short_selling
 
         return validate_short_selling(symbol, qty, price)
 
-    def _reconcile_partial_fills(self, *args, requested_qty=None, remaining_qty=None, symbol=None, side=None, **_kwargs) -> None:
+    def _reconcile_partial_fills(
+        self, *args, requested_qty=None, remaining_qty=None, symbol=None, side=None, **_kwargs
+    ) -> None:
         """Detect partial fills and emit guardrail alerts.
 
         Test contract:
@@ -806,7 +855,7 @@ class ExecutionEngine:
         try:
             # Accept alias used in tests: submitted_qty -> requested_qty
             if requested_qty is None:
-                requested_qty = _kwargs.get('submitted_qty')
+                requested_qty = _kwargs.get("submitted_qty")
             if requested_qty is None or remaining_qty is None:
                 return
             rq = float(requested_qty)
@@ -814,8 +863,8 @@ class ExecutionEngine:
             if rq <= 0:
                 return
             # Prefer last_order.filled_qty when available
-            order = _kwargs.get('last_order')
-            if order is not None and hasattr(order, 'filled_qty') and order.filled_qty is not None:
+            order = _kwargs.get("last_order")
+            if order is not None and hasattr(order, "filled_qty") and order.filled_qty is not None:
                 try:
                     filled = float(order.filled_qty)
                 except (ValueError, TypeError):
@@ -827,7 +876,7 @@ class ExecutionEngine:
             ord_filled: float | None
             if order is not None:
                 try:
-                    ord_filled = float(order.filled_qty) if getattr(order, 'filled_qty', None) is not None else None
+                    ord_filled = float(order.filled_qty) if getattr(order, "filled_qty", None) is not None else None
                 except (ValueError, TypeError):
                     ord_filled = None
             else:
@@ -837,7 +886,13 @@ class ExecutionEngine:
                 try:
                     self.logger.warning(
                         f"QUANTITY_MISMATCH_DETECTED: calculated_filled_qty={int(calc_filled)} reported_filled_qty={int(ord_filled or 0)}",
-                        extra={'symbol': symbol, 'side': side, 'reported_filled_qty': int(ord_filled or 0), 'calculated_filled_qty': int(calc_filled), 'requested_qty': int(rq)}
+                        extra={
+                            "symbol": symbol,
+                            "side": side,
+                            "reported_filled_qty": int(ord_filled or 0),
+                            "calculated_filled_qty": int(calc_filled),
+                            "requested_qty": int(rq),
+                        },
                     )
                 except Exception:
                     pass
@@ -849,8 +904,14 @@ class ExecutionEngine:
                 fill_rate = (filled_for_eval / rq) if rq else 0.0
                 # Structured log for tests to parse via `extra`, keep message token stable
                 self.logger.warning(
-                    'PARTIAL_FILL_DETECTED',
-                    extra={'symbol': symbol, 'side': side, 'filled_qty': int(filled_for_eval), 'requested_qty': int(rq), 'fill_rate_pct': round(fill_rate * 100.0, 2)}
+                    "PARTIAL_FILL_DETECTED",
+                    extra={
+                        "symbol": symbol,
+                        "side": side,
+                        "filled_qty": int(filled_for_eval),
+                        "requested_qty": int(rq),
+                        "fill_rate_pct": round(fill_rate * 100.0, 2),
+                    },
                 )
                 # Human-readable detail to satisfy substring checks in some tests
                 try:
@@ -861,16 +922,21 @@ class ExecutionEngine:
                 # - LOW at <= 20%
                 # - MODERATE at (20%, 35%]
                 if fill_rate <= 0.20:
-                    self.logger.error('LOW_FILL_RATE_ALERT')
+                    self.logger.error("LOW_FILL_RATE_ALERT")
                 elif fill_rate <= 0.35:
-                    self.logger.warning(f'MODERATE_FILL_RATE_ALERT: {fill_rate:.2%}')
+                    self.logger.warning(f"MODERATE_FILL_RATE_ALERT: {fill_rate:.2%}")
             else:
                 # Full fill
                 # Only claim full-fill when sources agree or no mismatch detected
                 if not mismatch:
                     self.logger.info(
-                        'FULL_FILL_SUCCESS',
-                        extra={'symbol': symbol, 'side': side, 'filled_qty': int(filled_for_eval), 'requested_qty': int(rq)}
+                        "FULL_FILL_SUCCESS",
+                        extra={
+                            "symbol": symbol,
+                            "side": side,
+                            "filled_qty": int(filled_for_eval),
+                            "requested_qty": int(rq),
+                        },
                     )
         except (ValueError, TypeError):
             pass
@@ -900,7 +966,7 @@ class ExecutionEngine:
             explicit_signal_weight = kwargs.pop("signal_weight", None)
             api = self._select_api()
             if api is None:
-                logger.debug('NO_API_SELECTED')
+                logger.debug("NO_API_SELECTED")
             if isinstance(side, str):
                 side = OrderSide(side)
 
@@ -917,9 +983,7 @@ class ExecutionEngine:
                     self.execution_stats["rejected_orders"] += 1
                     return None
             elif side == OrderSide.SELL_SHORT:
-                self.logger.info(
-                    "SHORT_SELL_INITIATED | symbol=%s qty=%d", symbol, quantity
-                )
+                self.logger.info("SHORT_SELL_INITIATED | symbol=%s qty=%d", symbol, quantity)
                 if not self._validate_short_selling(api, symbol, quantity):
                     self.execution_stats["rejected_orders"] += 1
                     return None
@@ -927,7 +991,7 @@ class ExecutionEngine:
             kwargs["limit_price"] = _ensure_valid_price(kwargs.get("limit_price"))
             kwargs["stop_price"] = _ensure_valid_price(kwargs.get("stop_price"))
             # Ensure a sane default for broker-mirrored payload fields
-            tif = (kwargs.get("time_in_force") or "day")
+            tif = kwargs.get("time_in_force") or "day"
             payload: dict[str, Any] = {
                 "symbol": symbol,
                 "side": getattr(side, "value", side),
@@ -939,20 +1003,24 @@ class ExecutionEngine:
             }
             logger.debug(
                 "ORDER_SUBMIT_PAYLOAD",
-                extra={k: payload.get(k) for k in (
-                    "symbol",
-                    "side",
-                    "qty",
-                    "type",
-                    "time_in_force",
-                    "limit_price",
-                    "stop_price",
-                )},
+                extra={
+                    k: payload.get(k)
+                    for k in (
+                        "symbol",
+                        "side",
+                        "qty",
+                        "type",
+                        "time_in_force",
+                        "limit_price",
+                        "stop_price",
+                    )
+                },
             )
             if order_type == OrderType.MARKET:
                 if not get_env("TESTING", "false", cast=bool):
                     try:
                         import importlib
+
                         be = importlib.import_module("ai_trading.core.bot_engine")
                         quote_info: SimpleNamespace | None = None
                         if hasattr(be, "resolve_trade_quote"):
@@ -1063,10 +1131,16 @@ class ExecutionEngine:
             filled_qty = 0
         delta = filled_qty - meta.reported_fill_qty
         if delta > 0:
+            self._persist_meta_trade(order, delta, getattr(meta, "signal", None))
             if self._forward_risk_fill(order, delta, meta):
                 meta.reported_fill_qty = filled_qty
         status = ExecutionResult._normalize_status(getattr(order, "status", None))
-        if (status is not None and status.is_terminal) or event_type in {"completed", "cancelled", "canceled", "expired"}:
+        if (status is not None and status.is_terminal) or event_type in {
+            "completed",
+            "cancelled",
+            "canceled",
+            "expired",
+        }:
             if delta <= 0 and filled_qty > meta.reported_fill_qty:
                 meta.reported_fill_qty = filled_qty
             if status is None or status.is_terminal or event_type in {"cancelled", "canceled", "expired"}:
@@ -1078,6 +1152,54 @@ class ExecutionEngine:
             return int(value)
         except (TypeError, ValueError):
             return None
+
+    def _persist_meta_trade(self, order: Order, delta_qty: int, signal: Any | None) -> None:
+        """Persist fills for meta-learning trade history."""
+
+        if delta_qty <= 0 or signal is None:
+            return
+        try:
+            fill = order.fills[-1] if getattr(order, "fills", None) else None
+            price_obj = None
+            timestamp = None
+            fill_id = None
+            if isinstance(fill, dict):
+                price_obj = fill.get("price")
+                timestamp = fill.get("timestamp")
+                fill_id = fill.get("fill_id")
+            if price_obj is None:
+                price_obj = getattr(order, "average_fill_price", None)
+            if timestamp is None:
+                timestamp = getattr(order, "updated_at", datetime.now(UTC))
+            if isinstance(price_obj, Money):
+                price = float(price_obj)
+            else:
+                try:
+                    price = float(price_obj) if price_obj is not None else None
+                except (TypeError, ValueError):
+                    price = None
+            side_val = getattr(order.side, "value", order.side)
+            signal_tags = getattr(signal, "signal_tags", None) or getattr(signal, "tags", "")
+            try:
+                confidence = float(getattr(signal, "confidence", 0.0))
+            except (TypeError, ValueError):
+                confidence = 0.0
+            record_trade_fill(
+                {
+                    "symbol": getattr(order, "symbol", ""),
+                    "entry_time": timestamp,
+                    "entry_price": price,
+                    "qty": int(delta_qty),
+                    "side": str(side_val).lower(),
+                    "strategy": getattr(signal, "strategy", ""),
+                    "signal_tags": signal_tags,
+                    "confidence": confidence,
+                    "order_id": getattr(order, "id", None),
+                    "fill_id": fill_id,
+                }
+            )
+        except Exception:  # pragma: no cover - persistence best effort
+            logger.debug("META_TRADE_PERSIST_FAILED", exc_info=True)
 
     def _forward_risk_fill(self, order: Order, delta_qty: int, meta: _SignalMeta) -> bool:
         """Forward ``delta_qty`` fills to the risk engine when possible."""
@@ -1130,6 +1252,7 @@ class ExecutionEngine:
         try:
             # Lazy import to avoid heavy imports at startup
             import importlib
+
             be = importlib.import_module("ai_trading.core.bot_engine")
             if hasattr(be, "get_latest_price"):
                 p = be.get_latest_price(symbol)
@@ -1167,11 +1290,7 @@ class ExecutionEngine:
         ``threshold_bps``.
         """
         try:
-            diff_bps = (
-                ((delayed_price - reference_price) / reference_price) * 10000
-                if reference_price
-                else 0.0
-            )
+            diff_bps = ((delayed_price - reference_price) / reference_price) * 10000 if reference_price else 0.0
         except Exception:
             diff_bps = 0.0
         order.slippage_bps = diff_bps
@@ -1194,9 +1313,7 @@ class ExecutionEngine:
                     "threshold_bps": round(threshold_bps, 2),
                 },
             )
-            raise AssertionError(
-                f"delayed price {delayed_price} deviates {diff_bps:.2f} bps from reference"
-            )
+            raise AssertionError(f"delayed price {delayed_price} deviates {diff_bps:.2f} bps from reference")
         return delayed_price
 
     def _simulate_market_execution(self, order: Order):
@@ -1223,16 +1340,11 @@ class ExecutionEngine:
                 expected = float(base_price)
 
             price_source = (
-                getattr(order, "expected_price_source", None)
-                or getattr(order, "price_source", None)
-                or "unknown"
+                getattr(order, "expected_price_source", None) or getattr(order, "price_source", None) or "unknown"
             )
-            base_threshold_env = get_env(
-                "MAX_SLIPPAGE_BPS", str(order.max_slippage_bps), cast=float
-            )
+            base_threshold_env = get_env("MAX_SLIPPAGE_BPS", str(order.max_slippage_bps), cast=float)
             apply_slippage_controls = bool(
-                had_manual_price
-                or (isinstance(price_source, str) and price_source.startswith("alpaca"))
+                had_manual_price or (isinstance(price_source, str) and price_source.startswith("alpaca"))
             )
             if apply_slippage_controls:
                 base_threshold = base_threshold_env
@@ -1262,34 +1374,22 @@ class ExecutionEngine:
                 expected = float(base_price or 1.0)
             predicted_fill = base_price * (1 + (hash(order.id) % 100 - 50) / 10000)
             if expected:
-                predicted_slippage_bps = (
-                    (predicted_fill - expected) / expected
-                ) * 10000
+                predicted_slippage_bps = ((predicted_fill - expected) / expected) * 10000
             else:
                 base_ref = float(base_price) if base_price else 1.0
-                predicted_slippage_bps = (
-                    (predicted_fill - base_ref) / base_ref
-                ) * 10000
+                predicted_slippage_bps = ((predicted_fill - base_ref) / base_ref) * 10000
             side = _normalize_order_side(getattr(order, "side", None))
             if side is None:
                 adverse_predicted_bps = abs(predicted_slippage_bps)
             else:
-                directional_predicted = (
-                    predicted_slippage_bps
-                    if side == OrderSide.BUY
-                    else -predicted_slippage_bps
-                )
+                directional_predicted = predicted_slippage_bps if side == OrderSide.BUY else -predicted_slippage_bps
                 adverse_predicted_bps = max(directional_predicted, 0.0)
             if adverse_predicted_bps > threshold:
                 tol_bps = get_env("SLIPPAGE_LIMIT_TOLERANCE_BPS", "5", cast=float)
                 limit_conversion_ok = True
                 if order.order_type == OrderType.MARKET:
                     adj = float(expected) * (tol_bps / 10000.0)
-                    limit_price = (
-                        float(expected) + adj
-                        if side == OrderSide.BUY
-                        else float(expected) - adj
-                    )
+                    limit_price = float(expected) + adj if side == OrderSide.BUY else float(expected) - adj
                     tick = TICK_BY_SYMBOL.get(order.symbol)
                     try:
                         price_money = Money(limit_price, tick)
@@ -1307,9 +1407,7 @@ class ExecutionEngine:
                             "adverse_slippage_bps": round(adverse_predicted_bps, 2),
                         },
                     )
-                reduced = max(
-                    1, int(order.quantity * threshold / adverse_predicted_bps)
-                )
+                reduced = max(1, int(order.quantity * threshold / adverse_predicted_bps))
                 qty_reduced = False
                 if reduced < order.quantity:
                     order.quantity = reduced
@@ -1319,9 +1417,7 @@ class ExecutionEngine:
                         extra={
                             "order_id": order.id,
                             "new_qty": reduced,
-                            "adverse_slippage_bps": round(
-                                adverse_predicted_bps, 2
-                            ),
+                            "adverse_slippage_bps": round(adverse_predicted_bps, 2),
                         },
                     )
                 else:
@@ -1330,35 +1426,23 @@ class ExecutionEngine:
                         "SLIPPAGE_ORDER_REJECTED",
                         extra={
                             "order_id": order.id,
-                            "adverse_slippage_bps": round(
-                                adverse_predicted_bps, 2
-                            ),
+                            "adverse_slippage_bps": round(adverse_predicted_bps, 2),
                         },
                     )
                     if had_manual_price:
-                        raise AssertionError(
-                            f"predicted slippage {predicted_slippage_bps:.2f} bps exceeds threshold"
-                        )
+                        raise AssertionError(f"predicted slippage {predicted_slippage_bps:.2f} bps exceeds threshold")
                     return
                 if had_manual_price:
                     if not limit_conversion_ok or not qty_reduced:
-                        raise AssertionError(
-                            f"predicted slippage {predicted_slippage_bps:.2f} bps exceeds threshold"
-                        )
+                        raise AssertionError(f"predicted slippage {predicted_slippage_bps:.2f} bps exceeds threshold")
                     return order
                 try:
                     from ai_trading.core.bot_engine import get_trade_logger
 
                     tl = get_trade_logger()
                     strategy = getattr(order, "strategy_id", None) or "slippage_adjust"
-                    side_val = (
-                        order.side.value if isinstance(order.side, OrderSide) else order.side
-                    )
-                    price_for_log = (
-                        float(order.price)
-                        if order.price is not None
-                        else float(base_price)
-                    )
+                    side_val = order.side.value if isinstance(order.side, OrderSide) else order.side
+                    price_for_log = float(order.price) if order.price is not None else float(base_price)
                     tl.log_entry(
                         order.symbol,
                         price_for_log,
@@ -1383,23 +1467,29 @@ class ExecutionEngine:
                 if remaining > 0:
                     time.sleep(0.1)
             if order.is_filled:
-                self.execution_stats['filled_orders'] += 1
+                self.execution_stats["filled_orders"] += 1
                 # Ensure float accumulation to avoid Decimal/float TypeError
                 try:
-                    nv = float(getattr(order, 'notional_value', 0.0))
+                    nv = float(getattr(order, "notional_value", 0.0))
                 except Exception:
                     try:
-                        avg = getattr(order, 'average_fill_price', None)
-                        nv = (float(avg) * float(order.filled_quantity)) if avg is not None else float(base_price) * float(order.quantity)
+                        avg = getattr(order, "average_fill_price", None)
+                        nv = (
+                            (float(avg) * float(order.filled_quantity))
+                            if avg is not None
+                            else float(base_price) * float(order.quantity)
+                        )
                     except Exception:
                         nv = float(order.quantity) * float(base_price)
-                self.execution_stats['total_volume'] += nv
+                self.execution_stats["total_volume"] += nv
                 fill_time = (order.executed_at - order.created_at).total_seconds()
-                self.execution_stats['average_fill_time'] = (self.execution_stats['average_fill_time'] * (self.execution_stats['filled_orders'] - 1) + fill_time) / self.execution_stats['filled_orders']
+                self.execution_stats["average_fill_time"] = (
+                    self.execution_stats["average_fill_time"] * (self.execution_stats["filled_orders"] - 1) + fill_time
+                ) / self.execution_stats["filled_orders"]
 
                 # Compare expected vs actual fill price and check slippage
                 try:
-                    if getattr(order, 'expected_price', None) is not None:
+                    if getattr(order, "expected_price", None) is not None:
                         expected = float(order.expected_price)
                     elif order.price is not None:
                         expected = float(order.price)
@@ -1420,38 +1510,38 @@ class ExecutionEngine:
                     slippage_bps = ((actual - ref) / ref) * 10000
                 order.slippage_bps = slippage_bps
                 logger.info(
-                    'SLIPPAGE_DIAGNOSTIC',
+                    "SLIPPAGE_DIAGNOSTIC",
                     extra={
-                        'symbol': order.symbol,
-                        'expected_price': round(expected, 4),
-                        'actual_price': round(actual, 4),
-                        'slippage_bps': round(slippage_bps, 2),
+                        "symbol": order.symbol,
+                        "expected_price": round(expected, 4),
+                        "actual_price": round(actual, 4),
+                        "slippage_bps": round(slippage_bps, 2),
                     },
                 )
                 threshold = self._adaptive_slippage_threshold(order.symbol, base_threshold)
                 if side is None:
                     adverse_actual_bps = abs(slippage_bps)
                 else:
-                    directional_actual = (
-                        slippage_bps if side == OrderSide.BUY else -slippage_bps
-                    )
+                    directional_actual = slippage_bps if side == OrderSide.BUY else -slippage_bps
                     adverse_actual_bps = max(directional_actual, 0.0)
                 if adverse_actual_bps > threshold:
                     logger.warning(
-                        'SLIPPAGE_THRESHOLD_EXCEEDED',
+                        "SLIPPAGE_THRESHOLD_EXCEEDED",
                         extra={
-                            'order_id': order.id,
-                            'slippage_bps': round(slippage_bps, 2),
-                            'adverse_slippage_bps': round(adverse_actual_bps, 2),
-                            'threshold_bps': threshold,
+                            "order_id": order.id,
+                            "slippage_bps": round(slippage_bps, 2),
+                            "adverse_slippage_bps": round(adverse_actual_bps, 2),
+                            "threshold_bps": threshold,
                         },
                     )
         except (KeyError, ValueError, TypeError, RuntimeError) as e:
-            logger.error('SIMULATION_FAILED', extra={'cause': e.__class__.__name__, 'detail': str(e), 'order_id': order.id})
+            logger.error(
+                "SIMULATION_FAILED", extra={"cause": e.__class__.__name__, "detail": str(e), "order_id": order.id}
+            )
 
     def get_execution_stats(self) -> dict:
         """Get execution engine statistics."""
         stats = self.execution_stats.copy()
-        stats['active_orders'] = len(self.order_manager.active_orders)
-        stats['success_rate'] = stats['filled_orders'] / stats['total_orders'] if stats['total_orders'] > 0 else 0
+        stats["active_orders"] = len(self.order_manager.active_orders)
+        stats["success_rate"] = stats["filled_orders"] / stats["total_orders"] if stats["total_orders"] > 0 else 0
         return stats

--- a/ai_trading/meta_learning/persistence.py
+++ b/ai_trading/meta_learning/persistence.py
@@ -1,0 +1,268 @@
+"""Persistence helpers for meta-learning trade history.
+
+Provides lightweight append and load utilities that persist fills to a
+canonical parquet store while remaining tolerant of missing optional
+dependencies in lean deployments.
+"""
+
+from __future__ import annotations
+
+import os
+
+from collections.abc import Iterable, Mapping
+from dataclasses import asdict, is_dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+from ai_trading.logging import get_logger
+
+logger = get_logger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover - typing aid
+    import pandas as pd
+
+_CANONICAL_PATH = Path(
+    Path.cwd()
+    / Path(
+        # Allow callers/tests to override through environment while keeping a
+        # stable default inside the repository workspace.
+        os.getenv("AI_TRADING_TRADE_HISTORY_PATH", "artifacts/trade_history.parquet")
+    )
+)
+
+_PANDAS_MISSING_LOGGED = False
+
+
+def _ensure_parent(path: Path) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logger.debug("TRADE_HISTORY_PARENT_CREATE_FAILED", exc_info=True)
+
+
+def _coerce_mapping(record: Mapping[str, Any] | Any) -> dict[str, Any]:
+    if isinstance(record, Mapping):
+        return dict(record)
+    if is_dataclass(record):
+        return asdict(record)
+    return dict(getattr(record, "__dict__", {}))
+
+
+def _normalise_record(raw: Mapping[str, Any]) -> dict[str, Any]:
+    record = dict(raw)
+    # Normalise timestamps to datetime for parquet; accept iso strings.
+    ts = record.get("entry_time")
+    if isinstance(ts, str):
+        try:
+            record["entry_time"] = datetime.fromisoformat(ts)
+        except ValueError:
+            record["entry_time"] = datetime.now(UTC)
+    elif ts is None:
+        record["entry_time"] = datetime.now(UTC)
+
+    if "exit_time" in record and isinstance(record["exit_time"], str):
+        try:
+            record["exit_time"] = datetime.fromisoformat(record["exit_time"])
+        except ValueError:
+            record["exit_time"] = None
+
+    defaults: dict[str, Any] = {
+        "entry_price": None,
+        "exit_price": None,
+        "qty": 0,
+        "side": "",
+        "strategy": "",
+        "classification": "",
+        "signal_tags": "",
+        "confidence": 0.0,
+        "reward": None,
+        "order_id": record.get("order_id"),
+        "fill_id": record.get("fill_id"),
+    }
+    for key, value in defaults.items():
+        record.setdefault(key, value)
+    return record
+
+
+def _read_parquet(path: Path) -> "pd.DataFrame" | None:
+    global _PANDAS_MISSING_LOGGED
+    try:
+        import pandas as pd
+    except ImportError:
+        if not _PANDAS_MISSING_LOGGED:
+            logger.warning("TRADE_HISTORY_PANDAS_MISSING")
+            _PANDAS_MISSING_LOGGED = True
+        return None
+    if not path.exists():
+        return None
+    try:
+        return pd.read_parquet(path)
+    except (OSError, ValueError) as exc:  # pragma: no cover - corrupt file guard
+        logger.warning(
+            "TRADE_HISTORY_READ_FAILED",
+            extra={"path": str(path), "cause": exc.__class__.__name__, "detail": str(exc)},
+        )
+        return None
+
+
+def _write_parquet(path: Path, frame: "pd.DataFrame") -> None:
+    _ensure_parent(path)
+    try:
+        frame.to_parquet(path, index=False)
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "TRADE_HISTORY_WRITE_FAILED",
+            extra={"path": str(path), "cause": exc.__class__.__name__, "detail": str(exc)},
+        )
+
+
+def record_trade_fill(record: Mapping[str, Any] | Any) -> None:
+    """Append a single fill record to the canonical parquet history."""
+
+    payload = _coerce_mapping(record)
+    data = _normalise_record(payload)
+    try:
+        import pandas as pd
+    except ImportError:
+        global _PANDAS_MISSING_LOGGED
+        if not _PANDAS_MISSING_LOGGED:
+            logger.warning("TRADE_HISTORY_PANDAS_MISSING")
+            _PANDAS_MISSING_LOGGED = True
+        return
+
+    existing = _read_parquet(_CANONICAL_PATH)
+    new_frame = pd.DataFrame([data])
+    if existing is not None and not existing.empty:
+        combined = pd.concat([existing, new_frame], ignore_index=True)
+        if {"order_id", "fill_id"}.issubset(combined.columns):
+            combined = combined.drop_duplicates(subset=["order_id", "fill_id"], keep="last")
+    else:
+        combined = new_frame
+    _write_parquet(_CANONICAL_PATH, combined)
+
+
+def _extract_attr(obj: Any, *candidates: str) -> Any:
+    for name in candidates:
+        if isinstance(obj, Mapping) and name in obj:
+            return obj[name]
+        if hasattr(obj, name):
+            return getattr(obj, name)
+    return None
+
+
+def _broker_rows(broker: Any) -> Iterable[dict[str, Any]]:
+    if broker is None:
+        return []
+    orders: Iterable[Any]
+    fetch_methods = (
+        "list_orders",
+        "get_orders",
+        "list_trades",
+        "get_fills",
+    )
+    for name in fetch_methods:
+        if hasattr(broker, name):
+            try:
+                candidate = getattr(broker, name)
+                orders = candidate() if name == "get_fills" else candidate(status="all")
+                break
+            except TypeError:
+                try:
+                    orders = getattr(broker, name)()
+                    break
+                except Exception:
+                    continue
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug(
+                    "TRADE_HISTORY_BROKER_FETCH_FAILED",
+                    exc_info=True,
+                    extra={"method": name, "detail": str(exc)},
+                )
+                return []
+    else:
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for order in orders or []:
+        status = str(_extract_attr(order, "status") or "").lower()
+        if "filled" not in status:
+            continue
+        qty_raw = _extract_attr(order, "filled_qty", "quantity", "qty")
+        price_raw = _extract_attr(order, "filled_avg_price", "average_price", "price")
+        timestamp = _extract_attr(order, "filled_at", "executed_at", "updated_at")
+        strategy = _extract_attr(order, "strategy", "strategy_id") or ""
+        try:
+            qty = int(float(qty_raw or 0))
+        except (TypeError, ValueError):
+            continue
+        try:
+            price = float(price_raw or 0)
+        except (TypeError, ValueError):
+            price = None
+        if qty <= 0:
+            continue
+        side_raw = _extract_attr(order, "side") or ""
+        side = str(getattr(side_raw, "value", side_raw)).lower()
+        order_id = _extract_attr(order, "id", "order_id")
+        rows.append(
+            {
+                "symbol": _extract_attr(order, "symbol") or "",
+                "entry_time": timestamp,
+                "entry_price": price,
+                "qty": qty,
+                "side": side,
+                "strategy": strategy,
+                "signal_tags": "",
+                "confidence": 0.0,
+                "order_id": order_id,
+                "fill_id": _extract_attr(order, "fill_id"),
+            }
+        )
+    return rows
+
+
+def load_trade_history(
+    *, sync_from_broker: bool = False, broker: Any | None = None
+) -> tuple["pd.DataFrame" | None, str | None]:
+    """Load canonical history with optional broker reconciliation."""
+
+    frame = _read_parquet(_CANONICAL_PATH)
+    source: str | None = None
+    if frame is not None and not frame.empty:
+        source = "canonical"
+
+    broker_frame = None
+    if sync_from_broker:
+        rows = list(_broker_rows(broker))
+        if rows:
+            try:
+                import pandas as pd
+            except ImportError:
+                rows = []
+            else:
+                broker_frame = pd.DataFrame([_normalise_record(r) for r in rows])
+                if broker_frame.empty:
+                    broker_frame = None
+
+    if broker_frame is not None:
+        try:
+            import pandas as pd
+        except ImportError:
+            broker_frame = None
+        else:
+            if frame is not None and not frame.empty:
+                combined = pd.concat([frame, broker_frame], ignore_index=True)
+                if {"order_id", "fill_id"}.issubset(combined.columns):
+                    combined = combined.drop_duplicates(subset=["order_id", "fill_id"], keep="last")
+                frame = combined
+                source = "merged"
+            else:
+                frame = broker_frame
+                source = "broker"
+            _write_parquet(_CANONICAL_PATH, frame)
+
+    return frame, source
+
+
+__all__ = ["load_trade_history", "record_trade_fill"]

--- a/tests/test_allocator_caps.py
+++ b/tests/test_allocator_caps.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from ai_trading.risk.engine import RiskEngine, TradeSignal
+from ai_trading.strategy_allocator import StrategyAllocator, EPS
+
+pytest.importorskip("numpy")
+
+
+def test_available_exposure_respects_adaptive_cap() -> None:
+    engine = RiskEngine()
+    engine.exposure = {"equity": 0.2}
+    engine.strategy_exposure = {"momentum": 0.1}
+    engine.asset_limits["equity"] = 0.9
+    engine.strategy_limits["momentum"] = 0.9
+    engine._returns = [0.01, -0.005, 0.015, 0.0]
+    signal = TradeSignal(
+        symbol="AAPL",
+        side="buy",
+        confidence=0.7,
+        strategy="momentum",
+        weight=0.7,
+        asset_class="equity",
+    )
+    available = engine._apply_weight_limits(signal)
+    assert available == pytest.approx(0.6, rel=1e-6)
+
+
+def test_allocator_scaling_preserves_proportions(caplog: pytest.LogCaptureFixture) -> None:
+    allocator = StrategyAllocator()
+    sig1 = SimpleNamespace(weight=0.4, symbol="AAA")
+    sig2 = SimpleNamespace(weight=0.4 + EPS / 2, symbol="BBB")
+    unchanged = allocator._scale_buy_weights([sig1, sig2], 0.8)
+    assert not unchanged
+    assert sig1.weight == pytest.approx(0.4)
+    assert sig2.weight == pytest.approx(0.4 + EPS / 2)
+
+    heavy1 = SimpleNamespace(weight=0.6, symbol="CCC")
+    heavy2 = SimpleNamespace(weight=0.3, symbol="DDD")
+    caplog.set_level(logging.INFO)
+    scaled = allocator._scale_buy_weights([heavy1, heavy2], 0.8)
+    assert scaled
+    assert heavy1.weight + heavy2.weight <= 0.8 + EPS
+    ratio_before = 0.6 / 0.3
+    ratio_after = heavy1.weight / heavy2.weight if heavy2.weight else 0.0
+    assert pytest.approx(ratio_before, rel=1e-6) == ratio_after
+    records = [rec for rec in caplog.records if rec.message.startswith("ALLOCATION_SCALED |")]
+    assert records, "expected allocation scaling log"

--- a/tests/test_meta_learn_persistence.py
+++ b/tests/test_meta_learn_persistence.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from ai_trading.execution.engine import (
+    ExecutionEngine,
+    Order,
+    OrderSide,
+    OrderType,
+    _SignalMeta,
+)
+from ai_trading.math.money import Money
+
+pd = pytest.importorskip("pandas")
+
+
+def test_trade_persistence_updates_canonical_history(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    canonical_path = tmp_path / "trade_history.parquet"
+    trade_log_path = tmp_path / "trades.csv"
+
+    import ai_trading.meta_learning.persistence as persistence
+
+    monkeypatch.setattr(persistence, "_CANONICAL_PATH", canonical_path)
+    monkeypatch.setattr(persistence, "_PANDAS_MISSING_LOGGED", False)
+
+    import ai_trading.core.bot_engine as bot_engine
+
+    monkeypatch.setattr(bot_engine, "TRADE_LOG_FILE", str(trade_log_path), raising=False)
+    bot_engine._TRADE_LOGGER_SINGLETON = None
+    bot_engine._TRADE_LOG_CACHE = None
+    bot_engine._TRADE_LOG_CACHE_LOADED = False
+    bot_engine._EMPTY_TRADE_LOG_INFO_EMITTED = False
+
+    caplog.set_level(logging.INFO)
+    first_read = bot_engine._read_trade_log(str(trade_log_path))
+    assert first_read is None
+    empty_logs = [rec for rec in caplog.records if "TRADE_LOG_EMPTY" in rec.getMessage()]
+    assert empty_logs, "expected empty trade log notification"
+
+    ctx = SimpleNamespace(risk_engine=SimpleNamespace(register_fill=lambda *_: None))
+    engine = ExecutionEngine(ctx=ctx)
+    order = Order("AAPL", OrderSide.BUY, 100, order_type=OrderType.MARKET, price=Money(150))
+    order.add_fill(100, Money(151))
+    signal = SimpleNamespace(
+        symbol="AAPL",
+        side="buy",
+        strategy="alpha",
+        confidence=0.8,
+        signal_tags="alpha",
+        weight=0.5,
+    )
+    engine._order_signal_meta[order.id] = _SignalMeta(signal=signal, requested_qty=100, signal_weight=0.5)
+    caplog.clear()
+    engine._handle_execution_event(order, "completed")
+
+    assert canonical_path.exists()
+    frame = pd.read_parquet(canonical_path)
+    assert len(frame) >= 1
+
+    caplog.clear()
+    loaded = bot_engine._read_trade_log(str(trade_log_path))
+    assert loaded is not None
+    assert len(loaded) >= 1
+    loaded_logs = [rec for rec in caplog.records if rec.getMessage().startswith("TRADE_LOG_LOADED")]
+    assert loaded_logs, "expected TRADE_LOG_LOADED log"
+    fallback_logs = [rec for rec in caplog.records if "TRADE_LOG_EMPTY" in rec.getMessage()]
+    assert not fallback_logs, "empty log should not repeat after trades"

--- a/tests/test_trailing_stops.py
+++ b/tests/test_trailing_stops.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from ai_trading.position.trailing_stops import TrailingStopManager
+
+
+def _make_position(entry: float, qty: int, trail_pct: float | None = None) -> SimpleNamespace:
+    payload: dict[str, float | int] = {
+        "avg_entry_price": entry,
+        "qty": qty,
+    }
+    if trail_pct is not None:
+        payload["trail_pct"] = trail_pct
+    return SimpleNamespace(**payload)
+
+
+def test_trailing_stop_initialization_and_ratchet(caplog: pytest.LogCaptureFixture) -> None:
+    manager = TrailingStopManager()
+    position = _make_position(100.0, 10)
+    caplog.set_level(logging.INFO)
+    level = manager.update_trailing_stop("AAPL", position, 101.0)
+    assert level is not None
+    assert level.stop_price < 101.0
+    assert level.side == "long"
+    assert not level.is_triggered
+
+    # Ratchet upward as price makes new highs.
+    level = manager.update_trailing_stop("AAPL", position, 110.0)
+    first_stop = level.stop_price
+    level = manager.update_trailing_stop("AAPL", position, 115.0)
+    assert level.stop_price >= first_stop
+
+
+def test_trailing_stop_correction_logged(caplog: pytest.LogCaptureFixture) -> None:
+    manager = TrailingStopManager()
+    position = _make_position(50.0, 5)
+    level = manager.update_trailing_stop("MSFT", position, 55.0)
+    # Introduce inconsistent state to force correction.
+    level.stop_price = 500.0
+    caplog.set_level(logging.INFO)
+    manager.update_trailing_stop("MSFT", position, 56.0)
+    corrections = [rec for rec in caplog.records if rec.msg == "TRAILING_STOP_CORRECTED"]
+    assert corrections, "expected correction log"
+    payload = corrections[-1].__dict__
+    assert payload["side"] == "long"
+    assert pytest.approx(level.trail_pct) == payload["trail_pct"]
+    assert "max_since_entry" in payload
+
+
+def test_trailing_stop_trigger_logs_details(caplog: pytest.LogCaptureFixture) -> None:
+    manager = TrailingStopManager()
+    position = _make_position(30.0, 8)
+    level = manager.update_trailing_stop("TSLA", position, 36.0)
+    target_stop = float(level.stop_price)
+    caplog.clear()
+    caplog.set_level(logging.WARNING)
+    # Price crosses the stop level which should trigger the stop.
+    manager.update_trailing_stop("TSLA", position, target_stop * 0.99)
+    triggered = [rec for rec in caplog.records if rec.msg == "TRAILING_STOP_TRIGGERED"]
+    assert triggered, "expected trailing stop trigger log"
+    payload = triggered[-1].__dict__
+    assert payload["side"] == "long"
+    assert payload["reason"] == "price_crossed_stop"
+    assert "max_since_entry" in payload


### PR DESCRIPTION
## Summary
- tighten trailing stop tracking to maintain directional state, ratchet with trail_pct, and emit detailed trigger/correction logs to avoid false inits
- expose adaptive exposure capacity via `RiskEngine.available_exposure`, harden weight limits, and rescale allocator weights proportionally with EPS tolerance logging `ALLOCATION_SCALED`
- persist fills to canonical trade history with broker merge fallback, adjust trade log loading to sync once per cycle, and add regression tests

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_trailing_stops.py tests/test_allocator_caps.py tests/test_meta_learn_persistence.py`


------
https://chatgpt.com/codex/tasks/task_e_68d30e8356c0833092cf79fa7ef0fbe0