### PR TITLE
Prioritize environment overrides for Alpaca base URL logging

### DIFF
--- a/ai_trading/env/config_redaction.py
+++ b/ai_trading/env/config_redaction.py
@@ -1,24 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Dict
+from typing import Any
 
-from ai_trading.logging.redact import redact_env
-
-# Mapping of environment variable aliases to their canonical names.
-_ALIAS_MAP: Dict[str, str] = {
-    "ALPACA_BASE_URL": "ALPACA_API_URL",
-}
-
-
-def _apply_aliases(env: Mapping[str, Any]) -> Dict[str, Any]:
-    """Return a new mapping with aliases normalized to canonical keys."""
-    resolved: Dict[str, Any] = {}
-    for key, value in env.items():
-        canonical = _ALIAS_MAP.get(key, key)
-        if canonical not in resolved:
-            resolved[canonical] = value
-    return resolved
+from ai_trading.logging.redact import normalize_aliases, redact_env
 
 
 def redact_config_env(env: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -28,7 +13,7 @@ def redact_config_env(env: Mapping[str, Any]) -> Mapping[str, Any]:
     ``ALPACA_API_URL`` key so logs remain consistent regardless of which
     variant the user provided.
     """
-    normalized = _apply_aliases(env)
+    normalized = normalize_aliases(env)
     return redact_env(normalized, drop=True)
 
 

--- a/tests/unit/test_env_config_redaction.py
+++ b/tests/unit/test_env_config_redaction.py
@@ -7,7 +7,7 @@ if not hasattr(config_pkg, "get_settings"):
     config_pkg.get_settings = settings_mod.get_settings
 
 from ai_trading import main
-from ai_trading.config.management import validate_required_env
+from ai_trading.config.management import _resolve_alpaca_env, validate_required_env
 from ai_trading.logging.redact import _ENV_MASK, _SENSITIVE_ENV, redact_env
 from ai_trading.env.config_redaction import redact_config_env
 
@@ -96,3 +96,11 @@ def test_base_url_alias_logged(caplog, monkeypatch):
     main._fail_fast_env()
     env_log = next(rec for rec in caplog.records if rec.getMessage() == "ENV_CONFIG_LOADED")
     assert env_log.ALPACA_API_URL == "https://alias-api.alpaca.markets"
+    assert not hasattr(env_log, "ALPACA_BASE_URL")
+
+    redacted = redact_env({"ALPACA_BASE_URL": "https://alias-api.alpaca.markets"})
+    assert redacted["ALPACA_API_URL"] == "https://alias-api.alpaca.markets"
+    assert "ALPACA_BASE_URL" not in redacted
+
+    _, _, resolved_base_url = _resolve_alpaca_env()
+    assert resolved_base_url == "https://alias-api.alpaca.markets"


### PR DESCRIPTION
## Summary
- inspect the current process environment for Alpaca base URLs before falling back to the cached TradingConfig and backfill the canonical key when only the alias is present
- normalize Alpaca base URL aliases inside the shared redaction helpers so logs consistently emit `ALPACA_API_URL`
- extend the environment logging test to assert the canonical key exposure and the resolver’s new precedence

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_env_config_redaction.py -q *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68dcb927479883309b9a70b2f9bc3cb5