### PR TITLE
Add fallbacks for cycle budget helpers

### DIFF
--- a/ai_trading/main.py
+++ b/ai_trading/main.py
@@ -91,6 +91,19 @@ except Exception:  # pragma: no cover - fallback when budget module unavailable
 
     def set_cycle_budget_context(*args, **kwargs):  # type: ignore[override]
         return nullcontext()
+
+try:
+    from ai_trading.core.bot_engine import (
+        emit_cycle_budget_summary,
+        clear_cycle_budget_context,
+    )
+except Exception:  # pragma: no cover - fallback when bot engine unavailable
+
+    def emit_cycle_budget_summary(*args, **kwargs):
+        return None
+
+    def clear_cycle_budget_context(*args, **kwargs):
+        return None
 from ai_trading.config.management import (
     get_env,
     validate_required_env,


### PR DESCRIPTION
## Summary
- extend the cycle budget helper guard to expose emit_cycle_budget_summary and clear_cycle_budget_context
- provide no-op fallbacks when ai_trading.core.bot_engine cannot be imported so the compute stage finally block remains safe

## Testing
- python -m ai_trading.main --iterations 1 --interval 60 *(fails: ModuleNotFoundError: No module named 'urllib3')*

------
https://chatgpt.com/codex/tasks/task_e_68d759305bb8833080b8bf1fe69a354f