### PR TITLE
Initialize bot engine metric globals

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -3462,6 +3462,25 @@ from ai_trading.metrics import (
 
 # Prometheus metrics - lazy initialization to prevent duplicates
 _METRICS_READY = False
+
+# Initialize metric globals eagerly so test fixtures can monkeypatch them
+# without having to guard against missing attributes. These are populated with
+# real metric instances the first time ``_init_metrics`` runs.
+orders_total = None
+order_failures = None
+daily_drawdown = None
+signals_evaluated = None
+run_all_trades_duration = None
+minute_cache_hit = None
+minute_cache_miss = None
+daily_cache_hit = None
+daily_cache_miss = None
+event_cooldown_hits = None
+slippage_total = None
+slippage_count = None
+weekly_drawdown = None
+skipped_duplicates = None
+skipped_cooldown = None
 sentiment_api_failures = None
 sentiment_cb_state = None
 


### PR DESCRIPTION
## Summary
- initialize all bot engine Prometheus metric globals to ``None`` at import time so tests can safely monkeypatch them

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runner_additional.py -q
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_daily_cache.py::test_daily_fetcher_uses_cache -q *(fails: fallback fetch path never calls patched bars.safe_get_stock_bars, so assertion expects 1 call but observed 0)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c5e1a1308330b1c4aebb6f14e34c