### PR TITLE
Ensure HTTP host limit cache refresh propagates to semaphores

### DIFF
--- a/ai_trading/net/http.py
+++ b/ai_trading/net/http.py
@@ -262,6 +262,15 @@ def reload_host_limit_if_env_changed(session: TimeoutSession | None = None) -> N
     target = session or _GLOBAL_SESSION
     if target is None:
         return
+    try:
+        from ai_trading.http import pooling as _pooling
+    except Exception:  # pragma: no cover - pooling optional during stubbed tests
+        pass
+    else:
+        try:
+            _pooling.reload_host_limit_if_env_changed()
+        except Exception:
+            pass
     _HOST_LIMIT_CONTROLLER.reload_if_changed(target)
 
 


### PR DESCRIPTION
## Summary
- teach the pooling helpers to expose host-limit snapshots, refresh caches when env vars change, and embed metadata on semaphores
- update the fallback concurrency helpers to reuse refreshed limit/version info and refresh loop-local semaphores when needed
- extend the host limit tests to cover env reloads while keeping the HTTP session reloader in sync

## Testing
- pytest tests/test_http_host_limit.py tests/data/test_fallback_concurrency.py -q


------
https://chatgpt.com/codex/tasks/task_e_68dca2e162988330b3a770f6fd3c8f4a