### PR TITLE
Unify Alpaca credentials and downgrade data feed when missing

### DIFF
--- a/ai_trading/broker/alpaca_credentials.py
+++ b/ai_trading/broker/alpaca_credentials.py
@@ -9,6 +9,16 @@ from dataclasses import dataclass
 _DEFAULT_BASE_URL = "https://paper-api.alpaca.markets"
 
 
+_CANONICAL_KEY = "ALPACA_API_KEY"
+_CANONICAL_SECRET = "ALPACA_SECRET_KEY"
+_DATA_KEY_FALLBACKS: tuple[str, ...] = ("ALPACA_DATA_API_KEY",)
+_DATA_SECRET_FALLBACKS: tuple[str, ...] = ("ALPACA_DATA_SECRET_KEY",)
+_EXEC_KEY_FALLBACKS: tuple[str, ...] = ("APCA_API_KEY_ID", "ALPACA_API_KEY_ID")
+_EXEC_SECRET_FALLBACKS: tuple[str, ...] = ("APCA_API_SECRET_KEY", "ALPACA_API_SECRET_KEY")
+_FALLBACK_SOURCE: dict[str, str | None] = {"api": None, "secret": None}
+_FALLBACK_ACTIVE: dict[str, bool] = {"api": False, "secret": False}
+
+
 @dataclass(slots=True)
 class AlpacaCredentials:
     """Typed container for Alpaca API credentials."""
@@ -16,17 +26,109 @@ class AlpacaCredentials:
     api_key: str | None = None
     secret_key: str | None = None
     base_url: str = _DEFAULT_BASE_URL
+    api_source: str | None = None
+    secret_source: str | None = None
+
+    def has_data_credentials(self) -> bool:
+        """Return ``True`` when credentials originate from data-capable keys."""
+
+        return (
+            self.api_source in (_CANONICAL_KEY,) + _DATA_KEY_FALLBACKS
+            and self.secret_source in (_CANONICAL_SECRET,) + _DATA_SECRET_FALLBACKS
+        )
+
+    def has_execution_credentials(self) -> bool:
+        """Return ``True`` when credentials can authenticate trading."""
+
+        return (
+            self.api_source in (_CANONICAL_KEY,) + _EXEC_KEY_FALLBACKS
+            and self.secret_source in (_CANONICAL_SECRET,) + _EXEC_SECRET_FALLBACKS
+        )
+
+    def as_dict(self) -> dict[str, str | None]:
+        """Return a mapping representation for structured logging/tests."""
+
+        return {
+            "api_key": self.api_key,
+            "secret_key": self.secret_key,
+            "base_url": self.base_url,
+            "api_source": self.api_source,
+            "secret_source": self.secret_source,
+        }
+
+
+def _select_env_value(env: Mapping[str, str], canonical: str, aliases: tuple[str, ...]) -> tuple[str | None, str | None]:
+    for key in (canonical, *aliases):
+        value = env.get(key)
+        if value:
+            return value, key
+    return None, None
 
 
 def resolve_alpaca_credentials(env: Mapping[str, str] | None = None) -> AlpacaCredentials:
-    """Return Alpaca credentials from *env* as an :class:`AlpacaCredentials` dataclass."""
+    """Return Alpaca credentials resolved from the environment."""
 
