### PR TITLE
Harden health diagnostics for Alpaca import failures

### DIFF
--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,4 +1,7 @@
 import builtins
+
+import pytest
+
 import ai_trading.app as app_module
 
 
@@ -8,6 +11,8 @@ def test_health_endpoint_handles_import_error(monkeypatch):
     def fail_alpaca(name, *args, **kwargs):
         if name == "ai_trading.alpaca_api":
             raise ImportError("boom")
+        if name == "ai_trading.core.bot_engine":
+            pytest.fail("_resolve_alpaca_env should not be touched when alpaca import fails")
         return original_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fail_alpaca)
@@ -65,3 +70,57 @@ def test_health_endpoint_returns_plain_dict_when_jsonify_fails(monkeypatch):
             "shadow_mode": False,
         },
     }
+
+
+def test_health_endpoint_structure_is_stable():
+    app = app_module.create_app()
+    client = app.test_client()
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    alpaca_keys = {
+        "sdk_ok",
+        "initialized",
+        "client_attached",
+        "has_key",
+        "has_secret",
+        "base_url",
+        "paper",
+        "shadow_mode",
+    }
+    assert set(data.keys()) >= {"ok", "alpaca"}
+    assert set(data["alpaca"].keys()) == alpaca_keys
+    assert isinstance(data["ok"], bool)
+    bool_keys = alpaca_keys - {"base_url"}
+    assert all(isinstance(data["alpaca"][key], bool) for key in bool_keys)
+    assert isinstance(data["alpaca"]["base_url"], str)
+
+
+def test_health_endpoint_jsonify_failure_uses_sanitized_payload(monkeypatch):
+    def broken_jsonify(payload):
+        raise RuntimeError("json busted")
+
+    monkeypatch.setattr(app_module, "jsonify", broken_jsonify)
+
+    app = app_module.create_app()
+    client = app.test_client()
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is False
+    assert "error" in data
+    assert isinstance(data["error"], str) and data["error"]
+    alpaca_keys = {
+        "sdk_ok",
+        "initialized",
+        "client_attached",
+        "has_key",
+        "has_secret",
+        "base_url",
+        "paper",
+        "shadow_mode",
+    }
+    assert set(data["alpaca"].keys()) == alpaca_keys
+    bool_keys = alpaca_keys - {"base_url"}
+    assert all(isinstance(data["alpaca"][key], bool) for key in bool_keys)
+    assert isinstance(data["alpaca"]["base_url"], str)


### PR DESCRIPTION
## Summary
- skip Alpaca environment resolution when the Alpaca API module cannot be imported and fall back to empty credentials in the health payload
- return a sanitized health payload when jsonify is unavailable or raises instead of leaking partial state
- extend the health check tests to cover both healthy responses and jsonify failure handling

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_health_check.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d896b445f08330bbd194081d4f120e