### PR TITLE
Block non-shortable sell orders

### DIFF
--- a/ai_trading/execution/engine.py
+++ b/ai_trading/execution/engine.py
@@ -58,6 +58,7 @@ KNOWN_EXECUTE_ORDER_KWARGS: frozenset[str] = frozenset(
         "allow_partial",
         "asset_class",
         "client_order_id",
+        "closing_position",
         "execution_algorithm",
         "expected_price",
         "expected_price_source",


### PR DESCRIPTION
## Summary
- prevent new short positions on non-shortable symbols by checking Alpaca asset metadata before order submission
- propagate a `closing_position` flag through the execution path so shortability checks can distinguish closing trades
- cover the new shortability preflight with a broker capacity test that ensures the order is skipped before capacity checks run

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/execution/test_broker_capacity_preflight.py

------
https://chatgpt.com/codex/tasks/task_e_68d7369bbfa0833085c4f1443bf719ba