### PR TITLE
Treat mixed-format trade logs as valid

### DIFF
--- a/ai_trading/meta_learning/core.py
+++ b/ai_trading/meta_learning/core.py
@@ -421,7 +421,10 @@ def validate_trade_data_quality(trade_log_path: str) -> dict:
                 quality_report['recommendations'].append(
                     'Separate audit and meta-learning logs or implement unified parsing'
                 )
-                quality_report['has_valid_format'] = audit_format_rows > 0 or meta_format_rows > 0
+                # Mixed-format files should still be treated as having a valid structure so
+                # downstream consumers do not reject them outright. The recommendation above
+                # guides operators to split or convert the data without blocking ingestion.
+                quality_report['has_valid_format'] = True
                 logger.warning(
                     'TRADE_HISTORY_MIXED_FORMAT: %s',
                     trade_log_path,

--- a/tests/test_validate_trade_data_quality_mixed_format.py
+++ b/tests/test_validate_trade_data_quality_mixed_format.py
@@ -26,3 +26,5 @@ def test_mixed_format_detection(mixed_format_file):
     assert report["mixed_format_detected"] is True
     assert report["audit_format_rows"] >= 1
     assert report["meta_format_rows"] >= 1
+    assert report["has_valid_format"] is True
+    assert report["data_quality_score"] > 0


### PR DESCRIPTION
## Summary
- treat mixed audit/meta trade logs as structurally valid while still flagging the mix
- add regression coverage to ensure mixed-format files maintain positive quality scores

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_validate_trade_data_quality_mixed_format.py -q

------
https://chatgpt.com/codex/tasks/task_e_68db55eb1d608330895415ee1572cfa9