### PR TITLE
Improve data handling and provider stability

### DIFF
--- a/ai_trading/execution/live_trading.py
+++ b/ai_trading/execution/live_trading.py
@@ -573,6 +573,19 @@ class ExecutionEngine:
             },
         )
 
+    def end_cycle(self) -> None:
+        """Best-effort end-of-cycle hook aligned with core engine expectations."""
+
+        order_mgr = getattr(self, "order_manager", None)
+        if order_mgr is None:
+            return
+        flush = getattr(order_mgr, "flush", None)
+        if callable(flush):
+            try:
+                flush()
+            except Exception:  # pragma: no cover - diagnostics only
+                logger.debug("ORDER_MANAGER_FLUSH_FAILED", exc_info=True)
+
     def _refresh_settings(self) -> None:
         """Refresh cached execution settings from configuration."""
 

--- a/tests/test_provider_monitor_backoff.py
+++ b/tests/test_provider_monitor_backoff.py
@@ -170,3 +170,13 @@ def test_failure_duration_metric(monkeypatch, caplog):
         assert metric._value.get() == 30
     assert any(r.message == "DATA_PROVIDER_FAILURE_DURATION" for r in caplog.records)
 
+
+def test_record_switchover_same_provider_logs_stay(caplog):
+    monitor = pm.ProviderMonitor(cooldown=15)
+
+    with caplog.at_level(logging.INFO):
+        monitor.record_switchover("yahoo", "yahoo")
+
+    assert monitor.consecutive_switches == 0
+    assert any("DATA_PROVIDER_STAY" in rec.message for rec in caplog.records)
+

--- a/tests/utils/test_safe_to_datetime.py
+++ b/tests/utils/test_safe_to_datetime.py
@@ -1,0 +1,31 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading.utils.base import safe_to_datetime
+
+
+def test_safe_to_datetime_parses_epoch_seconds():
+    result = safe_to_datetime([1_700_000_000, 1_700_000_060])
+    expected = pd.to_datetime([1_700_000_000, 1_700_000_060], unit="s", utc=True)
+    pd.testing.assert_index_equal(result, expected)
+
+
+def test_safe_to_datetime_parses_epoch_milliseconds():
+    result = safe_to_datetime([1_700_000_000_000, 1_700_000_060_000])
+    expected = pd.to_datetime([1_700_000_000_000, 1_700_000_060_000], unit="ms", utc=True)
+    pd.testing.assert_index_equal(result, expected)
+
+
+def test_safe_to_datetime_coerces_placeholders_to_nat():
+    result = safe_to_datetime([
+        "2024-01-01 09:30:00",
+        "0",
+        "",
+        None,
+    ])
+    assert result.tz is not None
+    assert result[0] == pd.Timestamp("2024-01-01 09:30:00", tz="UTC")
+    assert pd.isna(result[1])
+    assert pd.isna(result[2])
+    assert pd.isna(result[3])


### PR DESCRIPTION
## Summary
- add a defensive `end_cycle` implementation for the live execution engine and guard the trading loop when calling it
- relax data gating by honoring a configurable gap-ratio limit and improving OHLCV normalization & datetime coercion
- prevent SIP usage when entitlement is absent and harden provider monitoring to avoid redundant switchovers

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/utils/test_safe_to_datetime.py (skipped: pandas not installed)
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_provider_monitor_backoff.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_provider_decision_single_outcome.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/data/test_provider_decision_single_outcome.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_normalize_columns.py (fails: pandas not installed)

------
https://chatgpt.com/codex/tasks/task_e_68d6ceac418c8330b22b20484ccb44f3