### PR TITLE
Ensure safe_subprocess_run normalizes TimeoutExpired streams

### DIFF
--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -62,8 +62,10 @@ def safe_subprocess_run(
             check=False,
         )
     except subprocess.TimeoutExpired as exc:
-        stdout_text = _normalize_stream(exc.stdout)
-        stderr_text = _normalize_stream(exc.stderr)
+        stdout_text = _normalize_stream(
+            getattr(exc, "stdout", getattr(exc, "output", None))
+        )
+        stderr_text = _normalize_stream(getattr(exc, "stderr", None))
         return SafeSubprocessResult(stdout_text, stderr_text, 124, True)
     except OSError as exc:
         logger.warning("safe_subprocess_run(%s) failed: %s", argv, exc)

--- a/tests/utils/test_safe_subprocess_run.py
+++ b/tests/utils/test_safe_subprocess_run.py
@@ -3,7 +3,7 @@ import subprocess
 
 import pytest
 
-from ai_trading.utils.safe_subprocess import safe_subprocess_run
+from ai_trading.utils.safe_subprocess import SafeSubprocessResult, safe_subprocess_run
 
 
 def test_safe_subprocess_run_success():
@@ -18,10 +18,7 @@ def test_safe_subprocess_run_timeout(caplog):
     cmd = [sys.executable, "-c", "import time; time.sleep(1)"]
     with caplog.at_level("WARNING"):
         res = safe_subprocess_run(cmd, timeout=0.1)
-    assert res.stdout == ""
-    assert res.stderr == ""
-    assert res.timeout
-    assert res.returncode == 124
+    assert res == SafeSubprocessResult("", "", 124, True)
     assert not caplog.records  # timeout should not emit warnings
 
 


### PR DESCRIPTION
## Summary
- normalize TimeoutExpired stdout/stderr handling when running subprocesses
- extend the timeout regression test to assert the exact SafeSubprocessResult payload

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/utils/test_safe_subprocess_run.py -k timeout

------
https://chatgpt.com/codex/tasks/task_e_68dc7bc25624833093058547d1c3ac32