### PR TITLE
Handle stub quote requests in price sourcing

### DIFF
--- a/tests/test_order_price_sourcing.py
+++ b/tests/test_order_price_sourcing.py
@@ -14,15 +14,50 @@ class DummyDataClient:
     def __init__(self, quotes: dict[str | None, Any]) -> None:
         self.quotes = quotes
         self.calls: list[str | None] = []
+        self.requests: list[Any] = []
 
     def get_stock_latest_quote(self, req: Any) -> Any:
         feed = getattr(req, "feed", None)
         self.calls.append(feed)
+        self.requests.append(req)
         return self.quotes.get(feed)
 
 
 def _ctx_with_quotes(quotes: dict[str | None, Any]) -> SimpleNamespace:
     return SimpleNamespace(data_client=DummyDataClient(quotes))
+
+
+@pytest.fixture
+def stub_stock_quote_request(monkeypatch: pytest.MonkeyPatch) -> list[tuple[Any, str | None]]:
+    calls: list[tuple[Any, str | None]] = []
+
+    class StubStockLatestQuoteRequest(SimpleNamespace):
+        def __init__(
+            self,
+            *,
+            symbol_or_symbols: Any,
+            feed: str | None = None,
+            **kwargs: Any,
+        ) -> None:
+            super().__init__(
+                symbol_or_symbols=symbol_or_symbols,
+                feed=feed,
+                params=dict(kwargs),
+            )
+            symbols: Any
+            if isinstance(symbol_or_symbols, (list, tuple)):
+                symbols = tuple(symbol_or_symbols)
+            else:
+                symbols = symbol_or_symbols
+            calls.append((symbols, feed))
+
+    def _unexpected_ensure_call() -> None:
+        raise AssertionError("_ensure_alpaca_classes should not run when stubbed")
+
+    monkeypatch.setattr(bot_engine, "StockLatestQuoteRequest", StubStockLatestQuoteRequest, raising=False)
+    monkeypatch.setattr(bot_engine, "_ensure_alpaca_classes", _unexpected_ensure_call)
+    monkeypatch.setattr(bot_engine, "_ALPACA_IMPORT_ERROR", None, raising=False)
+    return calls
 
 
 def test_price_source_prefers_nbbo(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -91,3 +126,60 @@ def test_price_source_last_close_fallback(monkeypatch: pytest.MonkeyPatch, caplo
     assert price == pytest.approx(50.01, rel=1e-6)
     messages = [rec.message for rec in caplog.records if rec.message.startswith("ORDER_PRICE_SOURCE")]
     assert messages and "reason=broker_nbbo:unavailable;primary_mid:iex:unavailable" in messages[-1]
+
+
+def test_price_source_prefers_nbbo_with_stubbed_request(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    stub_stock_quote_request: list[tuple[Any, str | None]],
+) -> None:
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("PRICE_SLIPPAGE_BPS", "2")
+    quotes = {
+        None: SimpleNamespace(bid_price=102.0, ask_price=102.5),
+    }
+    ctx = _ctx_with_quotes(quotes)
+    price, source = bot_engine._resolve_limit_price(ctx, "NVDA", "buy", None, None)
+    assert source == "broker_nbbo"
+    assert price == pytest.approx(102.27505, rel=1e-6)
+    assert stub_stock_quote_request == [("NVDA", None)]
+
+
+def test_price_source_primary_mid_with_stubbed_request(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_stock_quote_request: list[tuple[Any, str | None]],
+) -> None:
+    monkeypatch.setenv("PRICE_SLIPPAGE_BPS", "2")
+    monkeypatch.setattr(bot_engine, "DATA_FEED_INTRADAY", "iex", raising=False)
+    quotes = {
+        None: SimpleNamespace(bid_price=0.0, ask_price=0.0),
+        "iex": SimpleNamespace(bid_price=108.0, ask_price=109.0),
+    }
+    ctx = _ctx_with_quotes(quotes)
+    price, source = bot_engine._resolve_limit_price(ctx, "META", "sell", None, None)
+    assert source == "primary_mid"
+    assert price == pytest.approx(108.4791, rel=1e-6)
+    assert stub_stock_quote_request == [("META", None), ("META", "iex")]
+
+
+def test_price_source_backup_mid_with_stubbed_request(
+    monkeypatch: pytest.MonkeyPatch,
+    stub_stock_quote_request: list[tuple[Any, str | None]],
+) -> None:
+    monkeypatch.setenv("PRICE_SLIPPAGE_BPS", "2")
+    monkeypatch.setattr(bot_engine, "DATA_FEED_INTRADAY", "iex", raising=False)
+    monkeypatch.setattr(bot_engine.data_fetcher_module, "_sip_configured", lambda: True, raising=False)
+    quotes = {
+        None: SimpleNamespace(bid_price=0.0, ask_price=0.0),
+        "iex": SimpleNamespace(bid_price=0.0, ask_price=0.0),
+        "sip": SimpleNamespace(bid_price=210.0, ask_price=211.0),
+    }
+    ctx = _ctx_with_quotes(quotes)
+    price, source = bot_engine._resolve_limit_price(ctx, "AMZN", "buy", None, None)
+    assert source == "backup_mid"
+    assert price == pytest.approx(210.04202, rel=1e-6)
+    assert stub_stock_quote_request == [
+        ("AMZN", None),
+        ("AMZN", "iex"),
+        ("AMZN", "sip"),
+    ]


### PR DESCRIPTION
## Summary
- add a readiness helper that preserves injected StockLatestQuoteRequest stubs instead of re-importing Alpaca classes
- reuse the helper across liquidity, fallback age checks, and quote fetching so simple bid/ask objects remain valid
- extend the order price sourcing tests with stubbed StockLatestQuoteRequest regression cases that cover broker_nbbo, primary_mid, and backup_mid flows

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_order_price_sourcing.py *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68db45399ac48330b5d0a3f8ee9822ea