### PR TITLE
Cache monotonic timestamp reuse in daily data refresh

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -7674,7 +7674,7 @@ class DataFetcher:
                 if age <= window_limit:
                     cached_df = entry_df
                     cached_reason = "memo"
-                    refresh_stamp = time.monotonic()
+                    refresh_stamp = now_monotonic
                     refresh_df = cached_df
                     refresh_source = "memo"
                     break
@@ -7686,7 +7686,7 @@ class DataFetcher:
                 if entry and entry[0] == fetch_date:
                     cached_df = entry[1]
                     cached_reason = "cache"
-                    refresh_stamp = time.monotonic()
+                    refresh_stamp = now_monotonic
                     refresh_df = cached_df
                     refresh_source = "cache"
                 else:
@@ -7705,7 +7705,7 @@ class DataFetcher:
                     if now_monotonic - session_ts <= ttl_window:
                         cached_df = session_df
                         cached_reason = f"provider_session:{planned_provider}"
-                        refresh_stamp = time.monotonic()
+                        refresh_stamp = now_monotonic
                         refresh_df = cached_df
                         refresh_source = "provider_session"
                         refresh_provider_key = provider_key


### PR DESCRIPTION
## Summary
- reuse a single cached monotonic timestamp during daily data refresh evaluation
- propagate the cached timestamp through memo, cache, and provider session refresh bookkeeping

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_daily_fetch_debounce.py::test_daily_fetch_memo_reuses_recent_result (skipped: could not import 'pandas')

------
https://chatgpt.com/codex/tasks/task_e_68d832e13a308330af9d8a61d09ed1c8