### PR TITLE
Stop including timestamp column in normalized stock bars

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -7387,8 +7387,17 @@ class DataFetcher:
 
         normalized = data_fetcher_module.normalize_ohlcv_df(
             frame.drop(columns=["symbol"], errors="ignore"),
-            include_columns=("timestamp",),
         )
+
+        try:
+            index = normalized.index
+        except AttributeError:  # pragma: no cover - defensive guard for duck typing
+            return normalized
+
+        try:
+            normalized.index = index.rename(None)
+        except Exception:  # pragma: no cover - defensive fallback
+            pass
 
         return normalized
 


### PR DESCRIPTION
## Motivation & Context
- Normalize stock bar frames without surprising timestamp columns so downstream helpers can control the schema contract.

## Before
- `_normalize_stock_bars` always asked `normalize_ohlcv_df` to inject a `timestamp` column, which renamed the index and surfaced the extra column to callers.

## After
- Let `normalize_ohlcv_df` return only OHLCV columns and clear the index name so intraday/daily callers receive an anonymous `DatetimeIndex`.
- Leave timestamp column injection to downstream helpers such as `_prepare_daily_dataframe`.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_daily_fetch_column_normalization.py tests/bot_engine/test_fetch_minute_df_safe.py` *(skipped: pandas not installed in this environment)*

## Rollback Plan
- Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68ddbce0d7508330887539b34b642c39