### PR TITLE
Add asset class passthrough and throttle stage timing logs

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -10975,7 +10975,15 @@ def submit_order(
                 price = get_latest_close(md) if md is not None else 0.0
         # Pass through computed price so the execution engine can simulate
         # fills around the actual market price rather than a generic fallback.
-        return _exec_engine.execute_order(symbol, core_side, qty, price=price)
+        order_type = 'market' if price is None else 'limit'
+        limit_price = None if price is None else price
+        return _exec_engine.execute_order(
+            symbol,
+            core_side,
+            qty,
+            order_type=order_type,
+            limit_price=limit_price,
+        )
     except (APIError, TimeoutError, ConnectionError, AlpacaOrderHTTPError) as e:
         logger.error(
             "BROKER_OP_FAILED",
@@ -15710,11 +15718,14 @@ def run_multi_strategy(ctx) -> None:
         )
 
         try:
+            order_type = 'market' if price is None else 'limit'
+            limit_price = None if price is None else price
             result = ctx.execution_engine.execute_order(
                 sig.symbol,
                 sig.side,
                 qty,
-                price=price,
+                order_type=order_type,
+                limit_price=limit_price,
                 asset_class=sig.asset_class,
                 signal=sig,
                 signal_weight=getattr(sig, "weight", None),

--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -6,6 +6,7 @@ key in ``extra`` matching a reserved field is automatically prefixed with
 ``x_`` to keep structured logging safe. Use :func:`get_logger` to obtain a
 sanitizing adapter for all modules.
 """
+
 import atexit
 import contextlib
 import csv
@@ -24,19 +25,19 @@ from ai_trading.exc import COMMON_EXC
 from .json_formatter import JSONFormatter
 from ai_trading.logging.redact import _ENV_MASK
 
+
 def _ensure_finnhub_enabled_flag() -> None:
     """Set ENABLE_FINNHUB when a key is present; safe to call multiple times."""
 
     if os.getenv("FINNHUB_API_KEY") and os.getenv("ENABLE_FINNHUB") is None:
         os.environ["ENABLE_FINNHUB"] = "1"
-        logging.getLogger(__name__).debug(
-            "ENABLE_FINNHUB_SET", extra={"enabled": True}
-        )
+        logging.getLogger(__name__).debug("ENABLE_FINNHUB_SET", extra={"enabled": True})
 
 
 _ensure_finnhub_enabled_flag()
 
-def _ensure_single_handler(log: logging.Logger, level: int | None=None) -> None:
+
+def _ensure_single_handler(log: logging.Logger, level: int | None = None) -> None:
     """Ensure no duplicate handler types and attach default if none exist."""
 
     seen_types: set[type[logging.Handler]] = set()
@@ -55,54 +56,59 @@ def _ensure_single_handler(log: logging.Logger, level: int | None=None) -> None:
         seen_types.add(h_type)
         if not any(isinstance(f, ExtraSanitizerFilter) for f in h.filters):
             h.addFilter(ExtraSanitizerFilter())
+        if _THROTTLE_FILTER not in h.filters:
+            h.addFilter(_THROTTLE_FILTER)
         filtered.append(h)
 
     if not filtered:
         h = logging.StreamHandler()
-        fmt = logging.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s')
+        fmt = logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
         h.setFormatter(fmt)
         h.addFilter(ExtraSanitizerFilter())
+        h.addFilter(_THROTTLE_FILTER)
         filtered.append(h)
 
     log.handlers = filtered
 
     if level is not None:
         log.setLevel(level)
+
+
 _RESERVED_LOGRECORD_KEYS = {
-    'name',
-    'msg',
-    'message',
-    'args',
-    'levelname',
-    'levelno',
-    'pathname',
-    'filename',
-    'module',
-    'exc_info',
-    'exc_text',
-    'stack_info',
-    'lineno',
-    'funcName',
-    'created',
-    'msecs',
-    'relativeCreated',
-    'thread',
-    'threadName',
-    'processName',
-    'process',
-    'asctime',
+    "name",
+    "msg",
+    "message",
+    "args",
+    "levelname",
+    "levelno",
+    "pathname",
+    "filename",
+    "module",
+    "exc_info",
+    "exc_text",
+    "stack_info",
+    "lineno",
+    "funcName",
+    "created",
+    "msecs",
+    "relativeCreated",
+    "thread",
+    "threadName",
+    "processName",
+    "process",
+    "asctime",
 }
+
 
 def _sanitize_extra(extra: dict[str, Any] | None) -> dict[str, Any]:
     """Rename reserved ``LogRecord`` keys with ``x_`` prefix."""
     if not extra:
         return {}
-    return {
-        k if k not in _RESERVED_LOGRECORD_KEYS else f'x_{k}': v
-        for k, v in extra.items()
-    }
+    return {k if k not in _RESERVED_LOGRECORD_KEYS else f"x_{k}": v for k, v in extra.items()}
 
-_SENSITIVE_EXTRA_KEYS = ('api_key', 'secret')
+
+_SENSITIVE_EXTRA_KEYS = ("api_key", "secret")
+
 
 def sanitize_extra(extra: dict[str, Any] | None) -> dict[str, Any]:
     """Sanitize ``extra`` mapping.
@@ -120,21 +126,115 @@ def sanitize_extra(extra: dict[str, Any] | None) -> dict[str, Any]:
             out[k] = v
     return out
 
+
 class ExtraSanitizerFilter(logging.Filter):
     """Filter that sanitizes arbitrary ``LogRecord`` extras."""
 
     def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - lightweight
-        extras = {
-            k: v
-            for k, v in record.__dict__.items()
-            if k not in _RESERVED_LOGRECORD_KEYS
-        }
+        extras = {k: v for k, v in record.__dict__.items() if k not in _RESERVED_LOGRECORD_KEYS}
         if extras:
             sanitized = sanitize_extra(extras)
             for k in extras:
                 record.__dict__.pop(k, None)
             record.__dict__.update(sanitized)
         return True
+
+
+class MessageThrottleFilter(logging.Filter):
+    """Suppress identical log messages emitted within a short window."""
+
+    SUMMARY_INTERVAL = 30.0
+
+    def __init__(self, throttle_seconds: float | None = None) -> None:
+        super().__init__()
+        self.throttle_seconds = self._resolve_throttle_seconds(throttle_seconds)
+        self._lock = threading.Lock()
+        self._state: dict[str, dict[str, float | int]] = {}
+
+    @staticmethod
+    def _resolve_throttle_seconds(value: float | None) -> float:
+        if value is not None:
+            try:
+                return max(float(value), 0.0)
+            except (TypeError, ValueError):
+                return 2.0
+        raw = os.getenv("LOG_THROTTLE_SECONDS")
+        try:
+            return max(float(raw), 0.0) if raw is not None else 2.0
+        except (TypeError, ValueError):
+            return 2.0
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    @staticmethod
+    def _quote_message(message: str) -> str:
+        escaped = message.replace('"', '\\"')
+        return f'"{escaped}"'
+
+    def _normalize_stage_timing(self, record: logging.LogRecord) -> None:
+        if record.msg == "STAGE_TIMING":
+            stage = getattr(record, "stage", None)
+            elapsed_ms = getattr(record, "elapsed_ms", None)
+            if stage is not None and elapsed_ms is not None:
+                try:
+                    ms_value = int(elapsed_ms)
+                except (TypeError, ValueError):
+                    ms_value = elapsed_ms
+                record.msg = f"STAGE_TIMING | stage={stage} ms={ms_value}"
+                record.args = ()
+
+    def _emit_summary(self, record: logging.LogRecord, message: str, suppressed: int) -> None:
+        summary = f"LOG_THROTTLE_SUMMARY | suppressed={suppressed} message={self._quote_message(message)}"
+        logging.getLogger(record.name or _ROOT_LOGGER_NAME).info(summary)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if self.throttle_seconds <= 0:
+            return True
+
+        if isinstance(record.msg, str) and record.msg.startswith("LOG_THROTTLE_SUMMARY"):
+            return True
+
+        self._normalize_stage_timing(record)
+        message = record.getMessage()
+        if not isinstance(message, str) or not message:
+            return True
+
+        now = self._now()
+        with self._lock:
+            state = self._state.get(message)
+            if state is None:
+                self._state[message] = {
+                    "last_emit": now,
+                    "suppressed": 0,
+                    "last_summary": now,
+                }
+                return True
+
+            last_emit = float(state.get("last_emit", 0.0))
+            suppressed = int(state.get("suppressed", 0))
+            last_summary = float(state.get("last_summary", 0.0))
+
+            if now - last_emit < self.throttle_seconds:
+                suppressed += 1
+                state["suppressed"] = suppressed
+                if now - last_summary >= self.SUMMARY_INTERVAL and suppressed:
+                    self._emit_summary(record, message, suppressed)
+                    state["suppressed"] = 0
+                    state["last_summary"] = now
+                return False
+
+            if suppressed and now - last_summary >= self.SUMMARY_INTERVAL:
+                self._emit_summary(record, message, suppressed)
+                state["suppressed"] = 0
+                state["last_summary"] = now
+
+            state["last_emit"] = now
+            return True
+
+
+_THROTTLE_FILTER = MessageThrottleFilter()
+
 
 class SanitizingLoggerAdapter(logging.LoggerAdapter):
     """Adapter that sanitizes ``extra`` keys to avoid LogRecord collisions."""
@@ -179,28 +279,35 @@ class SanitizingLoggerAdapter(logging.LoggerAdapter):
         self.logger.propagate = value
 
     def process(self, msg, kwargs):
-        extra = kwargs.get('extra')
+        extra = kwargs.get("extra")
         if extra is not None:
-            kwargs['extra'] = sanitize_extra(extra)
+            kwargs["extra"] = sanitize_extra(extra)
         return (msg, kwargs)
-_ROOT_LOGGER_NAME = 'ai_trading'
 
-def with_extra(logger, level, msg: str, *, extra: dict | None=None, **_ignored):
+
+_ROOT_LOGGER_NAME = "ai_trading"
+
+
+def with_extra(logger, level, msg: str, *, extra: dict | None = None, **_ignored):
     """Log `msg` with structured fields via `extra` only (no arbitrary kwargs)."""
     payload = {} if extra is None else dict(extra)
     logger.log(level, msg, extra=payload)
 
-def info_kv(logger, msg: str, *, extra: dict | None=None):
+
+def info_kv(logger, msg: str, *, extra: dict | None = None):
     """Log at INFO level with structured key-value fields."""
     with_extra(logger, logging.INFO, msg, extra=extra)
 
-def warning_kv(logger, msg: str, *, extra: dict | None=None):
+
+def warning_kv(logger, msg: str, *, extra: dict | None = None):
     """Log at WARNING level with structured key-value fields."""
     with_extra(logger, logging.WARNING, msg, extra=extra)
 
-def error_kv(logger, msg: str, *, extra: dict | None=None):
+
+def error_kv(logger, msg: str, *, extra: dict | None = None):
     """Log at ERROR level with structured key-value fields."""
     with_extra(logger, logging.ERROR, msg, extra=extra)
+
 
 def _get_config():
     """Lazy import config management to avoid import-time dependencies.
@@ -208,7 +315,9 @@ def _get_config():
     Returns the imported module so callers can access attributes safely.
     """
     from ai_trading.config import management as config
+
     return config
+
 
 def _get_metrics_logger():
     """Lazy import metrics_logger to avoid import-time dependencies.
@@ -216,7 +325,9 @@ def _get_metrics_logger():
     Returns the module which provides log_* helpers.
     """
     from ai_trading.telemetry import metrics_logger
+
     return metrics_logger
+
 
 def _mask_secret(value: str) -> str:
     """Non-throwing redactor for secret-like values (config-independent).
@@ -224,36 +335,71 @@ def _mask_secret(value: str) -> str:
     Short values fully masked; longer values keep a tiny prefix/suffix.
     """
     try:
-        s = '' if value is None else str(value)
+        s = "" if value is None else str(value)
         n = len(s)
         if n == 0:
-            return ''
+            return ""
         if n <= 6:
-            return '***'
-        return f'{s[:2]}***{s[-2:]}'
+            return "***"
+        return f"{s[:2]}***{s[-2:]}"
     except COMMON_EXC:
-        return '***'
+        return "***"
+
+
 logging.Formatter.converter = time.gmtime
+
 
 class UTCFormatter(logging.Formatter):
     """Formatter with UTC timestamps and structured phase tags."""
+
     converter = time.gmtime
+
 
 class CompactJsonFormatter(JSONFormatter):
     """Compact JSON log formatter that drops large extra payloads."""
 
     def format(self, record: logging.LogRecord) -> str:
-        payload = {'ts': self.formatTime(record, self.datefmt), 'level': record.levelname, 'name': record.name, 'msg': record.getMessage()}
-        essential_fields = {'bot_phase', 'present', 'timestamp'}
+        payload = {
+            "ts": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "name": record.name,
+            "msg": record.getMessage(),
+        }
+        essential_fields = {"bot_phase", "present", "timestamp"}
         for k, v in record.__dict__.items():
-            if k in essential_fields and k not in {'msg', 'message', 'args', 'levelname', 'levelno', 'name', 'created', 'msecs', 'relativeCreated', 'asctime', 'pathname', 'filename', 'module', 'exc_info', 'exc_text', 'stack_info', 'lineno', 'funcName', 'thread', 'threadName', 'processName', 'process', 'taskName'}:
-                if 'key' in k.lower() or 'secret' in k.lower():
+            if k in essential_fields and k not in {
+                "msg",
+                "message",
+                "args",
+                "levelname",
+                "levelno",
+                "name",
+                "created",
+                "msecs",
+                "relativeCreated",
+                "asctime",
+                "pathname",
+                "filename",
+                "module",
+                "exc_info",
+                "exc_text",
+                "stack_info",
+                "lineno",
+                "funcName",
+                "thread",
+                "threadName",
+                "processName",
+                "process",
+                "taskName",
+            }:
+                if "key" in k.lower() or "secret" in k.lower():
                     v = _mask_secret(v)
                 payload[k] = v
         if record.exc_info:
             exc_type, exc_value, _exc_tb = record.exc_info
-            payload['exc'] = ''.join(traceback.format_exception_only(exc_type, exc_value)).strip()
-        return json.dumps(payload, default=self._json_default, ensure_ascii=False, separators=(',', ':'))
+            payload["exc"] = "".join(traceback.format_exception_only(exc_type, exc_value)).strip()
+        return json.dumps(payload, default=self._json_default, ensure_ascii=False, separators=(",", ":"))
+
 
 class EmitOnceLogger:
     """Logger wrapper that tracks emitted messages to prevent duplicates."""
@@ -277,25 +423,27 @@ class EmitOnceLogger:
         log_method = getattr(self._logger, level.lower())
         log_method(msg, *args, **kwargs)
 
-    def info(self, msg: str, key: str | None=None, *args, **kwargs) -> None:
+    def info(self, msg: str, key: str | None = None, *args, **kwargs) -> None:
         """Log info message once per key (defaults to message text as key)."""
         emit_key = key or msg
-        self._emit_if_new('info', emit_key, msg, *args, **kwargs)
+        self._emit_if_new("info", emit_key, msg, *args, **kwargs)
 
-    def debug(self, msg: str, key: str | None=None, *args, **kwargs) -> None:
+    def debug(self, msg: str, key: str | None = None, *args, **kwargs) -> None:
         """Log debug message once per key (defaults to message text as key)."""
         emit_key = key or msg
-        self._emit_if_new('debug', emit_key, msg, *args, **kwargs)
+        self._emit_if_new("debug", emit_key, msg, *args, **kwargs)
 
-    def warning(self, msg: str, key: str | None=None, *args, **kwargs) -> None:
+    def warning(self, msg: str, key: str | None = None, *args, **kwargs) -> None:
         """Log warning message once per key (defaults to message text as key)."""
         emit_key = key or msg
-        self._emit_if_new('warning', emit_key, msg, *args, **kwargs)
+        self._emit_if_new("warning", emit_key, msg, *args, **kwargs)
 
-    def error(self, msg: str, key: str | None=None, *args, **kwargs) -> None:
+    def error(self, msg: str, key: str | None = None, *args, **kwargs) -> None:
         """Log error message once per key (defaults to message text as key)."""
         emit_key = key or msg
-        self._emit_if_new('error', emit_key, msg, *args, **kwargs)
+        self._emit_if_new("error", emit_key, msg, *args, **kwargs)
+
+
 _configured = False
 _loggers: dict[str, SanitizingLoggerAdapter] = {}
 _log_queue: queue.Queue | None = None
@@ -308,30 +456,33 @@ _LOGGING_LISTENER: QueueListener | None = None
 _LOGGING_LOCK = threading.RLock()
 _LOGGING_CONFIGURED = False
 
-def ensure_logging_configured(level: int | None=None) -> None:
+
+def ensure_logging_configured(level: int | None = None) -> None:
     """Configure root logging once."""
     global _LOGGING_CONFIGURED
     root = logging.getLogger()
     if _LOGGING_CONFIGURED or root.handlers:
         return
-    logging.basicConfig(level=level or logging.INFO, format='%(asctime)s %(levelname)s %(name)s - %(message)s')
+    logging.basicConfig(level=level or logging.INFO, format="%(asctime)s %(levelname)s %(name)s - %(message)s")
     _LOGGING_CONFIGURED = True
 
-def get_rotating_handler(path: str, max_bytes: int=5000000, backup_count: int=5) -> logging.Handler:
+
+def get_rotating_handler(path: str, max_bytes: int = 5000000, backup_count: int = 5) -> logging.Handler:
     """Return a size-rotating file handler. Falls back to stderr on failure."""
     try:
         os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
     except PermissionError as exc:
-        logging.getLogger(__name__).warning('Cannot create log directory %s: %s', os.path.dirname(path), exc)
+        logging.getLogger(__name__).warning("Cannot create log directory %s: %s", os.path.dirname(path), exc)
         return logging.StreamHandler(sys.stderr)
     try:
         handler = RotatingFileHandler(path, maxBytes=max_bytes, backupCount=backup_count)
     except OSError as exc:
-        logging.getLogger(__name__).error('Cannot open log file %s: %s', path, exc)
+        logging.getLogger(__name__).error("Cannot open log file %s: %s", path, exc)
         handler = logging.StreamHandler(sys.stderr)
     return handler
 
-def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logger:
+
+def setup_logging(debug: bool = False, log_file: str | None = None) -> logging.Logger:
     """Configure the root logger in an idempotent way.
 
     The ``debug`` flag is retained for backward compatibility but the log
@@ -360,52 +511,56 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
         _ensure_single_handler(logger)
         logger.handlers.clear()
         S = None
-        level_name_env_default = os.getenv('LOG_LEVEL', 'INFO')
+        level_name_env_default = os.getenv("LOG_LEVEL", "INFO")
         try:
             from ai_trading.config import get_settings, management as config
+
             S = get_settings()
-            level_name = getattr(S, 'log_level', level_name_env_default)
+            level_name = getattr(S, "log_level", level_name_env_default)
             yf_level_name = getattr(
                 S,
-                'log_level_yfinance',
-                config.get_env('LOG_LEVEL_YFINANCE', 'WARNING'),
+                "log_level_yfinance",
+                config.get_env("LOG_LEVEL_YFINANCE", "WARNING"),
             )
             formatter = (
-                CompactJsonFormatter('%Y-%m-%dT%H:%M:%SZ')
-                if bool(getattr(S, 'log_compact_json', False))
-                else JSONFormatter('%Y-%m-%dT%H:%M:%SZ')
+                CompactJsonFormatter("%Y-%m-%dT%H:%M:%SZ")
+                if bool(getattr(S, "log_compact_json", False))
+                else JSONFormatter("%Y-%m-%dT%H:%M:%SZ")
             )
         except COMMON_EXC:
             from ai_trading.config import management as config
+
             level_name = level_name_env_default
-            yf_level_name = config.get_env('LOG_LEVEL_YFINANCE', 'WARNING')
-            formatter = JSONFormatter('%Y-%m-%dT%H:%M:%SZ')
+            yf_level_name = config.get_env("LOG_LEVEL_YFINANCE", "WARNING")
+            formatter = JSONFormatter("%Y-%m-%dT%H:%M:%SZ")
         level = getattr(logging, str(level_name).upper(), logging.INFO)
         logger.setLevel(level)
         yf_level = getattr(logging, str(yf_level_name).upper(), logging.WARNING)
-        logging.getLogger('yfinance').setLevel(yf_level)
+        logging.getLogger("yfinance").setLevel(yf_level)
         # Reduce noisy HTTP libraries unless explicitly requested
         try:
-            http_env_default = config.get_env('LOG_LEVEL_HTTP', 'WARNING')
+            http_env_default = config.get_env("LOG_LEVEL_HTTP", "WARNING")
         except Exception:
-            http_env_default = os.getenv('LOG_LEVEL_HTTP', 'WARNING')
-        http_level_name = getattr(S, 'log_level_http', http_env_default)
+            http_env_default = os.getenv("LOG_LEVEL_HTTP", "WARNING")
+        http_level_name = getattr(S, "log_level_http", http_env_default)
         http_level = getattr(logging, str(http_level_name).upper(), logging.WARNING)
-        for _name in ('urllib3', 'requests'):
+        for _name in ("urllib3", "requests"):
             logging.getLogger(_name).setLevel(http_level)
 
         class _PhaseFilter(logging.Filter):
 
             def filter(self, record: logging.LogRecord) -> bool:
-                if not hasattr(record, 'bot_phase'):
-                    record.bot_phase = 'GENERAL'
+                if not hasattr(record, "bot_phase"):
+                    record.bot_phase = "GENERAL"
                 return True
+
         handlers: list[logging.Handler] = []
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(formatter)
         stream_handler.setLevel(level)
         stream_handler.addFilter(_PhaseFilter())
         from ai_trading.logging_filters import SecretFilter
+
         secret_filter = SecretFilter()
         extra_filter = ExtraSanitizerFilter()
         stream_handler.addFilter(secret_filter)
@@ -420,7 +575,7 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
             rotating_handler.addFilter(extra_filter)
             handlers.append(rotating_handler)
         # In tests, avoid background queue threads to prevent timeout interference
-        if os.getenv('PYTEST_RUNNING') == '1' or os.getenv('LOG_DISABLE_QUEUE') == '1':
+        if os.getenv("PYTEST_RUNNING") == "1" or os.getenv("LOG_DISABLE_QUEUE") == "1":
             logger.handlers = handlers
             _listener = None
         else:
@@ -436,7 +591,7 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
         atexit.register(_safe_shutdown_logging)
         atexit.register(logging.shutdown)
         _LOGGING_CONFIGURED = True
-        logging.getLogger(__name__).info('Logging configured successfully - no duplicates possible')
+        logging.getLogger(__name__).info("Logging configured successfully - no duplicates possible")
         for h in handlers:
             with contextlib.suppress(Exception):
                 h.flush()
@@ -447,7 +602,7 @@ def setup_logging(debug: bool=False, log_file: str | None=None) -> logging.Logge
         return logger
 
 
-def configure_logging(debug: bool=False, log_file: str | None=None) -> SanitizingLoggerAdapter:
+def configure_logging(debug: bool = False, log_file: str | None = None) -> SanitizingLoggerAdapter:
     """Configure logging and return a sanitizing adapter.
 
     The function is resilient to configuration/setting import failures and
@@ -467,9 +622,10 @@ def configure_logging(debug: bool=False, log_file: str | None=None) -> Sanitizin
     _LOGGING_CONFIGURED = True
     return get_logger(_ROOT_LOGGER_NAME)
 
+
 def _safe_shutdown_logging():
     try:
-        listener = globals().get('_LOGGING_LISTENER', None)
+        listener = globals().get("_LOGGING_LISTENER", None)
         try:
             if listener is not None:
                 try:
@@ -477,8 +633,8 @@ def _safe_shutdown_logging():
                 except COMMON_EXC:
                     pass
                 try:
-                    t = getattr(listener, '_thread', None)
-                    if t is not None and hasattr(t, 'join'):
+                    t = getattr(listener, "_thread", None)
+                    if t is not None and hasattr(t, "join"):
                         t.join(timeout=1.0)
                 except COMMON_EXC:
                     pass
@@ -493,7 +649,7 @@ def _safe_shutdown_logging():
                 except COMMON_EXC:
                     pass
                 try:
-                    if hasattr(h, 'close'):
+                    if hasattr(h, "close"):
                         h.close()
                 except COMMON_EXC:
                     pass
@@ -501,6 +657,7 @@ def _safe_shutdown_logging():
                 pass
     except COMMON_EXC:
         pass
+
 
 def get_logger(name: str) -> SanitizingLoggerAdapter:
     "Return a named logger wrapped with :class:`SanitizingLoggerAdapter`."
@@ -515,6 +672,8 @@ def get_logger(name: str) -> SanitizingLoggerAdapter:
         base.setLevel(logging.NOTSET)
         _loggers[name] = SanitizingLoggerAdapter(base, {})
     return _loggers[name]
+
+
 logger = SanitizingLoggerAdapter(logging.getLogger(__name__), {})
 logger_once = EmitOnceLogger(logger)
 
@@ -585,6 +744,7 @@ def warn_finnhub_disabled_no_data(
         key=f"FINNHUB_DISABLED_NO_DATA:{dedupe_key}",
         extra=extra,
     )
+
 
 def log_fetch_attempt(provider: str, *, status: int | None = None, error: str | None = None, **extra: Any) -> None:
     """Log a market data fetch attempt and its outcome.
@@ -666,7 +826,8 @@ def log_empty_retries_exhausted(
         payload["retries"] = retries
     logger.error("EMPTY_RETRIES_EXHAUSTED", extra=payload)
 
-def get_phase_logger(name: str, phase: str | None=None) -> logging.Logger:
+
+def get_phase_logger(name: str, phase: str | None = None) -> logging.Logger:
     """
     Return a logger that prefixes messages with a trading 'phase' token so
     dedupe/filters in tests and structured logging can key off it.
@@ -690,16 +851,19 @@ def get_phase_logger(name: str, phase: str | None=None) -> logging.Logger:
         class _PhaseFilter(logging.Filter):
 
             def filter(self, record: logging.LogRecord) -> bool:
-                if not hasattr(record, 'bot_phase') or not record.bot_phase:
+                if not hasattr(record, "bot_phase") or not record.bot_phase:
                     record.bot_phase = phase
                 return True
+
         if not any((isinstance(f, _PhaseFilter) for f in logger.filters)):
             logger.addFilter(_PhaseFilter())
     return logger
 
+
 def init_logger(log_file: str) -> logging.Logger:
     """Wrapper used by utilities to initialize logging."""
     return setup_logging(log_file=log_file)
+
 
 def log_performance_metrics(
     exposure_pct: float,
@@ -712,6 +876,7 @@ def log_performance_metrics(
     """Log daily performance metrics to ``filename``."""
     import numpy as np
     import pandas as pd
+
     if not equity_curve:
         return
     as_of = as_of or date.today()
@@ -725,7 +890,15 @@ def log_performance_metrics(
         sortino = roll.mean() / (downside.std(ddof=0) or 1e-09) * np.sqrt(252 / 20)
         realized_vol = roll.std(ddof=0) * np.sqrt(252 / 20)
     max_dd = _get_metrics_logger().compute_max_drawdown(equity_curve)
-    rec = {'date': str(as_of), 'exposure_pct': exposure_pct, 'sharpe20': sharpe, 'sortino20': sortino, 'realized_vol': realized_vol, 'max_drawdown': max_dd, 'regime': regime}
+    rec = {
+        "date": str(as_of),
+        "exposure_pct": exposure_pct,
+        "sharpe20": sharpe,
+        "sortino20": sortino,
+        "realized_vol": realized_vol,
+        "max_drawdown": max_dd,
+        "regime": regime,
+    }
     if filename is None:
         from pathlib import Path
 
@@ -735,19 +908,22 @@ def log_performance_metrics(
     try:
         os.makedirs(os.path.dirname(filename), mode=0o700, exist_ok=True)
     except PermissionError as exc:
-        logger.warning('Failed to log performance metrics: %s', exc)
+        logger.warning("Failed to log performance metrics: %s", exc)
         return
     try:
         new = not os.path.exists(filename)
-        with open(filename, 'a', newline='', encoding='utf-8') as f:
+        with open(filename, "a", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=rec.keys())
             if new:
                 writer.writeheader()
             writer.writerow(rec)
     except COMMON_EXC as exc:
-        logger.warning('Failed to log performance metrics: %s', exc)
+        logger.warning("Failed to log performance metrics: %s", exc)
 
-def log_trading_event(event_type: str, symbol: str, details: dict[str, any], level: str='INFO', include_context: bool=True) -> None:
+
+def log_trading_event(
+    event_type: str, symbol: str, details: dict[str, any], level: str = "INFO", include_context: bool = True
+) -> None:
     """
     Log structured trading events with comprehensive context information.
 
@@ -796,26 +972,32 @@ def log_trading_event(event_type: str, symbol: str, details: dict[str, any], lev
     """
     logger = get_logger(__name__)
     if not isinstance(event_type, str) or not event_type.strip():
-        logger.error('Invalid event_type: %s', event_type)
+        logger.error("Invalid event_type: %s", event_type)
         return
     if not isinstance(symbol, str) or not symbol.strip():
-        logger.error('Invalid symbol: %s', symbol)
+        logger.error("Invalid symbol: %s", symbol)
         return
     if not isinstance(details, dict):
-        logger.error('Details must be a dictionary, got: %s', type(details))
+        logger.error("Details must be a dictionary, got: %s", type(details))
         return
     sanitized_details = _sanitize_log_data(details.copy())
-    log_entry = {'event_type': event_type.upper(), 'symbol': symbol.upper(), 'timestamp': datetime.now(UTC).isoformat(), 'details': sanitized_details}
+    log_entry = {
+        "event_type": event_type.upper(),
+        "symbol": symbol.upper(),
+        "timestamp": datetime.now(UTC).isoformat(),
+        "details": sanitized_details,
+    }
     if include_context:
-        log_entry['context'] = _get_system_context()
+        log_entry["context"] = _get_system_context()
     try:
-        json_message = json.dumps(log_entry, default=str, separators=(',', ':'), ensure_ascii=False)
+        json_message = json.dumps(log_entry, default=str, separators=(",", ":"), ensure_ascii=False)
     except (TypeError, ValueError) as e:
-        logger.error('Failed to serialize log entry: %s', e)
-        json_message = f'SERIALIZATION_ERROR: {event_type} {symbol}'
+        logger.error("Failed to serialize log entry: %s", e)
+        json_message = f"SERIALIZATION_ERROR: {event_type} {symbol}"
     base_logger = getattr(logger, "logger", logger)
     log_method = getattr(base_logger, level.lower(), base_logger.info)
-    log_method('TRADING_EVENT: %s', json_message)
+    log_method("TRADING_EVENT: %s", json_message)
+
 
 def _sanitize_log_data(data: dict[str, any]) -> dict[str, any]:
     """
@@ -831,12 +1013,12 @@ def _sanitize_log_data(data: dict[str, any]) -> dict[str, any]:
     Dict[str, any]
         Sanitized data with sensitive fields masked or removed
     """
-    sensitive_keys = {'api_key', 'secret_key', 'password', 'token', 'auth', 'credentials', 'private_key', 'session_id'}
+    sensitive_keys = {"api_key", "secret_key", "password", "token", "auth", "credentials", "private_key", "session_id"}
     sanitized = {}
     for key, value in data.items():
         key_lower = key.lower()
         if any((sensitive in key_lower for sensitive in sensitive_keys)):
-            sanitized[key] = '***MASKED***'
+            sanitized[key] = "***MASKED***"
         elif isinstance(value, str):
             sanitized[key] = value
         elif isinstance(value, dict):
@@ -844,6 +1026,7 @@ def _sanitize_log_data(data: dict[str, any]) -> dict[str, any]:
         else:
             sanitized[key] = value
     return sanitized
+
 
 def _get_system_context() -> dict[str, any]:
     """
@@ -857,32 +1040,40 @@ def _get_system_context() -> dict[str, any]:
     try:
         import psutil
     except COMMON_EXC as e:
-        return {'context_error': f'psutil missing: {e}'}
+        return {"context_error": f"psutil missing: {e}"}
     try:
         context = {
-            'memory_usage_mb': round(psutil.virtual_memory().used / 1024 / 1024, 1),
-            'memory_percent': psutil.virtual_memory().percent,
-            'cpu_percent': psutil.cpu_percent(interval=None),
-            'disk_usage_percent': psutil.disk_usage('/').percent,
+            "memory_usage_mb": round(psutil.virtual_memory().used / 1024 / 1024, 1),
+            "memory_percent": psutil.virtual_memory().percent,
+            "cpu_percent": psutil.cpu_percent(interval=None),
+            "disk_usage_percent": psutil.disk_usage("/").percent,
         }
         root = logging.getLogger()
-        handlers = getattr(root, 'handlers', [])
+        handlers = getattr(root, "handlers", [])
         try:
             handler_count = len(handlers)
         except TypeError:
             handler_count = 0
         context.update(
             {
-                'python_version': sys.version.split()[0],
-                'log_level': root.level,
-                'handlers_count': handler_count,
+                "python_version": sys.version.split()[0],
+                "log_level": root.level,
+                "handlers_count": handler_count,
             }
         )
         return context
     except COMMON_EXC as e:
-        return {'context_error': str(e)}
+        return {"context_error": str(e)}
 
-def setup_enhanced_logging(log_file: str=None, level: str='INFO', enable_json_format: bool=False, enable_performance_logging: bool=True, max_file_size_mb: int=100, backup_count: int=5) -> None:
+
+def setup_enhanced_logging(
+    log_file: str = None,
+    level: str = "INFO",
+    enable_json_format: bool = False,
+    enable_performance_logging: bool = True,
+    max_file_size_mb: int = 100,
+    backup_count: int = 5,
+) -> None:
     """
     Setup enhanced logging configuration for the trading bot.
 
@@ -907,15 +1098,18 @@ def setup_enhanced_logging(log_file: str=None, level: str='INFO', enable_json_fo
     global _LOGGING_CONFIGURED
     with _LOGGING_LOCK:
         if _LOGGING_CONFIGURED:
-            logging.getLogger(__name__).debug('Enhanced logging already configured, skipping duplicate setup')
+            logging.getLogger(__name__).debug("Enhanced logging already configured, skipping duplicate setup")
             return
         root_logger = logging.getLogger()
         root_logger.setLevel(getattr(logging, level.upper(), logging.INFO))
         root_logger.handlers.clear()
         console_handler = logging.StreamHandler(sys.stdout)
-        console_formatter = UTCFormatter('%(asctime)s [%(levelname)s] %(name)s: %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+        console_formatter = UTCFormatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+        )
         console_handler.setFormatter(console_formatter)
         from ai_trading.logging_filters import SecretFilter
+
         secret_filter = SecretFilter()
         console_handler.addFilter(secret_filter)
         root_logger.addHandler(console_handler)
@@ -926,44 +1120,54 @@ def setup_enhanced_logging(log_file: str=None, level: str='INFO', enable_json_fo
                     log_file,
                     maxBytes=max_file_size_mb * 1024 * 1024,
                     backupCount=backup_count,
-                    encoding='utf-8',
+                    encoding="utf-8",
                 )
                 if enable_json_format:
                     file_formatter = JSONFormatter()
                 else:
-                    file_formatter = UTCFormatter('%(asctime)s [%(levelname)s] %(name)s: %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+                    file_formatter = UTCFormatter(
+                        "%(asctime)s [%(levelname)s] %(name)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+                    )
                 file_handler.setFormatter(file_formatter)
                 file_handler.addFilter(secret_filter)
                 root_logger.addHandler(file_handler)
             except PermissionError as e:
-                logging.warning('Failed to setup file logging: %s', e)
+                logging.warning("Failed to setup file logging: %s", e)
             except OSError as e:
-                logging.error('Failed to setup file logging: %s', e)
+                logging.error("Failed to setup file logging: %s", e)
         if enable_performance_logging:
             _setup_performance_logging()
         _LOGGING_CONFIGURED = True
-        logging.info('Enhanced logging configured - Level: %s, File: %s, JSON: %s', level, log_file or 'console-only', enable_json_format)
+        logging.info(
+            "Enhanced logging configured - Level: %s, File: %s, JSON: %s",
+            level,
+            log_file or "console-only",
+            enable_json_format,
+        )
+
 
 def _setup_performance_logging():
     """Setup performance-specific logging handlers."""
-    perf_logger = get_logger('performance')
-    perf_file = os.path.join(os.getenv('BOT_LOG_DIR', 'logs'), 'performance.log')
+    perf_logger = get_logger("performance")
+    perf_file = os.path.join(os.getenv("BOT_LOG_DIR", "logs"), "performance.log")
     try:
         os.makedirs(os.path.dirname(perf_file), mode=0o700, exist_ok=True)
     except PermissionError as e:
-        logging.warning('Could not setup performance logging: %s', e)
+        logging.warning("Could not setup performance logging: %s", e)
         return
     try:
         perf_handler = RotatingFileHandler(perf_file, maxBytes=50 * 1024 * 1024, backupCount=3)
-        perf_formatter = UTCFormatter('%(asctime)s PERF %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+        perf_formatter = UTCFormatter("%(asctime)s PERF %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
         perf_handler.setFormatter(perf_formatter)
         from ai_trading.logging_filters import SecretFilter
+
         perf_handler.addFilter(SecretFilter())
         perf_logger.addHandler(perf_handler)
         perf_logger.setLevel(logging.INFO)
         perf_logger.propagate = False
     except OSError as e:
-        logging.warning('Could not setup performance logging: %s', e)
+        logging.warning("Could not setup performance logging: %s", e)
+
 
 def dedupe_stream_handlers(log: logging.Logger) -> int:
     """Public helper to dedupe duplicate ``StreamHandler`` instances on a logger.
@@ -974,10 +1178,11 @@ def dedupe_stream_handlers(log: logging.Logger) -> int:
     _ensure_single_handler(log)
     after = len(log.handlers)
     if after < before:
-        get_logger(__name__).info('LOGGING_SETUP_DEDUPED', extra={'before': before, 'after': after})
+        get_logger(__name__).info("LOGGING_SETUP_DEDUPED", extra={"before": before, "after": after})
     return after
 
-def validate_logging_setup(logger: logging.Logger | None=None, *, dedupe: bool=False) -> dict[str, Any]:
+
+def validate_logging_setup(logger: logging.Logger | None = None, *, dedupe: bool = False) -> dict[str, Any]:
     """Validate logging configuration and (optionally) dedupe handlers.
 
     Parameters
@@ -1000,17 +1205,55 @@ def validate_logging_setup(logger: logging.Logger | None=None, *, dedupe: bool=F
     else:
         after_count = before_count
         did_dedupe = False
-    validation_result = {'handlers_count': after_count, 'before_handlers_count': before_count, 'deduped': did_dedupe, 'is_configured': _LOGGING_CONFIGURED, 'expected_max_handlers': 2, 'validation_passed': True, 'issues': []}
+    validation_result = {
+        "handlers_count": after_count,
+        "before_handlers_count": before_count,
+        "deduped": did_dedupe,
+        "is_configured": _LOGGING_CONFIGURED,
+        "expected_max_handlers": 2,
+        "validation_passed": True,
+        "issues": [],
+    }
     if after_count > 2:
-        validation_result['validation_passed'] = False
-        validation_result['issues'].append(f'Too many handlers detected: {after_count} (expected ≤ 2)')
-        get_logger(__name__).warning('WARNING: %d handlers detected - possible duplicate logging setup', after_count)
+        validation_result["validation_passed"] = False
+        validation_result["issues"].append(f"Too many handlers detected: {after_count} (expected ≤ 2)")
+        get_logger(__name__).warning("WARNING: %d handlers detected - possible duplicate logging setup", after_count)
     if after_count == 0 and (not _LOGGING_CONFIGURED):
-        validation_result['validation_passed'] = False
-        validation_result['issues'].append('No logging handlers configured')
-    if validation_result['validation_passed']:
-        get_logger(__name__).info('Logging validation passed - %d handlers configured', after_count)
+        validation_result["validation_passed"] = False
+        validation_result["issues"].append("No logging handlers configured")
+    if validation_result["validation_passed"]:
+        get_logger(__name__).info("Logging validation passed - %d handlers configured", after_count)
     else:
-        get_logger(__name__).error('Logging validation failed: %s', validation_result['issues'])
+        get_logger(__name__).error("Logging validation failed: %s", validation_result["issues"])
     return validation_result
-__all__ = ['setup_logging', 'configure_logging', 'get_logger', 'get_phase_logger', 'init_logger', 'logger', 'logger_once', 'log_fetch_attempt', 'log_backup_provider_used', 'log_empty_retries_exhausted', 'log_performance_metrics', 'log_trading_event', 'log_finnhub_disabled', 'warn_finnhub_disabled_no_data', 'log_compact_json', 'log_market_fetch', 'setup_enhanced_logging', 'validate_logging_setup', 'dedupe_stream_handlers', 'EmitOnceLogger', 'CompactJsonFormatter', 'with_extra', 'info_kv', 'warning_kv', 'error_kv', 'SanitizingLoggerAdapter', 'sanitize_extra']
+
+
+__all__ = [
+    "setup_logging",
+    "configure_logging",
+    "get_logger",
+    "get_phase_logger",
+    "init_logger",
+    "logger",
+    "logger_once",
+    "log_fetch_attempt",
+    "log_backup_provider_used",
+    "log_empty_retries_exhausted",
+    "log_performance_metrics",
+    "log_trading_event",
+    "log_finnhub_disabled",
+    "warn_finnhub_disabled_no_data",
+    "log_compact_json",
+    "log_market_fetch",
+    "setup_enhanced_logging",
+    "validate_logging_setup",
+    "dedupe_stream_handlers",
+    "EmitOnceLogger",
+    "CompactJsonFormatter",
+    "with_extra",
+    "info_kv",
+    "warning_kv",
+    "error_kv",
+    "SanitizingLoggerAdapter",
+    "sanitize_extra",
+]

--- a/tests/test_execution_engine_signature.py
+++ b/tests/test_execution_engine_signature.py
@@ -1,0 +1,86 @@
+"""Regression tests for the live execution engine public signature."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ai_trading.execution.live_trading import ExecutionEngine
+
+
+@pytest.fixture()
+def engine(monkeypatch: pytest.MonkeyPatch) -> ExecutionEngine:
+    """Create an execution engine with broker calls patched out."""
+
+    engine = ExecutionEngine()
+
+    def fake_market(symbol: str, side: str, quantity: int, **kwargs: Any) -> dict[str, Any]:
+        fake_market.captured = kwargs  # type: ignore[attr-defined]
+        return {
+            "id": "mock-market-1",
+            "status": "accepted",
+            "qty": quantity,
+        }
+
+    def fake_limit(
+        symbol: str,
+        side: str,
+        quantity: int,
+        limit_price: float,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        fake_limit.captured = kwargs  # type: ignore[attr-defined]
+        return {
+            "id": "mock-limit-1",
+            "status": "accepted",
+            "qty": quantity,
+            "limit_price": limit_price,
+        }
+
+    monkeypatch.setattr(engine, "submit_market_order", fake_market)
+    monkeypatch.setattr(engine, "submit_limit_order", fake_limit)
+    return engine
+
+
+def test_execute_order_forwards_supported_asset_class(engine: ExecutionEngine, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When supported, ``asset_class`` is forwarded to the broker request."""
+
+    monkeypatch.setattr(engine, "_supports_asset_class", lambda: True)
+    result = engine.execute_order(
+        "AAPL",
+        "buy",
+        5,
+        order_type="limit",
+        limit_price=123.45,
+        asset_class="us_equity",
+    )
+    assert str(result) == "mock-limit-1"
+    captured = getattr(engine.submit_limit_order, "captured")  # type: ignore[attr-defined]
+    assert captured.get("asset_class") == "us_equity"
+
+
+def test_execute_order_ignores_unknown_kwargs(
+    engine: ExecutionEngine, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unknown kwargs are ignored gracefully with a debug breadcrumb."""
+
+    caplog.set_level("DEBUG", logger="ai_trading.execution.live_trading")
+    monkeypatch.setattr(engine, "_supports_asset_class", lambda: False)
+
+    result = engine.execute_order(
+        "AAPL",
+        "buy",
+        10,
+        order_type="market",
+        asset_class="us_equity",
+        foo="bar",
+    )
+    assert str(result) == "mock-market-1"
+    captured = getattr(engine.submit_market_order, "captured")  # type: ignore[attr-defined]
+    assert "asset_class" not in captured
+    assert "foo" not in captured
+
+    ignored = [record for record in caplog.records if record.msg == "EXEC_IGNORED_KWARG"]
+    logged_fields = {getattr(record, "kw", None) for record in ignored}
+    assert logged_fields >= {"asset_class", "foo"}

--- a/tests/test_logging_quality.py
+++ b/tests/test_logging_quality.py
@@ -1,0 +1,33 @@
+"""Quality gates for structured logging utilities."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from ai_trading.logging import get_logger
+
+
+def test_stage_timing_throttled(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Repeated stage timing logs are throttled and normalized."""
+
+    times = [100.0]
+
+    def fake_monotonic() -> float:
+        return times[0]
+
+    monkeypatch.setattr("ai_trading.logging.__init__.time.monotonic", fake_monotonic)
+
+    caplog.set_level(logging.INFO)
+    logger = get_logger("ai_trading.test.logging_quality")
+
+    caplog.clear()
+    logger.info("STAGE_TIMING", extra={"stage": "bootstrap", "elapsed_ms": 7})
+    times[0] += 1.0
+    logger.info("STAGE_TIMING", extra={"stage": "bootstrap", "elapsed_ms": 7})
+    times[0] += 1.0
+    logger.info("STAGE_TIMING", extra={"stage": "bootstrap", "elapsed_ms": 7})
+
+    stage_messages = [record.getMessage() for record in caplog.records if "STAGE_TIMING" in record.getMessage()]
+    assert stage_messages == ["STAGE_TIMING | stage=bootstrap ms=7"]


### PR DESCRIPTION
## Summary
- extend the live execution engine to accept the new execute_order signature, forward asset_class to brokers that support it, and ignore extra kwargs safely
- wire the bot engine call sites to the new signature and add regression tests for asset class passthrough and kwarg handling
- add a logging throttle that normalizes STAGE_TIMING messages, suppresses rapid duplicates, and reports summaries

## Testing
- `ruff check ai_trading/execution/live_trading.py ai_trading/logging/__init__.py tests/test_execution_engine_signature.py tests/test_logging_quality.py`
- `black ai_trading/logging/__init__.py`
- `black ai_trading/execution/live_trading.py ai_trading/core/bot_engine.py tests/test_execution_engine_signature.py tests/test_logging_quality.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68d319731af883308789ff46ae7df6a7