### PR TITLE
Harden Alpaca-IEX OHLCV normalization, expose provider anti-thrash knobs, and smooth screening-time fetch load

### DIFF
--- a/ai_trading/config/runtime.py
+++ b/ai_trading/config/runtime.py
@@ -701,6 +701,22 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
         min_value=60,
     ),
     ConfigSpec(
+        field="provider_switch_quiet_seconds",
+        env=("PROVIDER_SWITCH_QUIET_SECONDS",),
+        cast="float",
+        default=15.0,
+        description="Quiet period in seconds before repeated provider switchovers are blocked.",
+        min_value=0.0,
+    ),
+    ConfigSpec(
+        field="provider_max_cooldown_seconds",
+        env=("PROVIDER_MAX_COOLDOWN_SECONDS",),
+        cast="float",
+        default=600.0,
+        description="Maximum cooldown applied when providers are disabled for thrash protection.",
+        min_value=60.0,
+    ),
+    ConfigSpec(
         field="http_timeout_seconds",
         env=("AI_TRADING_HTTP_TIMEOUT",),
         cast="float",

--- a/tests/data/test_alpaca_iex_additional_shapes.py
+++ b/tests/data/test_alpaca_iex_additional_shapes.py
@@ -1,0 +1,72 @@
+import logging
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from ai_trading.data.fetch import ensure_ohlcv_schema
+
+
+def _assert_standard_columns(frame: pd.DataFrame) -> None:
+    assert list(frame.columns[:6]) == [
+        "timestamp",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    ]
+    assert "timestamp" in frame.index.names or frame.index.name == "timestamp"
+
+
+def test_compact_minute_bars_are_normalized(caplog: pytest.LogCaptureFixture) -> None:
+    rows = [
+        {"t": "2024-10-01T13:30:00Z", "o": 10.0, "h": 10.5, "l": 9.8, "c": 10.2, "v": 1500},
+        {"t": "2024-10-01T13:31:00Z", "o": 10.2, "h": 10.6, "l": 10.1, "c": 10.5, "v": 1800},
+    ]
+    df = pd.DataFrame(rows)
+
+    caplog.set_level(logging.INFO)
+    normalized = ensure_ohlcv_schema(df, source="alpaca_iex", frequency="1Min")
+
+    _assert_standard_columns(normalized)
+    assert "OHLCV_COLUMNS_MISSING" not in caplog.text
+
+
+def test_realtime_alias_variants_are_mapped(caplog: pytest.LogCaptureFixture) -> None:
+    rows = [
+        {
+            "timestamp": "2024-10-01T13:30:00Z",
+            "openIexRealtime": 25.0,
+            "highIex": 25.5,
+            "lowIex": 24.8,
+            "iexClosePrice": 25.2,
+            "volume": 2100,
+        }
+    ]
+    df = pd.DataFrame(rows)
+
+    caplog.set_level(logging.INFO)
+    normalized = ensure_ohlcv_schema(df, source="alpaca_iex", frequency="1Min")
+
+    _assert_standard_columns(normalized)
+    assert "OHLCV_COLUMNS_MISSING" not in caplog.text
+
+
+def test_nested_barset_payload_is_recovered(caplog: pytest.LogCaptureFixture) -> None:
+    payload = {
+        "bars": [
+            {"t": "2024-10-01T13:30:00Z", "o": 30.0, "h": 30.2, "l": 29.9, "c": 30.1, "v": 900},
+            {"t": "2024-10-01T13:31:00Z", "o": 30.1, "h": 30.4, "l": 30.0, "c": 30.3, "v": 950},
+        ],
+        "symbol": "AAPL",
+    }
+    df = pd.DataFrame([payload])
+
+    caplog.set_level(logging.INFO)
+    normalized = ensure_ohlcv_schema(df, source="alpaca_iex", frequency="1Min")
+
+    assert len(normalized) == 2
+    _assert_standard_columns(normalized)
+    assert "OHLCV_COLUMNS_MISSING" not in caplog.text
+    assert "OHLCV_SCHEMA_RECOVERED" in caplog.text

--- a/tests/test_provider_quiet_period_config.py
+++ b/tests/test_provider_quiet_period_config.py
@@ -1,0 +1,34 @@
+import logging
+from datetime import UTC, datetime
+
+import pytest
+
+from ai_trading.config.settings import get_settings
+from ai_trading.data.provider_monitor import ProviderMonitor
+
+
+def test_provider_quiet_period_respects_config(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("PROVIDER_SWITCH_QUIET_SECONDS", "45")
+    monkeypatch.setenv("PROVIDER_MAX_COOLDOWN_SECONDS", "180")
+    get_settings.cache_clear()
+
+    monitor = ProviderMonitor(cooldown=10, switchover_threshold=3)
+    assert monitor.max_cooldown == pytest.approx(180.0)
+
+    caplog.set_level(logging.WARNING)
+    for _ in range(3):
+        monitor.record_switchover("alpaca_iex", "yahoo")
+
+    blocked = [record for record in caplog.records if record.message == "DATA_PROVIDER_SWITCHOVER_BLOCKED"]
+    assert blocked
+    blocked_record = blocked[-1]
+    assert blocked_record.window_seconds == 45
+
+    disabled_until = monitor.disabled_until.get("alpaca_iex")
+    assert disabled_until is not None
+    remaining = (disabled_until - datetime.now(UTC)).total_seconds()
+    assert remaining == pytest.approx(180.0, rel=0.1)
+
+    get_settings.cache_clear()


### PR DESCRIPTION
WORKLOG
- Extended Alpaca IEX normalization to recognise additional alias tokens, recover nested bar payloads, and log successful recoveries so Yahoo fallbacks are avoided.
- Surfaced provider anti-thrash quiet windows and cooldown caps via runtime config and cached settings, and added a screening schema TTL cache to damp repeated warm-up fetches.
- Added focused tests covering new Alpaca payload shapes and provider monitor configuration behaviour.

PATCHSET
- `ai_trading/data/fetch/__init__.py`: Expanded alias tables, added Alpaca-specific token extraction and recovery helpers, and invoked recovery earlier to prevent false missing-column errors.
- `ai_trading/config/runtime.py`: Declared provider quiet-period and max-cooldown configuration specs.
- `ai_trading/data/provider_monitor.py`: Resolved quiet-period/cooldown values from settings at runtime and enforced them when blocking thrash.
- `ai_trading/core/bot_engine.py`: Added minute-schema cache structures and warm-up recording, and tightened fallback error handling.
- `tests/data/test_alpaca_iex_additional_shapes.py`: Added fixtures asserting recovery and alias handling for compact, realtime, and nested Alpaca bars.
- `tests/test_provider_quiet_period_config.py`: Exercised new quiet-period and cooldown configuration hooks.

VALIDATION
- `pytest -q tests/data/test_alpaca_iex_additional_shapes.py tests/test_provider_quiet_period_config.py`
- `pytest -q` *(fails: suite contains numerous pre-existing failures beyond the modified scope)*
- `ruff check ai_trading/data/fetch/__init__.py ai_trading/config/runtime.py ai_trading/data/provider_monitor.py ai_trading/core/bot_engine.py tests/data/test_alpaca_iex_additional_shapes.py tests/test_provider_quiet_period_config.py`
- `mypy ai_trading/data/fetch/__init__.py ai_trading/config/runtime.py ai_trading/data/provider_monitor.py ai_trading/core/bot_engine.py`
- `python -m py_compile $(git ls-files '*.py')`

RISK & ROLLBACK
- Recovery logic is scoped to Alpaca IEX and short TTL caching limits stale schemas; revert the commit to restore prior strict behaviour if issues arise.


------
https://chatgpt.com/codex/tasks/task_e_68decda6f0e483309b53af49cb1852c7