### PR TITLE
Respect SAFE_PREFIXES in audit repo scanner

### DIFF
--- a/tests/tools/test_audit_repo_tool.py
+++ b/tests/tools/test_audit_repo_tool.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tools import audit_repo
+
 
 def test_audit_repo_runs_clean():
     """AI-AGENT-REF: ensure audit script emits zero risky counts."""
@@ -15,5 +17,33 @@ def test_audit_repo_runs_clean():
     )
     metrics = json.loads(result.stdout.strip())
     assert metrics["exec_eval_count"] == 0
+    assert metrics["py_compile_failures"] == 0
+
+
+def test_scan_repo_skips_sensitive_checks(tmp_path, monkeypatch):
+    """SAFE_PREFIXES should bypass py_compile and exec/eval metrics."""
+    safe_prefix = next(iter(audit_repo.SAFE_PREFIXES))
+    safe_dir = tmp_path.joinpath(*safe_prefix)
+    safe_dir.mkdir(parents=True)
+
+    safe_file = safe_dir / "uses_exec.py"
+    safe_file.write_text("exec('danger')\n")
+
+    regular_file = tmp_path / "regular.py"
+    regular_file.write_text("exec('ok')\n")
+
+    compiled_paths: list[Path] = []
+
+    def fake_compile(filename: str, *args, **kwargs) -> None:
+        compiled_paths.append(Path(filename))
+
+    monkeypatch.setattr(audit_repo.py_compile, "compile", fake_compile)
+
+    metrics = audit_repo.scan_repo(tmp_path)
+
+    compiled_paths = [p.resolve() for p in compiled_paths]
+    assert regular_file.resolve() in compiled_paths
+    assert safe_file.resolve() not in compiled_paths
+    assert metrics["exec_eval_count"] == 1
     assert metrics["py_compile_failures"] == 0
 

--- a/tools/audit_repo.py
+++ b/tools/audit_repo.py
@@ -65,16 +65,16 @@ def scan_repo(root: Path) -> Dict[str, int]:
         if "site-packages" not in p.parts and not _is_dev_folder(p)
     ]
     for path in py_files:
-        try:
-            source = path.read_text()
-        except Exception:
-            continue
         skip_sensitive_metrics = _is_under_prefix(path, root, SAFE_PREFIXES)
         if not skip_sensitive_metrics:
             try:
                 py_compile.compile(str(path), doraise=True)
             except py_compile.PyCompileError:
                 metrics["py_compile_failures"] += 1
+        try:
+            source = path.read_text()
+        except Exception:
+            continue
         try:
             tree = ast.parse(source)
         except Exception:


### PR DESCRIPTION
## Summary
- skip py_compile checks for files located under SAFE_PREFIXES while still parsing them
- add regression coverage ensuring exec/eval metrics ignore files within SAFE_PREFIXES

## Testing
- pytest tests/tools/test_audit_repo_tool.py

------
https://chatgpt.com/codex/tasks/task_e_68d83be48d9c833099621e9f57ffdd1e