### PR TITLE
Handle missing Alpaca cancel adapters gracefully

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -423,7 +423,8 @@ def ensure_alpaca_attached(ctx) -> None:
         if not is_shadow_mode():
             raise RuntimeError("Failed to attach Alpaca client to context")
         return
-    _validate_trading_api(api)
+    if not _validate_trading_api(api):
+        return
 
 # Rebind canonical Alpaca helpers to modular implementations (post-definition override)
 from ai_trading.core.alpaca_client import (  # noqa: E402
@@ -19344,6 +19345,7 @@ def run_all_trades_worker(state: BotState, runtime) -> None:
 
             if not symbols:
                 logger.info("SKIP_MINUTE_FETCH", extra={"reason": "no_symbols"})
+                time.sleep(1.0)
                 return
 
             retries = 3

--- a/tests/unit/test_run_all_trades_api_error.py
+++ b/tests/unit/test_run_all_trades_api_error.py
@@ -59,6 +59,10 @@ def test_run_all_trades_handles_api_error(monkeypatch, caplog):
             self.called_with = kwargs
             return []
 
+        def cancel_order(self, *args, **kwargs):  # noqa: D401 - stub
+            """Provide minimal cancel capability for validation."""
+            return None
+
     class DummyRiskEngine:
         def wait_for_exposure_update(self, timeout: float) -> None:
             pass

--- a/tests/unit/test_run_all_trades_empty_symbols.py
+++ b/tests/unit/test_run_all_trades_empty_symbols.py
@@ -32,6 +32,10 @@ def test_run_all_trades_handles_empty_symbols(monkeypatch):
         def get_orders(self, *args, **kwargs):
             return []
 
+        def cancel_order(self, *args, **kwargs):  # noqa: D401 - stub
+            """Provide minimal cancel capability for validation."""
+            return None
+
     class DummyRiskEngine:
         def wait_for_exposure_update(self, timeout: float) -> None:
             pass

--- a/tests/unit/test_run_all_trades_trailing_stops.py
+++ b/tests/unit/test_run_all_trades_trailing_stops.py
@@ -47,6 +47,10 @@ def test_run_all_trades_calls_trailing_stops(monkeypatch):
         def get_orders(self, *args, **kwargs):
             return []
 
+        def cancel_order(self, *args, **kwargs):  # noqa: D401 - stub
+            """Provide minimal cancel capability for validation."""
+            return None
+
     class DummyRiskEngine:
         def wait_for_exposure_update(self, timeout: float) -> None:
             pass

--- a/tests/unit/test_run_all_trades_warning.py
+++ b/tests/unit/test_run_all_trades_warning.py
@@ -154,6 +154,10 @@ def test_run_all_trades_no_warning_with_valid_api(monkeypatch):
             self.called_with = kwargs
             return []
 
+        def cancel_order(self, *args, **kwargs):  # noqa: D401 - stub
+            """Provide minimal cancel capability for validation."""
+            return None
+
     class DummyRiskEngine:
         def wait_for_exposure_update(self, timeout: float) -> None:  # noqa: D401
             """No-op risk update."""
@@ -230,6 +234,10 @@ def test_run_all_trades_creates_trade_log(tmp_path, monkeypatch):
     class DummyAPI:
         def get_orders(self, *args, **kwargs):
             return []
+
+        def cancel_order(self, *args, **kwargs):  # noqa: D401 - stub
+            """Provide minimal cancel capability for validation."""
+            return None
 
     class DummyRiskEngine:
         def wait_for_exposure_update(self, timeout: float) -> None:
@@ -364,6 +372,10 @@ def test_run_multi_strategy_forwards_price_to_execution(monkeypatch):
             """Return a cash-only account."""
 
             return types.SimpleNamespace(cash=10_000)
+
+        def cancel_order(self, *args, **kwargs):  # noqa: D401 - stub
+            """Provide minimal cancel capability for validation."""
+            return None
 
     class DummyDataClient:
         def __init__(self):


### PR DESCRIPTION
## Summary
- make `_validate_trading_api` return `False` with logging when Alpaca cancel shims cannot be wired, and short-circuit callers accordingly
- pause the run loop briefly when no symbols are produced to avoid busy spinning
- update run_all_trades unit tests to provide minimal cancel stubs that satisfy the stricter validation

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python - <<'PY'
import importlib
import sys

sklearn = importlib.import_module("sklearn")
if getattr(sklearn, "__spec__", None) is None:
    sklearn.__spec__ = importlib.util.find_spec("sklearn")

import pytest

sys.exit(pytest.main([
    "tests/unit/test_run_all_trades_api_error.py::test_run_all_trades_handles_api_error",
    "tests/unit/test_run_all_trades_empty_symbols.py::test_run_all_trades_handles_empty_symbols",
    "tests/unit/test_run_all_trades_warning.py::test_run_all_trades_no_warning_with_valid_api",
    "tests/unit/test_run_all_trades_warning.py::test_run_all_trades_creates_trade_log",
    "tests/unit/test_run_all_trades_trailing_stops.py::test_run_all_trades_calls_trailing_stops",
    "-q",
]))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d6af6124048330b1faa2a340a0a82b