### PR TITLE
Fix systemd startup stubs for numpy-dependent imports

### DIFF
--- a/tests/stubs/pydantic/__init__.py
+++ b/tests/stubs/pydantic/__init__.py
@@ -38,10 +38,22 @@ def field_validator(*_, **__):
         return func
     return decorator
 
+def model_validator(*_, **__):
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        return func
+    return decorator
+
 class BaseModel:
     def __init__(self, **data: Any):
         for k, v in data.items():
             setattr(self, k, v)
+
+    def __init_subclass__(cls, **config: Any) -> None:
+        try:
+            super().__init_subclass__(**config)
+        except TypeError:
+            super().__init_subclass__()
+
     def model_dump(self) -> dict[str, Any]:  # pragma: no cover
         return self.__dict__.copy()
 

--- a/tests/stubs/urllib3/fields.py
+++ b/tests/stubs/urllib3/fields.py
@@ -1,0 +1,37 @@
+"""Minimal urllib3.fields stub providing RequestField for tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass
+class RequestField:
+    """Stub implementation matching urllib3.fields.RequestField API surface."""
+
+    name: str | None = None
+    data: Any = None
+    headers: Mapping[str, str] | None = None
+
+    @classmethod
+    def from_tuples(
+        cls,
+        fieldname: str,
+        value: Any,
+        header_formatter: Any | None = None,
+    ) -> "RequestField":
+        field = cls(name=fieldname, data=value, headers={})
+        return field
+
+    def make_multipart(
+        self,
+        content_disposition: str | None = None,
+        content_type: str | None = None,
+        header_formatter: Any | None = None,
+    ) -> None:
+        # No-op for tests; real implementation configures headers for multipart forms.
+        return None
+
+
+__all__ = ["RequestField"]

--- a/tests/stubs/urllib3/filepost.py
+++ b/tests/stubs/urllib3/filepost.py
@@ -1,0 +1,29 @@
+"""Minimal urllib3.filepost stub for dependency-light test imports."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Tuple
+
+
+def encode_multipart_formdata(
+    fields: Iterable[Tuple[str, Any]] | Mapping[str, Any],
+    boundary: str | None = None,
+) -> Tuple[bytes, str]:
+    """Return placeholder multipart payload and content type."""
+
+    if isinstance(fields, dict):
+        items = list(fields.items())
+    else:
+        items = list(fields)
+    body = str(items).encode("utf-8")
+    content_type = "multipart/form-data"
+    if boundary:
+        content_type += f"; boundary={boundary}"
+    return body, content_type
+
+
+def choose_boundary() -> str:
+    return "stub-boundary"
+
+
+__all__ = ["encode_multipart_formdata", "choose_boundary"]

--- a/tests/stubs/urllib3/util/retry.py
+++ b/tests/stubs/urllib3/util/retry.py
@@ -2,3 +2,7 @@ class Retry:
     def __init__(self, *args, **kwargs):
         self.total = kwargs.get("total", 0)
         self.backoff_factor = kwargs.get("backoff_factor", 0)
+
+    @classmethod
+    def from_int(cls, retries, redirect=True, status_forcelist=None, **kwargs):
+        return cls(total=retries, **kwargs)

--- a/tests/test_systemd_startup.py
+++ b/tests/test_systemd_startup.py
@@ -60,12 +60,26 @@ class TestSystemdStartupCompatibility:
                 )
                 numpy_stub.__dict__.update(
                     {
-                        "__version__": "0.0-stub",
+                        "__version__": "0.0.0",
                         "ndarray": _Array,
                         "nan": float("nan"),
                         "NaN": float("nan"),
                         "float64": float,
+                        "float32": float,
+                        "float16": float,
                         "int64": int,
+                        "int32": int,
+                        "int16": int,
+                        "int8": int,
+                        "intp": int,
+                        "intc": int,
+                        "uint64": int,
+                        "uint32": int,
+                        "uint16": int,
+                        "uint8": int,
+                        "bool_": bool,
+                        "complex64": complex,
+                        "complex128": complex,
                         "array": _array,
                         "asarray": _array,
                         "diff": _diff,
@@ -74,6 +88,51 @@ class TestSystemdStartupCompatibility:
                     }
                 )
                 sys.modules["numpy"] = numpy_stub
