### PR TITLE
Reset HTTP pooling caches on reload

### DIFF
--- a/ai_trading/http/pooling.py
+++ b/ai_trading/http/pooling.py
@@ -8,6 +8,21 @@ from typing import Final, NamedTuple
 from urllib.parse import urlparse
 from weakref import WeakKeyDictionary
 
+_previous_host_semaphores = globals().get("_HOST_SEMAPHORES")
+if isinstance(_previous_host_semaphores, WeakKeyDictionary):
+    _previous_host_semaphores.clear()
+elif hasattr(_previous_host_semaphores, "clear"):
+    try:
+        _previous_host_semaphores.clear()  # type: ignore[call-arg]  # pragma: no cover - defensive guard for exotic reload state
+    except Exception:  # pragma: no cover - defensive guard for exotic reload state
+        pass
+
+if "_LIMIT_CACHE" in globals():
+    globals()["_LIMIT_CACHE"] = None
+
+if "_LIMIT_VERSION" in globals():
+    globals()["_LIMIT_VERSION"] = 0
+
 from ai_trading.config import management as config
 
 _DEFAULT_LIMIT: Final[int] = 8


### PR DESCRIPTION
Title: Reset HTTP pooling caches on reload

Context:
- Ensure the HTTP pooling module imports asyncio and can be safely reloaded during tests without leaking stale state.
- Aligns with host limit tests that repeatedly reload the module.

Problem:
- Reloading `ai_trading.http.pooling` could retain old semaphore and limit cache objects, leading to inconsistent state across reloads.

Scope:
- ai_trading/http/pooling.py

Acceptance Criteria:
- Module-level caches are reinitialised on reload.
- Targeted host-limit pytest suite passes.

Changes:
- Added defensive cache reset logic at import time to clear reused semaphore and limit cache globals when the module reloads.
- Left the asyncio import in place to satisfy runtime dependencies used by the dataclasses and helpers.

Validation:
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_http_host_limit.py`
- `pytest -q` *(fails across the wider suite with numerous pre-existing errors; aborted after repeated failures)*
- `ruff check ai_trading/http/pooling.py`
- `mypy ai_trading/http/pooling.py`

Risk:
- Low; changes only touch reload-time cache initialisation for the pooling module.

------
https://chatgpt.com/codex/tasks/task_e_68def4c85ac483308534d8608a57dfa0