### PR TITLE
Add regression tests and changelog for recent fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,37 @@
+# Recent Fixes Summary
+
+## Pending order severity and cleanup cadence
+- Pending orders now emit `PENDING_ORDERS_DETECTED` and `PENDING_ORDERS_STILL_PRESENT` at warning level, while successful cleanups log at info level so alerts match urgency.
+- Tune or revert behaviour by adjusting `ORDER_STALE_CLEANUP_INTERVAL` (seconds) in the trading runtime config; increasing the interval delays cleanup and reduces warning frequency.
+
+## Provider health decisions stay single-sourced
+- The provider monitor now keeps a single active provider per pair, requiring two healthy passes plus cooldown expiry before switching back to primary, preventing oscillation.
+- Tuning knobs: `DATA_COOLDOWN_SECONDS` (minimum healthy cooldown), `DATA_PROVIDER_BACKOFF_FACTOR`, and `DATA_PROVIDER_MAX_COOLDOWN` all live in the env-config layer. Lower the cooldown to hasten recovery or raise the backoff factor to be more conservative.
+
+## Unified Alpaca credential resolution
+- `resolve_alpaca_credentials` and `initialize` use the same dataclass wrapper, updating the cached credential state used by other modules.
+- Override via `ALPACA_API_KEY`, `ALPACA_SECRET_KEY`, and `ALPACA_BASE_URL`. Clearing the keys (or setting `shadow=True`) reverts to stub behaviour.
+
+## Yahoo intraday fallback reliability
+- Oversized 1-minute windows now split into ≤8-day segments so Yahoo fallback remains reliable when Alpaca minute data is unavailable.
+- Operators can bias the system back toward Alpaca by disabling fallback (`ENABLE_FINNHUB=1` with valid keys, or altering provider priority) or by shortening the requested window.
+
+## Broker capacity preflight detection
+- Capacity exhaustion responses from Alpaca raise `NonRetryableBrokerError`, incrementing capacity skip stats and preventing wasteful retries.
+- Modify retry sensitivity by changing the execution engine's `retry_config` (e.g., lowering `max_attempts` or adjusting delays) in runtime overrides if you need to revert to permissive behaviour.
+
+## Transient order retry hygiene
+- Execution retries only repeat on transient network/API errors; non-retryable signals bubble immediately.
+- Tune retry aggressiveness through deployment overrides of `ExecutionEngine.retry_config` or by wrapping the engine with a custom retry policy.
+
+## Finnhub-disabled log deduplication
+- The once-logger now keys on symbol, timeframe, and window so repeated fallback checks for different ranges still log once per unique window.
+- To revert, disable the emit-once logger via logging configuration or force debug logging if every attempt must be recorded.
+
+## Trade log cached exactly once
+- `_load_trade_log_cache` hydrates the trade log only once per process, reusing the cached structure for later consumers.
+- Force a refresh by clearing `_TRADE_LOG_CACHE_LOADED` or by disabling memoisation via config flag `META_SYNC_FROM_BROKER=false` if broker sync should always re-read.
+
+## Daily fetch memo debounce
+- Daily bar fetches memoize per-symbol results for `DAILY_FETCH_MEMO_TTL` seconds, avoiding duplicate requests when the schedule polls frequently.
+- Shorten or disable the debounce by lowering `DAILY_FETCH_MEMO_TTL` (0 turns off memoisation); increase it to stretch the warm cache window.

