### PR TITLE
Fix SIP entitlement flag coercion

### DIFF
--- a/ai_trading/data/fetch/sip_disallowed.py
+++ b/ai_trading/data/fetch/sip_disallowed.py
@@ -8,7 +8,22 @@ from ai_trading.utils.environment import env
 def sip_disallowed() -> bool:
     """Return ``True`` when the SIP feed should not be used."""
 
-    allow_flag = getattr(env, "ALPACA_ALLOW_SIP", None)
+    def _coerce_flag(value):
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return None
+        try:
+            lowered = value.strip().lower()
+        except AttributeError:
+            return bool(value)
+        if lowered in {"1", "true", "yes", "on", "enable", "enabled"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "disable", "disabled"}:
+            return False
+        return None
+
+    allow_flag = _coerce_flag(getattr(env, "ALPACA_ALLOW_SIP", None))
     if allow_flag is False:
         return True
 
@@ -16,13 +31,13 @@ def sip_disallowed() -> bool:
     if not has_creds:
         return True
 
-    explicit_entitlement = getattr(env, "ALPACA_SIP_ENTITLED", None)
+    explicit_entitlement = _coerce_flag(getattr(env, "ALPACA_SIP_ENTITLED", None))
     if explicit_entitlement is not None:
-        return not bool(explicit_entitlement)
+        return not explicit_entitlement
 
-    has_sip = getattr(env, "ALPACA_HAS_SIP", None)
+    has_sip = _coerce_flag(getattr(env, "ALPACA_HAS_SIP", None))
     if has_sip is not None:
-        return not bool(has_sip)
+        return not has_sip
 
     return False
 

--- a/tests/test_feed_entitlement.py
+++ b/tests/test_feed_entitlement.py
@@ -34,3 +34,14 @@ def test_ensure_entitled_feed_keeps_when_env_unset(monkeypatch):
     monkeypatch.setenv("ALPACA_SECRET", "test-secret")
     client = _Client(['sip'])
     assert bars._ensure_entitled_feed(client, 'sip') == 'sip'
+
+
+def test_ensure_entitled_feed_keeps_when_account_advertises_sip(monkeypatch):
+    bars._ENTITLE_CACHE.clear()
+    for key in ("ALPACA_ALLOW_SIP", "ALPACA_SIP_ENTITLED"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("ALPACA_HAS_SIP", "1")
+    monkeypatch.setenv("ALPACA_KEY", "test-key")
+    monkeypatch.setenv("ALPACA_SECRET", "test-secret")
+    client = _Client(['sip'])
+    assert bars._ensure_entitled_feed(client, 'sip') == 'sip'

--- a/tests/test_sip_disallowed.py
+++ b/tests/test_sip_disallowed.py
@@ -51,3 +51,12 @@ def test_no_unauthorized_log_when_sip_disabled(monkeypatch):
     assert allowed is False
     assert all(msg != "UNAUTHORIZED_SIP" for msg in captured)
 
+
+def test_sip_disallowed_with_explicit_entitlement_false(monkeypatch):
+    for key in ("ALPACA_ALLOW_SIP", "ALPACA_HAS_SIP"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("ALPACA_SIP_ENTITLED", "0")
+    monkeypatch.setenv("ALPACA_API_KEY", "key")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "secret")
+    assert sip_disallowed() is True
+


### PR DESCRIPTION
## Summary
- normalize the ALPACA_* SIP flags inside `sip_disallowed` so explicit opt-outs are honoured while falling back to account entitlements when unset
- add regression coverage for explicit SIP entitlement opt-outs and for keeping SIP when the account advertises access

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_sip_disallowed.py -k "explicit_entitlement_false" -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_feed_entitlement.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d8a996ad008330a1fa7bba23ff9c7a