### PR TITLE
Warn once when trade cycle has no symbols

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -19970,6 +19970,10 @@ def run_all_trades_worker(state: BotState, runtime) -> None:
                 return
 
             if not symbols:
+                logger_once.warning(
+                    "RUN_ALL_TRADES_NO_SYMBOLS",
+                    key="run_all_trades_no_symbols_cycle",
+                )
                 logger.info("SKIP_MINUTE_FETCH", extra={"reason": "no_symbols"})
                 time.sleep(1.0)
                 return

--- a/tests/unit/test_run_all_trades_empty_symbols.py
+++ b/tests/unit/test_run_all_trades_empty_symbols.py
@@ -76,6 +76,8 @@ def test_run_all_trades_handles_empty_symbols(monkeypatch):
 
     eng.run_all_trades_worker(state, runtime)
 
-    warn_mock.assert_called_once()
+    warn_mock.assert_any_call(
+        "RUN_ALL_TRADES_NO_SYMBOLS", key="run_all_trades_no_symbols_cycle"
+    )
     process_mock.assert_not_called()
     sleep_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- emit a single-shot warning when run_all_trades_worker cycles without any screened symbols
- update the empty-symbol regression test to assert the new warning and keep throttling behaviour
- adjust the warning-focused test harness so it accepts the richer execute_order call and synthetic quote data

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_run_all_trades_empty_symbols.py tests/unit/test_run_all_trades_warning.py

------
https://chatgpt.com/codex/tasks/task_e_68d8498000d08330929fd533916dd577