### PR TITLE
Fix RL stub import error chaining

### DIFF
--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -238,10 +238,12 @@ try:  # Eagerly import to keep a stable module reference for reloads.
 except Exception as exc:  # pragma: no cover - optional dependency missing or other import failure
     stub = ModuleType(f"{__name__}.train")
 
-    def _raise_import_error(*_a: Any, **_k: Any) -> None:
+    def _raise_import_error(
+        *_a: Any, _exc: BaseException = exc, **_k: Any
+    ) -> None:
         raise ImportError(
             "RL stack not available; install stable-baselines3, gymnasium, and torch"
-        ) from exc
+        ) from _exc
 
     stub.__dict__.update(
         {

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -12,6 +12,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -88,7 +89,7 @@ def test_talib_imports():
     except ImportError:
         return False
 
-def _make_sample_df(pd, *, rows: int = 60, volume: int = 150_000) -> "pd.DataFrame":
+def _make_sample_df(pd, *, rows: int = 60, volume: int = 150_000) -> Any:
     base = pd.Series(range(rows), dtype="float64") + 100.0
     data = {
         "open": base - 0.5,


### PR DESCRIPTION
Title: Fix RL stub import error chaining

Context:
- Preserve structured logging and lazy import behavior for the RL training stub while addressing linter warnings.

Problem:
- The `_raise_import_error` helper referenced `exc` from the outer scope, triggering lint complaints because the name was not locally bound.

Scope:
- `ai_trading/rl_trading/__init__.py`
- `tests/test_fixes.py`

Acceptance Criteria:
- RL stub re-raises the original import failure using a locally bound exception reference.
- Linting passes on the touched files.
- Runtime behavior for the RL stub remains unchanged.

Changes:
- Capture the original import exception via a default argument in `_raise_import_error` to keep the name in local scope while preserving the chained traceback.
- Annotate the helper’s signature to accept keyword-only `_exc` while retaining structured logging semantics.
- Update the TA-lib fallback test helper to import `Any` and avoid referencing an undefined `pd` symbol in annotations.

Validation:
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check`
- `mypy .` *(fails: duplicate module discovery in tools/audit_repo.py)*
- `pytest -q` *(fails: numerous pre-existing test failures; run aborted after repeated failures)*

Risk & Rollback:
- Low risk; rollback by reverting commit `Fix RL import stub error chaining` if unexpected behavior occurs.

------
https://chatgpt.com/codex/tasks/task_e_68df2ecd9c888330801c5d6acfcc1e5f