### PR TITLE
Add automatic daily data fallback for missing OHLCV columns

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -6510,15 +6510,20 @@ def get_daily_df(
         adjustment = adjustment.lower()
     validate_adjustment(adjustment)
 
+    fetch_error: MissingOHLCVColumnsError | None = None
     if use_alpaca:
-        df = _get_bars_df(
-            symbol,
-            timeframe="1Day",
-            start=start,
-            end=end,
-            feed=normalized_feed,
-            adjustment=adjustment,
-        )
+        try:
+            df = _get_bars_df(
+                symbol,
+                timeframe="1Day",
+                start=start,
+                end=end,
+                feed=normalized_feed,
+                adjustment=adjustment,
+            )
+        except MissingOHLCVColumnsError as exc:
+            fetch_error = exc
+            df = None
 
     pd_mod = _ensure_pandas()
     if pd_mod is None:
@@ -6551,20 +6556,78 @@ def get_daily_df(
                 df = df.loc[:, ~df.columns.duplicated()]
             except Exception:  # pragma: no cover - defensive guard
                 pass
-    try:
-        df = ensure_ohlcv_schema(
-            df,
-            source=normalized_feed or "alpaca",
+    def _normalize_daily_frame(frame: Any, source_hint: str) -> Any:
+        resolved_source = source_hint
+        try:
+            attrs = getattr(frame, "attrs", None)
+        except Exception:  # pragma: no cover - defensive metadata access
+            attrs = None
+        if isinstance(attrs, dict):
+            resolved_source = (
+                str(
+                    attrs.get("data_provider")
+                    or attrs.get("fallback_provider")
+                    or attrs.get("data_feed")
+                    or source_hint
+                )
+                or source_hint
+            )
+        normalized = ensure_ohlcv_schema(
+            frame,
+            source=resolved_source or source_hint,
             frequency="1Day",
         )
-        df = normalize_ohlcv_df(df, include_columns=("timestamp",))
-        df = _restore_timestamp_column(df)
+        normalized = normalize_ohlcv_df(normalized, include_columns=("timestamp",))
+        return _restore_timestamp_column(normalized)
+
+    try:
+        if fetch_error is not None:
+            raise fetch_error
+        df = _normalize_daily_frame(df, normalized_feed or "alpaca")
     except MissingOHLCVColumnsError as exc:
         logger.error(
             "OHLCV_COLUMNS_MISSING",
             extra={"source": normalized_feed or "alpaca", "frequency": "1Day", "detail": str(exc)},
         )
-        return None
+        start_dt = ensure_datetime(
+            start if start is not None else datetime.now(UTC) - _dt.timedelta(days=10)
+        )
+        end_dt = ensure_datetime(end if end is not None else datetime.now(UTC))
+        fallback_df = _backup_get_bars(
+            symbol,
+            start_dt,
+            end_dt,
+            interval="1d",
+        )
+        if fallback_df is None or getattr(fallback_df, "empty", False):
+            return None
+        fallback_source_hint = normalized_feed or "alpaca"
+        try:
+            fallback_attrs = getattr(fallback_df, "attrs", None)
+        except Exception:  # pragma: no cover - defensive metadata access
+            fallback_attrs = None
+        if isinstance(fallback_attrs, dict):
+            fallback_source_hint = (
+                str(
+                    fallback_attrs.get("data_provider")
+                    or fallback_attrs.get("fallback_provider")
+                    or fallback_attrs.get("data_feed")
+                    or fallback_source_hint
+                )
+                or fallback_source_hint
+            )
+        try:
+            df = _normalize_daily_frame(fallback_df, fallback_source_hint)
+        except MissingOHLCVColumnsError as fallback_exc:
+            logger.error(
+                "OHLCV_COLUMNS_MISSING",
+                extra={
+                    "source": fallback_source_hint or (normalized_feed or "alpaca"),
+                    "frequency": "1Day",
+                    "detail": str(fallback_exc),
+                },
+            )
+            return None
     except DataFetchError as exc:
         logger.error(
             "DATA_FETCH_EMPTY",

--- a/docs/provider_configuration.md
+++ b/docs/provider_configuration.md
@@ -30,6 +30,7 @@ once. Future requests for the same pair use the working feed immediately, elimin
 
 - `BACKUP_DATA_PROVIDER`: fallback source when the primary feed returns empty data. The default is `yahoo`. Set to `finnhub` to use the Finnhub low-latency candles API when an API key is configured, or to `none` to disable backup queries.
 - When a fallback is used, the bot logs `USING_BACKUP_PROVIDER` with the chosen provider. If disabled or unknown, `BACKUP_PROVIDER_DISABLED` or `UNKNOWN_BACKUP_PROVIDER` is logged.
+- Daily-bar requests automatically fall back to the configured provider when the primary response is missing required OHLCV columns, ensuring cached consumers always receive canonical data.
 
 ## Provider Priority and Fallbacks
 

--- a/tests/data/test_daily_fetch_fallback.py
+++ b/tests/data/test_daily_fetch_fallback.py
@@ -1,0 +1,70 @@
+"""Regression tests for daily data fallback behaviour."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import sys
+import types
+
+import pytest
+
+from ai_trading.data import fetch as fetch_module
+from ai_trading.utils.lazy_imports import load_pandas
+
+pytest.importorskip("pandas")
+
+
+def test_get_daily_df_uses_backup_when_columns_missing(monkeypatch):
+    pd = load_pandas()
+    assert pd is not None
+
+    monkeypatch.setattr(fetch_module, "should_import_alpaca_sdk", lambda: True)
+    monkeypatch.setattr(
+        fetch_module,
+        "get_settings",
+        lambda: types.SimpleNamespace(
+            backup_data_provider="yahoo",
+            logging_dedupe_ttl_s=0,
+        ),
+    )
+
+    backup_calls: dict[str, tuple] = {}
+
+    def _fake_backup_get_bars(symbol, start, end, interval):
+        backup_calls["args"] = (symbol, start, end, interval)
+        df = pd.DataFrame(
+            {
+                "timestamp": pd.to_datetime(["2024-01-02"], utc=True),
+                "open": [1.0],
+                "high": [1.5],
+                "low": [0.5],
+                "close": [1.25],
+                "volume": [100],
+            }
+        )
+        df.attrs["fallback_provider"] = "yahoo"
+        return df
+
+    monkeypatch.setattr(fetch_module, "_backup_get_bars", _fake_backup_get_bars)
+
+    alpaca_stub = types.ModuleType("ai_trading.alpaca_api")
+
+    def _raise_missing(*_args, **_kwargs):
+        raise fetch_module.MissingOHLCVColumnsError("missing columns")
+
+    alpaca_stub.get_bars_df = _raise_missing
+    monkeypatch.setitem(sys.modules, "ai_trading.alpaca_api", alpaca_stub)
+
+    start = datetime(2024, 1, 1, tzinfo=UTC)
+    end = datetime(2024, 1, 3, tzinfo=UTC)
+
+    result = fetch_module.get_daily_df("AAPL", start=start, end=end)
+
+    assert "args" in backup_calls
+    symbol, start_dt, end_dt, interval = backup_calls["args"]
+    assert symbol == "AAPL"
+    assert interval == "1d"
+    assert start_dt <= start
+    assert end_dt >= end
+    assert list(result.columns) == ["timestamp", "open", "high", "low", "close", "volume"]
+    assert not result.empty


### PR DESCRIPTION
## Summary
- invoke the backup provider when `get_daily_df` encounters missing OHLCV columns and run the fallback data through the standard normalization
- add a regression test that forces the Alpaca fetcher to raise `MissingOHLCVColumnsError` and asserts the backup path supplies canonical columns
- document that daily-bar requests automatically fall back when the primary omits required columns

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/data/test_daily_fetch_fallback.py *(skipped: pandas not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68de93f51b04833099ad6c580fb5f477