### PR TITLE
Adjust price fallback ordering and cache resets

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -20208,12 +20208,6 @@ def get_latest_price(symbol: str, *, prefer_backup: bool = False):
     last_source = price_source
     prev_source = price_source
     for provider in provider_order:
-        if provider in {"yahoo", "bars"} and price is None:
-            degraded = _resolve_cached_quote_bid(symbol, cache)
-            if degraded is not None:
-                price, price_source = degraded
-                last_source = price_source
-                break
         candidate, source = _attempt_provider(provider)
         if source:
             prev_source = last_source
@@ -20226,12 +20220,6 @@ def get_latest_price(symbol: str, *, prefer_backup: bool = False):
             price = candidate
             price_source = source
             break
-        if provider in {"alpaca_trade", "alpaca_minute_close"} and price is None:
-            degraded = _resolve_cached_quote_bid(symbol, cache)
-            if degraded is not None:
-                price, price_source = degraded
-                last_source = price_source
-                break
         _record_primary_failure(source or provider)
 
     if price is None:
@@ -20239,6 +20227,13 @@ def get_latest_price(symbol: str, *, prefer_backup: bool = False):
         if degraded is not None:
             price, price_source = degraded
             last_source = price_source
+            cache_source = cache.get("quote_degraded_source")
+            if isinstance(cache_source, str):
+                price_source = cache_source
+                last_source = price_source
+            cache_price = cache.get("quote_degraded_price")
+            if cache_price is not None:
+                price = cache_price
 
     if price is None:
         if last_source != "unknown":

--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -64,6 +64,16 @@ def _short_intraday_defaults(monkeypatch):
         ProviderMonitor(),
         raising=False,
     )
+    try:
+        bot_engine._reset_cycle_cache()
+    except Exception:
+        pass
+    try:
+        cache_override = getattr(bot_engine.data_fetcher_module, "_cycle_feed_override", None)
+        if isinstance(cache_override, dict):
+            cache_override.clear()
+    except Exception:
+        pass
 
     def _tiny_session(current_date):
         end = datetime(2024, 1, 2, 15, 30, tzinfo=UTC)

--- a/tests/test_get_latest_price_fallback.py
+++ b/tests/test_get_latest_price_fallback.py
@@ -179,7 +179,7 @@ def test_get_latest_price_degrades_to_bid_after_fallback(monkeypatch, caplog):
     with caplog.at_level("WARNING", logger="ai_trading.core.bot_engine"):
         price = bot_engine.get_latest_price("AAPL")
 
-    assert calls["yahoo"] == 0
+    assert calls["yahoo"] == 1
     assert price == 94.5
     assert bot_engine._PRICE_SOURCE["AAPL"] == "alpaca_bid_degraded"
     assert "DELAYED_QUOTE_SLIPPAGE_FLAGGED" in caplog.text


### PR DESCRIPTION
## Summary
- ensure `get_latest_price` follows the configured provider order, short-circuits on authentication failures, and only degrades to cached bid pricing after exhaustively attempting fallbacks
- update fallback regression test to expect a Yahoo attempt before degrading to the bid
- reset per-cycle data feed caches in the minute data fixture so coverage tests run deterministically in-process

## Testing
- `pytest tests/test_get_latest_price_fallback.py -q`
- `pytest tests/bot_engine/test_fetch_minute_df_safe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d5cd57e3548330818fb8bbd110796f