### PR TITLE
Add per-cycle log throttle summaries

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -87,7 +87,7 @@ from ai_trading.data.timeutils import (
 )
 from ai_trading.data_validation import is_valid_ohlcv
 from ai_trading.utils import health_check as _health_check
-from ai_trading.logging import logger_once
+from ai_trading.logging import flush_log_throttle_summaries, logger_once
 from ai_trading.alpaca_api import (
     AlpacaAuthenticationError,
     AlpacaOrderHTTPError,
@@ -17585,6 +17585,7 @@ def run_all_trades_worker(state: BotState, runtime) -> None:
             state._strategies_loaded = False
             state.last_loop_duration = time.monotonic() - loop_start
             _log_loop_heartbeat(loop_id, loop_start)
+            flush_log_throttle_summaries()
 
             _check_runtime_stops(runtime)
 

--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -1334,6 +1334,7 @@ def main(argv: list[str] | None = None) -> None:
                     backoff_seconds = interval
                 backoff_seconds = max(1, min(30, backoff_seconds))
                 _interruptible_sleep(backoff_seconds)
+                _logging.flush_log_throttle_summaries()
                 if should_stop():
                     logger.info("SERVICE_SHUTDOWN", extra={"reason": "signal"})
                     break
@@ -1345,6 +1346,7 @@ def main(argv: list[str] | None = None) -> None:
                 "CYCLE_TIMING",
                 extra={"elapsed_ms": budget.elapsed_ms(), "within_budget": not budget.over_budget()},
             )
+            _logging.flush_log_throttle_summaries()
             now_mono = time.monotonic()
             if now_mono - last_health >= max(30, health_tick_seconds):
                 logger.info("HEALTH_TICK", extra={"iteration": count, "interval": effective_interval, "closed": closed})

--- a/tests/test_log_deduper_provider_spam.py
+++ b/tests/test_log_deduper_provider_spam.py
@@ -1,0 +1,69 @@
+import logging
+
+import pytest
+
+from tests.optdeps import require
+
+log_mod = require("ai_trading.logging")
+
+
+@pytest.mark.unit
+def test_throttle_summaries_flush_each_cycle(caplog):
+    flush = getattr(log_mod, "flush_log_throttle_summaries", None)
+    throttle_filter = getattr(log_mod, "_THROTTLE_FILTER", None)
+    if flush is None or throttle_filter is None:
+        pytest.skip("Log throttle helpers unavailable")
+
+    caplog.set_level(logging.INFO)
+    with throttle_filter._lock:  # type: ignore[attr-defined]
+        throttle_filter._state.clear()  # type: ignore[attr-defined]
+
+    logger = log_mod.get_logger("ai_trading.tests.deduper")
+
+    logger.info("PROVIDER_SPAM", extra={"provider": "feed-a"})
+    logger.info("PROVIDER_SPAM", extra={"provider": "feed-a"})
+
+    with throttle_filter._lock:  # type: ignore[attr-defined]
+        first_cycle_suppressed = int(
+            throttle_filter._state.get("PROVIDER_SPAM", {}).get("suppressed", 0)  # type: ignore[attr-defined]
+        )
+    assert first_cycle_suppressed >= 1
+
+    flush()
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    summaries = [msg for msg in messages if msg.startswith("LOG_THROTTLE_SUMMARY")]
+    assert summaries
+
+    def _suppressed_count(summary: str) -> int:
+        for token in summary.split():
+            if token.startswith("suppressed="):
+                try:
+                    return int(token.split("=", 1)[1])
+                except ValueError:  # pragma: no cover - defensive parsing
+                    continue
+        raise AssertionError(f"suppressed count missing in summary: {summary}")
+
+    assert _suppressed_count(summaries[-1]) == first_cycle_suppressed
+
+    with throttle_filter._lock:  # type: ignore[attr-defined]
+        suppressed_after = int(
+            throttle_filter._state.get("PROVIDER_SPAM", {}).get("suppressed", 0)  # type: ignore[attr-defined]
+        )
+    assert suppressed_after == 0
+
+    logger.info("PROVIDER_SPAM", extra={"provider": "feed-a"})
+    logger.info("PROVIDER_SPAM", extra={"provider": "feed-a"})
+
+    with throttle_filter._lock:  # type: ignore[attr-defined]
+        second_cycle_suppressed = int(
+            throttle_filter._state.get("PROVIDER_SPAM", {}).get("suppressed", 0)  # type: ignore[attr-defined]
+        )
+    assert second_cycle_suppressed >= 1
+
+    flush()
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    summaries = [msg for msg in messages if msg.startswith("LOG_THROTTLE_SUMMARY")]
+    assert len(summaries) == 2
+    assert _suppressed_count(summaries[-1]) == second_cycle_suppressed


### PR DESCRIPTION
## Summary
- add a cycle-flush helper to the log throttle filter so suppressed messages emit LOG_THROTTLE_SUMMARY entries and counters reset
- invoke the new flush hook at the scheduler and bot engine cycle boundaries to ensure per-cycle summaries
- add a regression test that exercises the new helper and verifies counters clear between cycles

## Testing
- ENV_IMPORT_GUARD=0 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_log_deduper_provider_spam.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d47533a96c8330b82faa650ae8d363