### PR TITLE
Normalize DataFetcher stock bars using shared OHLCV helpers

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -7378,13 +7378,14 @@ class DataFetcher:
             return None
 
         frame.index = idx
-        normalized = frame.rename(columns=lambda c: c.lower())
-        normalized = normalized.drop(columns=["symbol"], errors="ignore")
+        try:
+            frame = data_fetcher_module.normalize_ohlcv_columns(frame)
+        except AttributeError:  # pragma: no cover - objects without columns
+            pass
 
-        expected_cols = ["open", "high", "low", "close", "volume"]
-        available_cols = [col for col in expected_cols if col in normalized.columns]
-        if available_cols:
-            normalized = normalized[available_cols]
+        normalized = data_fetcher_module.normalize_ohlcv_df(
+            frame.drop(columns=["symbol"], errors="ignore")
+        )
 
         return normalized
 

--- a/tests/bot_engine/test_daily_fetch_column_normalization.py
+++ b/tests/bot_engine/test_daily_fetch_column_normalization.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+pytest.importorskip("pandas")
+
+from ai_trading.core import bot_engine as be
+
+
+def _make_fetcher(monkeypatch: pytest.MonkeyPatch) -> be.DataFetcher:
+    """Create a ``DataFetcher`` instance with heavy setup disabled."""
+
+    monkeypatch.setattr(be.DataFetcher, "__post_init__", lambda self: None)
+    fetcher = be.DataFetcher()
+    fetcher.settings = types.SimpleNamespace()
+    fetcher._warn_once = lambda *a, **k: None  # type: ignore[attr-defined]
+    return fetcher
+
+
+def test_normalize_stock_bars_accepts_short_ohlcv_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    import pandas as pd
+
+    fetcher = _make_fetcher(monkeypatch)
+    index = pd.to_datetime(["2024-01-02", "2024-01-03"], utc=True)
+    raw = pd.DataFrame(
+        {
+            "o": [101.0, 102.0],
+            "h": [103.0, 104.0],
+            "l": [99.5, 100.5],
+            "c": [102.5, 103.5],
+            "v": [1_000, 1_500],
+        },
+        index=index,
+    )
+
+    normalized = fetcher._normalize_stock_bars("AAPL", raw, label="Daily")
+    assert normalized is not None
+    assert list(normalized.columns) == ["open", "high", "low", "close", "volume"]
+    assert normalized.index.tz is not None
+
+    prepared = fetcher._prepare_daily_dataframe(normalized, "AAPL")
+    assert prepared is not None
+    assert "timestamp" in prepared.columns
+    for column in ("open", "high", "low", "close", "volume"):
+        assert column in prepared.columns


### PR DESCRIPTION
## Summary
- update `DataFetcher._normalize_stock_bars` to reuse the shared OHLCV normalization helpers so alias columns are preserved before filtering
- add a regression test covering Alpaca short-form OHLCV columns to ensure the normalized frame keeps all fields and integrates with the daily preparation helper

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_daily_fetch_column_normalization.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd814e0fb48330bce3cda303ecd35d