### PR TITLE
Fix concurrency rebinding and align data fetch timing

### DIFF
--- a/ai_trading/data/fallback/concurrency.py
+++ b/ai_trading/data/fallback/concurrency.py
@@ -72,12 +72,15 @@ def _maybe_recreate_lock(obj: object, loop: asyncio.AbstractEventLoop) -> object
 
     bound_loop = None
     for attr_name in ("_loop", "_bound_loop"):
-        if hasattr(obj, attr_name):
-            bound_loop = getattr(obj, attr_name)
-            if bound_loop is not None:
-                break
+        try:
+            candidate = getattr(obj, attr_name)
+        except Exception:
+            candidate = None
+        if candidate is not None:
+            bound_loop = candidate
+            break
 
-    if bound_loop is loop:
+    if bound_loop is None or bound_loop is loop:
         return obj
 
     def _capture_sem_state() -> dict[str, int]:

--- a/ai_trading/data/provider_monitor.py
+++ b/ai_trading/data/provider_monitor.py
@@ -751,7 +751,7 @@ class ProviderMonitor:
         env_allowed = os.getenv("ALPACA_SIP_ENABLED", "0") in {"1", "true", "True"}
         allowed = strict_enabled and env_allowed
         if not allowed:
-            now_monotonic = time.monotonic()
+            now_monotonic = monotonic_time()
             cooldown_window = max(float(self.cooldown), 1.0)
             if (
                 self._last_sip_warn_ts <= 0.0


### PR DESCRIPTION
## Summary
- preserve shared asyncio primitives when they already target the active loop so fallback concurrency tests no longer hang
- align daily memo timestamps with the patched `time.monotonic` used in tests and strip minute-bar index names
- route SIP/provider health gating through the resilient `monotonic_time` helper to avoid exhausting patched clocks

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/data/test_fallback_concurrency.py::test_run_with_concurrency_respects_limit
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/data/test_fallback_concurrency.py::test_run_with_concurrency_handles_blocking_and_failures
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/bot_engine/test_daily_fetch_debounce.py::test_daily_fetch_memo_reuses_recent_result
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/bot_engine/test_fetch_minute_df_safe.py::test_data_fetcher_stale_iex_retries_realtime_feed
- make test-all *(fails: aborted due to prohibitive dependency install during ensure-runtime stage)*

------
https://chatgpt.com/codex/tasks/task_e_68d816401bb883308f04320d10027fa1