### PR TITLE
Harden OHLCV normalization & provider fallback; fix Alpaca settings usage; keep runtime mocks safe

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -21043,9 +21043,10 @@ def main() -> None:
         logger.critical("Runtime configuration failed: %s", e)
         sys.exit(2)
 
-    # AI-AGENT-REF: Validate Alpaca credentials using settings singleton
+    # AI-AGENT-REF: Validate Alpaca credentials via existing Settings API
     cfg = get_settings()
-    api_key, api_secret = cfg.get_alpaca_keys()
+    api_key = getattr(cfg, "alpaca_api_key", None)
+    api_secret = get_alpaca_secret_key_plain()
     if not api_key or not api_secret:
         logger.critical("Alpaca credentials missing – aborting startup")
         logger.critical(

--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -1565,8 +1565,29 @@ def ensure_ohlcv_schema(
     if work_df.empty:
         raise DataFetchError("DATA_FETCH_EMPTY")
 
-    if "close" not in work_df.columns and "adj_close" in work_df.columns:
-        work_df["close"] = work_df["adj_close"]
+    if "close" not in work_df.columns:
+        close_aliases = (
+            "adj_close",
+            "c",
+            "close_price",
+            "closing_price",
+            "latest_price",
+            "end_price",
+            "final_price",
+            "official_price",
+            "value",
+        )
+        for alias in close_aliases:
+            if alias in work_df.columns:
+                work_df["close"] = work_df[alias]
+                break
+
+    if "open" not in work_df.columns and "o" in work_df.columns:
+        work_df["open"] = work_df["o"]
+    if "high" not in work_df.columns and "h" in work_df.columns:
+        work_df["high"] = work_df["h"]
+    if "low" not in work_df.columns and "l" in work_df.columns:
+        work_df["low"] = work_df["l"]
 
     required = ["open", "high", "low", "close"]
     missing = [col for col in required if col not in work_df.columns]

--- a/ai_trading/data/fetch/normalize.py
+++ b/ai_trading/data/fetch/normalize.py
@@ -32,6 +32,8 @@ _COLUMN_CANONICAL_MAP = {
     "time": "timestamp",
     "datetime": "timestamp",
     "date": "timestamp",
+    "ts": "timestamp",
+    "timestamp_utc": "timestamp",
     "bars_t": "timestamp",
     "bar_t": "timestamp",
     "bars_time": "timestamp",
@@ -63,12 +65,14 @@ _COLUMN_CANONICAL_MAP = {
     "bar_low": "low",
     "c": "close",
     "close_price": "close",
+    "closing_price": "close",
     "latest_price": "close",
     "latest_value": "close",
     "market_price": "close",
     "official_price": "close",
     "ending_price": "close",
     "end_price": "close",
+    "final_price": "close",
     "final_value": "close",
     "session_close": "close",
     "session_close_price": "close",
@@ -198,5 +202,10 @@ def normalize_ohlcv_df(df: "_pd.DataFrame | None") -> "_pd.DataFrame":
         try:
             normalized.attrs.update(attrs)
         except (AttributeError, TypeError, ValueError):  # pragma: no cover - metadata optional
+            pass
+    if "trade_count" not in normalized.columns:
+        try:
+            normalized["trade_count"] = 0
+        except Exception:  # pragma: no cover - defensive fallback
             pass
     return normalized


### PR DESCRIPTION
## Summary
- ensure the Alpaca startup credential check uses the Settings API instead of the removed get_alpaca_keys helper
- pre-normalize obvious vendor aliases for OHLC columns before raising OHLCV_COLUMNS_MISSING during fetch
- expand normalize_ohlcv_df alias coverage and supply a default trade_count column when missing

## Testing
- python -m compileall -q ai_trading
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/data/test_alpaca_iex_field_aliases.py
- python -m ai_trading.__main__ --paper --once --symbols AAPL *(fails: missing optional dependency portalocker in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7bb089e48330839dc62005dcece9