### PR TITLE
Return safe defaults for momentum and mean reversion signals

### DIFF
--- a/tests/test_indicator_window.py
+++ b/tests/test_indicator_window.py
@@ -32,9 +32,13 @@ def test_macd_insufficient_history_defers():
 
 def test_signal_manager_skips_nan_indicators():
     sm = be.SignalManager()
+    short_df = pd.DataFrame({"close": [1, 2, 3]})
+    assert sm.signal_momentum(short_df) == (-1, 0.0, "momentum")
     df = pd.DataFrame({"close": [1, 2, 3, float("nan")]})
     s, w, _ = sm.signal_momentum(df)
     assert s == -1 and w == 0.0
+    short_mean_rev = pd.DataFrame({"close": [1.0] * 10})
+    assert sm.signal_mean_reversion(short_mean_rev) == (-1, 0.0, "mean_reversion")
     df2 = pd.DataFrame({"close": [1.0] * 20 + [float("nan")]})
     s2, w2, _ = sm.signal_mean_reversion(df2)
     assert s2 == -1 and w2 == 0.0


### PR DESCRIPTION
## Summary
- ensure the momentum signal falls back to a neutral (-1, 0.0, "momentum") tuple when history is insufficient or NaNs appear
- do the same for the mean reversion signal and log when the safe default is used
- extend the indicator window test coverage to assert the new safe defaults

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_indicator_window.py -q

------
https://chatgpt.com/codex/tasks/task_e_68db4a8abf508330b7ee5cf8cda007a3