### PR TITLE
Debounce daily fetch requests and measure fetch stage

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -1276,13 +1276,18 @@ def main(argv: list[str] | None = None) -> None:
                 fraction_clamped = max(0.0, min(1.0, float(fraction)))
                 budget = SoftBudget(int(interval_ms * fraction_clamped))
                 try:
-                    if count % memory_check_interval == 0:
-                        gc_result = optimize_memory()
-                        if gc_result.get("objects_collected", 0) > 100:
-                            logger.info(f"Cycle {count}: Garbage collected {gc_result['objects_collected']} objects")
                     _t0 = _mono()
                     with StageTimer(logger, "CYCLE_FETCH"):
-                        pass
+                        if count % memory_check_interval == 0:
+                            gc_result = optimize_memory()
+                            if gc_result.get("objects_collected", 0) > 100:
+                                logger.info(
+                                    "CYCLE_FETCH_GC",
+                                    extra={
+                                        "cycle": count,
+                                        "objects_collected": gc_result["objects_collected"],
+                                    },
+                                )
                     try:
                         _cycle_stage_seconds.labels(stage="fetch").observe(max(0.0, _mono() - _t0))  # type: ignore[call-arg]
                     except Exception:

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -179,6 +179,13 @@ class Settings(BaseSettings):
         default=120,
         env="DATA_COOLDOWN_SECONDS",
     )
+    data_daily_fetch_min_interval_s: float = Field(
+        0.0,
+        validation_alias=AliasChoices(
+            "DATA_DAILY_FETCH_MIN_INTERVAL_S",
+            "DAILY_FETCH_MIN_INTERVAL_S",
+        ),
+    )
     price_slippage_bps: float = Field(
         default=10.0,
         env="PRICE_SLIPPAGE_BPS",


### PR DESCRIPTION
## Summary
- add a process-wide debounce table so repeated daily fetch calls within the configured window reuse cache and only emit one DAILY_FETCH_CACHE_HIT
- wire the debounce window to a new data_daily_fetch_min_interval_s setting and refresh memo/debounce state when serving cached data
- move cycle fetch work under the StageTimer so the CYCLE_FETCH timing reflects garbage collection work instead of always logging zero

## Testing
- ENV_IMPORT_GUARD=0 pytest tests/test_daily_fetch_debounce.py
- ENV_IMPORT_GUARD=0 pytest tests/test_daily_cache.py
- ENV_IMPORT_GUARD=0 pytest tests/test_main_smoke.py


------
https://chatgpt.com/codex/tasks/task_e_68d4752ac6008330b4dc9255ff9673f2