### PR TITLE
Guard health endpoint against jsonify failures

### DIFF
--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,5 +1,5 @@
 import builtins
-from ai_trading.app import create_app
+import ai_trading.app as app_module
 
 
 def test_health_endpoint_handles_import_error(monkeypatch):
@@ -11,7 +11,30 @@ def test_health_endpoint_handles_import_error(monkeypatch):
         return original_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fail_alpaca)
-    app = create_app()
+    app = app_module.create_app()
+    client = app.test_client()
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get("ok") is False
+    assert data.get("error") == "boom"
+
+
+def test_health_endpoint_returns_plain_dict_when_jsonify_fails(monkeypatch):
+    original_import = builtins.__import__
+
+    def fail_alpaca(name, *args, **kwargs):
+        if name == "ai_trading.alpaca_api":
+            raise ImportError("boom")
+        return original_import(name, *args, **kwargs)
+
+    def broken_jsonify(payload):
+        raise RuntimeError("json busted")
+
+    monkeypatch.setattr(builtins, "__import__", fail_alpaca)
+    monkeypatch.setattr(app_module, "jsonify", broken_jsonify)
+
+    app = app_module.create_app()
     client = app.test_client()
     resp = client.get("/health")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- ensure the /health route preserves import error details and falls back to a plain dict when JSON encoding is unavailable
- extend the health endpoint tests to cover jsonify failures while checking the propagated error payload

## Testing
- pytest tests/test_health_check.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ae253a048330ae4bbc5f6a9b0b37