### PR TITLE
Consolidate dataclass import handling in bot engine

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -16,6 +16,7 @@ import tempfile
 import sys
 from typing import Any, Dict, Iterable, Mapping, Sequence, TYPE_CHECKING, cast
 from collections import deque
+from dataclasses import dataclass, field
 from zoneinfo import ZoneInfo  # AI-AGENT-REF: timezone conversions
 from functools import cached_property, lru_cache
 
@@ -2691,7 +2692,6 @@ import time as pytime
 from argparse import ArgumentParser
 from collections.abc import Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass, field
 from datetime import UTC
 from datetime import datetime as dt_
 from datetime import time as dt_time


### PR DESCRIPTION
## Summary
- add the dataclass import to the top-level import block in `ai_trading/core/bot_engine.py`
- remove the duplicate dataclass import near the lazy import helpers so the module consolidates imports

## Testing
- python -m ai_trading *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68d59aa736e883309d4e2226e89a3eab