### PR TITLE
Handle safe_subprocess immediate timeouts

### DIFF
--- a/tests/utils/test_safe_subprocess_run.py
+++ b/tests/utils/test_safe_subprocess_run.py
@@ -21,6 +21,16 @@ def test_safe_subprocess_run_timeout(caplog):
     assert any("timed out" in rec.message for rec in caplog.records)
 
 
+def test_safe_subprocess_run_immediate_timeout(caplog):
+    cmd = [sys.executable, "-c", "print('never runs')"]
+    with caplog.at_level("WARNING"):
+        res = safe_subprocess_run(cmd, timeout=0)
+    assert res.stdout == ""
+    assert res.timeout
+    assert res.returncode == -1
+    assert any("timed out" in rec.message for rec in caplog.records)
+
+
 def test_safe_subprocess_run_nonzero_exit(caplog):
     cmd = [sys.executable, "-c", "import sys; sys.exit(2)"]
     with caplog.at_level("WARNING"):


### PR DESCRIPTION
## Summary
- ensure `safe_subprocess_run` always flags timeouts with `returncode=-1`
- treat non-positive timeouts as immediate timeouts while passing explicit values through to `subprocess.run`
- add regression coverage that verifies warning messaging and timeout flags

## Motivation
- align subprocess timeout handling with caller expectations and logging guarantees

## Before/After
- Before: non-positive timeouts were coerced to the default delay and TimeoutExpired return codes could vary.
- After: zero/negative timeouts short-circuit with deterministic timeout signalling and logging.

## Testing
- `pytest tests/utils/test_safe_subprocess_run.py`

## Rollback Plan
- Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68d6af6100b0833099f5b9d9a781100a