### PR TITLE
Handle generator exhaustion in memo caches

### DIFF
--- a/ai_trading/core/daily_fetch_memo.py
+++ b/ai_trading/core/daily_fetch_memo.py
@@ -7,6 +7,7 @@ from types import GeneratorType
 from typing import Any, Dict, Tuple
 
 from ai_trading.data.fetch.normalize import normalize_ohlcv_df
+from ai_trading.utils.time import is_generator_stop
 
 
 @dataclass(slots=True)
@@ -56,6 +57,12 @@ def get_daily_df_memoized(
         except StopIteration:
             stop_iteration = True
             candidate = None
+        except RuntimeError as exc:
+            if is_generator_stop(exc):
+                stop_iteration = True
+                candidate = None
+            else:
+                raise
 
         if isinstance(candidate, GeneratorType):
             generator = candidate
@@ -64,6 +71,12 @@ def get_daily_df_memoized(
             except StopIteration:
                 stop_iteration = True
                 candidate = None
+            except RuntimeError as exc:
+                if is_generator_stop(exc):
+                    stop_iteration = True
+                    candidate = None
+                else:
+                    raise
             finally:
                 with suppress(Exception):
                     generator.close()

--- a/tests/utils/test_monotonic_time.py
+++ b/tests/utils/test_monotonic_time.py
@@ -56,3 +56,29 @@ def test_monotonic_time_iterator_exhaustion_resilient(monkeypatch):
     assert results[2] >= results[1]
     assert results[3] >= results[2]
     assert results[4] >= results[3]
+
+
+def test_monotonic_time_runtime_error_from_generator(monkeypatch):
+    time_utils._LAST_MONOTONIC_VALUE = None
+    fallback_values = deque([3.0, 4.0])
+    real_time = time_utils._time_module.time
+
+    def fake_monotonic():
+        def _generator():
+            if False:  # pragma: no cover - generator marker
+                yield None
+            raise StopIteration
+
+        return next(_generator())
+
+    def fake_time():
+        if fallback_values:
+            return fallback_values.popleft()
+        return real_time()
+
+    monkeypatch.setattr(time_utils._time_module, "monotonic", fake_monotonic)
+    monkeypatch.setattr(time_utils._time_module, "time", fake_time)
+
+    assert time_utils.monotonic_time() == pytest.approx(3.0)
+    assert time_utils.monotonic_time() == pytest.approx(4.0)
+    assert isinstance(time_utils.monotonic_time(), float)


### PR DESCRIPTION
## Summary
- add a shared helper to detect generator exhaustion and use it inside `monotonic_time`
- guard the daily fetch memo helpers so generator-based factories that exhaust return cleanly and preserve last good data
- add regression tests covering runtime-error StopIteration paths for the memo caches and monotonic clock helper

## Testing
- pytest tests/utils/test_monotonic_time.py -q
- pytest tests/bot_engine/test_daily_fetch_debounce.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dc972d22c88330970606e798b04c33