### PR TITLE
Ensure runner reattaches explicit API clients

### DIFF
--- a/ai_trading/runner.py
+++ b/ai_trading/runner.py
@@ -54,19 +54,19 @@ def start(api: Any | None = None):
             except Exception:  # pragma: no cover - defensive
                 existing_api = None
 
-    if existing_api is None:
-        if api is not None:
-            setattr(inner, "api", api)
-        else:  # Defer to bot_engine to resolve the global trading client
-            bot_engine.ensure_alpaca_attached(inner)
-            try:
-                existing_api = getattr(inner, "api")
-            except Exception:
-                existing_api = getattr(getattr(inner, "__dict__", {}), "get", lambda *_a, **_k: None)("api")
-            if existing_api is None:
-                # Fallback to a minimal stub to satisfy tests when Alpaca
-                # clients are unavailable or intentionally absent.
-                setattr(inner, "api", object())
+    if api is not None:
+        setattr(inner, "api", api)
+    elif existing_api is None:
+        # Defer to bot_engine to resolve the global trading client
+        bot_engine.ensure_alpaca_attached(inner)
+        try:
+            existing_api = getattr(inner, "api")
+        except Exception:
+            existing_api = getattr(getattr(inner, "__dict__", {}), "get", lambda *_a, **_k: None)("api")
+        if existing_api is None:
+            # Fallback to a minimal stub to satisfy tests when Alpaca
+            # clients are unavailable or intentionally absent.
+            setattr(inner, "api", object())
     final_api = None
     if inner is not None:
         final_api = getattr(getattr(inner, "__dict__", {}), "get", lambda *_a, **_k: None)("api")

--- a/tests/test_runner_start.py
+++ b/tests/test_runner_start.py
@@ -16,3 +16,16 @@ def test_start_initializes_api():  # AI-AGENT-REF: ensure api set on start
     assert getattr(ctx, "api") is api
     bot_engine._global_ctx = None
 
+
+def test_start_replaces_existing_api_when_client_provided():
+    """Regression: explicit clients should override any previously attached API."""
+
+    bot_engine._global_ctx = None
+    runner.start(None)
+
+    new_api = _DummyAPI()
+    ctx = runner.start(new_api)
+    assert getattr(ctx, "api") is new_api
+
+    bot_engine._global_ctx = None
+


### PR DESCRIPTION
## Motivation
- `runner.start` kept a previously attached API client even when a new explicit client was supplied on a subsequent call, leaving call sites stuck with a stale connection.

## Summary
- Always assign the provided API client onto the runner context, regardless of any prior attachment.
- Preserve the legacy Alpaca auto-attachment path when no explicit client is provided.
- Add a regression test that covers invoking `runner.start` after a prior run and verifies the stub client is now attached.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_runner_start.py -q`

## Rollback Plan
- Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68d5fc77ff508330b97cbf4a2e18498c