### PR TITLE
Normalize fallback data and tighten metrics tests

### DIFF
--- a/tests/test_get_minute_df_fetch_logging.py
+++ b/tests/test_get_minute_df_fetch_logging.py
@@ -74,5 +74,14 @@ def test_fetch_error_logs_and_sets_none(monkeypatch, caplog, exc_type):
         out = data_fetcher.get_minute_df("AAPL", start, end)
 
     assert yahoo_called["called"]
-    assert out is fallback_df
+    assert list(out.loc[:, ["open", "high", "low", "close", "volume"]].iloc[0]) == [1, 1, 1, 1, 1]
+    assert list(out.columns[:6]) == [
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+    assert out.index.name == "timestamp"
     assert any(r.message == "ALPACA_FETCH_FAILED" for r in caplog.records)


### PR DESCRIPTION
## Summary
- normalize fallback OHLCV frames so single-letter columns are mapped before canonical processing
- ensure fallback metrics record the attempt before success and extend tests to validate order and dataframe contents
- enrich feed failover tests with metric capture and canonical column checks

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_get_minute_df_fetch_logging.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_data_fetcher_metrics.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_feed_failover.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d8a13a9ba083308d33c2b515c45b05