### PR TITLE
Add idempotent retry handling for transient order failures

### DIFF
--- a/ai_trading/core/order_ids.py
+++ b/ai_trading/core/order_ids.py
@@ -1,9 +1,13 @@
-from __future__ import annotations
-
 """Utilities for generating client order IDs.
 
-This module wraps the Alpaca helper so it can be easily patched during tests.
+This module wraps the Alpaca helper so it can be easily patched during tests
+and also exposes deterministic helpers used for retry idempotency.
 """
+
+from __future__ import annotations
+
+import hashlib
+import time
 
 from ai_trading.alpaca_api import (
     generate_client_order_id as _generate_client_order_id,
@@ -13,3 +17,25 @@ from ai_trading.alpaca_api import (
 def generate_client_order_id(prefix: str = "ai") -> str:
     """Return a unique client order ID with the given prefix."""
     return _generate_client_order_id(prefix)
+
+
+def stable_client_order_id(symbol: str, side: str, epoch_min: int | None = None) -> str:
+    """Return a deterministic client order identifier.
+
+    Parameters
+    ----------
+    symbol:
+        Trading symbol for the order.
+    side:
+        Order side (``"buy"``/``"sell"``). Case is normalized to lower-case.
+    epoch_min:
+        Unix epoch minute used to keep identifiers stable during retries. When
+        omitted, the current minute is used.
+    """
+
+    epoch_source = int(epoch_min if epoch_min is not None else time.time() // 60)
+    normalized_symbol = str(symbol or "").strip().upper()
+    normalized_side = str(side or "").strip().lower()
+    payload = f"{normalized_symbol}:{normalized_side}:{epoch_source}".encode()
+    digest = hashlib.sha256(payload).hexdigest()[:18]
+    return f"ai-{digest}"

--- a/tests/test_order_retry_transient.py
+++ b/tests/test_order_retry_transient.py
@@ -1,0 +1,127 @@
+import sys
+import types
+
+import pytest
+
+if "numpy" not in sys.modules:
+    class _RandomStub:
+        def seed(self, *_args, **_kwargs):
+            return None
+
+    class _NumpyStub(types.ModuleType):
+        def __init__(self):
+            super().__init__("numpy")
+            self.random = _RandomStub()
+            self.nan = float("nan")
+
+        def __getattr__(self, _name):  # type: ignore[override]
+            def _stub(*_args, **_kwargs):
+                return 0
+
+            return _stub
+
+    sys.modules["numpy"] = _NumpyStub()
+
+if "portalocker" not in sys.modules:
+    portalocker_stub = types.ModuleType("portalocker")
+    portalocker_stub.LOCK_EX = 1
+    portalocker_stub.lock = lambda *_args, **_kwargs: None
+    portalocker_stub.unlock = lambda *_args, **_kwargs: None
+    sys.modules["portalocker"] = portalocker_stub
+
+if "bs4" not in sys.modules:
+    bs4_stub = types.ModuleType("bs4")
+
+    class _Soup:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def find_all(self, *_args, **_kwargs):
+            return []
+
+        def find_parent(self, *_args, **_kwargs):
+            return None
+
+        def get_text(self, *_args, **_kwargs):
+            return ""
+
+    bs4_stub.BeautifulSoup = lambda *_args, **_kwargs: _Soup()
+    sys.modules["bs4"] = bs4_stub
+
+from ai_trading.core import bot_engine
+from ai_trading.core.order_ids import stable_client_order_id
+
+
+class FlakyBroker:
+    def __init__(self):
+        self.attempts = 0
+        self.orders: list[types.SimpleNamespace] = []
+        self.client_order_ids: list[str] = []
+        self.seen_ids: list[str | None] = []
+
+    def get_account(self):
+        return types.SimpleNamespace(buying_power="100000")
+
+    def list_positions(self):
+        return []
+
+    def submit_order(self, **kwargs):
+        self.attempts += 1
+        cid = kwargs.get("client_order_id")
+        self.seen_ids.append(cid)
+        if self.attempts == 1:
+            raise TimeoutError("transient timeout")
+        order = types.SimpleNamespace(
+            id="server-order",
+            status="filled",
+            qty=kwargs.get("qty", 0),
+            filled_qty=kwargs.get("qty", 0),
+            symbol=kwargs.get("symbol"),
+            client_order_id=cid,
+        )
+        self.orders.append(order)
+        return order
+
+    def get_order(self, order_id):
+        if not self.orders:
+            raise RuntimeError("no order recorded")
+        order = self.orders[-1]
+        return types.SimpleNamespace(
+            id=order_id,
+            status="filled",
+            qty=order.qty,
+            filled_qty=order.qty,
+            symbol=order.symbol,
+            client_order_id=order.client_order_id,
+        )
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_transient_retry_uses_stable_client_id(monkeypatch, caplog):
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+    monkeypatch.setattr(bot_engine.random, "uniform", lambda *_: 0.0)
+    monkeypatch.setattr(bot_engine.time, "sleep", lambda *_: None)
+    fixed_epoch = 1_700_000_000.0
+    monkeypatch.setattr(bot_engine.time, "time", lambda: fixed_epoch)
+
+    broker = FlakyBroker()
+    request = types.SimpleNamespace(symbol="AAPL", qty=5, side="buy")
+
+    caplog.set_level("INFO")
+    order = bot_engine.safe_submit_order(broker, request, bypass_market_check=True)
+
+    expected_id = stable_client_order_id("AAPL", "buy", int(fixed_epoch // 60))
+    assert order.client_order_id == expected_id
+    assert broker.seen_ids == [expected_id, expected_id]
+    assert broker.attempts == 2
+    assert len(broker.orders) == 1
+
+    retry_logs = [record for record in caplog.records if record.msg == "ORDER_RETRY_SCHEDULED"]
+    assert len(retry_logs) == 1
+    retry_record = retry_logs[0]
+    assert retry_record.attempt == 2
+    assert retry_record.reason == "timeout"
+    assert retry_record.symbol == "AAPL"
+
+    gave_up_logs = [record for record in caplog.records if record.msg == "ORDER_RETRY_GAVE_UP"]
+    assert not gave_up_logs


### PR DESCRIPTION
## Summary
- add a deterministic `stable_client_order_id` helper to reuse a consistent identifier across retries
- update `safe_submit_order` to request stable IDs, detect transient failures, and retry with backoff while logging the schedule
- cover the transient retry flow with a focused test that exercises the timeout-then-success path and validates logging

## Testing
- pytest tests/test_order_retry_transient.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d4750a936483309a962dbb3e153ce1