### PR TITLE
Fix execution engine stub check stops

### DIFF
--- a/tests/test_bot_engine_check_stops.py
+++ b/tests/test_bot_engine_check_stops.py
@@ -1,5 +1,10 @@
+import importlib
+import sys
 from types import SimpleNamespace
-from ai_trading.core.bot_engine import _check_runtime_stops
+from types import ModuleType
+
+def _import_bot_engine():
+    return importlib.import_module("ai_trading.core.bot_engine")
 
 
 class DummyEngine:
@@ -11,13 +16,33 @@ class DummyEngine:
 
 
 def test_check_stops_invoked_when_present():
+    bot_engine = _import_bot_engine()
     runtime = SimpleNamespace(exec_engine=DummyEngine())
-    _check_runtime_stops(runtime)
+    bot_engine._check_runtime_stops(runtime)
     assert runtime.exec_engine.called
 
 
 def test_warning_when_exec_engine_missing(caplog):
+    bot_engine = _import_bot_engine()
     runtime = SimpleNamespace()
     with caplog.at_level("WARNING"):
-        _check_runtime_stops(runtime)
+        bot_engine._check_runtime_stops(runtime)
     assert "risk-stop checks skipped" in caplog.text
+
+
+def test_stub_execution_engine_avoids_warning(monkeypatch, caplog):
+    fake_exec_pkg = ModuleType("ai_trading.execution")
+    monkeypatch.setitem(sys.modules, "ai_trading.execution", fake_exec_pkg)
+    monkeypatch.delitem(sys.modules, "ai_trading.execution.engine", raising=False)
+    monkeypatch.delitem(sys.modules, "ai_trading.core.bot_engine", raising=False)
+
+    stub_bot_engine = importlib.import_module("ai_trading.core.bot_engine")
+    runtime = SimpleNamespace(exec_engine=stub_bot_engine.ExecutionEngine())
+
+    with caplog.at_level("WARNING"):
+        stub_bot_engine._check_runtime_stops(runtime)
+
+    assert "risk-stop checks skipped" not in caplog.text
+
+    monkeypatch.delitem(sys.modules, "ai_trading.core.bot_engine", raising=False)
+    _import_bot_engine()


### PR DESCRIPTION
## Summary
- add a debug no-op check_stops hook to the fallback ExecutionEngine stub
- log a once-per-process warning when the stub engine is attached and allow a fallback import
- extend the bot engine stop-check tests to exercise the stub code path without warnings

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_bot_engine_check_stops.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dbfce3d4b08330a32906f5809b7ece