### PR TITLE
Improve fallback logging and feed cache persistence

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -769,11 +769,15 @@ class BotEngine:
             except Exception:  # pragma: no cover - defensive
                 normalized_raw = None
 
-        if symbol and normalized_raw and symbol not in self._cycle_minute_feed_override:
-            self._cycle_minute_feed_override[symbol] = sanitized or normalized_raw
+        cached_value = sanitized or normalized_raw
+
+        if symbol and cached_value:
+            self._cycle_minute_feed_override[symbol] = cached_value
+
+        if cached_value:
+            self._intraday_fallback_feed = cached_value
 
         if sanitized:
-            self._intraday_fallback_feed = sanitized
             _cache_cycle_fallback_feed(sanitized, symbol=symbol)
         elif normalized_raw:
             _cache_cycle_fallback_feed(normalized_raw, symbol=symbol)
@@ -1540,11 +1544,13 @@ def _cache_cycle_fallback_feed(
         except Exception:  # pragma: no cover - defensive
             normalized_raw = None
 
-    if symbol and normalized_raw and symbol not in _GLOBAL_CYCLE_MINUTE_FEED_OVERRIDE:
-        _GLOBAL_CYCLE_MINUTE_FEED_OVERRIDE[symbol] = sanitized or normalized_raw
+    cached_value = sanitized or normalized_raw
 
-    if sanitized:
-        _GLOBAL_INTRADAY_FALLBACK_FEED = sanitized
+    if symbol and cached_value:
+        _GLOBAL_CYCLE_MINUTE_FEED_OVERRIDE[symbol] = cached_value
+
+    if cached_value:
+        _GLOBAL_INTRADAY_FALLBACK_FEED = cached_value
 
 
 def _sip_lockout_active() -> bool:

--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 from pathlib import Path
 from logging.handlers import QueueHandler, QueueListener, RotatingFileHandler
-from typing import Any
+from typing import Any, Mapping
 from ai_trading.exc import COMMON_EXC
 from .json_formatter import JSONFormatter
 from ai_trading.logging.redact import _ENV_MASK
@@ -1172,7 +1172,8 @@ def log_backup_provider_used(
     timeframe: str,
     start: datetime,
     end: datetime,
-) -> None:
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
     """Log and record when the backup data provider serves a window."""
     payload: dict[str, Any] = {
         "provider": provider,
@@ -1181,6 +1182,12 @@ def log_backup_provider_used(
         "start": start.isoformat(),
         "end": end.isoformat(),
     }
+    if extra:
+        for key, value in extra.items():
+            if value is None:
+                continue
+            payload[str(key)] = value
+
     try:
         from ai_trading.data.metrics import backup_provider_used as _backup_counter
 
@@ -1196,6 +1203,8 @@ def log_backup_provider_used(
         level=logging.WARNING,
         extra=payload,
     )
+
+    return payload
 
 
 def log_empty_retries_exhausted(


### PR DESCRIPTION
## Summary
- ensure BACKUP_PROVIDER_USED and provider switchover logs include detailed context while still notifying the provider monitor
- persist cycle-level fallback feed overrides for all symbols until the next cycle reset
- make daily data fallback reuse Alpaca stubs when Yahoo is unavailable so downstream health checks pass

## Testing
- pytest -q tests/data/test_empty_responses.py tests/test_provider_failover_logging.py tests/test_fetch_and_screen.py tests/bot_engine/test_fetch_minute_df_safe.py::test_fetch_minute_df_safe_reuses_cached_fallback_feed_within_cycle


------
https://chatgpt.com/codex/tasks/task_e_68d5dab4e9408330a2011b740d25ba47