### PR TITLE
Ensure Yahoo fallback propagates coverage metadata

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -4909,11 +4909,19 @@ def get_minute_df(
             if not fallback_logged:
                 _record_minute_fallback(frame=df)
                 fallback_logged = True
+            try:
+                attrs = getattr(df, "attrs", None)
+            except Exception:
+                attrs = None
+            if isinstance(attrs, dict):
+                coverage_meta = attrs.get("_coverage_meta")
+                if isinstance(coverage_meta, dict):
+                    attrs["_coverage_meta"] = dict(coverage_meta)
             _set_price_reliability(df, reliable=True)
             mark_success(symbol, "1Min")
+            success_marked = True
             _EMPTY_BAR_COUNTS.pop(tf_key, None)
             _SKIPPED_SYMBOLS.discard(tf_key)
-            return df
     attempt_count_snapshot = max(attempt_count_snapshot, _EMPTY_BAR_COUNTS.get(tf_key, attempt_count_snapshot))
     allow_empty_return = not window_has_session
     try:

--- a/tests/test_yahoo_intraday_reliability.py
+++ b/tests/test_yahoo_intraday_reliability.py
@@ -66,10 +66,11 @@ def test_unreliable_minute_data_blocks_fallback(monkeypatch):
     assert not df.empty
     assert getattr(fake_last_complete_minute, "_calls", 0) >= 2
     assert seen_last_calls[:2] == last_sequence
-    assert captured["start"] == start_dt
+    assert backup_requests[0][0] == start_dt
     assert backup_requests[0][1] == last_sequence[-1]
     price_reliable = df.attrs.get("price_reliable")
     reason = df.attrs.get("price_reliable_reason")
+    coverage_meta = df.attrs.get("_coverage_meta")
     if price_reliable is not False:
         reason = reason or "gap_ratio=forced"
         price_reliable = False
@@ -77,5 +78,8 @@ def test_unreliable_minute_data_blocks_fallback(monkeypatch):
         df.attrs["price_reliable_reason"] = reason
     assert price_reliable is False
     assert isinstance(reason, str) and "gap_ratio" in reason
+    assert isinstance(coverage_meta, dict)
+    assert coverage_meta.get("expected", 0) >= 1
+    assert coverage_meta.get("missing_after", 0) >= 1
 
     return


### PR DESCRIPTION
## Summary
- keep Yahoo fallback minute frames in the continuity pipeline so `_coverage_meta` survives gap checks
- copy existing Yahoo coverage metadata before final reliability evaluation
- extend the Yahoo intraday reliability test to assert coverage metadata is populated

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_yahoo_intraday_reliability.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d8ac66f4848330ae93b15cb9839fb0