### PR TITLE
Adjust SIP disallow logic

### DIFF
--- a/ai_trading/data/fetch/sip_disallowed.py
+++ b/ai_trading/data/fetch/sip_disallowed.py
@@ -8,18 +8,23 @@ from ai_trading.utils.environment import env
 def sip_disallowed() -> bool:
     """Return ``True`` when the SIP feed should not be used."""
 
-    if not env.ALPACA_ALLOW_SIP:
+    allow_flag = getattr(env, "ALPACA_ALLOW_SIP", None)
+    if allow_flag is False:
         return True
 
     has_creds = bool(env.ALPACA_KEY) and bool(env.ALPACA_SECRET)
+    if not has_creds:
+        return True
+
     explicit_entitlement = getattr(env, "ALPACA_SIP_ENTITLED", None)
     if explicit_entitlement is not None:
-        if not bool(explicit_entitlement):
-            return True
-        return not has_creds
-    if hasattr(env, "ALPACA_HAS_SIP") and (env.ALPACA_HAS_SIP is not None):
-        return not (has_creds and bool(env.ALPACA_HAS_SIP))
-    return not has_creds
+        return not bool(explicit_entitlement)
+
+    has_sip = getattr(env, "ALPACA_HAS_SIP", None)
+    if has_sip is not None:
+        return not bool(has_sip)
+
+    return False
 
 
 __all__ = ["sip_disallowed"]

--- a/tests/test_feed_entitlement.py
+++ b/tests/test_feed_entitlement.py
@@ -24,3 +24,13 @@ def test_ensure_entitled_feed_keeps():
     bars._ENTITLE_CACHE.clear()
     client = _Client(['sip'])
     assert bars._ensure_entitled_feed(client, 'sip') == 'sip'
+
+
+def test_ensure_entitled_feed_keeps_when_env_unset(monkeypatch):
+    bars._ENTITLE_CACHE.clear()
+    for key in ("ALPACA_ALLOW_SIP", "ALPACA_SIP_ENTITLED", "ALPACA_HAS_SIP"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("ALPACA_KEY", "test-key")
+    monkeypatch.setenv("ALPACA_SECRET", "test-secret")
+    client = _Client(['sip'])
+    assert bars._ensure_entitled_feed(client, 'sip') == 'sip'


### PR DESCRIPTION
## Summary
- allow SIP usage when ALPACA_ALLOW_SIP is unset but entitlement and credentials are present
- return early when credentials are missing or an explicit opt-out is configured
- add a regression test to ensure _ensure_entitled_feed returns the SIP feed when permitted

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_feed_entitlement.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d896b677bc83308db8f9a9880c5135