### PR TITLE
Register RL train stub module before execution

### DIFF
--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -201,6 +201,7 @@ def _load_train_stub(module_name: str, original_exc: Exception) -> ModuleType:
             f"module {__name__!r} has no attribute 'train'"
         ) from original_exc
     module = importlib.util.module_from_spec(stub_spec)
+    sys.modules[module_name] = module
     try:
         stub_spec.loader.exec_module(module)
     except Exception as stub_exc:  # pragma: no cover - defensive guard


### PR DESCRIPTION
## Summary
- ensure the RL training stub is inserted into sys.modules before executing it so reload() can resolve the stub correctly

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rl_module.py::test_rl_train_module_reload_preserves_train_attr
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rl_module.py::test_rl_train_and_infer

------
https://chatgpt.com/codex/tasks/task_e_68dadf3292b0833081ac964c75f4450c