### PR TITLE
Improve SoftBudget timing semantics

### DIFF
--- a/ai_trading/utils/prof.py
+++ b/ai_trading/utils/prof.py
@@ -71,7 +71,7 @@ class SoftBudget:
 
     def __init__(self, millis: int):
         self.budget_ms = max(0, int(millis))
-        self._start_ns: int | None = None
+        self._start_ns: int | None = time.perf_counter_ns()
 
     def __enter__(self) -> "SoftBudget":
         self.reset()
@@ -83,29 +83,26 @@ class SoftBudget:
     def reset(self) -> None:
         self._start_ns = time.perf_counter_ns()
 
-    def _ensure_started(self) -> int:
+    def _elapsed_ns(self) -> int:
+        now = time.perf_counter_ns()
         if self._start_ns is None:
-            self.reset()
-        assert self._start_ns is not None  # for type checkers
-        return self._start_ns
+            self._start_ns = now
+            return 0
+        elapsed_ns = now - self._start_ns
+        return elapsed_ns if elapsed_ns >= 0 else 0
 
     def elapsed_ms(self) -> int:
-        start = self._ensure_started()
-        elapsed_ns = max(time.perf_counter_ns() - start, 0)
-        elapsed_ms = (elapsed_ns + 999_999) // 1_000_000
-        return max(1, int(elapsed_ms))
+        elapsed_ns = self._elapsed_ns()
+        return int((elapsed_ns + 500_000) // 1_000_000)
 
     def over_budget(self) -> bool:
-        return self.elapsed_ms() >= self.budget_ms
+        return self._elapsed_ns() >= (self.budget_ms * 1_000_000)
 
     def remaining(self) -> float:
-        start = self._ensure_started()
-        elapsed_ns = max(time.perf_counter_ns() - start, 0)
-        remaining_ns = (self.budget_ms * 1_000_000) - elapsed_ns
+        remaining_ns = (self.budget_ms * 1_000_000) - self._elapsed_ns()
         if remaining_ns <= 0:
             return 0.0
-        remaining_ms = (remaining_ns + 999_999) // 1_000_000
-        return int(remaining_ms) / 1000.0
+        return round(remaining_ns / 1_000_000_000, 3)
 
     def over(self) -> bool:  # Backward compatibility
         return self.over_budget()

--- a/tests/test_prof_budget.py
+++ b/tests/test_prof_budget.py
@@ -1,5 +1,8 @@
 import time
 
+import pytest
+
+from ai_trading.utils import prof
 from ai_trading.utils.prof import SoftBudget
 
 
@@ -34,3 +37,38 @@ def test_soft_budget_context_manager_resets_start():
 
     time.sleep(0.07)
     assert budget.over_budget() is True
+
+
+def test_elapsed_ms_rounds_to_nearest_monotonic(monkeypatch):
+    sequence = iter(
+        [
+            0,  # __init__
+            499_999,  # first elapsed -> < 0.5ms, rounds to 0
+            500_000,  # second elapsed -> == 0.5ms, rounds up to 1
+        ]
+    )
+
+    monkeypatch.setattr(prof.time, "perf_counter_ns", lambda: next(sequence))
+
+    budget = SoftBudget(10)
+    assert budget.elapsed_ms() == 0
+    assert budget.elapsed_ms() == 1
+
+
+def test_over_budget_and_remaining_use_existing_start(monkeypatch):
+    sequence = iter(
+        [
+            0,  # __init__
+            4_000_000,  # over_budget -> 4ms elapsed
+            7_000_000,  # remaining -> 7ms elapsed (> budget)
+            7_000_000,  # elapsed_ms -> same observation to confirm start retained
+        ]
+    )
+    monkeypatch.setattr(prof.time, "perf_counter_ns", lambda: next(sequence))
+
+    budget = SoftBudget(5)
+    assert budget.over_budget() is False
+    assert budget.remaining() == 0.0
+
+    # remaining should not reset start; calling elapsed should still reflect total time
+    assert budget.elapsed_ms() == 7


### PR DESCRIPTION
## Summary
- refine `SoftBudget` so it seeds its timer on creation, rounds elapsed milliseconds precisely, and keeps `over_budget`/`remaining` calculations tied to the stored start time
- expand `tests/test_prof_budget.py` to verify the new rounding behaviour and that `over_budget`/`remaining` do not reset the budget timer

## Testing
- pytest tests/test_prof_budget.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d5d59b5bf88330adadaf88a0abb523