### PR TITLE
Enable immediate fallback when Alpaca bars are empty

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -3230,13 +3230,14 @@ def _fetch_bars(
                                 total_elapsed=monotonic_time() - start_time,
                             )
                         )
-            should_backoff_first_empty = _ENABLE_HTTP_FALLBACK and not outside_market_hours
-            if should_backoff_first_empty:
+            should_backoff_first_empty = True
+            if _ENABLE_HTTP_FALLBACK and not outside_market_hours:
                 try:
-                    if max_data_fallbacks() > 0:
-                        should_backoff_first_empty = False
+                    remaining_fallbacks = max_data_fallbacks()
                 except Exception:
                     should_backoff_first_empty = True
+                else:
+                    should_backoff_first_empty = remaining_fallbacks <= 0
             logged_attempt = False
             if empty_attempts == 1 and should_backoff_first_empty:
                 retry_delay = _state.get("delay", 0.25)


### PR DESCRIPTION
## Summary
- allow _fetch_bars to immediately fall back when data fallbacks are available
- extend the empty response test to confirm the HTTP client issues both the primary and fallback requests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/data/test_empty_responses.py -q *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_68d5fc77ecd883309d4b126ecca7445b