### PR TITLE
Stabilize provider selection and improve data fetch resilience

### DIFF
--- a/tests/test_sip_disallowed.py
+++ b/tests/test_sip_disallowed.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+from ai_trading.data.fetch import _sip_fallback_allowed, logger
 from ai_trading.data.fetch.sip_disallowed import sip_disallowed
 
 
@@ -31,4 +34,20 @@ def test_sip_disallowed_when_entitlement_missing(monkeypatch):
     monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
     monkeypatch.setenv("ALPACA_HAS_SIP", "0")
     assert sip_disallowed() is True
+
+
+def test_no_unauthorized_log_when_sip_disabled(monkeypatch):
+    monkeypatch.setenv("ALPACA_ALLOW_SIP", "0")
+    monkeypatch.setattr("ai_trading.data.fetch._ALLOW_SIP", False)
+    monkeypatch.setattr("ai_trading.data.fetch._SIP_DISALLOWED_WARNED", False)
+    captured: list[str] = []
+
+    def _capture(message: str, *args, **kwargs):
+        captured.append(message)
+
+    monkeypatch.setattr(logger, "warning", _capture)
+    session = SimpleNamespace(get=lambda *a, **k: SimpleNamespace(status_code=401))
+    allowed = _sip_fallback_allowed(session, {}, "1Min")
+    assert allowed is False
+    assert all(msg != "UNAUTHORIZED_SIP" for msg in captured)
 


### PR DESCRIPTION
## Summary
- add a configurable provider decision window with severity-aware switching to reduce data source thrash and normalize provider labels
- harden fetch logic by treating large gap windows as degraded, surfacing structured OHLCV column errors, and suppressing SIP unauthorized logging when the feed is disabled
- expand daily fetch caching with provider/session memoization and sticky error handling, alongside new regression tests for provider hysteresis, SIP behaviour, and missing-column retries

## Testing
- `pytest tests/data/test_provider_decision_single_outcome.py tests/test_provider_decision_single_outcome.py tests/bot_engine/test_daily_fetch_debounce.py tests/test_sip_disallowed.py`


------
https://chatgpt.com/codex/tasks/task_e_68d5945f217c833090c6a373e7c6d751