### PR TITLE
Ensure safe_subprocess_run propagates timeout outputs

### DIFF
--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -84,7 +84,7 @@ def safe_subprocess_run(
         exc.stdout = stdout_text
         exc.stderr = stderr_text
         exc.result = result
-        raise
+        raise exc
     except subprocess.SubprocessError as exc:
         with suppress(ProcessLookupError):
             proc.kill()


### PR DESCRIPTION
## Summary
- raise the original TimeoutExpired after attaching the captured SafeSubprocessResult
- extend the timeout test to spawn a real Python subprocess and assert the bubbled-up result retains stdout/stderr

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/utils/test_safe_subprocess_run.py::test_safe_subprocess_run_timeout -q

------
https://chatgpt.com/codex/tasks/task_e_68dcb925698083308cd31865c28c57de