### PR TITLE
Respect execution mode for Alpaca auth preflight

### DIFF
--- a/ai_trading/config/runtime.py
+++ b/ai_trading/config/runtime.py
@@ -89,11 +89,14 @@ def _parse_execution_mode(raw: str) -> str:
         "simulation": "sim",
         "sim": "sim",
         "test": "sim",
+        "disabled": "disabled",
+        "off": "disabled",
+        "none": "disabled",
     }
     normalized = aliases.get(value, value)
-    if normalized not in {"sim", "paper", "live"}:
+    if normalized not in {"sim", "paper", "live", "disabled"}:
         raise ValueError(
-            "EXECUTION_MODE must be one of: sim, paper, live"
+            "EXECUTION_MODE must be one of: sim, paper, live, disabled"
         )
     return normalized
 


### PR DESCRIPTION
## Summary
- add support for a `disabled` execution mode when parsing the runtime configuration
- skip Alpaca client initialization and mark the service unavailable when execution is disabled or credentials are missing
- guard the trading runner against uninitialized contexts so it can still attach injected API stubs for tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runner_start.py::test_start_initializes_api tests/test_run_cycle_after_hours.py::test_run_cycle_aborts_on_alpaca_auth_failure -q

------
https://chatgpt.com/codex/tasks/task_e_68d4a0c0f37083308de88251905cc6fd