### PR TITLE
Ensure canonical python-dotenv is retained

### DIFF
--- a/ai_trading/env/__init__.py
+++ b/ai_trading/env/__init__.py
@@ -9,7 +9,10 @@ try:  # pragma: no cover - import resolution validated by tests
     import dotenv as _dotenv  # type: ignore
 
     _DOTENV_SPEC = importlib.util.find_spec("dotenv")
-    PYTHON_DOTENV_RESOLVED = bool(_DOTENV_SPEC and getattr(_DOTENV_SPEC, "origin", None))
+    if _DOTENV_SPEC and getattr(_DOTENV_SPEC, "origin", None):
+        PYTHON_DOTENV_RESOLVED = True
+    else:
+        PYTHON_DOTENV_RESOLVED = bool(getattr(_dotenv, "dotenv_values", None))
 except Exception:  # pragma: no cover - fallback path when python-dotenv missing
     _dotenv = None  # type: ignore[assignment]
     PYTHON_DOTENV_RESOLVED = False

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -36,6 +36,7 @@ def _load_canonical_dotenv() -> ModuleType:
 
     module = importlib.import_module("dotenv")
     if hasattr(module, "dotenv_values"):
+        sys.modules["dotenv"] = module
         return module
 
     for base in _iter_site_package_paths():
@@ -47,6 +48,7 @@ def _load_canonical_dotenv() -> ModuleType:
             canonical = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(canonical)  # type: ignore[misc]
             if hasattr(canonical, "dotenv_values"):
+                sys.modules["dotenv"] = canonical
                 return canonical
 
     path_hint = getattr(module, "__file__", "unknown")


### PR DESCRIPTION
## Summary
- ensure `sitecustomize` replaces stub `dotenv` modules with the canonical package from site/dist-packages
- treat the loaded canonical module as resolved in `ai_trading.env` even when `find_spec("dotenv")` returns `None`

## Testing
- python - <<'PY'
import importlib
import sitecustomize  # noqa: F401
import dotenv

print('has_dotenv_values', hasattr(dotenv, 'dotenv_values'))
print('module_file', getattr(dotenv, '__file__', None))
print('resolved_flag', getattr(importlib.import_module('ai_trading.env'), 'PYTHON_DOTENV_RESOLVED'))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d607e201f883308cff7f5682585278