### PR TITLE
Fix minute index renaming to respect unnamed feeds

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8229,8 +8229,6 @@ class DataFetcher:
                 raise ValueError(str(exc)) from exc
             if original_name is not None:
                 idx = idx.rename(original_name)
-            else:
-                idx = idx.rename("timestamp")
             working.index = idx
             return working
 


### PR DESCRIPTION
# Title
Fix minute index renaming to respect unnamed feeds

# Context
Minute-bar DataFrame normalization should preserve upstream index metadata so downstream comparisons remain stable across providers.

# Problem
`_normalize_minute_index` forcibly renamed unnamed indices to `"timestamp"`, causing spurious diffs and schema churn when the source feed intentionally left the index unnamed.

# Scope
Narrow adjustment to the minute index normalization helper.

# Acceptance Criteria
- Service boots without import errors.
- TradingConfig validation remains intact.
- Tests and linters execute (or document blocked dependencies).

# Changes
- Preserve the DataFrame index name as-provided, only reapplying it when the source supplied one.

# Validation
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/bot_engine/test_fetch_minute_df_safe.py::test_data_fetcher_stale_iex_retries_realtime_feed -q` *(skipped: pandas unavailable in environment)*
- `pytest -q` *(fails during collection: numpy missing in environment)*
- `ruff check ai_trading/core/bot_engine.py`
- `mypy ai_trading/core/bot_engine.py`

# Risk
Low. Behavior change is limited to omitting a synthetic index rename when the source feed did not provide one; existing named indices remain unaffected.

------
https://chatgpt.com/codex/tasks/task_e_68deed5f9884833096f7f30c14153e24