### PR TITLE
Short-circuit Alpaca quote fallbacks

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -21103,9 +21103,15 @@ def get_latest_price(symbol: str, *, prefer_backup: bool = False):
         if candidate is not None:
             price = candidate
             price_source = source or provider
-            if source in _ALPACA_TERMINAL_PRICE_SOURCES:
+            if source in _ALPACA_TERMINAL_PRICE_SOURCES or provider.startswith("alpaca"):
                 return _finalize_return()
             break
+        if provider == "alpaca_quote":
+            degraded = _resolve_cached_quote_bid(symbol, cache)
+            if degraded is not None:
+                price, price_source = degraded
+                last_source = price_source
+                return _finalize_return()
         _record_primary_failure(source or provider)
 
     if price is None:

--- a/tests/test_get_latest_price_fallback.py
+++ b/tests/test_get_latest_price_fallback.py
@@ -147,8 +147,8 @@ def test_get_latest_price_prefers_last_trade_when_ask_invalid(monkeypatch):
     assert bot_engine._PRICE_SOURCE["AAPL"] == "alpaca_last"
 
 
-def test_get_latest_price_degrades_to_bid_after_fallback(monkeypatch, caplog):
-    """Bid is accepted only after fallbacks fail when ask/last are unusable."""
+def test_get_latest_price_degrades_to_bid_before_backups(monkeypatch, caplog):
+    """Bid should be accepted without invoking Yahoo/bars when ask/last unusable."""
 
     monkeypatch.setattr(bot_engine, "_PRICE_SOURCE", {})
     monkeypatch.setattr(
@@ -168,18 +168,18 @@ def test_get_latest_price_degrades_to_bid_after_fallback(monkeypatch, caplog):
 
     calls = {"yahoo": 0}
 
-    def yahoo_zero(symbol, start, end, interval):  # noqa: ARG001
+    def yahoo_fail(symbol, start, end, interval):  # noqa: ARG001
         calls["yahoo"] += 1
-        return _df(0.0)
+        raise AssertionError("Yahoo fallback should not be invoked when degrading to bid")
 
-    monkeypatch.setattr(data_fetcher, "_backup_get_bars", yahoo_zero)
+    monkeypatch.setattr(data_fetcher, "_backup_get_bars", yahoo_fail)
     monkeypatch.setattr(bot_engine, "get_latest_close", lambda df: float(df["close"].iloc[-1]))
     monkeypatch.setattr(bot_engine, "get_bars_df", lambda symbol: (_ for _ in ()).throw(RuntimeError))
 
     with caplog.at_level("WARNING", logger="ai_trading.core.bot_engine"):
         price = bot_engine.get_latest_price("AAPL")
 
-    assert calls["yahoo"] == 1
+    assert calls["yahoo"] == 0
     assert price == 94.5
     assert bot_engine._PRICE_SOURCE["AAPL"] == "alpaca_bid_degraded"
     assert "DELAYED_QUOTE_SLIPPAGE_FLAGGED" in caplog.text


### PR DESCRIPTION
## Summary
- return immediately when Alpaca trade, quote, or bid values provide a usable price
- resolve cached Alpaca bid data before attempting Yahoo or bars fallbacks
- tighten fallback tests to assert Yahoo is not queried and PRICE_SOURCE is recorded

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_get_latest_price_fallback.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d7fdf6e8d483308d295222a0057f27