### PR TITLE
Fix default data feed propagation across modules

### DIFF
--- a/tests/test_settings_config.py
+++ b/tests/test_settings_config.py
@@ -72,6 +72,7 @@ def test_cfg_data_feed_updates_default_feed(monkeypatch):
 
     monkeypatch.setenv("ALPACA_ALLOW_SIP", "1")
     pytest.importorskip("numpy")
+    import ai_trading.config as config_pkg
     from ai_trading.config import settings as config_settings
     from ai_trading.data import fetch as data_fetch
     from ai_trading.core import bot_engine
@@ -81,9 +82,16 @@ def test_cfg_data_feed_updates_default_feed(monkeypatch):
     try:
         cfg.data_feed = "sip"
         assert cfg.data_feed == "sip"
+        assert data_fetch.get_default_feed() == "sip"
         assert data_fetch._DEFAULT_FEED == "sip"
+        assert bot_engine.get_default_feed() == "sip"
         assert bot_engine._DEFAULT_FEED == "sip"
+        assert config_pkg.DATA_FEED_INTRADAY == "sip"
     finally:
         cfg.data_feed = original_feed
-        assert data_fetch._DEFAULT_FEED == cfg.data_feed
-        assert bot_engine._DEFAULT_FEED == cfg.data_feed
+        expected_feed = cfg.data_feed
+        assert data_fetch.get_default_feed() == expected_feed
+        assert data_fetch._DEFAULT_FEED == expected_feed
+        assert bot_engine.get_default_feed() == expected_feed
+        assert bot_engine._DEFAULT_FEED == expected_feed
+        assert config_pkg.DATA_FEED_INTRADAY == expected_feed


### PR DESCRIPTION
## Summary
- add helpers so ai_trading.data.fetch and ai_trading.core.bot_engine refresh their cached default feed from settings
- expose setters for ai_trading.config.DATA_FEED_INTRADAY and update Settings propagation logic to call them
- extend cfg data feed test coverage to ensure all cached locations are updated

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_settings_config.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dad6a462008330ab0648d5fdcc0e01