### PR TITLE
Forward limit order price kwargs through execution engine

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -12370,14 +12370,11 @@ def submit_order(
                 price = get_latest_close(md) if md is not None else 0.0
         # Pass through computed price so the execution engine can simulate
         # fills around the actual market price rather than a generic fallback.
-        order_type = 'market' if price is None else 'limit'
-        limit_price = None if price is None else price
         return _exec_engine.execute_order(
             symbol,
             core_side,
             qty,
-            order_type=order_type,
-            limit_price=limit_price,
+            price=price,
         )
     except (APIError, TimeoutError, ConnectionError, AlpacaOrderHTTPError) as e:
         logger.error(


### PR DESCRIPTION
## Summary
- expose ExecutionEngine.trading_client at the class level so raw Alpaca clients remain introspectable in tests and bypass capacity checks when no broker is wired up
- preserve and forward the price kwarg when routing through execute_order so limit submissions receive price while still normalizing the resolved limit price
- simplify bot_engine.submit_order to rely on the price kwarg rather than constructing order_type/limit_price pairs

## Testing
- pytest tests/test_submit_order_fix.py tests/unit/test_price_quote_feed.py::test_execute_order_routes_limit -q
- pytest tests/unit/test_price_quote_feed.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d6b1721f5c8330b89954fbbe57c6e1