### PR TITLE
Improve health error payload handling

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -56,7 +56,8 @@ def create_app():
         last_error: str | None = None
 
         def record_error(exc: Exception) -> str:
-            nonlocal last_error
+            nonlocal last_error, ok
+            ok = False
             message = str(exc) or exc.__class__.__name__
             if message and message not in errors:
                 errors.append(message)
@@ -113,6 +114,8 @@ def create_app():
             func = globals().get("jsonify")
             fallback_error = data.get("error") or last_error
             fallback_payload = dict(data)
+            if data.get("error"):
+                data["ok"] = False
             fallback_payload["ok"] = False
             fallback_payload["error"] = fallback_error or "jsonify unavailable"
 

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -16,8 +16,20 @@ def test_health_endpoint_handles_import_error(monkeypatch):
     resp = client.get("/health")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data.get("ok") is False
-    assert data.get("error") == "boom"
+    assert data == {
+        "ok": False,
+        "error": "boom",
+        "alpaca": {
+            "sdk_ok": False,
+            "initialized": False,
+            "client_attached": False,
+            "has_key": False,
+            "has_secret": False,
+            "base_url": "",
+            "paper": False,
+            "shadow_mode": False,
+        },
+    }
 
 
 def test_health_endpoint_returns_plain_dict_when_jsonify_fails(monkeypatch):
@@ -39,5 +51,17 @@ def test_health_endpoint_returns_plain_dict_when_jsonify_fails(monkeypatch):
     resp = client.get("/health")
     assert resp.status_code == 200
     data = resp.get_json()
-    assert data.get("ok") is False
-    assert data.get("error") == "boom"
+    assert data == {
+        "ok": False,
+        "error": "boom",
+        "alpaca": {
+            "sdk_ok": False,
+            "initialized": False,
+            "client_attached": False,
+            "has_key": False,
+            "has_secret": False,
+            "base_url": "",
+            "paper": False,
+            "shadow_mode": False,
+        },
+    }


### PR DESCRIPTION
## Summary
- ensure `/health` forces `ok` to false and preserves the captured error message whenever imports or config checks fail
- make the error recorder mark the response as degraded as soon as a failure is captured
- extend the health endpoint tests to assert the full JSON payload for import-error scenarios

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_health_check.py


------
https://chatgpt.com/codex/tasks/task_e_68d7fdf7afb48330a6ca02cdd6fdd3a1