### PR TITLE
Preserve timestamp column in OHLCV normalization

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -969,7 +969,9 @@ def ensure_ohlcv_schema(
     if timestamp_col is None:
         if isinstance(work_df.index, pd_local.DatetimeIndex):
             timestamp_col = "timestamp"
-            work_df = work_df.reset_index().rename(columns={work_df.columns[0]: "timestamp"})
+            work_df = work_df.reset_index()
+            first_column = work_df.columns[0]
+            work_df = work_df.rename(columns={first_column: "timestamp"})
         else:
             raise MissingOHLCVColumnsError(
                 f"missing timestamp column | source={source} frequency={frequency}"


### PR DESCRIPTION
## Summary
- keep the timestamp column alongside the UTC index when normalizing OHLCV frames
- ensure ensure_ohlcv_schema renames the reset index column to timestamp before normalization

## Testing
- PYTHONPATH=.test_stubs PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python - <<'PY'
import sys
import pytest
import sklearn  # ensure available before pytest modifies sys.modules

sys.exit(pytest.main(["tests/test_health.py::test_ensure_schema_then_normalize_restores_timestamp_column"]))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d866245f2c8330a5b9abf679b44d49