### PR TITLE
Ensure Alpaca request classes are initialized before use

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -9259,6 +9259,8 @@ def audit_positions(ctx) -> None:
 
     max_order_size = _as_int(os.getenv("MAX_ORDER_SIZE", "1000"), 1000)
 
+    _ensure_alpaca_classes()
+
     # 3) For any symbol in remote whose remote_qty != local_qty, correct via market order
     for sym, rq in remote.items():
         lq = local.get(sym, 0)
@@ -9355,6 +9357,7 @@ def validate_open_orders(ctx: BotContext) -> None:
         return
 
     now = datetime.now(UTC)
+    _ensure_alpaca_classes()
     for od in open_orders:
         created = pd.to_datetime(getattr(od, "created_at", now))
         age = (now - created).total_seconds() / 60.0

--- a/ai_trading/core/execution_flow.py
+++ b/ai_trading/core/execution_flow.py
@@ -141,9 +141,6 @@ def vwap_pegged_submit(
         fetch_minute_df_safe,
         DataFetchError,
         ta,
-        LimitOrderRequest,
-        OrderSide,
-        TimeInForce,
         APIError,
         utc_now_iso,
         slippage_total,
@@ -154,6 +151,12 @@ def vwap_pegged_submit(
         safe_submit_order,
     )
     from ai_trading.core import bot_engine as _bot_engine
+
+    _bot_engine._ensure_alpaca_classes()
+    OrderSide = _bot_engine.OrderSide
+    TimeInForce = _bot_engine.TimeInForce
+    LimitOrderRequest = _bot_engine.LimitOrderRequest
+    MarketOrderRequest = _bot_engine.MarketOrderRequest
 
     start_time = pytime.time()
     placed = 0
@@ -302,13 +305,14 @@ def send_exit_order(
     raw_positions: list | None = None,
 ) -> None:
     """Submit an exit order (market or limit) with simple validations."""
-    from ai_trading.core.bot_engine import (
-        MarketOrderRequest,
-        LimitOrderRequest,
-        OrderSide,
-        TimeInForce,
-        safe_submit_order,
-    )
+    from ai_trading.core import bot_engine as _bot_engine
+
+    _bot_engine._ensure_alpaca_classes()
+    MarketOrderRequest = _bot_engine.MarketOrderRequest
+    LimitOrderRequest = _bot_engine.LimitOrderRequest
+    OrderSide = _bot_engine.OrderSide
+    TimeInForce = _bot_engine.TimeInForce
+    safe_submit_order = _bot_engine.safe_submit_order
 
     logger.info(
         f"EXIT_SIGNAL | symbol={symbol}  reason={reason}  exit_qty={exit_qty}  price={price}"


### PR DESCRIPTION
## Summary
- call `_ensure_alpaca_classes()` before constructing Alpaca order request objects in execution helpers
- teach the live trading engine to hydrate Alpaca request classes from `bot_engine` fallbacks when the SDK shims are missing
- add a regression test that deletes the Alpaca shim modules to confirm the request helper degrades gracefully

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_safe_submit_order_without_alpaca.py -q


------
https://chatgpt.com/codex/tasks/task_e_68db43034cf48330889e66c53652c8fb