### PR TITLE
Use monotonic_time helper in daily fetch memo

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -7656,7 +7656,7 @@ class DataFetcher:
         memo_key = (symbol, timeframe_key, start_ts.isoformat(), end_ts.isoformat())
         legacy_memo_key = (symbol, fetch_date.isoformat())
         min_interval = self._daily_fetch_min_interval(ctx)
-        now_monotonic = time.monotonic()
+        now_monotonic = monotonic_time()
         ttl_window = (
             _DAILY_FETCH_MEMO_TTL if min_interval <= 0 else max(_DAILY_FETCH_MEMO_TTL, float(min_interval))
         )
@@ -7899,7 +7899,7 @@ class DataFetcher:
             )
 
         with cache_lock:
-            stamp = time.monotonic()
+            stamp = monotonic_time()
             actual_provider = self._infer_provider_label(df, planned_provider)
             provider_session_key = (actual_provider, fetch_date.isoformat(), symbol)
             self._daily_cache[symbol] = (fetch_date, df)


### PR DESCRIPTION
## Summary
- switch DataFetcher.get_daily_df to use the shared monotonic_time helper when reading and writing memo timestamps
- avoid relying on the bare time.monotonic clock so tests and monotonic shims work consistently

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_daily_fetch_debounce.py::test_daily_fetch_memo_reuses_recent_result -q

------
https://chatgpt.com/codex/tasks/task_e_68d8a9943e9483309ed9ad95964534a6