### PR TITLE
Normalize unnamed minute indices to timestamp

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8184,7 +8184,7 @@ class DataFetcher:
             if original_name is not None:
                 idx = idx.rename(original_name)
             else:
-                idx = idx.rename(None)
+                idx = idx.rename("timestamp")
             working.index = idx
             return working
 

--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -1436,6 +1436,8 @@ def test_get_minute_df_handles_missing_safe_get(monkeypatch):
     assert isinstance(result, pd.DataFrame)
     expected_idx = idx.rename("timestamp")
     pd.testing.assert_index_equal(result.index, expected_idx)
+    assert idx.name is None
+    assert result.index.name == "timestamp"
     assert result.index.tz is not None
     assert result.index.tz.tzname(None) == UTC.tzname(None)
     assert list(result.columns[:5]) == ["open", "high", "low", "close", "volume"]


### PR DESCRIPTION
## Summary
- update minute DataFrame normalization to rename unnamed indices to `timestamp` while preserving existing names
- extend the safe minute fetch test to assert unnamed indices are normalized to `timestamp`

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/bot_engine/test_fetch_minute_df_safe.py::test_get_minute_df_handles_missing_safe_get *(skipped: pandas not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68de043aa98c833088becac42ab65bee