### PR TITLE
Gate optional OHLCV columns behind explicit requests

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -7384,7 +7384,8 @@ class DataFetcher:
             pass
 
         normalized = data_fetcher_module.normalize_ohlcv_df(
-            frame.drop(columns=["symbol"], errors="ignore")
+            frame.drop(columns=["symbol"], errors="ignore"),
+            include_columns=("timestamp",),
         )
 
         return normalized

--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -258,7 +258,7 @@ def _ensure_df(obj: Any) -> pd.DataFrame:
 def empty_bars_dataframe() -> pd.DataFrame:
     cols = ["timestamp", *_OHLCV_REQUIRED]
     base = pd.DataFrame({col: [] for col in cols})
-    return normalize_ohlcv_df(base)
+    return normalize_ohlcv_df(base, include_columns=("timestamp",))
 
 def _create_empty_bars_dataframe(timeframe: str | None = None) -> pd.DataFrame:
     """Return an empty OHLCV DataFrame including a timestamp column."""
@@ -278,7 +278,7 @@ def _normalize_bars_frame(df: Any) -> pd.DataFrame:
         attrs = dict(getattr(ensured, "attrs", {}) or {})
     except (AttributeError, TypeError):  # pragma: no cover - metadata best effort
         attrs = {}
-    normalized = normalize_ohlcv_df(ensured)
+    normalized = normalize_ohlcv_df(ensured, include_columns=("timestamp",))
     if normalized.empty:
         return empty_bars_dataframe()
     if attrs:

--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -1052,7 +1052,7 @@ def _normalize_with_attrs(df: pd.DataFrame) -> pd.DataFrame:
         attrs = dict(getattr(df, "attrs", {}) or {})
     except (AttributeError, TypeError):
         attrs = {}
-    normalized = normalize_ohlcv_df(df)
+    normalized = normalize_ohlcv_df(df, include_columns=("timestamp",))
     if attrs:
         try:
             normalized.attrs.update(attrs)
@@ -1736,7 +1736,7 @@ def _normalize_ohlcv_df(df, _pd: Any | None = None):
     except Exception:
         return None
     try:
-        normalized = normalize_ohlcv_df(normalized)
+        normalized = normalize_ohlcv_df(normalized, include_columns=("timestamp",))
     except Exception:
         return normalized
     restored = _restore_timestamp_column(normalized)
@@ -1755,7 +1755,7 @@ def _empty_ohlcv_frame(pd_local: Any | None = None) -> pd.DataFrame | None:
         return None
     cols = ["timestamp", "open", "high", "low", "close", "volume"]
     base = pd_local.DataFrame({col: [] for col in cols})
-    return normalize_ohlcv_df(base)
+    return normalize_ohlcv_df(base, include_columns=("timestamp",))
 
 
 def _resolve_backup_provider() -> tuple[str, str]:
