### PR TITLE
Refine health endpoint error handling

### DIFF
--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -17,4 +17,4 @@ def test_health_endpoint_handles_import_error(monkeypatch):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data.get("ok") is False
-    assert "boom" in data.get("error", "")
+    assert data.get("error") == "boom"


### PR DESCRIPTION
## Summary
- refactor the `/health` endpoint to collect diagnostics safely and build the JSON payload after handling import failures
- deduplicate captured error messages while preserving alpaca status details
- tighten the import error test to assert both the 200 response status and the exact error string returned

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_health_check.py -k import_error -q

------
https://chatgpt.com/codex/tasks/task_e_68d5fd79782483308bda17fa2e9d630b