### PR TITLE
Fix SoftBudget sub-millisecond accounting

### DIFF
--- a/ai_trading/utils/prof.py
+++ b/ai_trading/utils/prof.py
@@ -128,14 +128,19 @@ class SoftBudget:
         return self._elapsed_ms
 
     def over_budget(self) -> bool:
-        return self.elapsed_ms() >= self.budget_ms
+        self._update_elapsed_state()
+        total_elapsed_ns = (self._elapsed_ms * 1_000_000) + self._fractional_ns
+        budget_ns = self.budget_ms * 1_000_000
+        return total_elapsed_ns >= budget_ns
 
     def remaining(self) -> float:
-        elapsed_ms = self.elapsed_ms()
-        if elapsed_ms >= self.budget_ms:
+        self._update_elapsed_state()
+        budget_ns = self.budget_ms * 1_000_000
+        total_elapsed_ns = (self._elapsed_ms * 1_000_000) + self._fractional_ns
+        if total_elapsed_ns >= budget_ns:
             return 0.0
-        remaining_ms = self.budget_ms - elapsed_ms
-        return round(remaining_ms / 1_000, 3)
+        remaining_ns = budget_ns - total_elapsed_ns
+        return round(remaining_ns / 1_000_000_000, 3)
 
     def over(self) -> bool:  # Backward compatibility
         return self.over_budget()

--- a/tests/test_prof_soft_budget_regression.py
+++ b/tests/test_prof_soft_budget_regression.py
@@ -54,3 +54,70 @@ def test_soft_budget_context_manager_regression(monkeypatch):
 
     assert budget.elapsed_ms() == 6
     assert budget.remaining() == 0.0
+
+
+def test_soft_budget_short_sleep_respects_budget(monkeypatch):
+    sequence = iter(
+        [
+            0,  # __init__
+            500_000,  # elapsed_ms -> <1ms
+            500_000,  # over_budget -> same observation, still under budget
+            1_500_000,  # elapsed_ms -> crosses 1ms boundary
+            1_500_000,  # over_budget -> >= budget
+        ]
+    )
+
+    monkeypatch.setattr(
+        "ai_trading.utils.prof.time.perf_counter_ns", lambda: next(sequence)
+    )
+
+    budget = SoftBudget(1)
+
+    assert budget.elapsed_ms() == 1
+    assert budget.over_budget() is False
+    assert budget.elapsed_ms() == 1
+    assert budget.over_budget() is True
+
+
+def test_soft_budget_reset_clears_fractional_state(monkeypatch):
+    sequence = iter(
+        [
+            0,  # __init__
+            500_000,  # elapsed_ms -> <1ms
+            800_000,  # reset -> establishes new baseline
+            900_000,  # elapsed_ms after reset -> <1ms
+            900_000,  # over_budget -> same observation, still under budget
+        ]
+    )
+
+    monkeypatch.setattr(
+        "ai_trading.utils.prof.time.perf_counter_ns", lambda: next(sequence)
+    )
+
+    budget = SoftBudget(5)
+
+    assert budget.elapsed_ms() == 1
+    budget.reset()
+    assert budget.elapsed_ms() == 1
+    assert budget.over_budget() is False
+
+
+def test_soft_budget_fractional_over_budget_threshold(monkeypatch):
+    sequence = iter(
+        [
+            0,  # __init__
+            900_000,  # elapsed_ms -> <1ms
+            1_800_000,  # over_budget -> cumulative 1.8ms (< 2ms)
+            2_300_000,  # over_budget -> cumulative 2.3ms (>= 2ms)
+        ]
+    )
+
+    monkeypatch.setattr(
+        "ai_trading.utils.prof.time.perf_counter_ns", lambda: next(sequence)
+    )
+
+    budget = SoftBudget(2)
+
+    assert budget.elapsed_ms() == 1
+    assert budget.over_budget() is False
+    assert budget.over_budget() is True


### PR DESCRIPTION
## Summary
- ensure SoftBudget comparisons use nanosecond precision so sub-millisecond work does not prematurely exhaust budgets
- update remaining-time calculations and expand regression coverage for short sleeps, resets, and fractional over-budget thresholds

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_prof_soft_budget_regression.py tests/test_prof_budget.py -q


------
https://chatgpt.com/codex/tasks/task_e_68db43089b5883308320fa1d1a9bddcb