### PR TITLE
Log screen summary counts

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -15209,13 +15209,18 @@ def screen_universe(
                 f"Selected: {selected}. "
                 f"Filtered out: {len(filtered_out)} symbols: {filtered_out}"
             )
+            total_failed = failed + empty
+            summary_message = (
+                f"SCREEN_SUMMARY | symbols={tried} passed={valid} failed={total_failed}"
+            )
             logger.info(
-                "SCREEN_SUMMARY",
+                summary_message,
                 extra={
                     "tried": tried,
                     "valid": valid,
                     "empty": empty,
                     "failed": failed,
+                    "failed_total": total_failed,
                 },
             )
 

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -145,7 +145,9 @@ def test_screen_universe_logging(monkeypatch: pytest.MonkeyPatch, caplog: pytest
     assert selected == ["VALID"]
 
     summary_records = [
-        record for record in caplog.records if record.getMessage() == "SCREEN_SUMMARY"
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("SCREEN_SUMMARY |")
     ]
     assert summary_records, "Expected SCREEN_SUMMARY log entry"
     summary = summary_records[-1]
@@ -154,6 +156,11 @@ def test_screen_universe_logging(monkeypatch: pytest.MonkeyPatch, caplog: pytest
     assert summary.valid == 1
     assert summary.empty == 1
     assert summary.failed == 1
+
+    assert (
+        summary.getMessage()
+        == "SCREEN_SUMMARY | symbols=3 passed=1 failed=2"
+    ), "Summary log message did not match expected format"
 
     assert "[SCREEN_UNIVERSE] Starting screening" in caplog.text
     assert "Selected 1 of" in caplog.text


### PR DESCRIPTION
## Summary
- log SCREEN_SUMMARY records with the required formatted message including total attempts and failures
- keep per-category counters available on the log record for downstream consumers
- update regression test to assert on the new summary log format and totals

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fixes.py::test_screen_universe_logging

------
https://chatgpt.com/codex/tasks/task_e_68d4b6cd41008330a11050559a6a8871