### PR TITLE
Fix missing importlib import in env init

### DIFF
--- a/ai_trading/env/__init__.py
+++ b/ai_trading/env/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import logging
 import os


### PR DESCRIPTION
## Summary
- add the missing importlib import so _DOTENV_SPEC initialization can resolve correctly

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/config/test_import_sanity.py::test_python_dotenv_is_resolved

------
https://chatgpt.com/codex/tasks/task_e_68d5c55315c483309a1e4323d7966793