### PR TITLE
Fix fallback StockLatestQuoteRequest signature

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -3542,11 +3542,30 @@ def _ensure_alpaca_classes() -> None:
     try:  # pragma: no cover - independent imports with fallbacks
         from alpaca.data.requests import StockLatestQuoteRequest as _StockLatestQuoteRequest
     except ImportError:
-        from dataclasses import dataclass
+        from dataclasses import dataclass, field
+        from typing import Any as _Any
 
-        @dataclass
+        @dataclass(init=False)
         class _StockLatestQuoteRequest:  # pragma: no cover - lightweight fallback
-            symbol_or_symbols: Any
+            symbol_or_symbols: _Any
+            feed: _Any | None = None
+            currency: _Any | None = None
+            _extra: dict[str, _Any] = field(default_factory=dict)
+
+            def __init__(
+                self,
+                *,
+                symbol_or_symbols: _Any,
+                feed: _Any | None = None,
+                currency: _Any | None = None,
+                **kwargs: _Any,
+            ) -> None:
+                self.symbol_or_symbols = symbol_or_symbols
+                self.feed = feed
+                self.currency = currency
+                self._extra = dict(kwargs)
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
     try:
         from alpaca.trading.requests import (
             MarketOrderRequest as _MarketOrderRequest,


### PR DESCRIPTION
## Motivation
- Prevent fallback `StockLatestQuoteRequest` from rejecting keyword arguments that the real alpaca-py request accepts when the SDK is unavailable.
- Ensure quote fetching via the injected `data_client` can still provide prices for sizing and execution when running without alpaca-py.

## What changed
- Expanded the fallback `StockLatestQuoteRequest` dataclass to mirror the SDK signature, capturing optional keyword arguments for compatibility.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_run_all_trades_warning.py -q`

## Rollback Plan
- Revert this pull request.


------
https://chatgpt.com/codex/tasks/task_e_68d9d7fc30108330822cdd8656677175