### PR TITLE
Improve Alpaca credential detection and order failure handling

### DIFF
--- a/ai_trading/config/runtime.py
+++ b/ai_trading/config/runtime.py
@@ -242,7 +242,7 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
     ),
     ConfigSpec(
         field="alpaca_api_key",
-        env=("ALPACA_API_KEY",),
+        env=("ALPACA_API_KEY", "ALPACA_API_KEY_ID", "APCA_API_KEY_ID"),
         cast="str",
         default=None,
         description="Alpaca API key identifier.",
@@ -250,7 +250,7 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
     ),
     ConfigSpec(
         field="alpaca_secret_key",
-        env=("ALPACA_SECRET_KEY",),
+        env=("ALPACA_SECRET_KEY", "ALPACA_API_SECRET_KEY", "APCA_API_SECRET_KEY"),
         cast="str",
         default=None,
         description="Alpaca API secret.",


### PR DESCRIPTION
## Summary
- allow the runtime TradingConfig to resolve Alpaca credentials from the usual *_API_KEY_ID and *_API_SECRET_KEY aliases so the primary feed can authenticate instead of falling back to Yahoo
- harden the Alpaca execution engine so HTTP/network failures return cleanly, emit structured diagnostics, and no longer abort the scheduling cycle when the broker responds with empty payloads

## Testing
- pytest tests/test_alpaca_init_contract.py -q *(fails: TypeError: ValidateBaseModel.__init_subclass__() takes no keyword arguments — installed alpaca-py expects pydantic<2; environment ships pydantic 2.11.9)*

------
https://chatgpt.com/codex/tasks/task_e_68d4416348b88330b4ae6426277cb89a