### PR TITLE
Handle cached context positions in correlation analyzer

### DIFF
--- a/tests/test_intelligent_position_management.py
+++ b/tests/test_intelligent_position_management.py
@@ -378,6 +378,11 @@ class TestPortfolioCorrelationAnalyzer:
                 self.symbol = symbol; self.qty = qty
                 self.avg_entry_price = avg_entry_price; self.market_value = market_value
 
+        cached_positions = [
+            MockPosition('AAPL', 100, 100.0, 11000.0)
+        ]
+        self.mock_ctx.current_positions = cached_positions
+
         positions = [
             MockPosition('MSFT', 50, 200.0, 10500.0),
             MockPosition('GOOGL', 25, 150.0, 3750.0)


### PR DESCRIPTION
## Summary
- merge context-provided holdings exposed on the context object into `_extract_position_data`
- add a regression test to ensure cached positions are merged alongside the live portfolio input

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_intelligent_position_management.py::TestPortfolioCorrelationAnalyzer::test_position_data_extraction -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68db5192869883308c15878b75f26b11