### PR TITLE
Avoid duplicate feed switch history entries

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -723,10 +723,11 @@ def _record_feed_switch(symbol: str, timeframe: str, from_feed: str, to_feed: st
     _record_override(symbol, to_norm, tf_norm)
     attempted = _FEED_FAILOVER_ATTEMPTS.setdefault(key, set())
     attempted.add(to_norm)
-    _FEED_SWITCH_HISTORY.append((symbol, tf_norm, to_norm))
+    log_key = (symbol, tf_norm, to_norm)
+    if not _FEED_SWITCH_HISTORY or _FEED_SWITCH_HISTORY[-1] != log_key:
+        _FEED_SWITCH_HISTORY.append(log_key)
     if from_norm == "iex":
         _IEX_EMPTY_COUNTS.pop(key, None)
-    log_key = (symbol, tf_norm, to_norm)
     if log_key not in _FEED_SWITCH_LOGGED:
         logger.info(
             "ALPACA_FEED_SWITCH",


### PR DESCRIPTION
## Summary
- avoid appending duplicate entries to `_FEED_SWITCH_HISTORY` when the latest switch already matches the current request
- continue updating feed override caches while skipping redundant history entries

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_feed_failover.py::test_feed_override_used_on_subsequent_requests *(skipped: requires pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbce227908330a6c269ce728dd0fe