### PR TITLE
Handle StopIteration in monotonic_time fallback

### DIFF
--- a/ai_trading/utils/time.py
+++ b/ai_trading/utils/time.py
@@ -84,6 +84,8 @@ def monotonic_time() -> float:
             return float(monotonic())
         except RuntimeError:  # pragma: no cover - platform specific
             pass
+        except Exception:  # pragma: no cover - defensive: patched clocks may raise StopIteration, etc.
+            pass
     return float(_time_module.time())
 
 

--- a/tests/utils/test_monotonic_time.py
+++ b/tests/utils/test_monotonic_time.py
@@ -1,0 +1,30 @@
+from collections import deque
+
+import pytest
+
+from ai_trading.utils import time as time_utils
+
+
+def test_monotonic_time_iterator_fallback(monkeypatch):
+    monotonic_values = deque([1.23, 4.56])
+    fallback_values = deque([10.0, 20.0])
+    real_time = time_utils._time_module.time
+
+    def fake_monotonic():
+        if not monotonic_values:
+            raise StopIteration
+        return monotonic_values.popleft()
+
+    def fake_time():
+        if fallback_values:
+            return fallback_values.popleft()
+        return real_time()
+
+    monkeypatch.setattr(time_utils._time_module, "monotonic", fake_monotonic)
+    monkeypatch.setattr(time_utils._time_module, "time", fake_time)
+
+    assert time_utils.monotonic_time() == pytest.approx(1.23)
+    assert time_utils.monotonic_time() == pytest.approx(4.56)
+    assert time_utils.monotonic_time() == pytest.approx(10.0)
+    assert time_utils.monotonic_time() == pytest.approx(20.0)
+    assert isinstance(time_utils.monotonic_time(), float)


### PR DESCRIPTION
## Summary
- make `monotonic_time` resilient to patched clocks that raise StopIteration or other exceptions by falling back to `time.time`
- add a regression test that patches `time.monotonic` with an exhausting iterator to ensure the helper keeps returning floats

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/utils/test_monotonic_time.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d7f9bace0c83308787df30dd073790