### PR TITLE
Fix fallback tracking to record actual data providers

### DIFF
--- a/tests/test_yahoo_fallback_order.py
+++ b/tests/test_yahoo_fallback_order.py
@@ -61,3 +61,5 @@ def test_yahoo_used_after_two_alpaca_failures(monkeypatch):
     assert not df.empty
     assert after == before + 1
     assert fo.FALLBACK_ORDER.get("yahoo")
+    assert fo.FALLBACK_PROVIDERS and fo.FALLBACK_PROVIDERS[-1] == "yahoo"
+    assert fo.FALLBACK_SYMBOLS and fo.FALLBACK_SYMBOLS[-1] == symbol

--- a/tests/unit/test_heartbeat_fallback.py
+++ b/tests/unit/test_heartbeat_fallback.py
@@ -17,3 +17,4 @@ def test_fallback_called_when_primary_fails():
     assert primary.called
     assert fallback.called
     assert fo.FALLBACK_ORDER.get("yahoo")
+    assert fo.FALLBACK_PROVIDERS and fo.FALLBACK_PROVIDERS[-1] == "yahoo"


### PR DESCRIPTION
## Summary
- update `_mark_fallback` to resolve fallback provider/feed metadata from returned data frames and store the actual provider in fallback registries
- propagate the resolved metadata through Alpaca/Yahoo fallback call sites (including the minute-data helper and HTTP backoff) so cycle caches and logs reflect the producing provider
- extend the fallback order tests to assert the recorded provider sequence matches expectations

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_yahoo_fallback_order.py tests/unit/test_heartbeat_fallback.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d609abbe808330b64b877730997da8