### PR TITLE
Fix Alpaca guard logging and add urllib3 stubs

### DIFF
--- a/ai_trading/analysis/sentiment.py
+++ b/ai_trading/analysis/sentiment.py
@@ -9,7 +9,6 @@ import time as pytime
 from datetime import datetime
 from threading import Lock
 
-import requests
 from ai_trading.net.http import HTTPSession, get_http_session
 from ai_trading.utils.http import clamp_request_timeout
 from ai_trading.utils.retry import (
@@ -440,12 +439,12 @@ def analyze_text(text: str, logger=logger) -> dict:
     global _SENTIMENT_STUB_LOGGED
     try:
         deps = _load_transformers(logger)
-    except requests.exceptions.SSLError as exc:
+    except HTTPError as exc:
         raise RuntimeError(
             "SSL error loading FinBERT; download the model and set "
             "TRANSFORMERS_OFFLINE=1 to run without internet"
         ) from exc
-    except (requests.exceptions.RequestException, OSError) as exc:
+    except (RequestException, OSError) as exc:
         if not _SENTIMENT_STUB_LOGGED:
             logger.warning('SENTIMENT_FALLBACK_STUB', extra={'error': type(exc).__name__})
             _SENTIMENT_STUB_LOGGED = True

--- a/ai_trading/data/_alpaca_guard.py
+++ b/ai_trading/data/_alpaca_guard.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Helpers to determine whether Alpaca SDK access is required."""
+
+from ai_trading.config import get_execution_settings
+from ai_trading.config.settings import get_settings
+
+
+def _execution_enabled() -> bool:
+    """Return ``True`` when trade execution requires Alpaca SDK access."""
+
+    try:
+        mode = str(get_execution_settings().mode).lower()
+    except Exception:
+        return False
+    return mode in {"paper", "live"}
+
+
+def should_import_alpaca_sdk() -> bool:
+    """Return ``True`` when Alpaca SDK resources are required."""
+
+    try:
+        provider = getattr(get_settings(), "data_provider", "")
+    except Exception:
+        provider = ""
+    provider_normalized = str(provider or "").strip().lower()
+    return _execution_enabled() and provider_normalized == "alpaca"
+
+
+__all__ = ["should_import_alpaca_sdk"]

--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -18,15 +18,23 @@ from ai_trading.logging.normalize import canon_timeframe as _canon_tf
 from ai_trading.utils.time import now_utc
 from .timeutils import ensure_utc_datetime, expected_regular_minutes
 from .models import StockBarsRequest, TimeFrame
+from ._alpaca_guard import should_import_alpaca_sdk
 import time
 
-# Alpaca SDK APIError (optional during tests)
-try:  # pragma: no cover - alpaca may be missing
-    from alpaca.common.exceptions import APIError
-except (ImportError, AttributeError):  # pragma: no cover - define fallback
-    class APIError(Exception):
-        """Fallback APIError when Alpaca SDK is unavailable."""
+
+class _FallbackAPIError(Exception):
+    """Fallback APIError when Alpaca SDK is unavailable."""
+
+
+APIError = _FallbackAPIError
+
+if should_import_alpaca_sdk():  # pragma: no cover - alpaca optional
+    try:
+        from alpaca.common.exceptions import APIError as _RealAPIError
+    except (ImportError, AttributeError):
         pass
+    else:
+        APIError = _RealAPIError
 
 __all__ = ["TimeFrame", "StockBarsRequest"]
 

--- a/tests/stubs/urllib3/__init__.py
+++ b/tests/stubs/urllib3/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import types
 import warnings
 
 try:
@@ -10,19 +9,10 @@ try:
 except Exception:  # pragma: no cover - missing util stub
     Retry = None  # type: ignore[assignment]
 
+__version__ = "2.0.0"
 
-class HTTPWarning(Warning):
-    """Base warning type for HTTP issues."""
-
-
-class SystemTimeWarning(HTTPWarning):
-    """Warning for TLS clock skew issues."""
-
-
-exceptions = types.SimpleNamespace(
-    HTTPWarning=HTTPWarning,
-    SystemTimeWarning=SystemTimeWarning,
-)
+from . import exceptions as exceptions  # re-export module for import parity
+from .exceptions import HTTPError, HTTPWarning, SystemTimeWarning
 
 
 def disable_warnings(category: type[Warning] | None = HTTPWarning) -> None:
@@ -41,4 +31,7 @@ __all__ = [
     "Retry",
     "exceptions",
     "disable_warnings",
+    "HTTPWarning",
+    "SystemTimeWarning",
+    "HTTPError",
 ]

--- a/tests/stubs/urllib3/exceptions.py
+++ b/tests/stubs/urllib3/exceptions.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Minimal urllib3.exceptions stub for tests."""
+
+class HTTPWarning(Warning):
+    """Base warning type for HTTP issues."""
+
+
+class SystemTimeWarning(HTTPWarning):
+    """Warning for TLS clock skew issues."""
+
+
+class HTTPError(Exception):
+    """Placeholder matching urllib3's HTTPError."""
+
+
+class DependencyWarning(Warning):
+    """Dependency mismatch warning stub."""
+
+
+__all__ = ["HTTPWarning", "SystemTimeWarning", "HTTPError", "DependencyWarning"]
+
+_DYNAMIC_CACHE: dict[str, type] = {}
+
+
+def __getattr__(name: str):
+    if name in _DYNAMIC_CACHE:
+        return _DYNAMIC_CACHE[name]
+    base = Warning if name.endswith("Warning") else Exception
+    cls = type(name, (base,), {})
+    _DYNAMIC_CACHE[name] = cls
+    return cls

--- a/tests/stubs/urllib3/poolmanager.py
+++ b/tests/stubs/urllib3/poolmanager.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Minimal urllib3.poolmanager stub for requests compatibility."""
+
+from types import SimpleNamespace
+
+
+class PoolManager:
+    def __init__(self, num_pools: int = 0, maxsize: int = 0, block: bool = False, **kwargs):
+        self.num_pools = num_pools
+        self.maxsize = maxsize
+        self.block = block
+        self.pool_kwargs = dict(kwargs)
+
+    def clear(self) -> None:  # pragma: no cover - trivial stub
+        return None
+
+    def connection_from_host(self, host: str, port: int | None = None, scheme: str = "http") -> SimpleNamespace:
+        return SimpleNamespace(host=host, port=port, scheme=scheme)
+
+    def connection_from_url(self, url: str) -> SimpleNamespace:
+        return SimpleNamespace(url=url)
+
+
+def proxy_from_url(*args, **kwargs) -> PoolManager:
+    return PoolManager(**kwargs)
+
+
+__all__ = ["PoolManager", "proxy_from_url"]

--- a/tests/stubs/urllib3/util/__init__.py
+++ b/tests/stubs/urllib3/util/__init__.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Minimal urllib3.util stub for requests compatibility."""
+
+from types import SimpleNamespace
+from urllib.parse import urlparse
+import base64
+
+
+def make_headers(
+    keep_alive: bool | None = None,
+    accept_encoding: str | None = None,
+    user_agent: str | None = None,
+    proxy_basic_auth: str | None = None,
+    proxy_auth: str | None = None,
+) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if keep_alive:
+        headers["connection"] = "keep-alive"
+    if accept_encoding:
+        if accept_encoding is True:
+            headers["accept-encoding"] = "gzip, deflate, br"
+        else:
+            headers["accept-encoding"] = str(accept_encoding)
+    if user_agent:
+        headers["user-agent"] = user_agent
+    auth_value = proxy_auth or proxy_basic_auth
+    if auth_value:
+        token = base64.b64encode(auth_value.encode()).decode()
+        headers["proxy-authorization"] = f"Basic {token}"
+    return headers
+
+
+def parse_url(url: str) -> SimpleNamespace:
+    parsed = urlparse(url)
+    return SimpleNamespace(
+        scheme=parsed.scheme,
+        host=parsed.hostname,
+        port=parsed.port,
+        path=parsed.path,
+        query=parsed.query,
+    )
+
+
+class Timeout:
+    def __init__(self, total: float | None = None, connect: float | None = None, read: float | None = None):
+        self.total = total
+        self.connect = connect
+        self.read = read
+
+    @classmethod
+    def from_int(cls, value: int | float | None) -> "Timeout":
+        return cls(total=value)
+
+
+__all__ = ["make_headers", "parse_url", "Timeout"]


### PR DESCRIPTION
## Summary
- gate Alpaca-dependent imports and credential checks behind the new `should_import_alpaca_sdk` helper so non-execution paths avoid the SDK
- push overlap and missing-client messages into pytest's log capture while emitting a dedicated warning when Alpaca falls back to data-only mode
- extend the urllib3 stub package so `requests` can run under tests without the real dependency

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_run_overlap.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_broker_unavailable_paths.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_critical_trading_fixes.py::test_metalearn_invalid_prices_prevention -q`


------
https://chatgpt.com/codex/tasks/task_e_68d4a0adc2648330bdd9b8cbbc4206c6