--- a/tests/bot_engine/test_order_pending_severity.py
+++ b/tests/bot_engine/test_order_pending_severity.py
@@ -1,0 +1,149 @@
+"""Pending-order monitoring should escalate with warning severity."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+
+import pytest
+
+if "ai_trading.indicators" not in sys.modules:
+    indicators_stub = types.ModuleType("ai_trading.indicators")
+
+    def _unavailable_indicator(*_args, **_kwargs):  # pragma: no cover - safety stub
+        raise RuntimeError("Indicator module unavailable in tests")
+
+    indicators_stub.compute_atr = _unavailable_indicator
+    indicators_stub.atr = _unavailable_indicator
+    indicators_stub.mean_reversion_zscore = _unavailable_indicator
+    indicators_stub.rsi = _unavailable_indicator
+    sys.modules["ai_trading.indicators"] = indicators_stub
+
+if "ai_trading.signals" not in sys.modules:
+    signals_stub = types.ModuleType("ai_trading.signals")
+    signals_indicators_stub = types.ModuleType("ai_trading.signals.indicators")
+
+    def _composite_confidence_stub(*_args, **_kwargs):  # pragma: no cover - safety stub
+        return {}
+
+    signals_indicators_stub.composite_signal_confidence = _composite_confidence_stub
+    sys.modules["ai_trading.signals"] = signals_stub
+    sys.modules["ai_trading.signals.indicators"] = signals_indicators_stub
+    signals_stub.indicators = signals_indicators_stub
+
+if "ai_trading.features" not in sys.modules:
+    features_stub = types.ModuleType("ai_trading.features")
+    features_indicators_stub = types.ModuleType("ai_trading.features.indicators")
+
+    def _feature_passthrough(df, **_kwargs):  # pragma: no cover - safety stub
+        return df
+
+    features_indicators_stub.compute_macd = _feature_passthrough
+    features_indicators_stub.compute_macds = _feature_passthrough
+    features_indicators_stub.compute_vwap = _feature_passthrough
+    features_indicators_stub.compute_atr = _feature_passthrough
+    features_indicators_stub.compute_sma = _feature_passthrough
+    features_indicators_stub.ensure_columns = _feature_passthrough
+    sys.modules["ai_trading.features"] = features_stub
+    sys.modules["ai_trading.features.indicators"] = features_indicators_stub
+    features_stub.indicators = features_indicators_stub
+
+if "portalocker" not in sys.modules:
+    portalocker_stub = types.ModuleType("portalocker")
+    portalocker_stub.LOCK_EX = 1
+
+    def _noop_lock(*_args, **_kwargs):  # pragma: no cover - safety stub
+        return None
+
+    portalocker_stub.lock = _noop_lock
+    portalocker_stub.unlock = _noop_lock
+    sys.modules["portalocker"] = portalocker_stub
+
+if "bs4" not in sys.modules:
+    bs4_stub = types.ModuleType("bs4")
+
+    class _BeautifulSoup:  # pragma: no cover - safety stub
+        def __init__(self, *_args, **_kwargs):
+            self.text = ""
+
+        def find(self, *_args, **_kwargs):
+            return None
+
+    bs4_stub.BeautifulSoup = _BeautifulSoup
+    sys.modules["bs4"] = bs4_stub
+
+if "dotenv" not in sys.modules:
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *a, **k: None
+    sys.modules["dotenv"] = dotenv_stub
+
+if "numpy" not in sys.modules:
+    numpy_stub = types.ModuleType("numpy")
+    numpy_stub.array = lambda *a, **k: a
+    numpy_stub.ndarray = object
+    numpy_stub.float64 = float
+    numpy_stub.int64 = int
+    numpy_stub.nan = float("nan")
+    numpy_stub.NaN = float("nan")
+    numpy_stub.random = types.SimpleNamespace(seed=lambda *_a, **_k: None)
+    sys.modules["numpy"] = numpy_stub
+
+from ai_trading.core import bot_engine as be
+
+
+def _order(status: str, oid: str = "order-1") -> types.SimpleNamespace:
+    return types.SimpleNamespace(id=oid, status=status)
+
+
+@pytest.fixture(autouse=True)
+def _reset_pending_tracker():
+    be._PENDING_ORDER_STATUSES  # ensure module imported for coverage
+    yield
+
+
+def test_pending_orders_log_warning_levels(monkeypatch, caplog):
+    """The first detection and follow-up log entries use warning severity."""
+
+    runtime = types.SimpleNamespace(state={})
+    cancel_called: list[types.SimpleNamespace] = []
+
+    monkeypatch.setattr(
+        be,
+        "cancel_all_open_orders",
+        lambda rt: cancel_called.append(rt),
+    )
+    monkeypatch.setattr(
+        be,
+        "get_trading_config",
+        lambda: types.SimpleNamespace(order_stale_cleanup_interval=60),
+    )
+
+    clock = types.SimpleNamespace(value=1000.0)
+    monkeypatch.setattr(be.time, "time", lambda: clock.value)
+
+    caplog.set_level(logging.INFO)
+
+    pending = [_order("pending_new", "alpha")]
+
+    assert be._handle_pending_orders(pending, runtime) is True
+    assert caplog.records[0].message == "PENDING_ORDERS_DETECTED"
+    assert caplog.records[0].levelno == logging.WARNING
+
+    caplog.clear()
+    clock.value += be._PENDING_ORDER_LOG_INTERVAL_SECONDS + 1
+    assert be._handle_pending_orders(pending, runtime) is False
+    assert cancel_called == [runtime]
+    messages = [rec.message for rec in caplog.records]
+    assert "PENDING_ORDERS_STILL_PRESENT" in messages
+    assert "PENDING_ORDERS_CANCELED" in messages
+    warning_logs = [rec for rec in caplog.records if rec.message == "PENDING_ORDERS_STILL_PRESENT"]
+    assert warning_logs and warning_logs[0].levelno == logging.WARNING
+
+    caplog.clear()
+    clock.value += 1000
+    assert be._handle_pending_orders(pending, runtime) is True
+    detection_logs = [
+        rec for rec in caplog.records if rec.message == "PENDING_ORDERS_DETECTED"
+    ]
+    assert detection_logs and detection_logs[0].levelno == logging.WARNING

--- a/tests/broker/test_alpaca_credentials_unified.py
+++ b/tests/broker/test_alpaca_credentials_unified.py
@@ -1,0 +1,69 @@
+"""Alpaca credential helpers expose a unified dataclass view."""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+
+from ai_trading.broker import alpaca_credentials as creds_mod
+
+
+def test_resolve_alpaca_credentials_defaults(monkeypatch):
+    monkeypatch.delenv("ALPACA_API_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_BASE_URL", raising=False)
+    creds = creds_mod.resolve_alpaca_credentials({})
+    assert creds.api_key is None
+    assert creds.secret_key is None
+    assert creds.base_url.endswith("alpaca.markets")
+
+
+def test_resolve_alpaca_credentials_from_mapping():
+    data = {
+        "ALPACA_API_KEY": "key",
+        "ALPACA_SECRET_KEY": "secret",
+        "ALPACA_BASE_URL": "https://live.alpaca.markets",
+    }
+    creds = creds_mod.resolve_alpaca_credentials(data)
+    assert creds.api_key == "key"
+    assert creds.secret_key == "secret"
+    assert creds.base_url == "https://live.alpaca.markets"
+
+
+def test_check_alpaca_available_handles_missing(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("alpaca"):
+            raise ModuleNotFoundError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert creds_mod.check_alpaca_available() is False
+
+
+def test_initialize_shadow_allows_missing_sdk(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "alpaca":
+            raise ModuleNotFoundError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    stub = creds_mod.initialize({}, shadow=True)
+    assert isinstance(stub, object)
+
+
+def test_initialize_requires_sdk_when_not_shadow(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "alpaca":
+            raise ModuleNotFoundError
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(RuntimeError):
+        creds_mod.initialize({}, shadow=False)

--- a/tests/data/test_provider_decision_single_outcome.py
+++ b/tests/data/test_provider_decision_single_outcome.py
@@ -1,0 +1,47 @@
+"""Provider health updates should yield a single active source."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from ai_trading.data import provider_monitor as monitor_mod
+
+
+def _fresh_monitor() -> monitor_mod.ProviderMonitor:
+    mon = monitor_mod.ProviderMonitor(
+        threshold=3,
+        cooldown=10,
+        switchover_threshold=2,
+        backoff_factor=2.0,
+        max_cooldown=120,
+    )
+    return mon
+
+
+def test_update_data_health_tracks_single_active_provider(monkeypatch, caplog):
+    mon = _fresh_monitor()
+
+    # Avoid interference from global instance
+    monkeypatch.setattr(monitor_mod, "provider_monitor", mon)
+    monkeypatch.setattr(monitor_mod, "get_env", lambda *_, **__: "0")
+    monkeypatch.setattr(monitor_mod.logger, "info", lambda *a, **k: None)
+    monkeypatch.setattr(monitor_mod.logger, "warning", lambda *a, **k: None)
+
+    primary = "alpaca_primary"
+    backup = "yahoo"
+
+    assert mon.update_data_health(primary, backup, healthy=False, reason="empty") == backup
+    # First healthy pass keeps backup active
+    assert mon.update_data_health(primary, backup, healthy=True, reason="recovering") == backup
+
+    # Second healthy pass with elapsed cooldown switches back
+    state = mon._pair_states[(primary, backup)]
+    state["last_switch"] = datetime.now(UTC) - timedelta(seconds=15)
+    state["cooldown"] = 0
+    caplog.set_level(logging.INFO)
+    decision = mon.update_data_health(primary, backup, healthy=True, reason="stable")
+    assert decision == primary
+
+    # Subsequent healthy updates stick with primary
+    assert mon.update_data_health(primary, backup, healthy=True, reason="stable") == primary

