### PR TITLE
Allow re-registering identical model payloads

### DIFF
--- a/ai_trading/model_registry.py
+++ b/ai_trading/model_registry.py
@@ -315,10 +315,6 @@ class ModelRegistry:
         payload, pickler_name = self._serialise_model(model)
         model_hash = hashlib.sha256(payload).hexdigest()
 
-        for existing in self.model_index.values():
-            if existing.get("model_hash") == model_hash:
-                raise ValueError("Model already registered")
-
         registered_at = datetime.now(UTC)
         dataset_fp = str(dataset_fingerprint) if dataset_fingerprint is not None else None
 


### PR DESCRIPTION
## Summary
- remove the global model hash guard so identical payloads can be registered more than once
- add coverage ensuring sequential registrations succeed and `latest_for` reports the newest ID

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_model_registry.py -q


------
https://chatgpt.com/codex/tasks/task_e_68db547144408330bb27add411f53ce4