### PR TITLE
Guard pandas typing alias and fix RL stub exception handling

### DIFF
--- a/ai_trading/rl_trading/__init__.py
+++ b/ai_trading/rl_trading/__init__.py
@@ -237,17 +237,18 @@ try:  # Eagerly import to keep a stable module reference for reloads.
     train = _load_train_module()
 except Exception as exc:  # pragma: no cover - optional dependency missing or other import failure
     stub = ModuleType(f"{__name__}.train")
+    original_exc = exc
 
     def _raise_import_error(*_a: Any, **_k: Any) -> None:
         raise ImportError(
             "RL stack not available; install stable-baselines3, gymnasium, and torch"
-        ) from exc
+        ) from original_exc
 
     stub.__dict__.update(
         {
             "train": _raise_import_error,
             "USING_RL_TRAIN_STUB": True,
-            "__fallback_exception__": exc,
+            "__fallback_exception__": original_exc,
         }
     )
     sys.modules.setdefault(f"{__name__}.train", stub)

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -12,10 +12,14 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from ai_trading.core import bot_engine
+
+if TYPE_CHECKING:  # pragma: no cover - typing aid only
+    import pandas as pd
 
 
 def test_tickers_csv():


### PR DESCRIPTION
## Title
* Guard pandas typing alias and fix RL stub exception handling

## Context
* Ruff flagged undefined names in `tests/test_fixes.py` and the RL training stub during CI checks.

## Problem
* String annotations in `tests/test_fixes.py` referenced an alias (`pd`) that only exists at runtime, tripping `F821`.
* The RL training stub referenced the caught exception variable after it left scope, also triggering `F821`.

## Scope
* Limit changes to the RL training stub and the tests module that relies on pandas annotations.

## Acceptance Criteria
* Ruff no longer reports undefined-name violations for pandas annotations or the RL stub.
* The RL stub continues to surface the original import failure while remaining lazily loadable.

## Changes
* Added a `TYPE_CHECKING` guarded import for pandas in `tests/test_fixes.py` to bind the alias for static analysis.
* Captured the RL stub's import failure in a local `original_exc` variable so the nested helper raises with the correct context.

## Validation
* `python -m pip install -r requirements.txt`
* `python -m py_compile $(git ls-files '*.py')`
* `ruff check`
* `mypy .` *(fails: missing cachetools stubs; duplicate module path for tools/audit_repo)*
* `pytest -q` *(aborted after numerous pre-existing failures; see log)*

## Risk
* Low: modifications are isolated to test typing aids and fallback error handling without affecting runtime trading paths.

------
https://chatgpt.com/codex/tasks/task_e_68df2ecf81fc83308a874da3c5e1a195