--- a/tests/data/test_yahoo_intraday_reliability.py
+++ b/tests/data/test_yahoo_intraday_reliability.py
@@ -1,0 +1,51 @@
+"""Yahoo fallback should split oversized intraday windows."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import types
+
+import pytest
+
+from ai_trading.data import fetch as fetch_mod
+
+
+@pytest.mark.parametrize("days", [10])
+def test_backup_split_large_intraday_window(monkeypatch, days):
+    pd = pytest.importorskip("pandas")
+
+    monkeypatch.setattr(fetch_mod, "get_settings", lambda: types.SimpleNamespace(backup_data_provider="yahoo"))
+    monkeypatch.setattr(fetch_mod, "_has_alpaca_keys", lambda: False)
+    monkeypatch.setattr(fetch_mod, "fh_fetcher", None)
+    monkeypatch.setenv("ENABLE_FINNHUB", "0")
+    monkeypatch.setenv("FINNHUB_API_KEY", "")
+    monkeypatch.setattr(fetch_mod, "warn_finnhub_disabled_no_data", lambda *a, **k: None)
+    monkeypatch.setattr(fetch_mod, "log_finnhub_disabled", lambda *a, **k: None)
+    monkeypatch.setattr(fetch_mod.provider_monitor, "active_provider", lambda primary, backup: backup)
+    monkeypatch.setattr(fetch_mod.provider_monitor, "record_switchover", lambda *a, **k: None)
+    monkeypatch.setattr(fetch_mod, "_post_process", lambda df, **_: df)
+    monkeypatch.setattr(fetch_mod, "_verify_minute_continuity", lambda df, **_: df)
+    monkeypatch.setattr(fetch_mod, "_repair_rth_minute_gaps", lambda df, **_: (df, {"expected": 0, "missing_after": 0, "gap_ratio": 0.0}, False))
+    monkeypatch.setattr(fetch_mod, "mark_success", lambda *a, **k: None)
+    monkeypatch.setattr(fetch_mod, "_mark_fallback", lambda *a, **k: None)
+
+    calls: list[tuple[datetime, datetime]] = []
+
+    def fake_backup(symbol, start, end, *, interval):
+        calls.append((start, end))
+        frame = pd.DataFrame({"timestamp": [start], "close": [1.0]})
+        frame.attrs["data_provider"] = "yahoo"
+        frame.attrs["data_feed"] = "yahoo"
+        return frame
+
+    monkeypatch.setattr(fetch_mod, "_backup_get_bars", fake_backup)
+
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(days=days)
+
+    df = fetch_mod.get_bars("AAPL", "1Min", start, end, feed=None)
+
+    assert not df.empty
+    assert len(calls) >= 2  # range was split into chunks
+    max_span = max((end - start for start, end in calls), default=timedelta())
+    assert max_span <= timedelta(days=8)

--- a/tests/execution/test_broker_capacity_preflight.py
+++ b/tests/execution/test_broker_capacity_preflight.py
@@ -1,0 +1,43 @@
+"""Capacity exhaustion should raise a non-retryable broker error."""
+
+from __future__ import annotations
+
+import logging
+
+from ai_trading.execution import live_trading as lt
+
+
+class DummyAPIError(lt.APIError):
+    def __init__(self, status_code=403, code="40310000", message="insufficient day trading buying power"):
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+
+
+def _engine() -> lt.ExecutionEngine:
+    engine = lt.ExecutionEngine.__new__(lt.ExecutionEngine)
+    engine.stats = {"capacity_skips": 0, "skipped_orders": 0, "retry_count": 0}
+    engine.logger = lt.logger
+    return engine
+
+
+def test_nonretryable_capacity_error(monkeypatch, caplog):
+    engine = _engine()
+    caplog.set_level(logging.WARNING)
+
+    err = DummyAPIError()
+    result = engine._handle_nonretryable_api_error(err, {"symbol": "AAPL"})
+
+    assert isinstance(result, lt.NonRetryableBrokerError)
+    assert engine.stats["capacity_skips"] == 1
+    assert engine.stats["skipped_orders"] == 1
+    messages = [rec.message for rec in caplog.records]
+    assert "BROKER_CAPACITY_EXCEEDED" in messages
+
+
+def test_capacity_error_passthrough_for_other_codes():
+    engine = _engine()
+    err = DummyAPIError(status_code=500, code="other", message="different")
+    assert engine._handle_nonretryable_api_error(err, {"symbol": "AAPL"}) is None
+    assert engine.stats["capacity_skips"] == 0

--- a/tests/execution/test_order_retry_transient.py
+++ b/tests/execution/test_order_retry_transient.py
@@ -1,0 +1,52 @@
+"""Transient broker failures should retry before succeeding."""
+
+from __future__ import annotations
+
+from ai_trading.execution import live_trading as lt
+
+
+def _engine_with_retry() -> lt.ExecutionEngine:
+    engine = lt.ExecutionEngine.__new__(lt.ExecutionEngine)
+    engine.retry_config = {"max_attempts": 3, "base_delay": 0.0, "max_delay": 0.0, "exponential_base": 1.0}
+    engine.stats = {"retry_count": 0}
+    engine.circuit_breaker = {"failure_count": 0, "is_open": False, "last_failure": None}
+    engine._handle_nonretryable_api_error = lambda exc, *a, **k: None
+    engine._handle_execution_failure = lambda exc: None
+    return engine
+
+
+def test_retry_until_success(monkeypatch):
+    engine = _engine_with_retry()
+    attempts = {"count": 0}
+
+    def flaky():
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise TimeoutError("temporary")
+        return "ok"
+
+    result = engine._execute_with_retry(flaky)
+    assert result == "ok"
+    assert attempts["count"] == 3
+    assert engine.stats["retry_count"] == 2
+
+
+def test_nonretryable_error_stops_retry(monkeypatch):
+    engine = _engine_with_retry()
+
+    class StopError(lt.APIError):
+        pass
+
+    def fail():
+        raise StopError("fatal")
+
+    engine._handle_nonretryable_api_error = lambda exc, *a, **k: lt.NonRetryableBrokerError("fatal")
+
+    try:
+        engine._execute_with_retry(fail)
+    except lt.NonRetryableBrokerError:
+        pass
+    else:  # pragma: no cover - safeguard
+        raise AssertionError("Non-retryable error should propagate")
+
+    assert engine.stats["retry_count"] == 0

--- a/tests/logging/test_log_deduper_provider_spam.py
+++ b/tests/logging/test_log_deduper_provider_spam.py
@@ -1,0 +1,26 @@
+"""Ensure Finnhub disabled logs are deduped per window."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from ai_trading.logging import warn_finnhub_disabled_no_data
+
+
+def test_warn_finnhub_disabled_no_data_dedupes(caplog):
+    caplog.set_level("INFO")
+
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = start + timedelta(days=1)
+
+    warn_finnhub_disabled_no_data("AAPL", timeframe="1Min", start=start, end=end)
+    warn_finnhub_disabled_no_data("AAPL", timeframe="1Min", start=start, end=end)
+
+    records = [rec for rec in caplog.records if rec.message == "FINNHUB_DISABLED_NO_DATA"]
+    assert len(records) == 1
+
+    caplog.clear()
+    later_end = end + timedelta(days=1)
+    warn_finnhub_disabled_no_data("AAPL", timeframe="1Min", start=start, end=later_end)
+    records = [rec for rec in caplog.records if rec.message == "FINNHUB_DISABLED_NO_DATA"]
+    assert len(records) == 1

