### PR TITLE
Ensure sitecustomize is loaded during tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@ import importlib
 import importlib.util
 import sys
 import types
+import sitecustomize  # noqa: F401
 from pathlib import Path
 from typing import Any
 


### PR DESCRIPTION
## Summary
- import the repository's sitecustomize module from pytest's conftest to ensure test hooks have expected globals available

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot_engine_imports.py::TestBotEngineImports::test_import_error_when_module_missing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_env_aliases.py::test_get_news_api_key_env *(fails: missing optional dependency `numpy` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dadf3170048330b60a358bb954fabd