### PR TITLE
Ensure fallback price usage is logged

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -13607,10 +13607,16 @@ def _enter_long(
         quote_price, price_source = _resolve_order_quote(
             symbol, prefer_backup=prefer_backup_quote
         )
-        if price_source not in {"alpaca", "alpaca_iex", "alpaca_sip"}:
-            logger.warning(
+        _PRICE_SOURCE[symbol] = price_source
+        fallback_active = (
+            prefer_backup_quote
+            or price_source == _ALPACA_DISABLED_SENTINEL
+            or not _is_primary_price_source(price_source)
+        )
+        if fallback_active:
+            logger.info(
                 "PRIMARY_PROVIDER_FALLBACK_ACTIVE",
-                extra={"symbol": symbol, "provider": "alpaca"},
+                extra={"symbol": symbol, "provider": price_source or "unknown"},
             )
         if _should_skip_order_for_alpaca_unavailable(
             state, symbol, price_source
@@ -13658,6 +13664,12 @@ def _enter_long(
             )
             return True
 
+    fallback_active = (
+        prefer_backup_quote
+        or price_source == _ALPACA_DISABLED_SENTINEL
+        or not _is_primary_price_source(price_source)
+    )
+
     if price_source == "unknown":
         logger.warning(
             "SKIP_ORDER_PRICE_SOURCE",
@@ -13699,11 +13711,7 @@ def _enter_long(
                 "prefer_backup": prefer_backup_quote,
             },
         )
-    if (
-        not _is_primary_price_source(price_source)
-        or price_source == "feature_close"
-        or prefer_backup_quote
-    ) and not gate.block:
+    if fallback_active and quote_price is not None:
         logger.info(
             "ORDER_USING_FALLBACK_PRICE",
             extra={"symbol": symbol, "price_source": price_source},
@@ -13923,15 +13931,27 @@ def _enter_short(
         quote_price, price_source = _resolve_order_quote(
             symbol, prefer_backup=prefer_backup_quote
         )
-        if price_source not in {"alpaca", "alpaca_iex", "alpaca_sip"}:
-            logger.warning(
+        _PRICE_SOURCE[symbol] = price_source
+        fallback_active = (
+            prefer_backup_quote
+            or price_source == _ALPACA_DISABLED_SENTINEL
+            or not _is_primary_price_source(price_source)
+        )
+        if fallback_active:
+            logger.info(
                 "PRIMARY_PROVIDER_FALLBACK_ACTIVE",
-                extra={"symbol": symbol, "provider": "alpaca"},
+                extra={"symbol": symbol, "provider": price_source or "unknown"},
             )
         if _should_skip_order_for_alpaca_unavailable(
             state, symbol, price_source
         ):
             return True
+    fallback_active = (
+        prefer_backup_quote
+        or price_source == _ALPACA_DISABLED_SENTINEL
+        or not _is_primary_price_source(price_source)
+    )
+
     if quote_price is None:
         logger.warning(
             "SKIP_ORDER_NO_PRICE",
@@ -13979,11 +13999,7 @@ def _enter_short(
                 "prefer_backup": prefer_backup_quote,
             },
         )
-    if (
-        not _is_primary_price_source(price_source)
-        or price_source == "feature_close"
-        or prefer_backup_quote
-    ) and not gate.block:
+    if fallback_active and quote_price is not None:
         logger.info(
             "ORDER_USING_FALLBACK_PRICE",
             extra={"symbol": symbol, "price_source": price_source},
@@ -14273,6 +14289,10 @@ def trade_logic(
     if not provider_enabled:
         logger.warning(
             "PRIMARY_PROVIDER_DEGRADED",
+            extra={"symbol": symbol, "provider": "alpaca"},
+        )
+        logger.info(
+            "PRIMARY_PROVIDER_FALLBACK_ACTIVE",
             extra={"symbol": symbol, "provider": "alpaca"},
         )
         degraded = getattr(state, "degraded_providers", None)


### PR DESCRIPTION
## Summary
- ensure long and short entry paths track fallback price sources and emit fallback logging when non-Alpaca quotes are used
- emit primary provider fallback logging from trade_logic when Alpaca pricing is disabled

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_bot_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d5cc09c94483309d08d624fbcd8b89