### PR TITLE
Throttle provider churn logs

### DIFF
--- a/tests/test_log_deduper_provider_spam.py
+++ b/tests/test_log_deduper_provider_spam.py
@@ -67,3 +67,56 @@ def test_throttle_summaries_flush_each_cycle(caplog):
     summaries = [msg for msg in messages if msg.startswith("LOG_THROTTLE_SUMMARY")]
     assert len(summaries) == 2
     assert _suppressed_count(summaries[-1]) == second_cycle_suppressed
+
+
+@pytest.mark.unit
+def test_provider_dedupe_emits_summary(caplog):
+    deduper = getattr(log_mod, "provider_log_deduper", None)
+    record_suppressed = getattr(log_mod, "record_provider_log_suppressed", None)
+    reset = getattr(log_mod, "reset_provider_log_dedupe", None)
+    flush = getattr(log_mod, "flush_log_throttle_summaries", None)
+    if None in {deduper, record_suppressed, reset, flush}:
+        pytest.skip("Provider dedupe helpers unavailable")
+
+    reset()
+    caplog.set_level(logging.INFO)
+    logger = log_mod.get_logger("ai_trading.tests.provider")
+
+    raw_ttl = getattr(require("ai_trading.config.settings").get_settings(), "logging_dedupe_ttl_s", 0)
+    ttl = max(1, int(raw_ttl))
+    key = "DATA_PROVIDER_SWITCHOVER:primary->backup"
+
+    assert deduper.should_log(key, ttl)
+    logger.info("DATA_PROVIDER_SWITCHOVER", extra={"from_provider": "primary", "to_provider": "backup"})
+
+    assert not deduper.should_log(key, ttl)
+    record_suppressed("DATA_PROVIDER_SWITCHOVER")
+
+    flush()
+
+    def _summary_count(record) -> tuple[str, int]:
+        message = record.getMessage()
+        count = None
+        for token in message.split():
+            if token.startswith("suppressed="):
+                try:
+                    count = int(token.split("=", 1)[1])
+                except ValueError:  # pragma: no cover - defensive parsing
+                    count = None
+        return message, count if count is not None else -1
+
+    summaries = [rec for rec in caplog.records if rec.getMessage().startswith("LOG_THROTTLE_SUMMARY")]
+    matching = [rec for rec in summaries if 'message="DATA_PROVIDER_SWITCHOVER"' in rec.getMessage()]
+    assert matching, "Expected summary for DATA_PROVIDER_SWITCHOVER"
+    summary_message, suppressed = _summary_count(matching[-1])
+    assert suppressed == 1, summary_message
+
+    caplog.clear()
+    flush()
+    assert not any(
+        'message="DATA_PROVIDER_SWITCHOVER"' in rec.getMessage()
+        for rec in caplog.records
+        if rec.getMessage().startswith("LOG_THROTTLE_SUMMARY")
+    )
+
+    reset()


### PR DESCRIPTION
## Summary
- throttle backup-provider and provider-monitor logs with the shared LogDeduper and capture suppression counts for cycle summaries
- emit LOG_THROTTLE_SUMMARY lines for deduped provider churn messages at the end of each trading cycle
- extend the provider spam test to cover the new dedupe flow and summary reporting

## Testing
- ENV_IMPORT_GUARD=0 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_log_deduper_provider_spam.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d47e549a9483308da8eda958eacae3