### PR TITLE
Adjust fallback gating and gap limit

### DIFF
--- a/tests/bot_engine/test_bot_engine.py
+++ b/tests/bot_engine/test_bot_engine.py
@@ -837,7 +837,12 @@ def test_enter_long_blocks_on_stale_fallback_quote(monkeypatch, caplog):
     monkeypatch.setattr(
         bot_engine,
         "_check_fallback_quote_age",
-        lambda *_a, **_k: (False, 30.0, "quote_age=30.0s>limit=5.0s"),
+        lambda *_a, **_k: (False, 86400.0, "quote_age=86400.0s>limit=5.0s"),
+    )
+    monkeypatch.setattr(
+        bot_engine,
+        "_fallback_quote_newer_than_last_close",
+        lambda *_a, **_k: False,
     )
 
     caplog.set_level("INFO")


### PR DESCRIPTION
## Summary
- read the new AI_TRADING_GAP_LIMIT_BPS environment variable for the gap ratio gate and treat fallback quotes as fresh when they arrive after the last session close
- skip orders only when NBBO pricing is missing and the fallback quote is older than the prior close or exceeds the configurable gap limit, while still logging fallback usage when viable
- update gating tests for the higher default limit and add coverage for overriding the basis-point threshold

## Testing
- `pytest tests/test_data_gating.py` *(fails: optional dependency numpy is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d72f39c1c48330b9d2eaf4b4592bb5