### PR TITLE
Harden health endpoint around Alpaca env import

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -62,10 +62,10 @@ def create_app():
                 from ai_trading.core.bot_engine import _resolve_alpaca_env, trading_client
                 key, secret, base_url = _resolve_alpaca_env()
                 paper = bool(base_url and 'paper' in base_url)
-            except (KeyError, ValueError, TypeError) as exc:
+            except Exception as exc:  # pragma: no cover - defensive against unexpected import failures
                 trading_client, key, secret, base_url, paper = (None, None, None, '', False)
-                if not errors:
-                    errors.append(str(exc))
+                ok = False
+                errors.append(str(exc))
 
             from ai_trading.config.management import is_shadow_mode
 


### PR DESCRIPTION
## Summary
- broaden the Alpaca environment resolution guard in `/health` so unexpected import errors are caught
- ensure the handler forces `ok: false` and surfaces the error message when `_resolve_alpaca_env` raises

## Motivation & Context
- health checks must never raise; mid-handler import failures previously escaped and left the endpoint in an indeterminate state
- before: `_resolve_alpaca_env` only handled a handful of exception types, allowing other import errors to bubble out without marking the probe unhealthy
- after: all exceptions from the import or resolver path now flip the payload to unhealthy with a captured error string

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_health_check.py::test_health_endpoint_handles_import_error`

## Rollback Plan
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68d5d6b71cac833087bbec45815433bb