### PR TITLE
Maintain Alpaca shadow placeholder while honoring config

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -1040,11 +1040,6 @@ def submit_order(
     prefix = f"{symbol_part}-{side_part}"
     idempotency_key = idempotency_key or generate_client_order_id(prefix)
 
-    if client is not None and shadow is None:
-        # Respect explicit shadow override but default to real execution when a
-        # client is supplied (callers may choose shadow=True explicitly).
-        do_shadow = False
-
     def _ensure_client_order_id(payload: Any) -> Any:
         if not isinstance(payload, dict):
             return payload

--- a/tests/test_shadow_mode_runtime.py
+++ b/tests/test_shadow_mode_runtime.py
@@ -6,31 +6,69 @@ import pytest
 
 req_mod = types.ModuleType("requests")
 req_mod.post = lambda *a, **k: None
-req_mod.exceptions = types.SimpleNamespace(RequestException=Exception)
+
+
+class _RequestException(Exception):
+    pass
+
+
+req_mod.exceptions = types.SimpleNamespace(RequestException=_RequestException)
 sys.modules.setdefault("requests", req_mod)
 
-import ai_trading.shadow_mode.runtime  # registers lazy alpaca_api
+runtime_mod = importlib.import_module("ai_trading.shadow_mode.runtime")
 
 
-def test_lazy_alpaca_api_behavior_switch(monkeypatch):
+def test_lazy_alpaca_api_placeholder_persists_and_respects_shadow(monkeypatch):
     monkeypatch.delenv("SHADOW_MODE", raising=False)
 
-    api = sys.modules["ai_trading.alpaca_api"]
-    assert "submit_order" not in api.__dict__
+    sys.modules.pop("ai_trading.alpaca_api", None)
+    runtime = importlib.reload(runtime_mod)
 
-    class Dummy:
+    placeholder = runtime.ensure_alpaca_api()
+    assert isinstance(placeholder, runtime._LazyModule)
+    assert "submit_order" not in placeholder.__dict__
+
+    # Load the real module to patch configuration behaviour while keeping the
+    # placeholder registered.
+    real_module = placeholder._load()
+    assert sys.modules["ai_trading.alpaca_api"] is placeholder
+    assert placeholder._real is real_module
+
+    state: dict[str, bool] = {"shadow": True}
+
+    def _from_env():
+        return real_module._AlpacaConfig(
+            "https://paper-api.alpaca.markets", None, None, state["shadow"]
+        )
+
+    monkeypatch.setattr(real_module._AlpacaConfig, "from_env", staticmethod(_from_env))
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
         def submit_order(self, **kwargs):
+            self.calls += 1
             raise AssertionError("called real submit")
 
-    monkeypatch.setenv("SHADOW_MODE", "1")
-    res = api.submit_order("AAPL", "buy", qty=1, client=Dummy())
+    # In shadow mode the client must never be touched and the placeholder
+    # remains active in ``sys.modules``.
+    client_shadow = DummyClient()
+    res = placeholder.submit_order("AAPL", "buy", qty=1, client=client_shadow)
     assert res["id"].startswith("shadow-")
+    assert client_shadow.calls == 0
+    assert sys.modules["ai_trading.alpaca_api"] is placeholder
+    assert runtime.ensure_alpaca_api() is placeholder
 
-    monkeypatch.delenv("SHADOW_MODE", raising=False)
-    importlib.reload(sys.modules["ai_trading.alpaca_api"])
-
+    # Switching to non-shadow mode should call the real client while keeping the
+    # lazy module registered for future imports.
+    state["shadow"] = False
+    client_real = DummyClient()
     with pytest.raises(AssertionError):
-        sys.modules["ai_trading.alpaca_api"].submit_order("AAPL", "buy", qty=1, client=Dummy())
+        placeholder.submit_order("AAPL", "buy", qty=1, client=client_real)
+    assert client_real.calls == 1
+    assert sys.modules["ai_trading.alpaca_api"] is placeholder
+    assert runtime.ensure_alpaca_api() is placeholder
 
 
 def test_lazy_alpaca_api_placeholder_reinstated_after_real_import(monkeypatch):


### PR DESCRIPTION
## Summary
- keep the shadow-mode runtime proxy in place after loading the real Alpaca API module and guard against re-entrant loads
- ensure `submit_order` defers to the resolved shadow-mode flag even when a client is supplied and extend coverage for the lazy placeholder lifecycle
- update Alpaca API tests to patch the real module behind the proxy and verify request-object handling when shadow mode is disabled

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_shadow_mode_runtime.py tests/test_alpaca_api_module.py

------
https://chatgpt.com/codex/tasks/task_e_68dad6a57f948330856e914a50385fbc