### PR TITLE
Improve equity fetch resilience and runtime sizing cache

### DIFF
--- a/ai_trading/core/runtime.py
+++ b/ai_trading/core/runtime.py
@@ -12,6 +12,8 @@ from .protocols import AllocatorProtocol
 from ai_trading.position_sizing import (
     resolve_max_position_size,
     _get_equity_from_alpaca,
+    _CACHE as _POSITION_SIZING_CACHE,
+    _now_utc as _position_sizing_now,
 )
 from ai_trading.logging import get_logger
 logger = get_logger(__name__)
@@ -196,6 +198,8 @@ def build_runtime(cfg: TradingConfig, **kwargs: Any) -> BotRuntime:
     if resolved <= 0:
         raise ValueError("MAX_POSITION_SIZE must be positive")
     params["MAX_POSITION_SIZE"] = float(resolved)
+    _POSITION_SIZING_CACHE.value = float(resolved)
+    _POSITION_SIZING_CACHE.ts = _position_sizing_now()
     try:
         import ai_trading.core.bot_engine as be
 

--- a/ai_trading/utils/capital_scaling.py
+++ b/ai_trading/utils/capital_scaling.py
@@ -7,11 +7,21 @@ DEFAULT_MAX_POSITION_FALLBACK = 8000.0
 
 def derive_cap_from_settings(
     equity: Optional[float],
-    capital_cap: float = DEFAULT_CAPITAL_CAP,
+    capital_cap: float | None = DEFAULT_CAPITAL_CAP,
     fallback: float = DEFAULT_MAX_POSITION_FALLBACK,
 ) -> float:
-    if equity and equity > 0:
-        return float(equity) * float(capital_cap)
+    try:
+        cap = float(capital_cap) if capital_cap is not None else DEFAULT_CAPITAL_CAP
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        cap = DEFAULT_CAPITAL_CAP
+    if cap <= 0:
+        return float(fallback)
+    try:
+        eq = float(equity) if equity is not None else None
+    except (TypeError, ValueError):
+        eq = None
+    if eq is not None and eq > 0:
+        return eq * cap
     return float(fallback)
 
 

--- a/tests/test_dynamic_position_sizing.py
+++ b/tests/test_dynamic_position_sizing.py
@@ -29,6 +29,8 @@ def _stub_session(monkeypatch, status: int, payload: dict, *, calls: dict | None
 
 def test_auto_mode_resolves_from_equity_and_capital_cap(monkeypatch, caplog):
     ps._CACHE.value, ps._CACHE.ts, ps._CACHE.equity, ps._CACHE.equity_error = (None, None, None, None)
+    ps._CACHE.last_equity = None
+    ps._CACHE.last_equity_ts = None
     cfg = SimpleNamespace(
         alpaca_base_url="https://paper-api.alpaca.markets",
         alpaca_api_key="k",
@@ -52,6 +54,8 @@ def test_auto_mode_resolves_from_equity_and_capital_cap(monkeypatch, caplog):
 
 def test_auto_mode_raises_on_error_without_cached_equity(monkeypatch, caplog):
     ps._CACHE.value, ps._CACHE.ts, ps._CACHE.equity, ps._CACHE.equity_error = (None, None, None, None)
+    ps._CACHE.last_equity = None
+    ps._CACHE.last_equity_ts = None
     cfg = SimpleNamespace(
         alpaca_base_url="https://paper-api.alpaca.markets",
         alpaca_api_key="k",

--- a/tests/test_position_sizing_equity.py
+++ b/tests/test_position_sizing_equity.py
@@ -11,6 +11,8 @@ def _reset_cache():
     ps._CACHE.value = None
     ps._CACHE.ts = None
     ps._CACHE.equity = None
+    ps._CACHE.last_equity = None
+    ps._CACHE.last_equity_ts = None
     ps._CACHE.equity_error = None
     ps._CACHE.equity_missing_logged = False
     ps._CACHE.equity_ts = None


### PR DESCRIPTION
## Summary
- record the last successful equity value and treat zero-equity responses as cache misses
- harden AUTO sizing fallbacks to reuse cached equity, emit structured abort logs, and surface them to pytest caplog
- align runtime sizing cache hydration with position_sizing defaults and make capital scaling tolerant of overrides

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_position_sizing_equity.py tests/test_position_sizing_error_handling.py tests/test_dynamic_position_sizing.py tests/test_runtime_max_position_size.py tests/test_runtime_params_hydration.py tests/test_settings_max_position_size.py

------
https://chatgpt.com/codex/tasks/task_e_68d5d77325e4833087fad91c778ab459