### PR TITLE
Refactor module-level monkeypatch fixture in strategy tests

### DIFF
--- a/tests/test_strategies_module.py
+++ b/tests/test_strategies_module.py
@@ -8,8 +8,9 @@ from ai_trading.core.bot_engine import get_strategies
 
 
 @pytest.fixture(autouse=True, scope="module")
-def _stub_modules(monkeypatch):
+def _stub_modules():
     """Provide lightweight stubs for optional heavy dependencies."""
+    monkeypatch = pytest.MonkeyPatch()
     os.environ.setdefault("PYTEST_RUNNING", "1")
 
     monkeypatch.setitem(
@@ -76,7 +77,10 @@ def _stub_modules(monkeypatch):
     finnhub_stub.FinnhubAPIException = type("FinnhubAPIException", (Exception,), {})
     monkeypatch.setitem(sys.modules, "finnhub", finnhub_stub)
 
-    yield
+    try:
+        yield
+    finally:
+        monkeypatch.undo()
 
 
 def _prep_settings(strategies):


### PR DESCRIPTION
## Summary
- create the module-level `MonkeyPatch` manually in `test_strategies_module` to avoid pytest injection
- ensure the stubs are undone via `monkeypatch.undo()` while preserving existing behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc75d07d208330ab8b11a00366406b