### PR TITLE
Normalize tools package imports

### DIFF
--- a/tests/config/test_apca_strict.py
+++ b/tests/config/test_apca_strict.py
@@ -18,7 +18,7 @@ def test_apca_env_strict_raises(monkeypatch):
 
 def test_env_doctor_detects_process_env(monkeypatch):
     monkeypatch.setenv("APCA_FAKE", "1")
-    from tools import env_doctor
+    import tools.env_doctor as env_doctor
 
     exit_code = env_doctor.main()
     assert exit_code != 0

--- a/tests/test_run_pytest_command.py
+++ b/tests/test_run_pytest_command.py
@@ -5,7 +5,7 @@ import importlib.util as iu
 import os
 import sys
 
-from tools import run_pytest
+import tools.run_pytest as run_pytest
 
 
 def test_build_pytest_cmd_echo(monkeypatch):  # AI-AGENT-REF: verify exact command

--- a/tests/test_runner_smoke.py
+++ b/tests/test_runner_smoke.py
@@ -30,7 +30,7 @@ def test_runner_echo_exact_command(tmp_path):  # AI-AGENT-REF: check exact runne
     proc = subprocess.run(args, capture_output=True, text=True, env=env)
     assert proc.returncode == 0
     echo = _first_echo_line(proc.stderr)
-    from tools import run_pytest
+    import tools.run_pytest as run_pytest
 
     cmd = [sys.executable, "-m", "pytest", "-q", "-W", "ignore"]
     addopts = os.environ.get("PYTEST_ADDOPTS", "")

--- a/tests/tools/test_audit_repo_tool.py
+++ b/tests/tools/test_audit_repo_tool.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from tools import audit_repo
+import tools.audit_repo as audit_repo
 
 
 def test_audit_repo_runs_clean():

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,2 @@
+"""Utility scripts packaged under :mod:`tools`."""
+


### PR DESCRIPTION
Title: Normalize tools package imports

Context:
- Ensure the local tooling directory behaves as a standard Python package rather than a namespace package.
- Keep dependent tests aligned with the updated import semantics.

Problem:
- The `tools` directory lacked an `__init__.py`, causing namespace package semantics and duplicate-module complaints in tooling.
- Several test helpers relied on implicit namespace imports (`from tools import ...`) that break when moving to a regular package.

Scope:
- Limit changes to the `tools` package boundary and its direct consumers in tests.

Acceptance Criteria:
- `tools` is a regular package with an `__init__.py` marker file.
- Tests reference tooling helpers via explicit module imports (e.g., `import tools.audit_repo as audit_repo`).
- Repo remains otherwise untouched.

Changes:
- Added a minimal `tools/__init__.py` to establish normal package semantics.
- Updated tests under `tests/` to import tooling modules via fully-qualified package paths.

Validation:
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check` *(fails: pre-existing undefined names in unrelated modules)*
- `mypy .` *(fails: pre-existing typing gaps across tooling/scripts)*
- `pytest -q` *(aborted after numerous pre-existing failures in unrelated suites)*

Risk & Rollback:
- Low risk; change only affects import resolution. Roll back by removing `tools/__init__.py` and restoring prior imports in tests.


------
https://chatgpt.com/codex/tasks/task_e_68df2b4d0d6c8330aabec44a07ea7f74