### PR TITLE
Ensure sitecustomize restores essential modules after sys.modules clear

### DIFF
--- a/tests/test_bot_engine_imports.py
+++ b/tests/test_bot_engine_imports.py
@@ -1,5 +1,7 @@
 """Tests for bot engine import behavior using canonical modules."""
 
+import builtins
+import importlib
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -29,3 +31,13 @@ class TestBotEngineImports:
         with patch.dict(sys.modules, {}, clear=True):
             with pytest.raises(ImportError):
                 from ai_trading.pipeline import model_pipeline  # type: ignore
+
+    def test_sys_module_restored_after_clear(self):
+        """Clearing ``sys.modules`` should keep essential modules accessible."""
+
+        with patch.dict(sys.modules, {}, clear=True):
+            optimizer = importlib.import_module("ai_trading.portfolio.optimizer")
+
+            assert optimizer  # imported without NameError due to missing sys
+            assert sys.modules.get("sys") is sys
+            assert sys.modules.get("builtins") is builtins


### PR DESCRIPTION
## Summary
- ensure `sitecustomize._safe_clear_dict` repopulates essential modules even when they were missing during initialization
- add a regression test that clears `sys.modules` and imports `ai_trading.portfolio.optimizer` to confirm `sys` and `builtins` remain available

## Testing
- pytest tests/test_bot_engine_imports.py tests/test_current_api.py


------
https://chatgpt.com/codex/tasks/task_e_68daf7782f208330a3406e774a86ac8d