### PR TITLE
Ensure limit orders pass price alias

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -17975,16 +17975,19 @@ def run_multi_strategy(ctx) -> None:
 
         try:
             order_type = 'market' if price is None else 'limit'
-            limit_price = None if price is None else price
+            order_kwargs = {
+                'order_type': order_type,
+                'asset_class': sig.asset_class,
+                'signal': sig,
+                'signal_weight': getattr(sig, "weight", None),
+            }
+            if price is not None:
+                order_kwargs['price'] = price
             result = ctx.execution_engine.execute_order(
                 sig.symbol,
                 sig.side,
                 qty,
-                order_type=order_type,
-                limit_price=limit_price,
-                asset_class=sig.asset_class,
-                signal=sig,
-                signal_weight=getattr(sig, "weight", None),
+                **order_kwargs,
             )
         except AssertionError as exc:
             logger.warning(

--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -1045,7 +1045,15 @@ class ExecutionEngine:
                     self.execution_stats["rejected_orders"] += 1
                     return None
             quantity = int(_ensure_positive_qty(quantity))
+            raw_price = kwargs.get("price")
+            price_alias = _ensure_valid_price(raw_price)
+            if price_alias is None:
+                kwargs.pop("price", None)
+            else:
+                kwargs["price"] = price_alias
             limit_price = _ensure_valid_price(kwargs.get("limit_price"))
+            if limit_price is None and price_alias is not None:
+                limit_price = price_alias
             stop_price = _ensure_valid_price(kwargs.get("stop_price"))
             kwargs["limit_price"] = limit_price
             kwargs["stop_price"] = stop_price


### PR DESCRIPTION
## Summary
- forward limit order executions from the multi-strategy runner using the `price` keyword argument expected by the execution engine
- normalize the institutional execution engine so a provided `price` alias populates the outgoing limit price payload

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_run_all_trades_warning.py::test_run_multi_strategy_forwards_price_to_execution -q` *(fails: missing optional dependencies such as scikit-learn/pydantic in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b484a760833092085cd69dbc2ab2