### PR TITLE
Add OHLCV dataframe normalizer helper

### DIFF
--- a/ai_trading/data/fetch/normalize.py
+++ b/ai_trading/data/fetch/normalize.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ai_trading.utils.lazy_imports import load_pandas
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    import pandas as _pd
+
+pd = load_pandas()
+
+REQUIRED = ("open", "high", "low", "close", "volume")
+
+
+def normalize_ohlcv_df(df: "_pd.DataFrame | None") -> "_pd.DataFrame":
+    """Return a normalized OHLCV dataframe with canonical columns."""
+
+    if df is None or len(df) == 0:
+        return pd.DataFrame(columns=REQUIRED)
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df = df.copy()
+        df.columns = [str(levels[0]).lower() for levels in df.columns]
+        df = df.loc[:, ~pd.Index(df.columns).duplicated()]
+    else:
+        df = df.copy()
+        df.columns = [str(col).lower().strip() for col in df.columns]
+
+    if "adj close" in df.columns and "close" not in df.columns:
+        df["close"] = df["adj close"]
+    if "close" not in df.columns and "value" in df.columns:
+        df["close"] = df["value"]
+
+    for column in REQUIRED:
+        if column in df.columns:
+            df[column] = pd.to_numeric(df[column], errors="coerce")
+
+    subset = [column for column in REQUIRED if column in df.columns]
+    if subset:
+        df = df.dropna(subset=subset)
+
+    index = df.index
+    if isinstance(index, pd.DatetimeIndex):
+        if index.tz is None:
+            df.index = index.tz_localize("UTC")
+    elif hasattr(index, "tz") and getattr(index, "tz", None) is None:
+        try:
+            df.index = index.tz_localize("UTC")  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+    df = df.sort_index()
+
+    return df[[column for column in REQUIRED if column in df.columns]]

--- a/tests/test_normalize_ohlcv.py
+++ b/tests/test_normalize_ohlcv.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading.data.fetch.normalize import REQUIRED, normalize_ohlcv_df
+
+
+def test_normalize_basic_yfinance_columns():
+    idx = pd.date_range("2024-01-01", periods=3, freq="1D")
+    df = pd.DataFrame(
+        {
+            "Open": [10.0, 10.5, 10.25],
+            "High": [10.5, 10.75, 10.5],
+            "Low": [9.5, 10.0, 9.75],
+            "Close": [10.25, 10.6, 10.4],
+            "Volume": [1000, 1200, 1100],
+        },
+        index=idx,
+    )
+
+    out = normalize_ohlcv_df(df)
+
+    assert list(out.columns) == list(REQUIRED)
+    assert out.index.tz is not None
+    assert str(out.index.tz) == "UTC"
+
+
+def test_normalize_multiindex_columns_dedup():
+    idx = pd.date_range("2024-01-01", periods=2, freq="1D", tz="UTC")
+    columns = pd.MultiIndex.from_product(
+        [["Open", "High", "Low", "Close", "Volume"], ["AAPL", "MSFT"]]
+    )
+    data = {
+        col: [float(i), float(i) + 0.5]
+        for i, col in enumerate(columns)
+    }
+    df = pd.DataFrame(data, index=idx)
+
+    out = normalize_ohlcv_df(df)
+
+    assert list(out.columns) == list(REQUIRED)
+    # Ensure the first ticker's values survive the deduplication.
+    pd.testing.assert_series_equal(out["open"], pd.Series([0.0, 0.5], index=idx))
+
+
+def test_normalize_adj_close_mapping():
+    idx = pd.date_range("2024-01-01", periods=2, freq="1D")
+    df = pd.DataFrame(
+        {
+            "Adj Close": [100.0, 101.0],
+            "Volume": [500, 600],
+        },
+        index=idx,
+    )
+
+    out = normalize_ohlcv_df(df)
+
+    assert "close" in out.columns
+    pd.testing.assert_series_equal(out["close"], pd.Series([100.0, 101.0], index=out.index))


### PR DESCRIPTION
## Summary
- add a normalize_ohlcv_df helper to standardize OHLCV dataframes and coerce common aliases
- ensure multi-index, adj-close, and baseline column shapes are covered with targeted tests

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_normalize_ohlcv.py -q *(skipped: pandas optional dependency not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d728b72f54833093b6b8b44b0089a0