### PR TITLE
Avoid HTTP fetch when request window lacks trading session

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -3680,6 +3680,7 @@ def _fetch_bars(
             ),
         )
         _state["window_has_session"] = False
+        return pd.DataFrame()
     else:
         _state["window_has_session"] = True
     if not _has_alpaca_keys():

--- a/tests/test_fetch_param_validation.py
+++ b/tests/test_fetch_param_validation.py
@@ -5,6 +5,9 @@ import pytest
 from ai_trading.data import fetch
 
 
+pd = pytest.importorskip("pandas")
+
+
 def _trading_range():
     start = datetime(2024, 1, 2, tzinfo=UTC)
     end = start + timedelta(minutes=1)
@@ -27,7 +30,8 @@ def test_window_without_trading_session_returns_empty():
     start = datetime(2024, 1, 6, tzinfo=UTC)
     end = start + timedelta(days=1)
     out = fetch._fetch_bars("AAPL", start, end, "1Min")
-    assert out is None or out.empty
+    assert isinstance(out, pd.DataFrame)
+    pd.testing.assert_frame_equal(out, pd.DataFrame())
 
 
 def test_missing_session_raises(monkeypatch):


### PR DESCRIPTION
## Summary
- short-circuit `_fetch_bars` when a requested window lacks a trading session so we never attempt an HTTP call
- update the parameter validation test to assert that the fetcher returns an explicit empty DataFrame for these windows

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_fetch_param_validation.py -q


------
https://chatgpt.com/codex/tasks/task_e_68dcb7858aa88330aa62520947b01474