### PR TITLE
Normalize minute bar index naming to timestamp

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8327,8 +8327,8 @@ class DataFetcher:
                     idx = idx.tz_convert("UTC")
             except (TypeError, ValueError) as exc:
                 raise ValueError(str(exc)) from exc
-            if original_name is not None:
-                idx = idx.rename(original_name)
+            new_name = original_name if original_name is not None else "timestamp"
+            idx = idx.rename(new_name)
             working.index = idx
             return working
 


### PR DESCRIPTION
Title: Normalize minute bar index naming to timestamp

Context:
- Minute-bar DataFrames fetched by the bot engine may arrive without an index name, which breaks downstream expectations.

Problem:
- `_normalize_minute_index` preserved the original index name when present but left it unset otherwise, resulting in unnamed indices that consumers expect to be labeled `timestamp`.

Scope:
- Update `_normalize_minute_index` in `ai_trading/core/bot_engine.py` and run the targeted regression and repository checks.

Acceptance Criteria:
- `_normalize_minute_index` assigns the name `timestamp` when the incoming index lacks a name.
- Targeted regression `pytest tests/bot_engine/test_fetch_minute_df_safe.py::test_get_minute_df_handles_missing_safe_get` passes.
- Repository linters and type checks succeed on the touched path.

Changes:
- Default the normalized index name to `"timestamp"` whenever the source index is unnamed.

Validation:
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/bot_engine/test_fetch_minute_df_safe.py::test_get_minute_df_handles_missing_safe_get`
- `pytest -q` *(fails across numerous pre-existing tests; abort after observing pervasive baseline failures)*
- `ruff check ai_trading/core/bot_engine.py`
- `mypy --config-file mypy.ini ai_trading/core/bot_engine.py`

Risk:
- Low; the change only affects the fallback naming of normalized minute-bar indices and maintains existing behavior when an explicit index name is supplied.

------
https://chatgpt.com/codex/tasks/task_e_68df0d0671f0833085bc3c51d6c6a878