### PR TITLE
Fix ai_trading run-module warning handling

### DIFF
--- a/ai_trading/__init__.py
+++ b/ai_trading/__init__.py
@@ -9,6 +9,11 @@ import sys
 from pathlib import Path
 from importlib import import_module as _import_module
 
+# Ensure a prior ``python -m ai_trading`` run does not leave behind a stale
+# ``ai_trading.__main__`` module entry that would short-circuit lazy exports
+# during package initialization.
+sys.modules.pop(f"{__name__}.__main__", None)
+
 PYTEST_DONT_REWRITE = ["ai_trading"]
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -65,6 +70,4 @@ def __getattr__(name: str):  # pragma: no cover - thin lazy loader
     mod = _import_module(mod_name)
     obj = getattr(mod, attr) if attr else mod
     globals()[name] = obj
-    if not attr:
-        sys.modules.setdefault(name, obj)
     return obj

--- a/tests/test_import_side_effects.py
+++ b/tests/test_import_side_effects.py
@@ -1,8 +1,10 @@
-import runpy, sys
+import runpy
+import sys
+import warnings
 
 
 def test_module_imports_without_heavy_stacks(monkeypatch):
-    heavy_roots = {"torch","gymnasium","pandas","pyarrow","sklearn","matplotlib"}
+    heavy_roots = {"torch", "gymnasium", "pandas", "pyarrow", "sklearn", "matplotlib"}
     before = set(sys.modules)
     # Running the module main should not pull heavy deps implicitly
     monkeypatch.setattr(sys, "argv", ["ai_trading"])
@@ -11,3 +13,13 @@ def test_module_imports_without_heavy_stacks(monkeypatch):
     after = set(sys.modules)
     loaded = {m.split('.')[0] for m in (after - before)}
     assert heavy_roots.isdisjoint(loaded), f"Heavy modules imported at startup: {heavy_roots & loaded}"
+
+
+def test_run_module_emits_no_runtime_warning(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["ai_trading"])
+    monkeypatch.setenv("PYTEST_RUNNING", "1")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", RuntimeWarning)
+        runpy.run_module("ai_trading", run_name="__main__")
+    runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    assert not runtime_warnings, f"RuntimeWarning emitted: {runtime_warnings}"


### PR DESCRIPTION
## Summary
- drop stale ai_trading.__main__ entries before initializing lazy exports and stop aliasing submodules in sys.modules
- extend the import side-effects test suite with a regression check that runpy.run_module("ai_trading", run_name="__main__") emits no RuntimeWarning

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_import_side_effects.py -q

------
https://chatgpt.com/codex/tasks/task_e_68db4cab4f288330addb78ca357a846b