### PR TITLE
Short-circuit Alpaca fetch for sessionless windows

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -4453,7 +4453,6 @@ def _fetch_bars(
     else:
         window_has_session = bool(window_has_session)
     _state["window_has_session"] = window_has_session
-    should_probe_sip = False
     short_circuit_empty = False
     if not window_has_session:
         tf_key = (symbol, _interval)
@@ -4476,36 +4475,7 @@ def _fetch_bars(
             ),
         )
         _state["skip_empty_metrics"] = True
-        try:
-            _state["preferred_feeds_snapshot"] = tuple(_preferred_feed_failover())
-        except Exception:
-            _state["preferred_feeds_snapshot"] = ()
-        should_probe_sip = False
-        preferred_snapshot = _state.get("preferred_feeds_snapshot") or ()
-        preferred_norm: set[str] = set()
-        for candidate in preferred_snapshot:
-            try:
-                normalized = _normalize_feed_value(candidate)
-            except Exception:
-                continue
-            preferred_norm.add(normalized)
-        if explicit_feed_request:
-            try:
-                requested_feed = _normalize_feed_value(_feed)
-            except Exception:
-                try:
-                    requested_feed = str(_feed).strip().lower()
-                except Exception:
-                    requested_feed = ""
-            should_probe_sip = bool(
-                requested_feed
-                and (
-                    requested_feed == "sip"
-                    or (requested_feed == "iex" and "sip" in preferred_norm)
-                )
-            )
-        if not should_probe_sip:
-            short_circuit_empty = True
+        short_circuit_empty = True
     else:
         _state["skip_empty_metrics"] = False
     if not _has_alpaca_keys():


### PR DESCRIPTION
Title: Short-circuit Alpaca fetch for sessionless windows

Context:
- Align empty-window handling with expectations when no market session exists for the requested range.

Problem:
- `_fetch_bars` could still reach out to Alpaca (or backup providers) even when the requested window has no trading session, delaying responses and wasting quota.

Scope:
- Limit changes to `_fetch_bars` in `ai_trading/data/fetch/__init__.py`.

AC:
- Requests for windows lacking a trading session skip HTTP work and return an empty frame immediately.
- Existing SIP failover hints do not bypass the early exit.
- Regression suite for fetch validation continues to pass.

Changes:
- Remove SIP-probing logic in the no-session path and always set `short_circuit_empty` when a session is absent.
- Preserve skip-empty metrics while guaranteeing the fetch returns immediately without contacting Alpaca or fallbacks.

Validation:
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_fetch_param_validation.py::test_window_without_trading_session_returns_empty tests/test_fetch_empty_early_exit.py::test_persistent_empty_aborts_early tests/unit/test_data_fetcher_http.py`
- `ruff check ai_trading/data/fetch/__init__.py`
- `mypy ai_trading/data/fetch/__init__.py`

Risk:
- Low; logic only affects windows explicitly lacking trading sessions and keeps existing metrics/logging behavior intact.

------
https://chatgpt.com/codex/tasks/task_e_68deef79229c8330a9d9d0ccb422511f