### PR TITLE
Allow fallback quote outages to warn without blocking

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -13607,6 +13607,9 @@ def _extract_quote_timestamp(payload: Any) -> datetime | None:
     return None
 
 
+_TRANSIENT_FALLBACK_REASONS = frozenset({"quote_source_unavailable", "quote_fetch_error"})
+
+
 def _check_fallback_quote_age(
     ctx: Any,
     symbol: str,
@@ -13675,6 +13678,7 @@ def _evaluate_data_gating(
             )
             if ok:
                 annotations["fallback_quote_age"] = age
+                annotations["fallback_quote_error"] = None
                 _update_data_quality(
                     state,
                     symbol,
@@ -13682,12 +13686,18 @@ def _evaluate_data_gating(
                     fallback_quote_error=None,
                 )
             else:
-                fatal_reasons.append(reason or "fallback_quote_invalid")
+                reason_label = reason or "fallback_quote_invalid"
+                annotations["fallback_quote_age"] = age
+                annotations["fallback_quote_error"] = reason_label
+                if reason_label in _TRANSIENT_FALLBACK_REASONS:
+                    reasons.append(reason_label)
+                else:
+                    fatal_reasons.append(reason_label)
                 _update_data_quality(
                     state,
                     symbol,
                     fallback_quote_age=age,
-                    fallback_quote_error=reason,
+                    fallback_quote_error=reason_label,
                 )
     else:
         if fallback_source and not quality.get("price_reliable", True):

--- a/tests/bot_engine/test_bot_engine.py
+++ b/tests/bot_engine/test_bot_engine.py
@@ -729,6 +729,145 @@ def test_enter_long_logs_fallback_for_non_alpaca_sources(monkeypatch, caplog):
     )
 
 
+def test_enter_long_warns_when_fallback_quote_unavailable(monkeypatch, caplog):
+    pd = pytest.importorskip("pandas")
+
+    symbol = "AAPL"
+    orders: list[tuple[str, int, str, float | None]] = []
+    ctx, state, feat_df = _build_dummy_long_context(pd, symbol)
+    ctx.data_client = None
+
+    monkeypatch.setenv("AI_TRADING_STRICT_GATING", "1")
+    bot_engine._strict_data_gating_enabled.cache_clear()
+
+    monkeypatch.delenv("PYTEST_RUNNING", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    monkeypatch.setattr(
+        bot_engine,
+        "_apply_sector_cap_qty",
+        lambda _ctx, _sym, qty, _price: qty,
+    )
+    monkeypatch.setattr(bot_engine, "scaled_atr_stop", lambda **_k: (95.95, 106.05))
+    monkeypatch.setattr(bot_engine, "is_high_vol_regime", lambda: False)
+    monkeypatch.setattr(bot_engine, "get_take_profit_factor", lambda: 1.0)
+    monkeypatch.setattr(
+        bot_engine,
+        "_record_trade_in_frequency_tracker",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        bot_engine,
+        "submit_order",
+        lambda _ctx, sym, qty, side, price=None: orders.append((sym, qty, side, price))
+        or types.SimpleNamespace(id="order-1"),
+    )
+    monkeypatch.setattr(
+        bot_engine,
+        "_resolve_order_quote",
+        lambda *_a, **_k: (101.0, "iex"),
+    )
+
+    caplog.set_level("INFO")
+
+    result = bot_engine._enter_long(
+        ctx,
+        state,
+        symbol,
+        balance=100000.0,
+        feat_df=feat_df,
+        final_score=1.0,
+        conf=0.8,
+        strat="fallback_source_transient_warning",
+    )
+
+    assert result is True
+    assert orders and orders[0][3] == pytest.approx(101.0)
+    assert any(
+        record.message == "DATA_GATING_PASS_THROUGH" for record in caplog.records
+    )
+    assert any(
+        record.message == "ORDER_USING_FALLBACK_PRICE" for record in caplog.records
+    )
+
+    quality_meta = state.data_quality.get(symbol, {})
+    assert "quote_source_unavailable" in quality_meta.get("gate_reasons", ())
+    assert quality_meta.get("fallback_quote_error") == "quote_source_unavailable"
+
+
+def test_enter_long_blocks_on_stale_fallback_quote(monkeypatch, caplog):
+    pd = pytest.importorskip("pandas")
+
+    symbol = "AAPL"
+    orders: list[tuple[str, int, str, float | None]] = []
+    ctx, state, feat_df = _build_dummy_long_context(pd, symbol)
+
+    monkeypatch.setenv("AI_TRADING_STRICT_GATING", "1")
+    bot_engine._strict_data_gating_enabled.cache_clear()
+
+    monkeypatch.delenv("PYTEST_RUNNING", raising=False)
+    monkeypatch.delenv("TESTING", raising=False)
+    monkeypatch.delenv("DRY_RUN", raising=False)
+
+    monkeypatch.setattr(
+        bot_engine,
+        "_apply_sector_cap_qty",
+        lambda _ctx, _sym, qty, _price: qty,
+    )
+    monkeypatch.setattr(bot_engine, "scaled_atr_stop", lambda **_k: (95.95, 106.05))
+    monkeypatch.setattr(bot_engine, "is_high_vol_regime", lambda: False)
+    monkeypatch.setattr(bot_engine, "get_take_profit_factor", lambda: 1.0)
+    monkeypatch.setattr(
+        bot_engine,
+        "_record_trade_in_frequency_tracker",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        bot_engine,
+        "submit_order",
+        lambda _ctx, sym, qty, side, price=None: orders.append((sym, qty, side, price))
+        or types.SimpleNamespace(id="order-1"),
+    )
+    monkeypatch.setattr(
+        bot_engine,
+        "_resolve_order_quote",
+        lambda *_a, **_k: (101.0, "iex"),
+    )
+    monkeypatch.setattr(
+        bot_engine,
+        "_check_fallback_quote_age",
+        lambda *_a, **_k: (False, 30.0, "quote_age=30.0s>limit=5.0s"),
+    )
+
+    caplog.set_level("INFO")
+
+    result = bot_engine._enter_long(
+        ctx,
+        state,
+        symbol,
+        balance=100000.0,
+        feat_df=feat_df,
+        final_score=1.0,
+        conf=0.8,
+        strat="fallback_source_stale_block",
+    )
+
+    assert result is True
+    assert orders == []
+    assert any(
+        record.message.startswith("ORDER_SKIPPED_UNRELIABLE_PRICE")
+        for record in caplog.records
+    )
+    assert not any(
+        record.message == "ORDER_USING_FALLBACK_PRICE" for record in caplog.records
+    )
+
+    quality_meta = state.data_quality.get(symbol, {})
+    assert "quote_age=" in next(iter(quality_meta.get("gate_reasons", ())), "")
+    assert "quote_age=" in quality_meta.get("fallback_quote_error", "")
+
+
 def test_enter_short_skips_fallback_log_for_alpaca_sources(monkeypatch, caplog):
     pd = pytest.importorskip("pandas")
 


### PR DESCRIPTION
## Summary
- treat transient fallback quote failures as warnings so data gating can pass through while persisting annotations
- record fallback quote warning metadata and keep stale data failures blocking
- add regression coverage for fallback warning logging and stale quote blocking

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_bot_engine.py::test_enter_long_warns_when_fallback_quote_unavailable tests/bot_engine/test_bot_engine.py::test_enter_long_blocks_on_stale_fallback_quote


------
https://chatgpt.com/codex/tasks/task_e_68d5f321cb5c8330aa7643fb7f5fea88