### PR TITLE
Relax SIP entitlement gating when credentials absent

### DIFF
--- a/ai_trading/data/fetch/sip_disallowed.py
+++ b/ai_trading/data/fetch/sip_disallowed.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 from ai_trading.utils.environment import env
 
 
+def _has_alpaca_credentials() -> bool:
+    return bool(env.ALPACA_KEY) and bool(env.ALPACA_SECRET)
+
+
+def sip_credentials_missing() -> bool:
+    """Return ``True`` when Alpaca API credentials are absent."""
+
+    return not _has_alpaca_credentials()
+
+
 def sip_disallowed() -> bool:
     """Return ``True`` when the SIP feed should not be used."""
 
@@ -27,10 +37,6 @@ def sip_disallowed() -> bool:
     if allow_flag is False:
         return True
 
-    has_creds = bool(env.ALPACA_KEY) and bool(env.ALPACA_SECRET)
-    if not has_creds:
-        return True
-
     explicit_entitlement = _coerce_flag(getattr(env, "ALPACA_SIP_ENTITLED", None))
     if explicit_entitlement is not None:
         return not explicit_entitlement
@@ -39,8 +45,11 @@ def sip_disallowed() -> bool:
     if has_sip is not None:
         return not has_sip
 
+    if not _has_alpaca_credentials():
+        return True
+
     return False
 
 
-__all__ = ["sip_disallowed"]
+__all__ = ["sip_disallowed", "sip_credentials_missing"]
 


### PR DESCRIPTION
## Title
* Relax SIP entitlement gating when credentials absent

## Context
* Requests to use Alpaca SIP data should be honored when the account advertises SIP entitlement even if environment credentials are missing.

## Problem
* `sip_disallowed()` previously returned `True` strictly because `ALPACA_KEY`/`ALPACA_SECRET` were unset, causing `_ensure_entitled_feed` to fall back to IEX even when the Alpaca account subscription listed SIP.

## Scope
* `ai_trading/data/fetch/sip_disallowed.py`
* `ai_trading/data/bars.py`

## Acceptance Criteria
* Respect positive entitlement signals from the account or environment when credentials are absent.
* Maintain ability to block SIP usage when explicitly disabled via environment flags.
* Default test suite continues to run, with targeted entitlement tests passing.

## Changes
* Added `sip_credentials_missing()` helper and deferred the credential check in `sip_disallowed()` until after entitlement flags are evaluated.
* Updated `_ensure_entitled_feed()` to treat `_get_entitled_feeds()` SIP entries as authoritative when the only previous block was missing credentials.

## Validation
* `python -m py_compile $(git ls-files '*.py')`
* `pytest tests/test_feed_entitlement.py`
* `pytest -q` *(fails early due to numerous pre-existing suite issues; aborted to prevent runaway runtime after confirming failures)*
* `ruff check ai_trading/data/fetch/sip_disallowed.py ai_trading/data/bars.py`
* `mypy ai_trading/data/fetch/sip_disallowed.py ai_trading/data/bars.py`

## Risk
* Low — changes narrow the credential gating logic around SIP entitlement while keeping explicit disable flags authoritative. `_ensure_entitled_feed` still guards against lacking entitlement information.


------
https://chatgpt.com/codex/tasks/task_e_68df28848a4083309ee180f18503edcf