### PR TITLE
Gracefully handle skipped Alpaca orders

### DIFF
--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -605,12 +605,16 @@ class ExecutionEngine:
             message = str(exc) or "order execution failed"
             raise AlpacaOrderHTTPError(status_code, message) from exc
 
-        if not order:
-            raise AlpacaOrderHTTPError(
-                500,
-                "order submission returned empty response",
-                payload={"symbol": symbol, "side": mapped_side, "type": order_type_normalized},
+        if order is None:
+            logger.warning(
+                "EXEC_ORDER_NO_RESULT",
+                extra={
+                    "symbol": symbol,
+                    "side": mapped_side,
+                    "type": order_type_normalized,
+                },
             )
+            return None
 
         if isinstance(order, dict):
             order_id = order.get("id") or order.get("client_order_id")


### PR DESCRIPTION
## Summary
- stop raising AlpacaOrderHTTPError when Alpaca returns a non-retryable 403/500 and no order payload
- log the missing-order condition and return cleanly so the trading cycle continues processing other symbols

## Testing
- ruff check ai_trading/execution/live_trading.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q *(fails: ai_trading.util.env_check.DotenvImportError: python-dotenv not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d43e578f488330b6da8896d5d7505f