### PR TITLE
Ensure SIP override persists after IEX empty threshold

### DIFF
--- a/tests/test_iex_sip_fallback.py
+++ b/tests/test_iex_sip_fallback.py
@@ -3,22 +3,45 @@ import types
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+import pytest
+
 import ai_trading.data.fetch as fetch
+import ai_trading.net.http as http
 from ai_trading.data.fetch.metrics import inc_provider_fallback
 
+pytest.importorskip("pandas")
 
-def test_iex_empty_switches_to_sip(monkeypatch, caplog):
+
+@pytest.mark.parametrize(
+    ("preferred_feeds", "provider_order"),
+    [
+        (("sip",), ["alpaca_iex", "alpaca_sip"]),
+        ((), ["alpaca_iex"]),
+    ],
+    ids=["preferred_list", "no_preference"],
+)
+def test_iex_empty_switches_to_sip(monkeypatch, caplog, preferred_feeds, provider_order):
     symbol = "AAPL"
     start = datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC"))
     end = start + timedelta(days=1)
 
     fetch._IEX_EMPTY_COUNTS.clear()
+    fetch._FEED_OVERRIDE_BY_TF.clear()
+    fetch._FEED_FAILOVER_ATTEMPTS.clear()
+    fetch._FEED_SWITCH_HISTORY.clear()
+    fetch._FEED_SWITCH_LOGGED.clear()
+    fetch._cycle_feed_override.clear()
     fetch._IEX_EMPTY_COUNTS[(symbol, "1Min")] = fetch._IEX_EMPTY_THRESHOLD + 1
+    monkeypatch.setenv("TESTING", "1")
+    monkeypatch.setenv("ALPACA_API_KEY", "dummy")
+    monkeypatch.setenv("ALPACA_SECRET_KEY", "dummy")
     monkeypatch.setattr(fetch, "_ALLOW_SIP", True, raising=False)
     monkeypatch.setattr(fetch, "_SIP_UNAUTHORIZED", False, raising=False)
     monkeypatch.setattr(fetch, "_window_has_trading_session", lambda *a, **k: True)
     monkeypatch.setattr(fetch, "_outside_market_hours", lambda *a, **k: False)
     monkeypatch.setattr(fetch, "is_market_open", lambda: False)
+    monkeypatch.setattr(fetch, "alpaca_feed_failover", lambda: preferred_feeds)
+    monkeypatch.setattr(fetch, "provider_priority", lambda: provider_order)
 
     feeds = []
 
@@ -36,6 +59,7 @@ def test_iex_empty_switches_to_sip(monkeypatch, caplog):
         )
 
     monkeypatch.setattr(fetch.requests, "get", fake_get)
+    monkeypatch.setattr(http.requests, "get", fake_get, raising=False)
 
     allowed = [False, True]
 
@@ -52,4 +76,7 @@ def test_iex_empty_switches_to_sip(monkeypatch, caplog):
     assert feeds == ["iex", "sip"]
     assert not df.empty
     assert any(rec.message == "ALPACA_IEX_FALLBACK_SIP" for rec in caplog.records)
-    assert after == before + 1
+    assert fetch._FEED_OVERRIDE_BY_TF[(symbol, "1Min")] == "sip"
+    assert fetch._cycle_feed_override.get(symbol) == "sip"
+    assert "sip" in fetch._FEED_FAILOVER_ATTEMPTS.get((symbol, "1Min"), set())
+    assert after == before + 2


### PR DESCRIPTION
## Summary
- push SIP overrides and emit ALPACA_IEX_FALLBACK_SIP when repeated IEX empty bars trigger the failover threshold
- avoid double-counting provider fallback metrics by letting the SIP switch record metrics before delegating to the fallback request
- add parametrized coverage to confirm the override persists for both preferred-feed lists and empty alpaca_feed_failover() results

## Testing
- pytest tests/test_iex_sip_fallback.py *(skipped: pandas not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db4730fc948330bd16b1e477da73c0