### PR TITLE
Add configuration defaults and logging deduper utilities

### DIFF
--- a/ai_trading/utils/ids.py
+++ b/ai_trading/utils/ids.py
@@ -1,0 +1,22 @@
+"""Helpers for generating stable identifiers used across execution paths."""
+
+from __future__ import annotations
+
+import secrets
+import string
+
+_SUFFIX_ALPHABET = string.ascii_lowercase + string.digits
+
+
+def _random_suffix(length: int = 8) -> str:
+    return "".join(secrets.choice(_SUFFIX_ALPHABET) for _ in range(length))
+
+
+def stable_client_order_id(symbol: str, side: str, epoch_min: int) -> str:
+    """Return a client order identifier derived from the trade context."""
+
+    base = f"{symbol}-{side}-{int(epoch_min)}"
+    return f"{base}-{_random_suffix()}"
+
+
+__all__ = ["stable_client_order_id"]

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -1,0 +1,30 @@
+"""Regression tests for new configuration defaults."""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_trading.config.management import TradingConfig
+
+
+@pytest.mark.parametrize(
+    ("field", "expected", "type_"),
+    (
+        ("orders_pending_new_warn_s", 60, int),
+        ("orders_pending_new_error_s", 180, int),
+        ("data_max_gap_ratio_intraday", 0.005, float),
+        ("data_daily_fetch_min_interval_s", 60, int),
+        ("execution_min_qty", 1, int),
+        ("execution_min_notional", 1.0, float),
+        ("execution_max_open_orders", 100, int),
+        ("logging_dedupe_ttl_s", 120, int),
+    ),
+)
+def test_config_defaults(field: str, expected: float | int, type_: type[object]) -> None:
+    cfg = TradingConfig()
+    value = getattr(cfg, field)
+    assert isinstance(value, type_)
+    if isinstance(expected, float):
+        assert value == pytest.approx(expected)
+    else:
+        assert value == expected

--- a/tests/test_log_deduper.py
+++ b/tests/test_log_deduper.py
@@ -1,0 +1,28 @@
+"""Tests for the lightweight log deduplication helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from ai_trading.logging import LogDeduper
+
+
+def test_log_deduper_enforces_ttl() -> None:
+    deduper = LogDeduper()
+    assert deduper.should_log("order", ttl_s=10, now=100.0)
+    assert not deduper.should_log("order", ttl_s=10, now=105.0)
+    assert deduper.should_log("order", ttl_s=10, now=111.0)
+
+
+def test_log_deduper_handles_multiple_keys() -> None:
+    deduper = LogDeduper()
+    assert deduper.should_log("a", ttl_s=5, now=0.0)
+    assert deduper.should_log("b", ttl_s=5, now=1.0)
+    assert not deduper.should_log("a", ttl_s=5, now=3.0)
+    assert deduper.should_log("b", ttl_s=5, now=6.0)
+
+
+def test_log_deduper_rejects_negative_ttl() -> None:
+    deduper = LogDeduper()
+    with pytest.raises(ValueError):
+        deduper.should_log("bad", ttl_s=-1, now=0.0)


### PR DESCRIPTION
## Summary
- extend the runtime configuration schema with new defaults for order handling, data fetch cadence, execution guards, and logging dedupe TTL, and expose an `update` helper on `TradingConfig`
- add a lightweight `LogDeduper` helper and export it from `ai_trading.logging`
- introduce a stable client order ID utility and regression tests covering the new config defaults and deduper behaviour

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_config_defaults.py tests/test_log_deduper.py tests/unit/test_trading_config_fields.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d474a5b9c08330894a74dfb195953c