### PR TITLE
Add Alpaca bars failure sentinel and fallback tests

### DIFF
--- a/tests/test_bars_http_failure.py
+++ b/tests/test_bars_http_failure.py
@@ -1,0 +1,62 @@
+from datetime import UTC, datetime
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading.data import bars as bars_mod
+from ai_trading.data.bars import StockBarsRequest, TimeFrame
+
+
+class _HTTPBoom(RuntimeError):
+    status_code = 503
+
+
+def test_http_get_bars_returns_sentinel(monkeypatch):
+    """Wrapper should emit a sentinel when the underlying call raises."""
+
+    def fail_get_bars(*_args, **_kwargs):
+        raise _HTTPBoom("service unavailable")
+
+    monkeypatch.setattr(bars_mod, "_raw_http_get_bars", fail_get_bars)
+
+    start = datetime(2024, 1, 2, tzinfo=UTC)
+    end = datetime(2024, 1, 3, tzinfo=UTC)
+    result = bars_mod.http_get_bars("SPY", "1Min", start, end, feed="iex")
+
+    assert isinstance(result, bars_mod.BarsFetchFailed)
+    assert result.symbol == "SPY"
+    assert result.feed == "iex"
+    assert result.status == 503
+
+
+def test_safe_get_stock_bars_handles_sentinel(monkeypatch):
+    """``safe_get_stock_bars`` should degrade to an empty frame on sentinel."""
+
+    class DummyClient:
+        pass
+
+    req = StockBarsRequest(
+        symbol_or_symbols="SPY",
+        timeframe=TimeFrame.Day,
+        start=datetime(2024, 1, 2, tzinfo=UTC),
+        end=datetime(2024, 1, 3, tzinfo=UTC),
+        feed="iex",
+    )
+
+    def fail_client_fetch(*_args, **_kwargs):
+        raise RuntimeError("client failure")
+
+    def fail_http_fetch(*_args, **_kwargs):
+        raise _HTTPBoom("service unavailable")
+
+    monkeypatch.setattr(bars_mod, "_client_fetch_stock_bars", fail_client_fetch)
+    monkeypatch.setattr(bars_mod, "_raw_http_get_bars", fail_http_fetch)
+    monkeypatch.setattr(bars_mod, "get_minute_df", lambda *args, **kwargs: pd.DataFrame())
+    monkeypatch.setattr(bars_mod.time, "sleep", lambda *_: None)
+
+    frame = bars_mod.safe_get_stock_bars(DummyClient(), req, symbol="SPY", context="TEST")
+
+    assert isinstance(frame, pd.DataFrame)
+    assert frame.empty
+

--- a/tests/test_fetch_core.py
+++ b/tests/test_fetch_core.py
@@ -1,6 +1,8 @@
 import pytest
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
+from ai_trading.data.bars import BarsFetchFailed
 from ai_trading.data.fetch.core import fetch
 
 
@@ -23,3 +25,16 @@ def test_fetch_uses_session():
     resp = fetch("https://example.com", session=sess)
     assert sess.called
     assert resp.url == "https://example.com"
+
+
+def test_fetch_propagates_bars_sentinel():
+    sentinel = BarsFetchFailed(symbol="SPY", feed="iex", since=datetime(2024, 1, 2, tzinfo=UTC))
+
+    class SentinelSession(DummySession):
+        def get(self, url, **kwargs):
+            super().get(url, **kwargs)
+            return sentinel
+
+    sess = SentinelSession()
+    resp = fetch("https://example.com", session=sess)
+    assert resp is sentinel


### PR DESCRIPTION
## Summary
- add a BarsFetchFailed sentinel and wrap Alpaca http_get_bars to log ALPACA_BARS_FETCH_FAILED once with status, symbol, feed, and since metadata
- coerce sentinel responses to empty data frames so safe_get_stock_bars can continue fallback processing without raising
- have fetch.core surface the sentinel and add unit tests covering both the wrapper and fetch core behavior

## Testing
- pytest tests/test_fetch_core.py tests/test_bars_http_failure.py

------
https://chatgpt.com/codex/tasks/task_e_68d72b9fb5fc83308ccea07fb9f7aa51