### PR TITLE
Implement intraday gap repair and deterministic price sourcing

### DIFF
--- a/tests/test_minute_gap_repair.py
+++ b/tests/test_minute_gap_repair.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+import ai_trading.data.fetch as fetch_module
+
+
+def _build_base_frame(start_local: datetime, end_local: datetime, missing: set[pd.Timestamp]) -> pd.DataFrame:
+    tz = ZoneInfo("America/New_York")
+    index_local = pd.date_range(start_local, end_local, freq="T", tz=tz, inclusive="left")
+    index_utc = index_local.tz_convert("UTC")
+    rows: list[dict[str, object]] = []
+    for ts in index_utc:
+        if ts in missing:
+            continue
+        rows.append(
+            {
+                "timestamp": ts,
+                "open": 1.0,
+                "high": 1.0,
+                "low": 1.0,
+                "close": 1.0,
+                "volume": 100.0,
+            }
+        )
+    frame = pd.DataFrame(rows)
+    frame.attrs["symbol"] = "AAPL"
+    return frame
+
+
+def test_repair_rth_gap_uses_backup(monkeypatch: pytest.MonkeyPatch) -> None:
+    tz = ZoneInfo("America/New_York")
+    start_local = datetime(2024, 1, 2, 9, 30, tzinfo=tz)
+    end_local = datetime(2024, 1, 2, 16, 0, tzinfo=tz)
+    expected_local = pd.date_range(start_local, end_local, freq="T", tz=tz, inclusive="left")
+    missing = {expected_local[5].tz_convert("UTC"), expected_local[25].tz_convert("UTC")}
+    base_df = _build_base_frame(start_local, end_local, missing)
+
+    captured: dict[str, pd.Timestamp] = {}
+
+    def fake_backup(symbol: str, start: datetime, end: datetime, interval: str) -> pd.DataFrame:
+        captured["start"] = start
+        captured["end"] = end
+        rows = []
+        for ts in sorted(missing):
+            rows.append(
+                {
+                    "timestamp": ts,
+                    "open": 2.0,
+                    "high": 2.0,
+                    "low": 2.0,
+                    "close": 2.0,
+                    "volume": 50.0,
+                }
+            )
+        return pd.DataFrame(rows)
+
+    monkeypatch.setattr(fetch_module, "_backup_get_bars", fake_backup)
+    repaired, meta, used_backup = fetch_module._repair_rth_minute_gaps(  # type: ignore[attr-defined]
+        base_df,
+        symbol="AAPL",
+        start=start_local.astimezone(UTC),
+        end=end_local.astimezone(UTC),
+        tz=tz,
+    )
+
+    assert used_backup is True
+    assert meta["missing_after"] == 0
+    assert captured["start"] == min(missing)
+    assert captured["end"] == max(missing) + timedelta(minutes=1)
+    repaired_index = pd.to_datetime(repaired["timestamp"], utc=True)
+    for ts in missing:
+        assert ts in set(repaired_index)
+
+
+def test_should_skip_symbol_logs_on_excessive_gap(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    tz = ZoneInfo("America/New_York")
+    start_local = datetime(2024, 1, 3, 9, 30, tzinfo=tz)
+    end_local = datetime(2024, 1, 3, 16, 0, tzinfo=tz)
+    expected_local = pd.date_range(start_local, end_local, freq="T", tz=tz, inclusive="left")
+    missing = {expected_local[i].tz_convert("UTC") for i in range(0, 30)}
+    df = _build_base_frame(start_local, end_local, missing)
+    df.attrs["symbol"] = "SKIPX"
+    fetch_module._SKIP_LOGGED.clear()  # type: ignore[attr-defined]
+    caplog.set_level("WARNING")
+    should_skip = fetch_module.should_skip_symbol(
+        df,
+        window=(start_local.astimezone(UTC), end_local.astimezone(UTC)),
+        tz=tz,
+        max_gap_ratio=0.0,
+    )
+    assert should_skip is True
+    assert any(
+        "SKIP_SYMBOL_INSUFFICIENT_INTRADAY_COVERAGE" in record.message
+        for record in caplog.records
+    )

--- a/tests/test_order_price_sourcing.py
+++ b/tests/test_order_price_sourcing.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from ai_trading.core import bot_engine
+
+
+class DummyDataClient:
+    def __init__(self, quotes: dict[str | None, Any]) -> None:
+        self.quotes = quotes
+        self.calls: list[str | None] = []
+
+    def get_stock_latest_quote(self, req: Any) -> Any:
+        feed = getattr(req, "feed", None)
+        self.calls.append(feed)
+        return self.quotes.get(feed)
+
+
+def _ctx_with_quotes(quotes: dict[str | None, Any]) -> SimpleNamespace:
+    return SimpleNamespace(data_client=DummyDataClient(quotes))
+
+
+def test_price_source_prefers_nbbo(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("SLIPPAGE_BPS", "2")
+    quotes = {
+        None: SimpleNamespace(bid_price=100.0, ask_price=100.5),
+    }
+    ctx = _ctx_with_quotes(quotes)
+    price, source = bot_engine._resolve_limit_price(ctx, "AAPL", "buy", None, None)
+    assert source == "broker_nbbo"
+    assert price == pytest.approx(100.27005, rel=1e-6)
+    assert any("fallback_chain=[\"primary_mid\",\"backup_mid\",\"last_close\"]" in rec.message for rec in caplog.records)
+
+
+def test_price_source_primary_mid_when_nbbo_missing(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("SLIPPAGE_BPS", "2")
+    monkeypatch.setattr(bot_engine, "DATA_FEED_INTRADAY", "iex", raising=False)
+    quotes = {
+        None: SimpleNamespace(bid_price=0.0, ask_price=0.0),
+        "iex": SimpleNamespace(bid_price=104.0, ask_price=105.0),
+    }
+    ctx = _ctx_with_quotes(quotes)
+    price, source = bot_engine._resolve_limit_price(ctx, "MSFT", "sell", None, None)
+    assert source == "primary_mid"
+    assert price == pytest.approx(104.4791, rel=1e-6)
+    assert any("fallback_chain=[\"backup_mid\",\"last_close\"]" in rec.message for rec in caplog.records)
+
+
+def test_price_source_backup_mid(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("SLIPPAGE_BPS", "2")
+    monkeypatch.setattr(bot_engine, "DATA_FEED_INTRADAY", "iex", raising=False)
+    monkeypatch.setattr(bot_engine.data_fetcher_module, "_sip_configured", lambda: True, raising=False)
+    quotes = {
+        None: SimpleNamespace(bid_price=0.0, ask_price=0.0),
+        "iex": SimpleNamespace(bid_price=0.0, ask_price=0.0),
+        "sip": SimpleNamespace(bid_price=200.0, ask_price=201.0),
+    }
+    ctx = _ctx_with_quotes(quotes)
+    price, source = bot_engine._resolve_limit_price(ctx, "TSLA", "buy", None, None)
+    assert source == "backup_mid"
+    assert price == pytest.approx(200.0402, rel=1e-6)
+    assert any("fallback_chain=[\"last_close\"]" in rec.message for rec in caplog.records)
+
+
+def test_price_source_last_close_fallback(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("SLIPPAGE_BPS", "2")
+    monkeypatch.setattr(bot_engine, "DATA_FEED_INTRADAY", "iex", raising=False)
+    monkeypatch.setattr(bot_engine.data_fetcher_module, "_sip_configured", lambda: False, raising=False)
+    quotes = {
+        None: None,
+        "iex": None,
+    }
+    ctx = _ctx_with_quotes(quotes)
+    minute_df = pd.DataFrame()
+    price, source = bot_engine._resolve_limit_price(ctx, "NFLX", "buy", minute_df, 50.0)
+    assert source == "last_close"
+    assert price == pytest.approx(50.01, rel=1e-6)
+    assert any("fallback_chain=[]" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- repair RTH minute gaps by reindexing against the NYSE trading session, fetching missing rows from the backup provider, and exposing a reusable skip helper with provider monitor integration
- extend the provider monitor with circuit-breaker logic and update the bot engine to respect coverage skips, logging succinct switchover and skip decisions
- implement deterministic price sourcing with slippage-aware limit prices and add focused tests for gap repair and price resolution

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d32463757c83309184776e63b4a24b