### PR TITLE
Ensure audit log respects runtime overrides

### DIFF
--- a/ai_trading/audit.py
+++ b/ai_trading/audit.py
@@ -194,7 +194,11 @@ def log_trade(
     Accepts an optional `exposure` param and writes a compact schema when
     `extra_info` suggests a test/audit mode.
     """
-    main_path = Path(TRADE_LOG_FILE)
+    override = os.getenv("TRADE_LOG_FILE") or os.getenv("AI_TRADING_TRADE_LOG_FILE")
+    if override:
+        main_path = Path(override)
+    else:
+        main_path = Path(TRADE_LOG_FILE)
     targets = _compute_targets(main_path)
     for p in targets:
         try:


### PR DESCRIPTION
## Summary
- honor runtime trade log environment overrides when writing audit records
- keep audit helpers available by ensuring their required imports remain in place

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_talib_enforcement.py tests/test_talib_audit_permissions.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d6b2b700748330904a6bdc3f157ff5