### PR TITLE
Fix legacy Alpaca bar fallback index sanitization

### DIFF
--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -1423,7 +1423,11 @@ def test_get_minute_df_handles_missing_safe_get(monkeypatch):
     result = fetcher.get_minute_df(ctx, "AAPL", lookback_minutes=2)
 
     assert isinstance(result, pd.DataFrame)
-    pd.testing.assert_index_equal(result.index, idx)
+    expected_idx = idx.rename("timestamp")
+    pd.testing.assert_index_equal(result.index, expected_idx)
+    assert result.index.tz is not None
+    assert result.index.tz.tzname(None) == UTC.tzname(None)
+    assert list(result.columns[:5]) == ["open", "high", "low", "close", "volume"]
     assert calls and calls[0] == "MINUTE"
     assert not hasattr(bot_engine.bars, "safe_get_stock_bars")
 


### PR DESCRIPTION
## Summary
- normalize legacy Alpaca stock bar responses when safe_get_stock_bars is unavailable by coercing to a UTC timestamp index
- add regression coverage ensuring the minute data fallback preserves the expected timestamp index metadata and OHLCV columns

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py::test_get_minute_df_handles_missing_safe_get -q

------
https://chatgpt.com/codex/tasks/task_e_68d609adecf883309fffe039cc754a8e