### PR TITLE
Return dict fallback when health response_class missing

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -206,8 +206,14 @@ def create_app():
         if callable(response_factory):
             final_payload = _ensure_core_fields(final_payload)
             return response_factory(body, status=status, mimetype="application/json")
+
+        # When ``response_class`` is unavailable (for example when stub clients swap
+        # Flask out for light-weight shims) surface the fully populated payload
+        # directly so callers don't need to understand Flask's ``(body, status)``
+        # tuple convention. Callers running under a real Flask stack will already
+        # receive a wrapped ``Response`` above, preserving status semantics.
         final_payload = _ensure_core_fields(final_payload)
-        return final_payload, status
+        return final_payload
 
     @app.route('/health')
     def health():


### PR DESCRIPTION
## Summary
- ensure the health endpoint fallback returns a populated payload dict when Flask's response_class is unavailable
- update the health check tests to exercise the dict fallback path used by stub Flask clients

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_health_check.py`


------
https://chatgpt.com/codex/tasks/task_e_68ddca2d1f808330ae55aa772ee5e804