### PR TITLE
Ensure SIP failover is tracked for no-session Alpaca windows

### DIFF
--- a/tests/test_feed_failover.py
+++ b/tests/test_feed_failover.py
@@ -276,6 +276,8 @@ def test_no_session_empty_payload_uses_sip_before_backup(monkeypatch):
     tf_key = ("AAPL", "1Min")
     assert tf_key not in fetch._IEX_EMPTY_COUNTS or fetch._IEX_EMPTY_COUNTS[tf_key] == 0
     assert "sip" in fetch._FEED_FAILOVER_ATTEMPTS.get(tf_key, set())
+    assert fetch._FEED_OVERRIDE_BY_TF[tf_key] == "sip"
+    assert fetch._FEED_SWITCH_HISTORY[-1] == ("AAPL", "1Min", "sip")
 
 
 def test_cached_override_respects_ttl(monkeypatch):


### PR DESCRIPTION
## Summary
- honor configured Alpaca feed failovers for windows with no trading session while skipping external backups
- record SIP fallback attempts in the override and history caches even when the window is empty
- harden the fallback retry flow and add regression coverage for the no-session SIP path

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_feed_failover.py::test_no_session_empty_payload_uses_sip_before_backup tests/test_feed_failover.py::test_alt_feed_switch_records_override


------
https://chatgpt.com/codex/tasks/task_e_68de0b761948833082f1d112c59cdc63