### PR TITLE
Add HTTP host limit legacy env fallback

### DIFF
--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -121,8 +121,14 @@ class HostLimitController:
         return max(limit, 1)
 
     def current_limit(self) -> int | None:
-        raw = os.getenv("AI_TRADING_HTTP_HOST_LIMIT")
-        return self._parse_limit(raw)
+        """Return the active pool limit honoring legacy environment names."""
+
+        raw_new = os.getenv("AI_TRADING_HTTP_HOST_LIMIT")
+        if raw_new is not None:
+            return self._parse_limit(raw_new)
+
+        raw_legacy = os.getenv("AI_TRADING_HOST_LIMIT")
+        return self._parse_limit(raw_legacy)
 
     def apply(self, session: TimeoutSession) -> None:
         limit = self.current_limit()


### PR DESCRIPTION
## Summary
- make HostLimitController fall back to AI_TRADING_HOST_LIMIT when AI_TRADING_HTTP_HOST_LIMIT is not set
- add regression coverage to ensure the legacy environment variable still adjusts the HTTP adapter pool sizing

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_http_host_limit.py::test_http_host_limit_controller_legacy_env -q

------
https://chatgpt.com/codex/tasks/task_e_68d7fc7946d4833086712cc857585ffe