### PR TITLE
Handle non-pandas sequences in RSI utilities

### DIFF
--- a/ai_trading/pipeline/__init__.py
+++ b/ai_trading/pipeline/__init__.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from ai_trading.logging import get_logger
 from ai_trading.utils.lazy_imports import (
+    load_pandas,
     load_sklearn_linear_model,
     load_sklearn_pipeline,
     load_sklearn_preprocessing,
@@ -57,6 +58,13 @@ class FeatureBuilder:
 
     def _calculate_rsi(self, close, period: int = 14):
         """Calculate RSI indicator."""
+        pd = load_pandas()
+        if not hasattr(close, "diff"):
+            close = pd.Series(close)
+
+        if not hasattr(close, "diff"):
+            return pd.Series([50.0] * len(close))
+
         delta = close.diff()
         gain = delta.where(delta > 0, 0).rolling(window=period).mean()
         loss = (-delta.where(delta < 0, 0)).rolling(window=period).mean()

--- a/ai_trading/position/profit_taking.py
+++ b/ai_trading/position/profit_taking.py
@@ -339,6 +339,16 @@ class ProfitTakingEngine:
         try:
             if len(prices) < period + 1:
                 return 50.0
+
+            if not hasattr(prices, "diff"):
+                try:
+                    prices = pd.Series(prices)
+                except TypeError:
+                    return 50.0
+
+            if not hasattr(prices, "diff"):
+                return 50.0
+
             deltas = prices.diff()
             gains = deltas.where(deltas > 0, 0)
             losses = -deltas.where(deltas < 0, 0)

--- a/ai_trading/position/technical_analyzer.py
+++ b/ai_trading/position/technical_analyzer.py
@@ -342,6 +342,16 @@ class TechnicalSignalAnalyzer:
         try:
             if len(prices) < period + 1:
                 return 50.0
+
+            if not hasattr(prices, "diff"):
+                try:
+                    prices = pd.Series(prices)
+                except TypeError:
+                    return 50.0
+
+            if not hasattr(prices, "diff"):
+                return 50.0
+
             deltas = prices.diff()
             gains = deltas.where(deltas > 0, 0)
             losses = -deltas.where(deltas < 0, 0)

--- a/ai_trading/position/trailing_stops.py
+++ b/ai_trading/position/trailing_stops.py
@@ -566,6 +566,16 @@ class TrailingStopManager:
         try:
             if len(prices) < period + 1:
                 return 50.0
+
+            if not hasattr(prices, "diff"):
+                try:
+                    prices = pd.Series(prices)
+                except TypeError:
+                    return 50.0
+
+            if not hasattr(prices, "diff"):
+                return 50.0
+
             deltas = prices.diff()
             gains = deltas.where(deltas > 0, 0)
             losses = -deltas.where(deltas < 0, 0)

--- a/tests/test_rsi_sequence_inputs.py
+++ b/tests/test_rsi_sequence_inputs.py
@@ -1,0 +1,76 @@
+"""Tests for RSI helpers accepting non-pandas sequences."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import pytest
+
+from ai_trading.position.profit_taking import ProfitTakingEngine
+from ai_trading.position.technical_analyzer import TechnicalSignalAnalyzer
+from ai_trading.position.trailing_stops import TrailingStopManager
+
+
+class MockSequence:
+    """Simple sequence without pandas methods like ``diff``."""
+
+    def __init__(self, values: Iterable[float]) -> None:
+        self._values = list(values)
+
+    def __len__(self) -> int:  # pragma: no cover - simple delegation
+        return len(self._values)
+
+    def __iter__(self):  # pragma: no cover - simple delegation
+        return iter(self._values)
+
+    def __getitem__(self, index):  # pragma: no cover - simple delegation
+        return self._values[index]
+
+
+@pytest.mark.parametrize("factory", (list, MockSequence))
+def test_technical_analyzer_rsi_accepts_sequences(factory) -> None:
+    analyzer = TechnicalSignalAnalyzer()
+    prices = factory(range(1, 40))
+
+    value = analyzer._calculate_rsi(prices, 14)
+
+    assert isinstance(value, float)
+    assert 0.0 <= value <= 100.0
+
+
+@pytest.mark.parametrize("factory", (list, MockSequence))
+def test_trailing_stop_rsi_accepts_sequences(factory) -> None:
+    manager = TrailingStopManager()
+    prices = factory(range(1, 40))
+
+    value = manager._calculate_rsi(prices, 14)
+
+    assert isinstance(value, float)
+    assert 0.0 <= value <= 100.0
+
+
+@pytest.mark.parametrize("factory", (list, MockSequence))
+def test_profit_taking_rsi_accepts_sequences(factory) -> None:
+    engine = ProfitTakingEngine()
+    prices = factory(range(1, 40))
+
+    value = engine._calculate_rsi(prices, 14)
+
+    assert isinstance(value, float)
+    assert 0.0 <= value <= 100.0
+
+
+@pytest.mark.parametrize("factory", (list, MockSequence))
+def test_feature_builder_rsi_accepts_sequences(factory) -> None:
+    pytest.importorskip("numpy")
+    pytest.importorskip("sklearn.pipeline")
+
+    from ai_trading.pipeline import FeatureBuilder
+
+    builder = FeatureBuilder()
+    close = factory(range(1, 40))
+
+    result = builder._calculate_rsi(close, 14)
+
+    assert hasattr(result, "iloc")
+    assert len(result) == len(close)


### PR DESCRIPTION
## Summary
- normalize positional RSI helpers to coerce non-pandas sequences via `load_pandas()` before using diff-based calculations
- extend the feature pipeline RSI helper to coerce inputs and return a neutral series when diff is unavailable
- add unit coverage that exercises list and mock sequence inputs, skipping the pipeline-specific assertions when numpy or scikit-learn are absent

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_rsi_sequence_inputs.py -q

------
https://chatgpt.com/codex/tasks/task_e_68db55ef4280833084a4e2f46bd47f26