### PR TITLE
Improve minute data reliability and skip unreliable fallback prices

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -1018,7 +1018,12 @@ def _flatten_and_normalize_ohlcv(
             df.columns = ["_".join([str(x) for x in tup if x is not None]) for tup in df.columns]
     normalize_ohlcv_columns(df)
 
-    if "close" not in df.columns and "adj_close" in df.columns:
+    timeframe_norm = str(timeframe or "").lower()
+    is_daily = "day" in timeframe_norm or timeframe_norm.endswith("d")
+    if is_daily:
+        if "adj_close" in df.columns:
+            df["close"] = df["adj_close"]
+    elif "close" not in df.columns and "adj_close" in df.columns:
         df["close"] = df["adj_close"]
 
     required = ["open", "high", "low", "close", "volume"]
@@ -1164,12 +1169,35 @@ def _flatten_and_normalize_ohlcv(
     return df_out
 
 
+def _set_price_reliability(
+    df: pd.DataFrame,
+    *,
+    reliable: bool,
+    reason: str | None = None,
+) -> None:
+    try:
+        attrs = getattr(df, "attrs", None)
+        if not isinstance(attrs, dict):
+            return
+        attrs["price_reliable"] = bool(reliable)
+        if reason:
+            attrs["price_reliable_reason"] = str(reason)
+        else:
+            attrs.pop("price_reliable_reason", None)
+    except Exception:
+        pass
+
+
 def _yahoo_get_bars(symbol: str, start: Any, end: Any, interval: str) -> pd.DataFrame:
     """Return a DataFrame with a tz-aware 'timestamp' column between start and end."""
     pd = _ensure_pandas()
     yf = _ensure_yfinance()
     start_dt = ensure_datetime(start)
     end_dt = ensure_datetime(end)
+    if str(interval).lower() in {"1m", "1min", "1minute"}:
+        safe_end = datetime.now(UTC).replace(second=0, microsecond=0) - _dt.timedelta(minutes=1)
+        if end_dt > safe_end:
+            end_dt = max(start_dt, safe_end)
     window_seconds = max((end_dt - start_dt).total_seconds(), 0.0)
     if pd is None:
         return []  # type: ignore[return-value]
@@ -1910,6 +1938,10 @@ def _fetch_bars(
     # Normalize timestamps to the minute to avoid querying empty slices
     _start = _start.replace(second=0, microsecond=0)
     _end = _end.replace(second=0, microsecond=0)
+    if _canon_tf(timeframe) == "1Min":
+        last_complete_minute = datetime.now(UTC).replace(second=0, microsecond=0) - _dt.timedelta(minutes=1)
+        if _end > last_complete_minute:
+            _end = max(_start, last_complete_minute)
     session = _HTTP_SESSION
     if session is None or not hasattr(session, "get"):
         raise ValueError("session_required")
@@ -3291,6 +3323,9 @@ def get_minute_df(
     pd = _ensure_pandas()
     start_dt = ensure_datetime(start)
     end_dt = ensure_datetime(end)
+    last_complete_minute = datetime.now(UTC).replace(second=0, microsecond=0) - _dt.timedelta(minutes=1)
+    if end_dt > last_complete_minute:
+        end_dt = max(start_dt, last_complete_minute)
     window_has_session = _window_has_trading_session(start_dt, end_dt)
     tf_key = (symbol, "1Min")
     normalized_feed = _normalize_feed_value(feed) if feed is not None else None
@@ -3762,6 +3797,32 @@ def get_minute_df(
             healthy=gap_ratio <= max_gap_ratio,
             reason=f"gap_ratio={gap_ratio * 100:.2f}%",
         )
+    try:
+        settings_obj = get_settings()
+    except Exception:
+        settings_obj = None
+    gap_limit = None
+    if settings_obj is not None:
+        try:
+            data_settings = getattr(settings_obj, "data", None)
+            if data_settings is not None:
+                candidate = getattr(data_settings, "max_gap_ratio_intraday", None)
+                if candidate is not None:
+                    gap_limit = max(float(candidate), 0.0)
+        except Exception:
+            gap_limit = None
+    if gap_limit is None:
+        gap_limit = max_gap_ratio
+    price_reliable = True
+    unreliable_reason: str | None = None
+    try:
+        ratio_value = float(gap_ratio)
+    except (TypeError, ValueError):
+        ratio_value = 0.0
+    if ratio_value > gap_limit:
+        price_reliable = False
+        unreliable_reason = f"gap_ratio={ratio_value * 100:.2f}%>limit={gap_limit * 100:.2f}%"
+    _set_price_reliability(df, reliable=price_reliable, reason=unreliable_reason)
     if df is None or getattr(df, "empty", False):
         if allow_empty_return:
             if used_backup and not fallback_logged:

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Literal
+from types import SimpleNamespace
 import os
 import sys
 from pydantic import AliasChoices, Field, SecretStr, computed_field, field_validator
@@ -439,6 +440,13 @@ class Settings(BaseSettings):
     @property
     def trade_cooldown(self) -> timedelta:
         return timedelta(minutes=_to_int(getattr(self, "trade_cooldown_min", 15), 15))
+
+    @computed_field
+    @property
+    def data(self) -> SimpleNamespace:
+        ratio_bps = _to_float(getattr(self, "data_max_gap_ratio_bps", 50.0), 50.0)
+        ratio = max(float(ratio_bps) / 10000.0, 0.0)
+        return SimpleNamespace(max_gap_ratio_intraday=ratio)
 
     @property
     def data_feed(self) -> Literal["iex", "sip"]:

--- a/tests/test_yahoo_intraday_reliability.py
+++ b/tests/test_yahoo_intraday_reliability.py
@@ -1,0 +1,90 @@
+import logging
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+import ai_trading.data.fetch as fetch_module
+@pytest.mark.usefixtures("caplog")
+def test_unreliable_minute_data_blocks_fallback(monkeypatch, caplog):
+    pd = pytest.importorskip("pandas")
+    pytest.importorskip("numpy")
+    import ai_trading.core.bot_engine as bot_engine_module
+    from ai_trading.core.bot_engine import BotState
+    symbol = "XYZ"
+    now_floor = datetime.now(UTC).replace(second=0, microsecond=0)
+    start_dt = now_floor - timedelta(minutes=5)
+    end_dt = now_floor
+
+    captured: dict[str, datetime] = {}
+
+    def fake_backup_get_bars(sym: str, start, end, interval: str):
+        captured["start"] = start
+        captured["end"] = end
+        index = pd.date_range(start, end, freq="1min", tz="UTC", inclusive="left")
+        if len(index) > 1:
+            index = index.delete(len(index) - 1)
+        frame = pd.DataFrame(
+            {
+                "timestamp": index,
+                "open": [100.0] * len(index),
+                "high": [101.0] * len(index),
+                "low": [99.0] * len(index),
+                "close": [100.5] * len(index),
+                "volume": [1000] * len(index),
+            }
+        )
+        return frame
+
+    monkeypatch.setattr(fetch_module, "_has_alpaca_keys", lambda: False)
+    monkeypatch.setattr(fetch_module, "_window_has_trading_session", lambda *_: True)
+    monkeypatch.setattr(fetch_module, "_backup_get_bars", fake_backup_get_bars)
+    monkeypatch.setattr(fetch_module, "_resolve_backup_provider", lambda: ("yahoo", "yahoo"))
+
+    caplog.set_level(logging.INFO)
+    df = fetch_module.get_minute_df(symbol, start_dt, end_dt)
+    assert df is not None
+    assert not df.empty
+    assert captured["end"] == now_floor - timedelta(minutes=1)
+    price_reliable = df.attrs.get("price_reliable")
+    reason = df.attrs.get("price_reliable_reason")
+    assert price_reliable is False
+    assert isinstance(reason, str) and "gap_ratio" in reason
+
+    state = BotState()
+    state.price_reliability[symbol] = (price_reliable, reason)
+
+    feat_df = df.copy()
+    feat_df["atr"] = 1.0
+
+    ctx = SimpleNamespace(portfolio_weights={}, api=None, config=SimpleNamespace(exposure_cap_aggressive=0.88))
+
+    monkeypatch.setattr(
+        bot_engine_module,
+        "_resolve_order_quote",
+        lambda sym, prefer_backup=False: (float(df["close"].iloc[-1]), "yahoo_close"),
+    )
+
+    submit_called = False
+
+    def fake_submit_order(*_, **__):
+        nonlocal submit_called
+        submit_called = True
+        return "order-id"
+
+    monkeypatch.setattr(bot_engine_module, "submit_order", fake_submit_order)
+
+    result = bot_engine_module._enter_long(
+        ctx,
+        state,
+        symbol,
+        balance=10_000.0,
+        feat_df=feat_df,
+        final_score=1.0,
+        conf=0.7,
+        strat="test",
+    )
+
+    assert result is True
+    assert submit_called is False
+    assert any("ORDER_SKIPPED_UNRELIABLE_PRICE" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- clamp all 1-minute fetch windows to the last completed minute and normalize Yahoo bars so daily data prefers adjusted closes
- compute a price_reliable flag based on gap ratios, propagate it through feature fetching, and skip orders when fallback quotes rely on unreliable minute data
- expose max_gap_ratio_intraday via settings and cover the behaviour with a new reliability test

## Testing
- ENV_IMPORT_GUARD=0 pytest tests/test_yahoo_intraday_reliability.py

------
https://chatgpt.com/codex/tasks/task_e_68d474f2b3708330995d3f3684f35d57