### PR TITLE
Emit empty metric before skipping no-session windows

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -3861,6 +3861,9 @@ def _fetch_bars(
         tf_key = (symbol, _interval)
         _SKIPPED_SYMBOLS.discard(tf_key)
         _IEX_EMPTY_COUNTS.pop(tf_key, None)
+        if not _state.get("empty_metric_emitted"):
+            _incr("data.fetch.empty", value=1.0, tags=_tags())
+            _state["empty_metric_emitted"] = True
         logger.info(
             "DATA_WINDOW_NO_SESSION",
             extra=_norm_extra(


### PR DESCRIPTION
## Summary
- emit the `data.fetch.empty` metric once when an Alpaca window lacks a trading session before enabling the skip guard so primary feed empty responses are recorded

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_data_fetcher_metrics.py::test_window_no_session_metrics *(fails: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ddca2deb9c8330a0be9e04c237c2af