### PR TITLE
Handle liquidity fallback without Alpaca quotes

### DIFF
--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -152,6 +152,12 @@ class Settings(BaseSettings):
     score_size_gamma: float = Field(
         1.0, alias="SCORE_SIZE_GAMMA", description="Shape parameter: 1.0 linear, <1 concave, >1 convex"
     )
+    default_liquidity_factor: float = Field(
+        1.0,
+        alias="DEFAULT_LIQUIDITY_FACTOR",
+        ge=0.0,
+        description="Fallback liquidity multiplier when live quotes are unavailable.",
+    )
     buy_threshold: float = Field(default=0.4, env="AI_TRADING_BUY_THRESHOLD")
     sector_exposure_cap: float = Field(default=0.33, env="AI_TRADING_SECTOR_EXPOSURE_CAP")
     max_portfolio_positions: int = Field(default=20, env="AI_TRADING_MAX_PORTFOLIO_POSITIONS")

--- a/tests/bot_engine/test_liquidity_factor.py
+++ b/tests/bot_engine/test_liquidity_factor.py
@@ -1,0 +1,100 @@
+import sys
+import types
+from types import SimpleNamespace
+
+import ai_trading.logging.emit_once as emit_once_module
+
+
+class _NumPyStub(types.ModuleType):
+    ndarray = object
+    float64 = float
+    int64 = int
+    nan = float("nan")
+    NaN = float("nan")
+
+    class _RandomStub:
+        def seed(self, *args, **kwargs):  # noqa: D401 - compatibility shim
+            return None
+
+    random = _RandomStub()
+
+    def array(self, *args, **kwargs):  # noqa: D401 - compatibility shim
+        return args[0] if args else None
+
+    def zeros(self, *args, **kwargs):  # noqa: D401 - compatibility shim
+        return [0] * (args[0] if args else 0)
+
+    def ones(self, *args, **kwargs):  # noqa: D401 - compatibility shim
+        return [1] * (args[0] if args else 0)
+
+    def __getattr__(self, name: str):
+        return lambda *args, **kwargs: None
+
+
+if "numpy" not in sys.modules:
+    sys.modules["numpy"] = _NumPyStub("numpy")
+
+if "portalocker" not in sys.modules:
+    portalocker_stub = types.ModuleType("portalocker")
+    portalocker_stub.LOCK_EX = 1
+
+    def _noop(*args, **kwargs):  # noqa: D401 - compatibility shim
+        return None
+
+    portalocker_stub.lock = _noop
+    portalocker_stub.unlock = _noop
+    sys.modules["portalocker"] = portalocker_stub
+
+if "bs4" not in sys.modules:
+    bs4_stub = types.ModuleType("bs4")
+
+    class _BeautifulSoup:
+        def __init__(self, *args, **kwargs):  # noqa: D401 - compatibility shim
+            self.args = args
+            self.kwargs = kwargs
+
+    bs4_stub.BeautifulSoup = _BeautifulSoup
+    sys.modules["bs4"] = bs4_stub
+
+from ai_trading.core import bot_engine
+
+
+def _reset_emit_once(monkeypatch):
+    monkeypatch.setattr(emit_once_module, "_emitted", {}, raising=False)
+
+
+def test_liquidity_factor_handles_missing_data_client(monkeypatch):
+    _reset_emit_once(monkeypatch)
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+    stub_settings = SimpleNamespace(default_liquidity_factor=0.75)
+    monkeypatch.setattr(bot_engine, "get_settings", lambda: stub_settings)
+    ctx = SimpleNamespace(data_client=None, volume_threshold=100_000, last_bar_by_symbol={})
+
+    factor = bot_engine.liquidity_factor(ctx, "FAKE")
+
+    assert abs(factor - 0.75) < 1e-6
+    monkeypatch.delenv("PYTEST_RUNNING", raising=False)
+
+
+def test_liquidity_factor_falls_back_to_last_bar(monkeypatch):
+    _reset_emit_once(monkeypatch)
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+    stub_settings = SimpleNamespace(default_liquidity_factor=0.9)
+    monkeypatch.setattr(bot_engine, "get_settings", lambda: stub_settings)
+
+    class FailingClient:
+        def get_stock_latest_quote(self, req):  # noqa: D401 - simple stub
+            raise bot_engine.APIError("quote unavailable")
+
+    last_bar = SimpleNamespace(high=102, low=98, close=100, volume=2_000_000)
+    ctx = SimpleNamespace(
+        data_client=FailingClient(),
+        volume_threshold=100_000,
+        last_bar_by_symbol={"FAKE": last_bar},
+    )
+
+    factor = bot_engine.liquidity_factor(ctx, "FAKE")
+
+    assert 0.1 <= factor <= 0.9
+    assert factor < 0.9  # Uses last-bar heuristics rather than default directly
+    monkeypatch.delenv("PYTEST_RUNNING", raising=False)

