### PR TITLE
Improve empty data logging and pytest capture integration

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -256,15 +256,26 @@ def get_trading_client_cls():
     """Return the Alpaca TradingClient class if available."""
 
     if not ALPACA_AVAILABLE or TradingClient is None:
-        raise RuntimeError("alpaca-py TradingClient not available")
+        class _UnavailableTradingClient:
+            def __init__(self, *_a, **_k):
+                raise RuntimeError("alpaca-py TradingClient not available")
+
+        return _UnavailableTradingClient
     return TradingClient
 
 
 def get_data_client_cls():
     """Return the Alpaca StockHistoricalDataClient class via lazy import."""
-    from alpaca.data.historical.stock import StockHistoricalDataClient  # type: ignore
+    try:
+        from alpaca.data.historical.stock import StockHistoricalDataClient  # type: ignore
 
-    return StockHistoricalDataClient
+        return StockHistoricalDataClient
+    except Exception as exc:
+        class _UnavailableDataClient:
+            def __init__(self, *_a, **_k):
+                raise RuntimeError("alpaca-py StockHistoricalDataClient not available") from exc
+
+        return _UnavailableDataClient
 
 
 def get_api_error_cls():


### PR DESCRIPTION
## Summary
- tighten `_emit_capture_record` and `_push_to_caplog` so empty-bar warnings surface in pytest without duplicating records when handlers are active
- ensure Finnhub-disabled minute fetches only inject caplog records when pytest logging handlers are detached
- provide soft fallback TradingClient/DataClient stubs when alpaca SDK modules are missing and preserve pytest LogCapture handlers during logging setup

## Testing
- `pytest tests/test_empty_bar_backoff.py tests/test_empty_dataframe_logging.py tests/test_fetch_empty_early_exit.py tests/test_fetch_empty_handling.py tests/test_fetch_empty_priority.py tests/test_fetch_empty_retry_once.py tests/test_fetch_empty_retry_exhausted.py tests/test_fetch_summary_log.py tests/test_finnhub_disabled.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d5d77428ac833084bee4caff5f4cbd