### PR TITLE
Refresh host limit snapshot before concurrency runs

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -193,6 +193,11 @@ def _cache_fallback(symbol: str, feed: str, timeframe: str = "1Min") -> None:
 async def run_with_concurrency(limit: int, coros):
     """Execute *coros* concurrently while keeping at most *limit* in flight."""
 
+    try:
+        reload_host_limit_if_env_changed()
+    except Exception:
+        pass
+
     max_concurrency = max(1, int(limit or 1))
     semaphore = asyncio.Semaphore(max_concurrency)
 


### PR DESCRIPTION
## Summary
- invalidate cached pooling snapshots before each fallback concurrency run so host limits refresh per execution
- track locally computed pooling versions when recomputing limits to keep semaphore metadata in sync
- reload HTTP host limits in the data fetch concurrency helper to observe environment changes

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_http_host_limit.py tests/data/test_fallback_concurrency.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ddcddac0fc833092bdef9620809888