### PR TITLE
Ensure safe_subprocess_run re-raises augmented timeout

### DIFF
--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -75,7 +75,7 @@ def safe_subprocess_run(
     try:
         stdout_text, stderr_text = proc.communicate(timeout=run_timeout)
     except subprocess.TimeoutExpired as exc:
-        raise _augment_timeout_exception(proc, exc)
+        raise _augment_timeout_exception(proc, exc) from None
     except subprocess.SubprocessError as exc:
         with suppress(ProcessLookupError):
             proc.kill()

--- a/tests/utils/test_safe_subprocess_run.py
+++ b/tests/utils/test_safe_subprocess_run.py
@@ -28,9 +28,11 @@ def test_safe_subprocess_run_timeout(caplog):
 
     expected_result = SafeSubprocessResult("ready\n", "warn\n", 124, True)
     assert excinfo.value.cmd == cmd
+    assert isinstance(excinfo.value.result, SafeSubprocessResult)
     assert excinfo.value.result == expected_result
     assert excinfo.value.stdout == "ready\n"
     assert excinfo.value.stderr == "warn\n"
+    assert excinfo.value.__cause__ is None
     assert not caplog.records  # timeout should not emit warnings
 
 
@@ -95,6 +97,8 @@ def test_safe_subprocess_run_timeout_without_captured_output(monkeypatch, caplog
     assert result.returncode == 124
     assert result.stdout == ""
     assert result.stderr == ""
+    assert excinfo.value.stdout == ""
+    assert excinfo.value.stderr == ""
     assert calls["args"] == (["dummy"],)
     assert calls["kwargs"]["stdout"] == subprocess.PIPE
     assert calls["kwargs"]["stderr"] == subprocess.PIPE


### PR DESCRIPTION
## Summary
- re-raise the augmented TimeoutExpired from safe_subprocess_run so callers observe the timeout
- extend timeout tests to assert the SafeSubprocessResult and timeout metadata are attached as expected

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/utils/test_safe_subprocess_run.py::test_safe_subprocess_run_timeout

------
https://chatgpt.com/codex/tasks/task_e_68de0a1177888330b91b175892dd5c22