### PR TITLE
Handle Freezegun when resolving sleep helper

### DIFF
--- a/ai_trading/utils/sleep.py
+++ b/ai_trading/utils/sleep.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import importlib
+import inspect
 import time as _time
+from typing import Callable
+
 from ai_trading.utils.time import monotonic_time
 
 __all__ = ["sleep"]
@@ -8,14 +12,101 @@ __all__ = ["sleep"]
 # Capture the original OS-level sleep to avoid monkeypatch interference
 _real_sleep = _time.sleep
 
+# Freezegun can replace ``time.sleep`` with a fast-forward stub. When that
+# happens we want to defer the lookup to runtime so we can locate a genuine
+# blocking sleep implementation as soon as it becomes available again.
+_initial_freezegun_sleep = "freezegun" in (getattr(_real_sleep, "__module__", "") or "").lower()
+
+# Hold on to the first known-good OS sleep so subsequent monkeypatches are
+# ignored (the historical behaviour of this helper).
+_os_level_sleep = None if _initial_freezegun_sleep else _real_sleep
+
+try:  # pragma: no cover - optional dependency
+    import freezegun.api as _freezegun_api  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    _freezegun_api = None  # type: ignore
+
+
+def _freezegun_active(runtime_sleep: Callable | None = None) -> bool:
+    """Return ``True`` when Freezegun currently controls the clock."""
+
+    if runtime_sleep is not None:
+        module_name = (getattr(runtime_sleep, "__module__", "") or "").lower()
+        if "freezegun" in module_name:
+            return True
+
+    if _initial_freezegun_sleep:
+        return True
+
+    if _freezegun_api is None:  # Freezegun not installed or import failed
+        return False
+
+    try:
+        factories = getattr(_freezegun_api, "freeze_factories", ())
+    except Exception:  # pragma: no cover - defensive
+        return False
+    return bool(factories)
+
+
+def _monotonic_now() -> float:
+    """Return a monotonic timestamp resilient to Freezegun freezes."""
+
+    if _freezegun_api is not None and _freezegun_active():
+        for attr in ("real_monotonic", "real_perf_counter", "real_time"):
+            func = getattr(_freezegun_api, attr, None)
+            if callable(func):
+                try:
+                    return float(func())
+                except Exception:  # pragma: no cover - defensive
+                    continue
+    return monotonic_time()
+
+
+def _resolve_sleep():
+    """Return the most reliable sleep callable available."""
+
+    global _os_level_sleep
+
+    runtime_sleep = getattr(_time, "sleep", None)
+    if callable(runtime_sleep):
+        runtime_module = (getattr(runtime_sleep, "__module__", "") or "").lower()
+        runtime_is_builtin = inspect.isbuiltin(runtime_sleep)
+        if _freezegun_active(runtime_sleep):
+            if runtime_is_builtin and "freezegun" not in runtime_module:
+                if _os_level_sleep is None:
+                    _os_level_sleep = runtime_sleep
+                return runtime_sleep
+
+            # ``time.sleep`` might be provided by Freezegun or another stub.
+            # Try to reload the module to obtain a genuine blocking sleep
+            # implementation.
+            try:
+                reloaded_time = importlib.import_module("time")
+            except Exception:  # pragma: no cover - defensive guard
+                reloaded_time = _time
+            reload_sleep = getattr(reloaded_time, "sleep", None)
+            if callable(reload_sleep):
+                reload_module = (getattr(reload_sleep, "__module__", "") or "").lower()
+                if inspect.isbuiltin(reload_sleep) and "freezegun" not in reload_module:
+                    if _os_level_sleep is None:
+                        _os_level_sleep = reload_sleep
+                    return reload_sleep
+        elif _os_level_sleep is None and runtime_is_builtin and "freezegun" not in runtime_module:
+            _os_level_sleep = runtime_sleep
+
+    if _os_level_sleep is not None:
+        return _os_level_sleep
+    return _real_sleep
+
 
 def sleep(seconds: float | int) -> float:
     """Sleep for ``seconds`` using :func:`time.sleep` and report elapsed time.
 
     ``time.sleep`` is captured at import time so monkeypatching ``time.sleep``
     later will not affect this helper. The elapsed duration is measured using
-    :func:`ai_trading.utils.time.monotonic_time` and returned to the caller. If ``seconds`` is zero or
-    negative, the function returns ``0.0`` without sleeping.
+    a monotonic clock resilient to Freezegun freezes and returned to the
+    caller. If ``seconds`` is zero or negative, the function returns ``0.0``
+    without sleeping.
     """
     try:
         s = float(seconds)
@@ -23,6 +114,7 @@ def sleep(seconds: float | int) -> float:
         return 0.0
     if s <= 0:
         return 0.0
-    start = monotonic_time()
-    _real_sleep(s)
-    return monotonic_time() - start
+    start = _monotonic_now()
+    sleeper = _resolve_sleep()
+    sleeper(s)
+    return _monotonic_now() - start


### PR DESCRIPTION
## Summary
- detect when Freezegun is controlling `time.sleep` and fall back to the runtime builtin while preserving the original OS-level sleeper
- source elapsed durations from Freezegun's real-time clocks so the helper still reports blocking sleep intervals when the clock is frozen

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_utils_sleep_shadowing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d6b480e3488330bd7536cbf7b5c07b