### PR TITLE
Align minute fallback caches with coverage failover

### DIFF
--- a/tests/core/bot_engine/test_coverage_recovery_provider.py
+++ b/tests/core/bot_engine/test_coverage_recovery_provider.py
@@ -132,4 +132,5 @@ def test_coverage_recovery_uses_backup_provider_annotation(monkeypatch, caplog):
         for record in caplog.records
     )
     assert cached_feeds == ["yahoo"]
-    assert bot_engine.state.minute_feed_cache.get("iex") == "yahoo"
+    assert bot_engine.state.minute_feed_cache == {"iex": "yahoo", "yahoo": "yahoo"}
+    assert set(bot_engine.state.minute_feed_cache_ts) == {"iex", "yahoo"}


### PR DESCRIPTION
## Summary
- normalize SIP/Yahoo fallback caching so canonical feed names drive both the configured and fallback entries in the minute feed caches, and clear stale mappings when coverage failovers cannot supply data
- update failover-focused tests to assert cache contents and override order expectations for SIP and Yahoo recovery scenarios

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/bot_engine/test_fetch_minute_df_safe.py::test_fetch_minute_df_safe_sip_success_skips_yahoo_and_caches_feed tests/bot_engine/test_fetch_minute_df_safe.py::test_fetch_minute_df_safe_reuses_cached_fallback_feed_within_cycle tests/bot_engine/test_fetch_minute_df_safe.py::test_fetch_minute_df_safe_sip_and_yahoo_sparse_abort tests/core/bot_engine/test_coverage_recovery_provider.py::test_coverage_recovery_uses_backup_provider_annotation *(fails: missing pandas/numpy dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b8d8c7548330920186d7e202d04a