### PR TITLE
Handle safe subprocess timeouts without logging

### DIFF
--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -60,11 +60,13 @@ def safe_subprocess_run(
             capture_output=True,
             text=True,
         )
-    except subprocess.TimeoutExpired as exc:
-        stdout = exc.stdout or ""
-        stderr = exc.stderr or ""
-        return SafeSubprocessResult(stdout, stderr, 124, True)
-    except (subprocess.SubprocessError, OSError) as exc:
+    except subprocess.TimeoutExpired:
+        return SafeSubprocessResult("", "", 124, True)
+    except OSError as exc:
+        logger.warning("safe_subprocess_run(%s) failed: %s", argv, exc)
+        return SafeSubprocessResult("", str(exc), getattr(exc, "returncode", -1), False)
+    except subprocess.SubprocessError as exc:
+        # ``TimeoutExpired`` is handled above; this branch captures other subprocess failures.
         logger.warning("safe_subprocess_run(%s) failed: %s", argv, exc)
         return SafeSubprocessResult("", str(exc), getattr(exc, "returncode", -1), False)
 


### PR DESCRIPTION
## Summary
- return an empty-stdio SafeSubprocessResult with return code 124 when subprocesses time out
- separate subprocess error handling branches so TimeoutExpired is never masked by broader exceptions

## Testing
- pytest tests/utils/test_safe_subprocess_run.py

------
https://chatgpt.com/codex/tasks/task_e_68d83f8b7dc08330a90a3ce6a5e3b201