### PR TITLE
Fix fallback concurrency lock rebinding and limit enforcement

### DIFF
--- a/tests/data/test_fallback_concurrency.py
+++ b/tests/data/test_fallback_concurrency.py
@@ -1,6 +1,6 @@
 import asyncio
 from dataclasses import dataclass
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 
 from ai_trading.data.fallback import concurrency
 
@@ -73,8 +73,8 @@ def test_run_with_concurrency_respects_limit():
     assert results == {symbol: symbol for symbol in symbols}
     assert succeeded == set(symbols)
     assert not failed
-    assert max_seen <= 2
-    assert concurrency.PEAK_SIMULTANEOUS_WORKERS <= 2
+    assert max_seen == 2
+    assert concurrency.PEAK_SIMULTANEOUS_WORKERS == 2
 
 
 def test_run_with_concurrency_peak_counter_respects_limit():
@@ -104,8 +104,96 @@ def test_run_with_concurrency_peak_counter_respects_limit():
     assert results == {symbol: symbol for symbol in symbols}
     assert succeeded == set(symbols)
     assert not failed
-    assert max_seen <= 3
-    assert concurrency.PEAK_SIMULTANEOUS_WORKERS <= 3
+    assert max_seen == 3
+    assert concurrency.PEAK_SIMULTANEOUS_WORKERS == 3
+
+
+def test_run_with_concurrency_respects_host_limit():
+    tracker_lock = asyncio.Lock()
+    running = 0
+    max_seen = 0
+
+    async def worker(sym: str) -> str:
+        nonlocal running, max_seen
+        async with tracker_lock:
+            running += 1
+            if running > max_seen:
+                max_seen = running
+        try:
+            await asyncio.sleep(0.01)
+            return sym
+        finally:
+            async with tracker_lock:
+                running -= 1
+
+    symbols = [f"HOST{i}" for i in range(6)]
+
+    original_host_limit = concurrency._get_effective_host_limit
+
+    def _fake_host_limit() -> int:
+        return 2
+
+    concurrency._get_effective_host_limit = _fake_host_limit
+    try:
+        results, succeeded, failed = asyncio.run(
+            concurrency.run_with_concurrency(symbols, worker, max_concurrency=5)
+        )
+    finally:
+        concurrency._get_effective_host_limit = original_host_limit
+
+    assert results == {symbol: symbol for symbol in symbols}
+    assert succeeded == set(symbols)
+    assert not failed
+    assert max_seen == 2
+    assert concurrency.PEAK_SIMULTANEOUS_WORKERS == 2
+
+
+def test_run_with_concurrency_waiter_cancellation_does_not_overshoot_limit():
+    class StrictSemaphore(asyncio.Semaphore):
+        def __init__(self, value: int):
+            super().__init__(value)
+            self._initial_value = value
+
+        def release(self) -> None:
+            super().release()
+            if self._value > self._initial_value:
+                raise AssertionError(
+                    f"Semaphore value exceeded initial limit: {self._value} > {self._initial_value}"
+                )
+
+    original_semaphore = concurrency.asyncio.Semaphore
+    concurrency.asyncio.Semaphore = StrictSemaphore
+
+    tracker_lock = asyncio.Lock()
+    running = 0
+    max_seen = 0
+
+    async def worker(sym: str) -> str:
+        nonlocal running, max_seen
+        async with tracker_lock:
+            running += 1
+            if running > max_seen:
+                max_seen = running
+        try:
+            await asyncio.sleep(0.1)
+            return sym
+        finally:
+            async with tracker_lock:
+                running -= 1
+
+    symbols = [f"WAIT{i}" for i in range(6)]
+
+    try:
+        results, succeeded, failed = asyncio.run(
+            concurrency.run_with_concurrency(symbols, worker, max_concurrency=2, timeout_s=0.05)
+        )
+    finally:
+        concurrency.asyncio.Semaphore = original_semaphore
+
+    assert any(value is None for value in results.values())
+    assert failed
+    assert max_seen == 2
+    assert concurrency.PEAK_SIMULTANEOUS_WORKERS == 2
 
 
 def test_run_with_concurrency_rebinds_nested_dataclass_lock():
@@ -259,6 +347,50 @@ def test_run_with_concurrency_rebinds_lock_inside_tuple_structure():
 
     holder_after = namespace.payload[0]
     assert holder_after.lock is not original_lock
+
+
+def test_run_with_concurrency_rebinds_lock_and_semaphore_inside_mapping_proxy():
+    @dataclass(frozen=True, eq=False)
+    class FrozenHolder:
+        lock: asyncio.Lock
+        semaphore: asyncio.Semaphore
+
+    def build_holder_in_fresh_loop() -> FrozenHolder:
+        loop = asyncio.new_event_loop()
+        try:
+            async def _factory() -> FrozenHolder:
+                return FrozenHolder(lock=asyncio.Lock(), semaphore=asyncio.Semaphore(1))
+
+            return loop.run_until_complete(_factory())
+        finally:
+            loop.close()
+
+    original_holder = build_holder_in_fresh_loop()
+    original_proxy = MappingProxyType({"holder": original_holder})
+    namespace = SimpleNamespace(payload=(original_proxy,))
+
+    async def worker(sym: str) -> str:
+        mapping = namespace.payload[0]
+        holder = mapping["holder"]
+        async with holder.lock:
+            async with holder.semaphore:
+                await asyncio.sleep(0)
+                return sym
+
+    symbols = ["MP1", "MP2"]
+    results, succeeded, failed = asyncio.run(
+        concurrency.run_with_concurrency(symbols, worker, max_concurrency=2)
+    )
+
+    assert results == {symbol: symbol for symbol in symbols}
+    assert succeeded == set(symbols)
+    assert not failed
+
+    mapping_after = namespace.payload[0]
+    assert mapping_after is not original_proxy
+    holder_after = mapping_after["holder"]
+    assert holder_after.lock is not original_holder.lock
+    assert holder_after.semaphore is not original_holder.semaphore
 
 
 def test_run_with_concurrency_rebinds_lock_inside_frozenset_of_tuple():


### PR DESCRIPTION
## Summary
- ensure asyncio locks and semaphores captured in worker closures are rebound even inside mapping proxies and immutable containers
- prevent the fallback concurrency semaphore from exceeding its configured limit and keep the peak worker counter accurate
- extend fallback concurrency tests with host-limit, cancellation, and mapping-proxy regressions

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/data/test_fallback_concurrency.py -q


------
https://chatgpt.com/codex/tasks/task_e_68d8a136d5188330a709623bc9ce9dbc