--- a/tests/data/test_provider_switchover.py
+++ b/tests/data/test_provider_switchover.py
@@ -1,0 +1,55 @@
+import logging
+from types import SimpleNamespace
+
+import ai_trading.logging.emit_once as emit_once_module
+from ai_trading.data import fetch
+
+
+def _reset_emit_once(monkeypatch):
+    monkeypatch.setattr(emit_once_module, "_emitted", {}, raising=False)
+
+
+def test_missing_alpaca_warning_suppressed_for_backup_provider(monkeypatch):
+    _reset_emit_once(monkeypatch)
+    monkeypatch.delenv("ALPACA_SIP_UNAUTHORIZED", raising=False)
+    monkeypatch.setattr(fetch, "_is_sip_unauthorized", lambda: False)
+    monkeypatch.setattr(fetch, "get_settings", lambda: SimpleNamespace(data_provider="yahoo"))
+    monkeypatch.setattr(fetch, "get_data_feed_override", lambda: "yahoo")
+    monkeypatch.setattr(fetch, "resolve_alpaca_feed", lambda _requested=None: None)
+
+    should_warn, extra = fetch._missing_alpaca_warning_context()
+
+    assert should_warn is False
+    assert extra.get("provider") == "yahoo"
+
+
+def test_missing_alpaca_warning_suppressed_when_sip_locked(monkeypatch):
+    _reset_emit_once(monkeypatch)
+    monkeypatch.setenv("ALPACA_SIP_UNAUTHORIZED", "1")
+    monkeypatch.setattr(fetch, "_is_sip_unauthorized", lambda: True)
+    monkeypatch.setattr(fetch, "get_settings", lambda: SimpleNamespace(data_provider="alpaca"))
+    monkeypatch.setattr(fetch, "get_data_feed_override", lambda: None)
+    monkeypatch.setattr(fetch, "resolve_alpaca_feed", lambda _requested=None: "sip")
+
+    should_warn, extra = fetch._missing_alpaca_warning_context()
+
+    assert should_warn is False
+    assert extra.get("sip_locked") is True
+    monkeypatch.delenv("ALPACA_SIP_UNAUTHORIZED", raising=False)
+
+
+def test_warn_missing_alpaca_emits_once(monkeypatch, caplog):
+    _reset_emit_once(monkeypatch)
+    monkeypatch.delenv("ALPACA_SIP_UNAUTHORIZED", raising=False)
+    monkeypatch.setattr(fetch, "_is_sip_unauthorized", lambda: False)
+    monkeypatch.setattr(fetch, "get_settings", lambda: SimpleNamespace(data_provider="alpaca"))
+    monkeypatch.setattr(fetch, "get_data_feed_override", lambda: None)
+    monkeypatch.setattr(fetch, "resolve_alpaca_feed", lambda _requested=None: "iex")
+
+    caplog.set_level(logging.WARNING)
+
+    fetch._warn_missing_alpaca("FAKE", "1Min")
+    fetch._warn_missing_alpaca("FAKE", "1Min")
+
+    messages = [record.message for record in caplog.records]
+    assert messages.count("ALPACA_API_KEY_MISSING") == 1


### PR DESCRIPTION
## Summary
- make `liquidity_factor` resilient to missing Alpaca quotes by falling back to cached bars or a configurable default and throttling logs with `emit_once`
- throttle `ALPACA_API_KEY_MISSING` so it only emits when Alpaca data is active and SIP is allowed, leveraging once-per-day logging
- add the `AI_TRADING_DEFAULT_LIQUIDITY_FACTOR` setting and targeted unit tests for the fallback and warning logic

## Testing
- PYTHONPATH=.venv PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/bot_engine/test_liquidity_factor.py tests/data/test_provider_switchover.py
- python -m compileall ai_trading -q

------
https://chatgpt.com/codex/tasks/task_e_68d581eddbdc8330ac680baf99220a23