### PR TITLE
Record data fetch fallback success overrides and metrics

### DIFF
--- a/tests/test_feed_failover.py
+++ b/tests/test_feed_failover.py
@@ -102,8 +102,14 @@ def test_empty_payload_switches_to_preferred_feed(monkeypatch, capmetrics):
     names = [name for name, _ in capmetrics]
     assert "data.fetch.fallback_attempt" in names
     assert "data.fetch.success" in names
-    assert names.index("data.fetch.fallback_attempt") < names.index("data.fetch.success")
-    success_tags = capmetrics[names.index("data.fetch.success")][1]
+    assert "data.fetch.fallback_success" in names
+    idx_attempt = names.index("data.fetch.fallback_attempt")
+    idx_fb_success = names.index("data.fetch.fallback_success")
+    idx_success = names.index("data.fetch.success")
+    assert idx_attempt < idx_fb_success < idx_success
+    fallback_success_tags = capmetrics[idx_fb_success][1]
+    assert fallback_success_tags.get("feed") == "sip"
+    success_tags = capmetrics[idx_success][1]
     assert success_tags.get("feed") == "sip"
 
 
@@ -157,8 +163,14 @@ def test_empty_payload_switch_records_override_without_preferred_list(monkeypatc
     names = [name for name, _ in capmetrics]
     assert "data.fetch.fallback_attempt" in names
     assert "data.fetch.success" in names
-    assert names.index("data.fetch.fallback_attempt") < names.index("data.fetch.success")
-    success_tags = capmetrics[names.index("data.fetch.success")][1]
+    assert "data.fetch.fallback_success" in names
+    idx_attempt = names.index("data.fetch.fallback_attempt")
+    idx_fb_success = names.index("data.fetch.fallback_success")
+    idx_success = names.index("data.fetch.success")
+    assert idx_attempt < idx_fb_success < idx_success
+    fallback_success_tags = capmetrics[idx_fb_success][1]
+    assert fallback_success_tags.get("feed") == "sip"
+    success_tags = capmetrics[idx_success][1]
     assert success_tags.get("feed") == "sip"
 
 

--- a/tests/unit/test_data_fetcher_metrics.py
+++ b/tests/unit/test_data_fetcher_metrics.py
@@ -88,12 +88,17 @@ def test_rate_limit_fallback_success(monkeypatch: pytest.MonkeyPatch, capmetrics
     assert names == [
         "data.fetch.rate_limited",
         "data.fetch.fallback_attempt",
+        "data.fetch.fallback_success",
         "data.fetch.success",
     ]
-    assert names.index("data.fetch.fallback_attempt") < names.index("data.fetch.success")
+    idx_attempt = names.index("data.fetch.fallback_attempt")
+    idx_fb_success = names.index("data.fetch.fallback_success")
+    idx_success = names.index("data.fetch.success")
+    assert idx_attempt < idx_fb_success < idx_success
     assert capmetrics[0].tags["feed"] == "iex"
-    assert capmetrics[1].tags["feed"] == "sip"
-    assert capmetrics[2].tags["feed"] == "sip"
+    assert capmetrics[idx_attempt].tags["feed"] == "sip"
+    assert capmetrics[idx_fb_success].tags["feed"] == "sip"
+    assert capmetrics[idx_success].tags["feed"] == "sip"
 
 
 def test_rate_limit_no_retry_when_sip_unauthorized(
@@ -151,11 +156,17 @@ def test_timeout_fallback_success(monkeypatch: pytest.MonkeyPatch, capmetrics: l
     assert names == [
         "data.fetch.timeout",
         "data.fetch.fallback_attempt",
+        "data.fetch.fallback_success",
         "data.fetch.success",
     ]
-    assert names.index("data.fetch.fallback_attempt") < names.index("data.fetch.success")
+    idx_attempt = names.index("data.fetch.fallback_attempt")
+    idx_fb_success = names.index("data.fetch.fallback_success")
+    idx_success = names.index("data.fetch.success")
+    assert idx_attempt < idx_fb_success < idx_success
     assert capmetrics[0].tags["feed"] == "iex"
-    assert capmetrics[1].tags["feed"] == "sip"
+    assert capmetrics[idx_attempt].tags["feed"] == "sip"
+    assert capmetrics[idx_fb_success].tags["feed"] == "sip"
+    assert capmetrics[idx_success].tags["feed"] == "sip"
 
 
 def test_unauthorized_sip_returns_empty(
@@ -210,9 +221,15 @@ def test_empty_payload_fallback_success(
     assert names == [
         "data.fetch.empty",
         "data.fetch.fallback_attempt",
+        "data.fetch.fallback_success",
         "data.fetch.success",
     ]
-    assert names.index("data.fetch.fallback_attempt") < names.index("data.fetch.success")
+    idx_attempt = names.index("data.fetch.fallback_attempt")
+    idx_fb_success = names.index("data.fetch.fallback_success")
+    idx_success = names.index("data.fetch.success")
+    assert idx_attempt < idx_fb_success < idx_success
     assert capmetrics[0].tags["feed"] == "iex"
-    assert capmetrics[1].tags["feed"] == "sip"
+    assert capmetrics[idx_attempt].tags["feed"] == "sip"
+    assert capmetrics[idx_fb_success].tags["feed"] == "sip"
+    assert capmetrics[idx_success].tags["feed"] == "sip"
 


### PR DESCRIPTION
## Summary
- ensure fallback responses record override history and `data.fetch.fallback_success` metrics in the fetch pipeline
- share a reusable helper for detecting non-empty frames and apply it to Alpaca backup and minute fallback flows
- extend feed failover and metrics unit tests to assert fallback success metrics and ordering

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_data_fetcher_metrics.py tests/test_feed_failover.py tests/unit/test_data_fetcher_http.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68db55ecd9b483308737fb2c90d23b8b