--- a/tests/trade_log/test_trade_log_cached_once.py
+++ b/tests/trade_log/test_trade_log_cached_once.py
@@ -1,0 +1,108 @@
+"""Trade log boot cache is loaded exactly once per process."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+if "ai_trading.indicators" not in sys.modules:
+    indicators_stub = types.ModuleType("ai_trading.indicators")
+
+    def _unavailable_indicator(*_args, **_kwargs):  # pragma: no cover - safety stub
+        raise RuntimeError("Indicator module unavailable in tests")
+
+    indicators_stub.compute_atr = _unavailable_indicator
+    indicators_stub.atr = _unavailable_indicator
+    indicators_stub.mean_reversion_zscore = _unavailable_indicator
+    indicators_stub.rsi = _unavailable_indicator
+    sys.modules["ai_trading.indicators"] = indicators_stub
+
+if "ai_trading.signals" not in sys.modules:
+    signals_stub = types.ModuleType("ai_trading.signals")
+    signals_indicators_stub = types.ModuleType("ai_trading.signals.indicators")
+
+    def _composite_confidence_stub(*_args, **_kwargs):  # pragma: no cover - safety stub
+        return {}
+
+    signals_indicators_stub.composite_signal_confidence = _composite_confidence_stub
+    sys.modules["ai_trading.signals"] = signals_stub
+    sys.modules["ai_trading.signals.indicators"] = signals_indicators_stub
+    signals_stub.indicators = signals_indicators_stub
+
+if "ai_trading.features" not in sys.modules:
+    features_stub = types.ModuleType("ai_trading.features")
+    features_indicators_stub = types.ModuleType("ai_trading.features.indicators")
+
+    def _feature_passthrough(df, **_kwargs):  # pragma: no cover - safety stub
+        return df
+
+    features_indicators_stub.compute_macd = _feature_passthrough
+    features_indicators_stub.compute_macds = _feature_passthrough
+    features_indicators_stub.compute_vwap = _feature_passthrough
+    features_indicators_stub.compute_atr = _feature_passthrough
+    features_indicators_stub.compute_sma = _feature_passthrough
+    features_indicators_stub.ensure_columns = _feature_passthrough
+    sys.modules["ai_trading.features"] = features_stub
+    sys.modules["ai_trading.features.indicators"] = features_indicators_stub
+    features_stub.indicators = features_indicators_stub
+
+if "portalocker" not in sys.modules:
+    portalocker_stub = types.ModuleType("portalocker")
+    portalocker_stub.LOCK_EX = 1
+
+    def _noop_lock(*_args, **_kwargs):  # pragma: no cover - safety stub
+        return None
+
+    portalocker_stub.lock = _noop_lock
+    portalocker_stub.unlock = _noop_lock
+    sys.modules["portalocker"] = portalocker_stub
+
+if "bs4" not in sys.modules:
+    bs4_stub = types.ModuleType("bs4")
+
+    class _BeautifulSoup:  # pragma: no cover - safety stub
+        def __init__(self, *_args, **_kwargs):
+            self.text = ""
+
+        def find(self, *_args, **_kwargs):
+            return None
+
+    bs4_stub.BeautifulSoup = _BeautifulSoup
+    sys.modules["bs4"] = bs4_stub
+
+if "dotenv" not in sys.modules:
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *a, **k: None
+    sys.modules["dotenv"] = dotenv_stub
+
+if "numpy" not in sys.modules:
+    numpy_stub = types.ModuleType("numpy")
+    numpy_stub.array = lambda *a, **k: a
+    numpy_stub.ndarray = object
+    numpy_stub.float64 = float
+    numpy_stub.int64 = int
+    numpy_stub.nan = float("nan")
+    numpy_stub.NaN = float("nan")
+    numpy_stub.random = types.SimpleNamespace(seed=lambda *_a, **_k: None)
+    sys.modules["numpy"] = numpy_stub
+
+from ai_trading.core import bot_engine as be
+
+
+def test_load_trade_log_cache_only_hits_disk_once(monkeypatch):
+    call_count = {"value": 0}
+
+    def fake_read(path, **kwargs):  # noqa: ARG001 - signature mirrors real helper
+        call_count["value"] += 1
+        return {"rows": 1}
+
+    monkeypatch.setattr(be, "_read_trade_log", fake_read)
+    monkeypatch.setattr(be, "TRADE_LOG_FILE", "trades.csv")
+    be._TRADE_LOG_CACHE = None
+    be._TRADE_LOG_CACHE_LOADED = False
+
+    first = be._load_trade_log_cache()
+    second = be._load_trade_log_cache()
+
+    assert first is second
+    assert call_count["value"] == 1


### PR DESCRIPTION
## Summary
- add regression tests covering pending order severity, provider switchover, Alpaca credential unification, Yahoo fallback splitting, broker capacity preflight, transient retry hygiene, Finnhub log dedupe, trade log caching, and daily fetch memoisation
- document the nine fixes, configuration knobs, and rollback levers in CHANGES.md
- adjust the daily fetch memo test to exercise DataFetcher memo logic without requiring full BotEngine initialisation

## Testing
- ENV_IMPORT_GUARD=0 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/bot_engine/test_order_pending_severity.py tests/data/test_provider_decision_single_outcome.py tests/broker/test_alpaca_credentials_unified.py tests/data/test_yahoo_intraday_reliability.py tests/execution/test_broker_capacity_preflight.py tests/execution/test_order_retry_transient.py tests/logging/test_log_deduper_provider_spam.py tests/trade_log/test_trade_log_cached_once.py tests/bot_engine/test_daily_fetch_debounce.py

------
https://chatgpt.com/codex/tasks/task_e_68d4753a1e74833086d56bf7a5ce0b4d