### PR TITLE
Fix bot engine bars stubbing in daily fetch tests

### DIFF
--- a/tests/bot_engine/test_daily_fetch_debounce.py
+++ b/tests/bot_engine/test_daily_fetch_debounce.py
@@ -130,7 +130,12 @@ def test_daily_fetch_memo_reuses_recent_result(monkeypatch):
     monkeypatch.setattr(be, "is_market_open", lambda: True)
     be.daily_cache_hit = None
     be.daily_cache_miss = None
-    be.bars = types.SimpleNamespace(TimeFrame=types.SimpleNamespace(Day="Day"))
+    monkeypatch.setattr(
+        be,
+        "bars",
+        types.SimpleNamespace(TimeFrame=types.SimpleNamespace(Day="Day")),
+        raising=False,
+    )
 
     monotonic_values = iter([10.0, 11.0, 120.0, 121.0, 130.0, 140.0, 150.0])
     monkeypatch.setattr(be.time, "monotonic", lambda: next(monotonic_values))
@@ -218,7 +223,7 @@ def test_daily_fetch_skips_direct_when_safe_missing(monkeypatch):
         TimeFrame=types.SimpleNamespace(Day="Day"),
         _create_empty_bars_dataframe=lambda _tf: pd.DataFrame(),
     )
-    monkeypatch.setattr(be, "bars", bars_stub)
+    monkeypatch.setattr(be, "bars", bars_stub, raising=False)
 
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- use pytest monkeypatch to stub `bot_engine.bars` in daily fetch debounce tests so the module is restored after each test
- ensure the stub is still missing `safe_get_stock_bars` while remaining compatible with downstream monkeypatch usage

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_daily_fetch_debounce.py tests/bot_engine/test_fetch_minute_df_safe.py -k "test_daily_fetch_memo_reuses_recent_result or test_daily_fetch_skips_direct_when_safe_missing or test_data_fetcher_stale_iex_retries_realtime_feed" -q

------
https://chatgpt.com/codex/tasks/task_e_68d7f9bc2c7c833086633bee2c7528c5