### PR TITLE
Improve RL wrapper fallback without legacy config alias

### DIFF
--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -94,10 +94,15 @@ class RLAgent:
         if not rl_ready or PPO is None or is_stub:
             self._load_stub_model(model_path)
             return
-        if model_path.exists():
-            self.model = PPO.load(self.model_path)
-        else:
+        if not model_path.exists():
             logger.error("RL model not found at %s", self.model_path)
+            self._load_stub_model(model_path)
+            return
+        try:
+            self.model = PPO.load(self.model_path)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            logger.error("RL model load failed for %s: %s", self.model_path, exc)
+            self._load_stub_model(model_path)
 
     def predict(
         self, state: Iterable[Any] | Any, symbols: list[str] | None = None


### PR DESCRIPTION
## Summary
- clone RLConfig inputs in the lightweight RL wrapper and reload the active training module when the legacy `_C` alias is missing
- ensure stub trainers persist a model artifact when none was written and fall back to the stub agent if PPO loading fails

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rl_module.py

------
https://chatgpt.com/codex/tasks/task_e_68dafc4929c0833094ab5df71a2df908