### PR TITLE
Fix emit_once adapter support

### DIFF
--- a/ai_trading/logging/emit_once.py
+++ b/ai_trading/logging/emit_once.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import threading
 from datetime import UTC, date, datetime
-from logging import Logger
+from logging import Logger, LoggerAdapter
 from typing import Any, overload
 
 _emitted: dict[str, date] = {}
@@ -29,7 +29,14 @@ def emit_once(key: str, /) -> bool: ...
 
 
 @overload
-def emit_once(logger: Logger, key: str, level: str, msg: str, /, **extra: Any) -> bool: ...
+def emit_once(
+    logger: Logger | LoggerAdapter,
+    key: str,
+    level: str,
+    msg: str,
+    /,
+    **extra: Any,
+) -> bool: ...
 
 
 def emit_once(*args: Any, **extra: Any) -> bool:
@@ -48,7 +55,7 @@ def emit_once(*args: Any, **extra: Any) -> bool:
         raise TypeError("emit_once expects at least one positional argument")
 
     first = args[0]
-    if isinstance(first, Logger):
+    if isinstance(first, (Logger, LoggerAdapter)):
         if len(args) != 4:
             raise TypeError(
                 "emit_once(logger, key, level, msg) requires four positional arguments"

--- a/tests/test_emit_once.py
+++ b/tests/test_emit_once.py
@@ -20,3 +20,17 @@ def test_emit_once_emits_once_per_day(caplog, monkeypatch):
     msgs = [r.message for r in caplog.records]
     assert msgs.count("Hello") == 2
 
+
+def test_emit_once_accepts_logger_adapter(caplog, monkeypatch):
+    base_logger = logging.getLogger("ai_trading.test.adapter")
+    adapter = logging.LoggerAdapter(base_logger, {})
+    caplog.set_level(logging.INFO)
+
+    monkeypatch.setattr(emit_once_mod, "_utc_today", lambda: real_date(2024, 1, 1))
+
+    assert emit_once_mod.emit_once(adapter, "ADAPTER_KEY", "info", "Adapter Hello") is True
+    assert emit_once_mod.emit_once(adapter, "ADAPTER_KEY", "info", "Adapter Hello") is False
+
+    msgs = [r.message for r in caplog.records]
+    assert msgs.count("Adapter Hello") == 1
+


### PR DESCRIPTION
## Summary
- allow `emit_once` to accept both `logging.Logger` and `LoggerAdapter` instances so drawdown circuit breaker initialization succeeds with the global sanitizing logger
- add a regression test covering the LoggerAdapter usage pattern to guard against future regressions

## Testing
- pytest tests/test_emit_once.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d57196c1fc8330b1b1e1da7cc3961b