### PR TITLE
Capture execute_order ignored kwargs from original input

### DIFF
--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -971,6 +971,7 @@ class ExecutionEngine:
         """
 
         kwargs = dict(kwargs)
+        original_kwarg_keys = set(kwargs)
         mapped_side = self._map_core_side(side)
         if qty <= 0:
             raise ValueError(f"execute_order invalid qty={qty}")
@@ -980,8 +981,7 @@ class ExecutionEngine:
         kwargs.pop("signal", None)
         signal_weight = kwargs.pop("signal_weight", None)
         price_alias = kwargs.pop("price", None)
-        raw_keys = set(kwargs)
-        ignored_keys = {key for key in raw_keys if key not in KNOWN_EXECUTE_ORDER_KWARGS}
+        ignored_keys = {key for key in original_kwarg_keys if key not in KNOWN_EXECUTE_ORDER_KWARGS}
         for key in list(ignored_keys):
             kwargs.pop(key, None)
         if limit_price is None and price_alias is not None:


### PR DESCRIPTION
## Summary
- capture the initial execute_order kwargs before mutation to identify unknown keys
- ensure each unsupported key, including unsupported asset_class, is logged before submission

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_execution_engine_signature.py::test_execute_order_ignores_unknown_kwargs

------
https://chatgpt.com/codex/tasks/task_e_68d5d6b5c26c8330a1402eea02f4cd99