### PR TITLE
Add TypeAdapter stub to pydantic test shim

### DIFF
--- a/tests/stubs/pydantic/__init__.py
+++ b/tests/stubs/pydantic/__init__.py
@@ -44,3 +44,16 @@ class BaseModel:
             setattr(self, k, v)
     def model_dump(self) -> dict[str, Any]:  # pragma: no cover
         return self.__dict__.copy()
+
+
+class TypeAdapter:
+    """Minimal stub matching the interface used by pydantic_settings."""
+
+    def __init__(self, type_: Any):
+        self._type = type_
+
+    def validate_python(self, value: Any) -> Any:  # pragma: no cover - passthrough
+        return value
+
+    def dump_python(self, value: Any) -> Any:  # pragma: no cover - passthrough
+        return value


### PR DESCRIPTION
## Summary
- add a minimal `TypeAdapter` stub to the pydantic test shim so `pydantic_settings` can import successfully

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_systemd_startup.py::TestSystemdStartupCompatibility::test_import_no_crash_without_credentials


------
https://chatgpt.com/codex/tasks/task_e_68db0cca0ae883309e2ac09840bab2b0