### PR TITLE
Handle unpatched TimeoutSession.get when fetching Alpaca bars

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -3963,7 +3963,17 @@ def _fetch_bars(
         # Prefer an instance-level patched ``session.get`` when present (tests);
         # otherwise route through the module-level ``requests.get`` so tests
         # that monkeypatch ``df.requests.get`` can intercept deterministically.
-        use_session_get = hasattr(session, "get")
+        session_get = getattr(session, "get", None)
+        use_session_get = callable(session_get)
+        if use_session_get:
+            default_session_get = getattr(HTTPSession, "get", None)
+            bound_func = getattr(session_get, "__func__", None)
+            if (
+                isinstance(session, HTTPSession)
+                and default_session_get is not None
+                and bound_func is default_session_get
+            ):
+                use_session_get = False
         prev_corr = _state.get("corr_id")
         try:
             if use_session_get:


### PR DESCRIPTION
## Summary
- detect when the shared HTTPSession still uses the default TimeoutSession.get implementation
- fall back to the module-level requests.get in that scenario so request monkeypatches fire in tests
- extend the Yahoo fallback test to verify that patching fetch.requests.get is sufficient without swapping out the global session

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_yahoo_fallback_order.py -q *(skipped: pandas not installed in environment)*

## Motivation
- Prevent regressions where test suites rely on intercepting fetch.requests.get but the default session method bypasses that hook.

## Before/After
- Before: _fetch_bars always used session.get when available, ignoring module-level request patches.
- After: _fetch_bars routes through requests.get whenever the session method is still the default TimeoutSession.get.

## Rollback Plan
- Revert this commit to restore the prior session-first request behavior.


------
https://chatgpt.com/codex/tasks/task_e_68dcb7871a0c8330919bd919e8d5d2b3