### PR TITLE
Handle dotenv shadow detection regardless of resolver state

### DIFF
--- a/ai_trading/util/env_check.py
+++ b/ai_trading/util/env_check.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.machinery
 import pathlib
 import sys
 
@@ -9,22 +10,24 @@ class DotenvImportError(ImportError): ...
 
 
 def assert_dotenv_not_shadowed():
-    if not PYTHON_DOTENV_RESOLVED:
-        return
     existing = sys.modules.get("dotenv")
     if existing is not None and getattr(existing, "__spec__", None) is None:
         sys.modules.pop("dotenv", None)
-    try:
-        spec = importlib.util.find_spec("dotenv")
-    except ValueError as exc:
-        if not PYTHON_DOTENV_RESOLVED:
-            return
-        raise DotenvImportError("python-dotenv not importable") from exc
-    if spec is None or not spec.origin:
-        if not PYTHON_DOTENV_RESOLVED:
-            return
-        raise DotenvImportError("python-dotenv not importable")
     repo_root = pathlib.Path(__file__).resolve().parents[2]
+    stub_path = repo_root / "tests" / "stubs"
+    search_paths = [p for p in sys.path if pathlib.Path(p).resolve() != stub_path]
+
+    try:
+        spec = importlib.machinery.PathFinder.find_spec("dotenv", search_paths)
+    except ValueError as exc:
+        raise DotenvImportError("python-dotenv not importable") from exc
+    if spec is None:
+        try:
+            spec = importlib.util.find_spec("dotenv")
+        except ValueError as exc:
+            raise DotenvImportError("python-dotenv not importable") from exc
+    if spec is None or not spec.origin:
+        raise DotenvImportError("python-dotenv not importable")
     origin_path = pathlib.Path(spec.origin).resolve()
     try:
         relative_origin = origin_path.relative_to(repo_root)

--- a/tests/test_env_import_guard.py
+++ b/tests/test_env_import_guard.py
@@ -22,6 +22,27 @@ def test_guard_detects_shadowed_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
             return SimpleNamespace(origin=str(repo_root / "dotenv/__init__.py"))
         return real_find_spec(name)
     monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", lambda name, path=None, target=None: fake_find_spec(name))
+    monkeypatch.setattr(env_check, "PYTHON_DOTENV_RESOLVED", True)
+
+    with pytest.raises(env_check.DotenvImportError) as exc:
+        env_check.assert_dotenv_not_shadowed()
+
+    assert "python-dotenv is shadowed" in str(exc.value)
+
+
+def test_guard_detects_shadowed_dotenv_without_python_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = Path(env_check.__file__).resolve().parents[2]
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name: str):
+        if name == "dotenv":
+            return SimpleNamespace(origin=str(repo_root / "dotenv/__init__.py"))
+        return real_find_spec(name)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(importlib.machinery.PathFinder, "find_spec", lambda name, path=None, target=None: fake_find_spec(name))
+    monkeypatch.setattr(env_check, "PYTHON_DOTENV_RESOLVED", False)
 
     with pytest.raises(env_check.DotenvImportError) as exc:
         env_check.assert_dotenv_not_shadowed()


### PR DESCRIPTION
## Summary
- exclude the test stub directory when resolving python-dotenv so shadowed modules trigger DotenvImportError even without a resolver flag
- preload the real python-dotenv module in the pytest configuration when available to avoid stubs masking the import
- extend the env import guard tests to cover shadowed modules with and without an installed python-dotenv

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_env_import_guard.py -q

------
https://chatgpt.com/codex/tasks/task_e_68db4ca7420c8330a56d93d028246e66