### PR TITLE
Raise KeyError for missing OHLCV columns

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -13634,7 +13634,7 @@ def _fetch_feature_data(
         if feat_df.empty:
             logger.warning("Parsed feature DataFrame is empty; falling back to raw data")
             feat_df = raw_df.copy()
-    except ValueError as exc:
+    except (ValueError, KeyError) as exc:
         logger.warning(f"Indicator preparation failed for {symbol}: {exc}")
         return raw_df, None, True
     if feat_df.empty:

--- a/ai_trading/core/execution_flow.py
+++ b/ai_trading/core/execution_flow.py
@@ -544,7 +544,7 @@ def execute_entry(ctx: Any, symbol: str, qty: int, side: str) -> None:
         if df_ind is None or getattr(df_ind, "empty", True):
             logger.warning("INSUFFICIENT_INDICATORS_POST_ENTRY", extra={"symbol": symbol})
             return
-    except ValueError as exc:
+    except (ValueError, KeyError) as exc:
         logger.warning(f"Indicator preparation failed for {symbol}: {exc}")
         return
     entry_price = get_latest_close(df_ind)

--- a/ai_trading/signals/__init__.py
+++ b/ai_trading/signals/__init__.py
@@ -328,7 +328,7 @@ def _validate_input_df(data) -> None:
     if hasattr(data, "columns"):
         missing = [col for col in required if col not in data.columns]
         if missing:
-            raise ValueError(f"Input data missing required column(s): {missing}")
+            raise KeyError(f"missing required column(s): {missing}")
 
 
 def _apply_macd(data) -> Any | None:
@@ -374,8 +374,10 @@ def prepare_indicators(data, ticker: str | None = None) -> Any | None:
 
     Raises
     ------
+    KeyError
+        If required OHLCV columns are missing from ``data``.
     ValueError
-        If the MACD indicator fails to calculate or required columns are missing.
+        If the MACD indicator fails to calculate.
     """
     pd = _get_pandas()
     _validate_input_df(data)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -36,7 +36,7 @@ def sample_df():
 
 def test_prepare_indicators_requires_ohlcv():
     df = pd.DataFrame({"open": [1], "high": [2], "low": [1], "close": [1]})
-    with pytest.raises(ValueError, match="missing required column"):
+    with pytest.raises(KeyError, match="missing required column"):
         prepare_indicators(df)
 
 


### PR DESCRIPTION
## Summary
- raise a KeyError with the required message when OHLCV columns are missing during signal preparation
- update indicator preparation call sites to handle the new KeyError without changing logging behavior
- refresh signal tests to expect the new exception type

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_prepare_missing_ohlc.py -q *(skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ae28ede48330b577ce5e1171d44a