### PR TITLE
Ensure health fallback payload is normalised

### DIFF
--- a/ai_trading/app.py
+++ b/ai_trading/app.py
@@ -170,6 +170,13 @@ def create_app():
         if fallback_used:
             final_payload["ok"] = False
 
+        # Ensure the exposed payload always carries the canonical structure
+        # regardless of how we arrive here (missing ``jsonify`` or runtime
+        # failures). Re-running the normaliser guarantees ``ok`` and
+        # ``alpaca`` are present and that ``alpaca`` is seeded from
+        # ``_ALPACA_SECTION_DEFAULTS``.
+        final_payload = _ensure_core_fields(final_payload)
+
         message_candidates: list[str] = []
         existing_error = response_payload.get("error")
         if existing_error is None:


### PR DESCRIPTION
Title: Ensure health fallback payload is normalised

Context:
- WORKLOG:
  - Hardened the health response fallback to keep the payload schema stable when Flask helpers are unavailable.

Problem:
- Fallback execution paths could omit required keys when `jsonify` is missing or raising, leading to schema drift for callers expecting `ok` and `alpaca`.

Scope:
- Limit changes to the health response helper and associated health check tests.

Acceptance Criteria:
- Health fallback payloads always include `ok` and a normalised `alpaca` section.
- Unit coverage exercises the dict fallback path to ensure `_assert_payload_structure` passes.

Changes:
- Normalise the fallback payload before returning from `_json_response` to guarantee canonical keys.
- Added a regression test ensuring the handler returns a structured dict when `jsonify` is absent and Flask cannot build a response object.
- PATCHSET:
  - apply_patch: ai_trading/app.py
  - apply_patch: tests/test_health_check.py

Validation:
- `pytest tests/test_health_check.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: missing optional dependency numpy due to incomplete dependency installation)*
- `ruff check` *(fails: pre-existing undefined-name issues)*
- `mypy .` *(fails: missing cachetools stubs and duplicate module path)*

Risk:
- Low risk; updates are localized to health reporting paths. RISK & ROLLBACK:
  - Rollback by reverting commit 31d6960 or deploying previous revision if regressions appear.


------
https://chatgpt.com/codex/tasks/task_e_68df28858d4483309e76644942da0edd