### PR TITLE
Handle Alpaca IEX volume aliases and refresh tests

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -1247,6 +1247,7 @@ _OHLCV_COLUMN_ALIASES: dict[str, tuple[str, ...]] = {
         "total_volume",
         "volume_total",
         "volumetotal",
+        "totalvolume",
         "volume_traded",
         "volumetraded",
         "sharevolume",
@@ -2148,7 +2149,7 @@ def normalize_ohlcv_columns(df: pd.DataFrame) -> pd.DataFrame:
         "high": {"high", "h"},
         "low": {"low", "l"},
         "close": {"close", "c", "price"},
-        "volume": {"volume", "v"},
+        "volume": {"volume", "v", "totalvolume", "volume_total", "total_volume", "volumetotal"},
     }
     for canonical, aliases in alias_groups.items():
         for alias in list(aliases):
@@ -2195,7 +2196,7 @@ def _flatten_and_normalize_ohlcv(
                 "low": {"low", "l"},
                 "close": {"close", "c", "price"},
                 "adj_close": {"adj_close", "adjclose", "adjusted_close"},
-                "volume": {"volume", "v"},
+                "volume": {"volume", "v", "totalvolume", "volume_total", "total_volume", "volumetotal"},
             }
 
             def _normalize_token(token: Any) -> str:

--- a/ai_trading/data/fetch/normalize.py
+++ b/ai_trading/data/fetch/normalize.py
@@ -21,6 +21,10 @@ _COLUMN_CANONICAL_MAP = {
     "l": "low",
     "c": "close",
     "v": "volume",
+    "totalvolume": "volume",
+    "volumetotal": "volume",
+    "volume_total": "volume",
+    "total_volume": "volume",
 }
 
 


### PR DESCRIPTION
## Summary
- expand the OHLCV alias tables so Alpaca IEX payloads that report `totalVolume` map cleanly to the canonical schema
- synchronize the shared OHLCV normalizer with the new volume aliases
- update the Alpaca IEX field normalization regression tests to mirror the current payload shape and cover compact key variants

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/data/test_alpaca_iex_field_aliases.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dc1e2ba2f4833088fa6bf804c85225