+
+            if "pandas" not in sys.modules:
+                pandas_stub = types.ModuleType("pandas")
+
+                class DataFrame(dict):
+                    def __init__(self, *args, **kwargs):
+                        super().__init__()
+                        self.args = args
+                        self.kwargs = kwargs
+
+                    def to_dict(self, *args, **kwargs):
+                        return dict(self)
+
+                class Series(list):
+                    pass
+
+                pandas_stub.DataFrame = DataFrame
+                pandas_stub.Series = Series
+                pandas_stub.Timestamp = str
+                pandas_stub.__version__ = "0.0.0"
+                pandas_stub.to_datetime = lambda *a, **k: []
+                pandas_stub.date_range = lambda *a, **k: []
+                pandas_stub.isna = lambda *a, **k: False
+                sys.modules["pandas"] = pandas_stub
+
+            if "sklearn" not in sys.modules:
+                sklearn_stub = types.ModuleType("sklearn")
+                sklearn_stub.__version__ = "0.0.0"
+                sys.modules["sklearn"] = sklearn_stub
+
+            if "sklearn.utils" not in sys.modules:
+                sklearn_utils_stub = types.ModuleType("sklearn.utils")
+                sys.modules["sklearn.utils"] = sklearn_utils_stub
+
+            if "sklearn.utils._param_validation" not in sys.modules:
+                param_validation_stub = types.ModuleType("sklearn.utils._param_validation")
+
+                def validate_params(*args, **kwargs):
+                    def decorator(func):
+                        return func
+
+                    return decorator
+
+                param_validation_stub.validate_params = validate_params
+                sys.modules["sklearn.utils._param_validation"] = param_validation_stub
 
             if "portalocker" not in sys.modules:
                 portalocker_stub = types.ModuleType("portalocker")


### PR DESCRIPTION
### Title
- Fix numpy stub version and extend compatibility stubs for systemd startup test

### Context
- Systemd startup compatibility test relies on lightweight module stubs to avoid importing heavy third-party packages during import-time checks.
- Recent pandas/sklearn import paths require additional numpy dtype metadata and helper modules to be stubbed so the compatibility script can complete.

### Problem
- `tests/test_systemd_startup.py` injected a non-PEP440 numpy version string, blocking pandas parsing.
- Updating the version string exposed missing attributes and modules in our lightweight stubs, causing the subprocess to exit with errors.

### Scope
- Update the numpy stub version to a PEP 440 compliant string.
- Extend stub coverage to pandas, scikit-learn utilities, and urllib3 helpers used during import.
- Teach the pydantic stub to swallow subclass config kwargs used by modern pydantic decorators.

### Acceptance Criteria
- Systemd startup compatibility script runs without raising import-time errors.
- Added stubs satisfy pandas/sklearn/urllib3 expectations during the test harness run.
- Targeted unit test (`tests/test_systemd_startup.py`) passes locally.

### Changes
- Set the injected numpy stub version to `0.0.0` and expose additional dtype aliases plus pandas/sklearn module stubs inside `tests/test_systemd_startup.py`.
- Enhance the minimal pydantic stub with `model_validator` and an `__init_subclass__` implementation tolerant of keyword config.
- Provide lightweight urllib3 `fields`, `filepost`, and `Retry.from_int` stubs required by downstream imports.

### Validation
- `pip install -r requirements.txt`
- `pytest tests/test_systemd_startup.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails fast due to unrelated suite failures; aborted)*
- `ruff check tests/test_systemd_startup.py tests/stubs/pydantic/__init__.py tests/stubs/urllib3/fields.py tests/stubs/urllib3/filepost.py tests/stubs/urllib3/util/retry.py`
- `mypy tests/test_systemd_startup.py tests/stubs/pydantic/__init__.py tests/stubs/urllib3/fields.py tests/stubs/urllib3/filepost.py tests/stubs/urllib3/util/retry.py`

### Risk
- Low; changes are confined to test-time stubs and do not affect production code paths.

------
https://chatgpt.com/codex/tasks/task_e_68df0d05bcbc83309d1806cbb96c42a5