### PR TITLE
Harden health response fallbacks

### DIFF
--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -88,6 +88,22 @@ def test_health_endpoint_handles_import_error(monkeypatch):
     assert data["alpaca"] == EXPECTED_ALPACA_MINIMAL
     _assert_error_contains(data, "boom")
 
+    app.response_class = None
+    handler = None
+    view_functions = getattr(app, "view_functions", None)
+    if isinstance(view_functions, dict):
+        handler = view_functions.get("health")
+    if handler is None:
+        routes = getattr(app, "_routes", None)
+        if isinstance(routes, dict):
+            handler = routes.get("/health")
+    assert handler is not None, "health handler should be registered"
+
+    dict_payload = handler()
+    assert isinstance(dict_payload, dict)
+    _assert_payload_structure(dict_payload)
+    assert dict_payload["alpaca"] == EXPECTED_ALPACA_MINIMAL
+
 
 def test_health_endpoint_returns_plain_dict_when_jsonify_fails(monkeypatch):
     original_import = builtins.__import__


### PR DESCRIPTION
## Summary
- ensure `_json_response` always supplies `ok`/`alpaca` defaults and merges fallback payload data before responding
- align the `/health` route's canonical payload with its fallback schema and extend the import-error regression test

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_health_check.py::test_health_endpoint_handles_import_error

------
https://chatgpt.com/codex/tasks/task_e_68de0842a3988330a113d010e6e3d590