@@ -2538,7 +2538,7 @@ def _flatten_and_normalize_ohlcv(
                 df["volume"] = 0
 
     normalize_ohlcv_columns(df)
-    df = normalize_ohlcv_df(df)
+    df = normalize_ohlcv_df(df, include_columns=("timestamp",))
 
     required = ["open", "high", "low", "close", "volume"]
     missing = [col for col in required if col not in df.columns]
@@ -3053,7 +3053,7 @@ def _backup_get_bars(symbol: str, start: Any, end: Any, interval: str) -> pd.Dat
         return []  # type: ignore[return-value]
     cols = ["timestamp", "open", "high", "low", "close", "volume"]
     empty_df = pd_local.DataFrame({col: [] for col in cols})
-    normalized_df = normalize_ohlcv_df(empty_df)
+    normalized_df = normalize_ohlcv_df(empty_df, include_columns=("timestamp",))
     return _annotate_df_source(normalized_df, provider=normalized or "none", feed=normalized or None)
 
 
@@ -3137,7 +3137,7 @@ def _post_process(
         return None
     candidate = df if _is_normalized_ohlcv_frame(df, pd) else _flatten_and_normalize_ohlcv(df, symbol, timeframe)
     try:
-        normalized = normalize_ohlcv_df(candidate)
+        normalized = normalize_ohlcv_df(candidate, include_columns=("timestamp",))
     except Exception:
         normalized = candidate
 
@@ -6299,7 +6299,7 @@ def get_minute_df(
         )
         df = _mutate_dataframe_in_place(df, ensured_df)
 
-        normalized_df = normalize_ohlcv_df(df)
+        normalized_df = normalize_ohlcv_df(df, include_columns=("timestamp",))
         df = _mutate_dataframe_in_place(df, normalized_df)
 
         restored_df = _restore_timestamp_column(df)
@@ -6418,7 +6418,7 @@ def get_daily_df(
             source=normalized_feed or "alpaca",
             frequency="1Day",
         )
-        df = normalize_ohlcv_df(df)
+        df = normalize_ohlcv_df(df, include_columns=("timestamp",))
         df = _restore_timestamp_column(df)
     except MissingOHLCVColumnsError as exc:
         logger.error(

--- a/ai_trading/data/providers/yfinance_provider.py
+++ b/ai_trading/data/providers/yfinance_provider.py
@@ -38,7 +38,7 @@ class Provider:
         yf = self._yf()
         t = yf.Ticker(symbol)
         df = t.history(period=kwargs.get("period", "1y"), interval=interval)
-        df = normalize_ohlcv_df(df)
+        df = normalize_ohlcv_df(df, include_columns=("timestamp",))
         if len(df) == 0:
             return []
         return df
@@ -59,7 +59,7 @@ class Provider:
             df_raw = t.history(period=f"{int(limit)}d", interval="1d")
         except Exception:  # pragma: no cover - network/third-party errors
             return []
-        df = normalize_ohlcv_df(df_raw)
+        df = normalize_ohlcv_df(df_raw, include_columns=("timestamp",))
         if len(df) == 0:
             return []
         df = df.tail(limit)

--- a/tests/test_feed_failover.py
+++ b/tests/test_feed_failover.py
@@ -84,7 +84,7 @@ def test_empty_payload_switches_to_preferred_feed(monkeypatch, capmetrics):
 
     assert hasattr(df, "empty")
     assert not getattr(df, "empty", True)
-    normalized = fetch.normalize_ohlcv_df(df)
+    normalized = fetch.normalize_ohlcv_df(df, include_columns=("timestamp",))
     assert list(normalized.columns[:6]) == [
         "timestamp",
         "open",
@@ -146,7 +146,7 @@ def test_empty_payload_switch_records_override_without_preferred_list(monkeypatc
 
     assert hasattr(df, "empty")
     assert not getattr(df, "empty", True)
-    normalized = fetch.normalize_ohlcv_df(df)
+    normalized = fetch.normalize_ohlcv_df(df, include_columns=("timestamp",))
     assert list(normalized.columns[:6]) == [
         "timestamp",
         "open",

--- a/tests/test_fetch_normalize_compat.py
+++ b/tests/test_fetch_normalize_compat.py
@@ -48,7 +48,7 @@ def test_normalize_aliases_compact_and_adjclose() -> None:
         index=_make_index(ts),
     )
 
-    normalized = normalize_ohlcv_df(df)
+    normalized = normalize_ohlcv_df(df, include_columns=("timestamp",))
     assert list(normalized.columns) == [
         "timestamp",
         "open",

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -224,7 +224,7 @@ def test_ensure_schema_then_normalize_restores_timestamp_column():
     )
 
     ensured = data_fetch.ensure_ohlcv_schema(df, source="test", frequency="1Day")
-    normalized = data_fetch.normalize_ohlcv_df(ensured)
+    normalized = data_fetch.normalize_ohlcv_df(ensured, include_columns=("timestamp",))
 
     assert "timestamp" in normalized.columns
     expected = pd.Series(normalized.index, index=normalized.index, name="timestamp")


### PR DESCRIPTION
## Summary
- add an `include_columns` option to `normalize_ohlcv_df` so callers can opt into timestamp or trade count columns while keeping the default output lean
- update DataFetcher, minute fetch helpers, and bar/yfinance utilities to explicitly request timestamps when they depend on the column
- expand normalization tests to cover timestamp opt-in behaviour and the presence/absence of trade_count data

## Testing
- pytest tests/test_normalize_ohlcv.py tests/test_fetch_normalize_compat.py tests/test_feed_failover.py tests/test_health.py -q


------
https://chatgpt.com/codex/tasks/task_e_68dda36356c08330953017a5f0694d3a