-    env = dict(env or os.environ)
-    return AlpacaCredentials(
-        env.get("ALPACA_API_KEY"),
-        env.get("ALPACA_SECRET_KEY"),
-        env.get("ALPACA_BASE_URL") or _DEFAULT_BASE_URL,
+    env_map = dict(env or os.environ)
+    canonical_key_present = bool(env_map.get(_CANONICAL_KEY))
+    canonical_secret_present = bool(env_map.get(_CANONICAL_SECRET))
+
+    api_key, api_source = _select_env_value(env_map, _CANONICAL_KEY, _DATA_KEY_FALLBACKS + _EXEC_KEY_FALLBACKS)
+    secret_key, secret_source = _select_env_value(
+        env_map,
+        _CANONICAL_SECRET,
+        _DATA_SECRET_FALLBACKS + _EXEC_SECRET_FALLBACKS,
     )
+
+    effective_api_source = api_source
+    effective_secret_source = secret_source
+
+    if api_key:
+        if api_source == _CANONICAL_KEY:
+            stored = _FALLBACK_SOURCE.get("api")
+            if _FALLBACK_ACTIVE.get("api") and stored and env_map.get(stored) == api_key:
+                effective_api_source = stored
+            else:
+                _FALLBACK_SOURCE["api"] = None
+                _FALLBACK_ACTIVE["api"] = False
+        else:
+            _FALLBACK_SOURCE["api"] = api_source
+            _FALLBACK_ACTIVE["api"] = not canonical_key_present
+    else:
+        _FALLBACK_SOURCE["api"] = None
+        _FALLBACK_ACTIVE["api"] = False
+
+    if secret_key:
+        if secret_source == _CANONICAL_SECRET:
+            stored_secret = _FALLBACK_SOURCE.get("secret")
+            if _FALLBACK_ACTIVE.get("secret") and stored_secret and env_map.get(stored_secret) == secret_key:
+                effective_secret_source = stored_secret
+            else:
+                _FALLBACK_SOURCE["secret"] = None
+                _FALLBACK_ACTIVE["secret"] = False
+        else:
+            _FALLBACK_SOURCE["secret"] = secret_source
+            _FALLBACK_ACTIVE["secret"] = not canonical_secret_present
+    else:
+        _FALLBACK_SOURCE["secret"] = None
+        _FALLBACK_ACTIVE["secret"] = False
+
+    if env is None:
+        if api_key and not os.getenv(_CANONICAL_KEY):
+            os.environ[_CANONICAL_KEY] = api_key
+        if secret_key and not os.getenv(_CANONICAL_SECRET):
+            os.environ[_CANONICAL_SECRET] = secret_key
+
+    base_url = env_map.get("ALPACA_BASE_URL") or env_map.get("ALPACA_API_URL") or _DEFAULT_BASE_URL
+    return AlpacaCredentials(api_key, secret_key, base_url, effective_api_source, effective_secret_source)
+
+
+def reset_alpaca_credential_state() -> None:
+    """Clear cached fallback bookkeeping used for source tracking."""
+
+    _FALLBACK_SOURCE["api"] = None
+    _FALLBACK_SOURCE["secret"] = None
+    _FALLBACK_ACTIVE["api"] = False
+    _FALLBACK_ACTIVE["secret"] = False
 
 
 def check_alpaca_available() -> bool:
@@ -68,5 +170,6 @@ __all__ = [
     "resolve_alpaca_credentials",
     "check_alpaca_available",
     "initialize",
+    "reset_alpaca_credential_state",
 ]
 

--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -69,14 +69,18 @@ def _select_alpaca_base_url(env: Mapping[str, str] | None = None) -> tuple[str |
 def reload_env(path: str | os.PathLike[str] | None = None, override: bool = True) -> str | None:
     """Reload environment variables from a dotenv file."""
 
+    from ai_trading.utils.env import refresh_alpaca_credentials_cache
+
     if path is None:
         candidate = Path.cwd() / ".env"
         path = candidate if candidate.exists() else None
     if path is None:
         reload_trading_config()
+        refresh_alpaca_credentials_cache()
         return None
     load_dotenv(dotenv_path=path, override=override)
     reload_trading_config()
+    refresh_alpaca_credentials_cache()
     return os.fspath(path)
 
 

--- a/ai_trading/execution/__init__.py
+++ b/ai_trading/execution/__init__.py
@@ -22,9 +22,9 @@ def _missing_creds() -> list[str]:
     has_key, has_secret = alpaca_credential_status()
     missing: list[str] = []
     if not has_key:
-        missing.append("ALPACA_API_KEY_ID")
+        missing.append("ALPACA_API_KEY")
     if not has_secret:
-        missing.append("ALPACA_API_SECRET_KEY")
+        missing.append("ALPACA_SECRET_KEY")
     return missing
 
 

--- a/docs/API_KEY_SETUP.md
+++ b/docs/API_KEY_SETUP.md
@@ -149,7 +149,9 @@ creds = resolve_alpaca_credentials()
 print(creds.api_key)
 ```
 
-`resolve_alpaca_credentials` returns an `AlpacaCredentials` dataclass with `api_key`, `secret_key`, and `base_url` fields.
+`resolve_alpaca_credentials` returns an `AlpacaCredentials` dataclass with
+`api_key`, `secret_key`, and `base_url` fields along with `api_source` and
+`secret_source` metadata describing which environment variables were used.
 
 ## ❌ Common Issues
 

--- a/tests/test_alpaca_credentials_unified.py
+++ b/tests/test_alpaca_credentials_unified.py
@@ -1,0 +1,88 @@
+"""Tests for unified Alpaca credential handling across execution and data."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+
+import pytest
+
+from ai_trading.utils import env as env_utils
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure environment-related caches are reset between tests."""
+
+    for key in (
+        "ALPACA_API_KEY",
+        "ALPACA_SECRET_KEY",
+        "ALPACA_DATA_API_KEY",
+        "ALPACA_DATA_SECRET_KEY",
+        "APCA_API_KEY_ID",
+        "APCA_API_SECRET_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    env_utils.refresh_alpaca_credentials_cache()
+    # Remove cached data.fetch module to allow import-time hooks to rerun.
+    sys.modules.pop("ai_trading.data.fetch", None)
+    yield
+    env_utils.refresh_alpaca_credentials_cache()
+    sys.modules.pop("ai_trading.data.fetch", None)
+
+
+def test_execution_only_creds_downgrade_data_feed(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Execution credentials without data keys should downgrade the data feed."""
+
+    monkeypatch.setenv("APCA_API_KEY_ID", "exec-key")
+    monkeypatch.setenv("APCA_API_SECRET_KEY", "exec-secret")
+
+    creds = env_utils.get_resolved_alpaca_credentials()
+    assert creds.api_key == "exec-key"
+    assert creds.secret_key == "exec-secret"
+    assert creds.api_source == "APCA_API_KEY_ID"
+    assert creds.secret_source == "APCA_API_SECRET_KEY"
+    assert creds.has_execution_credentials()
+    assert not creds.has_data_credentials()
+
+    caplog.set_level(logging.INFO)
+    data_fetch = importlib.import_module("ai_trading.data.fetch")
+
+    downgrade_logs = [record for record in caplog.records if record.message == "DATA_PROVIDER_DOWNGRADED"]
+    assert len(downgrade_logs) == 1
+    record = downgrade_logs[0]
+    assert getattr(record, "from") == "alpaca_iex"
+    assert getattr(record, "to") == "yahoo"
+    assert getattr(record, "reason") == "missing_data_keys"
+
+    assert env_utils.is_data_feed_downgraded()
+    assert env_utils.get_data_feed_override() == "yahoo"
+    assert env_utils.get_data_feed_downgrade_reason() == "missing_data_keys"
+    assert env_utils.resolve_alpaca_feed(None) is None
+
+    # The data fetcher should also treat Alpaca credentials as unavailable in this mode.
+    assert data_fetch._has_alpaca_keys() is False
+
+
+def test_canonical_creds_enable_alpaca(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Canonical Alpaca keys should keep Alpaca as the primary data feed."""
+
+    monkeypatch.setenv("ALPACA_API_KEY", "real-key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "real-secret")
+
+    creds = env_utils.get_resolved_alpaca_credentials()
+    assert creds.api_source == "ALPACA_API_KEY"
+    assert creds.secret_source == "ALPACA_SECRET_KEY"
+    assert creds.has_data_credentials()
+
+    caplog.set_level(logging.INFO)
+    data_fetch = importlib.import_module("ai_trading.data.fetch")
+
+    assert env_utils.is_data_feed_downgraded() is False
+    assert env_utils.get_data_feed_override() is None
+    assert env_utils.resolve_alpaca_feed(None) == "iex"
+    assert data_fetch._has_alpaca_keys() is True
+
+    downgrade_logs = [record for record in caplog.records if record.message == "DATA_PROVIDER_DOWNGRADED"]
+    assert not downgrade_logs


### PR DESCRIPTION
## Summary
- resolve Alpaca credentials into canonical API/secret keys while tracking the original source for compatibility
- expose shared helpers so execution and data layers share the resolved credentials and automatically downgrade the data feed when only execution keys exist
- add documentation and regression tests covering the unified credential handling and downgrade logging

## Testing
- ENV_IMPORT_GUARD=0 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_alpaca_credentials_unified.py


------
https://chatgpt.com/codex/tasks/task_e_68d474e606108330b5da5cf67284414c