### PR TITLE
Throttle provider churn logs with per-cycle summaries

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -87,7 +87,7 @@ from ai_trading.data.timeutils import (
 )
 from ai_trading.data_validation import is_valid_ohlcv
 from ai_trading.utils import health_check as _health_check
-from ai_trading.logging import logger_once
+from ai_trading.logging import LogDeduper, logger_once
 from ai_trading.alpaca_api import (
     AlpacaAuthenticationError,
     AlpacaOrderHTTPError,
@@ -1209,6 +1209,7 @@ def _reset_cycle_cache() -> None:
     now = datetime.now(timezone.utc)
     _GLOBAL_CYCLE_ID = int(now.timestamp())
     _GLOBAL_INTRADAY_FALLBACK_FEED = None
+    LogDeduper.begin_cycle(_GLOBAL_CYCLE_ID)
 
 
 def _prefer_feed_this_cycle() -> str | None:
@@ -17587,6 +17588,8 @@ def run_all_trades_worker(state: BotState, runtime) -> None:
             _log_loop_heartbeat(loop_id, loop_start)
 
             _check_runtime_stops(runtime)
+
+            LogDeduper.emit_summaries(logger)
 
             # AI-AGENT-REF: Perform memory cleanup after trading cycle
             if MEMORY_OPTIMIZATION_AVAILABLE:

--- a/tests/test_log_deduper_provider_spam.py
+++ b/tests/test_log_deduper_provider_spam.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from ai_trading.logging import LogDeduper, dedupe_ttl_s, get_logger
+
+
+@pytest.fixture(autouse=True)
+def _reset_deduper() -> None:
+    """Ensure deduper state is isolated between tests."""
+
+    LogDeduper.reset()
+    yield
+    LogDeduper.reset()
+
+
+def test_provider_logs_deduped_and_summarized() -> None:
+    """Duplicate provider logs within a cycle are suppressed and summarized."""
+
+    logger = get_logger("ai_trading.test.log_deduper")
+
+    records: list[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - trivial
+            records.append(record)
+
+    handler = _Collector(level=logging.INFO)
+    logger.logger.addHandler(handler)
+    try:
+        LogDeduper.begin_cycle("cycle-1")
+
+        key = "USING_BACKUP_PROVIDER:test:AAPL:1Min"
+        assert LogDeduper.should_log(key, dedupe_ttl_s)
+        logger.info("USING_BACKUP_PROVIDER", extra={"provider": "test", "symbol": "AAPL"})
+
+        assert not LogDeduper.should_log(key, dedupe_ttl_s)
+        assert not LogDeduper.should_log(key, dedupe_ttl_s)
+
+        LogDeduper.emit_summaries(logger)
+
+        using_backup = [rec for rec in records if rec.getMessage() == "USING_BACKUP_PROVIDER"]
+        summaries = [rec.getMessage() for rec in records if rec.getMessage().startswith("LOG_THROTTLE_SUMMARY")]
+
+        assert len(using_backup) == 1
+        assert summaries == ['LOG_THROTTLE_SUMMARY | message="USING_BACKUP_PROVIDER" suppressed=2']
+
+        records.clear()
+        LogDeduper.emit_summaries(logger)
+        assert not records
+    finally:
+        logger.logger.removeHandler(handler)


### PR DESCRIPTION
## Summary
- add a reusable LogDeduper with configurable TTL to suppress churny provider logs and emit cycle summaries
- wrap backup-provider usage and switchover/failure logs with the deduper and flush summaries at the end of each trading cycle
- cover the deduper behaviour with a focused provider spam test

## Testing
- ENV_IMPORT_GUARD=0 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_log_deduper_provider_spam.py

------
https://chatgpt.com/codex/tasks/task_e_68d47514b480833082a319967bb21628