### PR TITLE
Ensure Alpaca fallback requests rebuild their payloads

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -3950,15 +3950,18 @@ def _fetch_bars(
                 )
             return result
 
-        params = {
-            "symbols": symbol,
-            "timeframe": _interval,
-            "start": _start.isoformat(),
-            "end": _end.isoformat(),
-            "limit": 10000,
-            "feed": _feed,
-            "adjustment": adjustment,
-        }
+        def _build_request_params() -> dict[str, Any]:
+            return {
+                "symbols": symbol,
+                "timeframe": _interval,
+                "start": _start.isoformat(),
+                "end": _end.isoformat(),
+                "limit": 10000,
+                "feed": _feed,
+                "adjustment": adjustment,
+            }
+
+        params: dict[str, Any] = {}
         url = "https://data.alpaca.markets/v2/stocks/bars"
         # Prefer an instance-level patched ``session.get`` when present (tests);
         # otherwise route through the module-level ``requests.get`` so tests
@@ -3966,6 +3969,7 @@ def _fetch_bars(
         use_session_get = hasattr(session, "get")
         prev_corr = _state.get("corr_id")
         try:
+            params = _build_request_params()
             if use_session_get:
                 resp = session.get(url, params=params, headers=headers, timeout=timeout)
             else:

--- a/tests/test_feed_failover.py
+++ b/tests/test_feed_failover.py
@@ -212,6 +212,7 @@ def test_window_no_session_prefers_alpaca_fallback(monkeypatch, capmetrics):
 
     assert hasattr(df, "empty")
     assert not getattr(df, "empty", True)
+    assert len(session.calls) == 2
     assert session.calls[0]["feed"] == "iex"
     assert session.calls[1]["feed"] == "sip"
     assert fetch._FEED_OVERRIDE_BY_TF[("AAPL", "1Min")] == "sip"


### PR DESCRIPTION
## Summary
- rebuild the Alpaca bar request parameters from the current feed immediately before each HTTP call so fallback recursion uses the correct payload
- extend the Alpaca fallback regression test to assert the stub session issues two calls and the second targets the SIP feed

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_feed_failover.py -q *(skipped: pandas not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb784c00c83309d0f979cfb1740bd