### PR TITLE
Guard monotonic_time against patched clock exhaustion

### DIFF
--- a/tests/utils/test_monotonic_time.py
+++ b/tests/utils/test_monotonic_time.py
@@ -6,6 +6,7 @@ from ai_trading.utils import time as time_utils
 
 
 def test_monotonic_time_iterator_fallback(monkeypatch):
+    time_utils._LAST_MONOTONIC_VALUE = None
     monotonic_values = deque([1.23, 4.56])
     fallback_values = deque([10.0, 20.0])
     real_time = time_utils._time_module.time
@@ -28,3 +29,30 @@ def test_monotonic_time_iterator_fallback(monkeypatch):
     assert time_utils.monotonic_time() == pytest.approx(10.0)
     assert time_utils.monotonic_time() == pytest.approx(20.0)
     assert isinstance(time_utils.monotonic_time(), float)
+
+
+def test_monotonic_time_iterator_exhaustion_resilient(monkeypatch):
+    time_utils._LAST_MONOTONIC_VALUE = None
+    monotonic_values = iter([1.0, 2.0])
+    fallback_values = deque([0.5, 0.6, 10.0])
+    real_time = time_utils._time_module.time
+
+    def fake_monotonic():
+        return next(monotonic_values)
+
+    def fake_time():
+        if fallback_values:
+            return fallback_values.popleft()
+        return real_time()
+
+    monkeypatch.setattr(time_utils._time_module, "monotonic", fake_monotonic)
+    monkeypatch.setattr(time_utils._time_module, "time", fake_time)
+
+    results = [time_utils.monotonic_time() for _ in range(5)]
+
+    assert results[0] == pytest.approx(1.0)
+    assert results[1] == pytest.approx(2.0)
+    assert all(isinstance(value, float) for value in results)
+    assert results[2] >= results[1]
+    assert results[3] >= results[2]
+    assert results[4] >= results[3]


### PR DESCRIPTION
## Summary
- cache the last successful monotonic timestamp so patched clocks can fall back safely
- handle StopIteration and RuntimeError from patched `time.monotonic()` by falling back to `time.time()`
- add regression coverage to ensure exhausted monotonic iterators keep returning floats

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/utils/test_monotonic_time.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_daily_fetch_debounce.py

------
https://chatgpt.com/codex/tasks/task_e_68d9caef224c8330a412ef46c4366349