### PR TITLE
Reset provider suppression counts only after summary emission

### DIFF
--- a/ai_trading/logging/__init__.py
+++ b/ai_trading/logging/__init__.py
@@ -582,12 +582,18 @@ def record_provider_log_suppressed(message: str) -> None:
 
 
 def _drain_provider_log_summaries() -> list[tuple[str, int]]:
+    """Return provider suppression totals that warrant a summary this cycle."""
+
     with _provider_log_lock:
         if not _provider_log_suppressed:
             return []
-        items = list(_provider_log_suppressed.items())
-        _provider_log_suppressed.clear()
-        return items
+
+        ready: list[tuple[str, int]] = []
+        for message, suppressed in list(_provider_log_suppressed.items()):
+            if suppressed >= 3:
+                ready.append((message, suppressed))
+                del _provider_log_suppressed[message]
+        return ready
 
 
 def _flush_provider_log_summaries() -> None:


### PR DESCRIPTION
## Summary
- only clear provider suppression counters once a LOG_THROTTLE_SUMMARY entry is emitted so counts carry across cycles
- broaden log deduper tests to exercise multiple flush cycles and verify summaries reset between runs

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_log_deduper_provider_spam.py -q

------
https://chatgpt.com/codex/tasks/task_e_68db5191dd208330a129b2d114f6bad0