### PR TITLE
Fix pandas typing references in interfaces

### DIFF
--- a/ai_trading/core/interfaces.py
+++ b/ai_trading/core/interfaces.py
@@ -15,9 +15,7 @@ from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import numpy as np
-    from ai_trading.utils.lazy_imports import load_pandas
-
-    pd = load_pandas()
+    import pandas as pd
 
 from ai_trading.order.types import OrderSide
 
@@ -87,7 +85,7 @@ class IDataProvider(ABC):
     """Interface for market data providers."""
 
     @abstractmethod
-    async def get_market_data(self, symbol: str, timeframe: str='1min', start: datetime | None=None, end: datetime | None=None) -> "pd.DataFrame":
+    async def get_market_data(self, symbol: str, timeframe: str='1min', start: datetime | None=None, end: datetime | None=None) -> pd.DataFrame:
         """Get historical market data."""
 
     @abstractmethod
@@ -205,30 +203,30 @@ class IIndicatorCalculator(ABC):
     """Interface for technical indicator calculations."""
 
     @abstractmethod
-    def calculate_sma(self, data: "pd.Series", period: int) -> "pd.Series":
+    def calculate_sma(self, data: pd.Series, period: int) -> pd.Series:
         """Calculate Simple Moving Average."""
 
     @abstractmethod
-    def calculate_ema(self, data: "pd.Series", period: int) -> "pd.Series":
+    def calculate_ema(self, data: pd.Series, period: int) -> pd.Series:
         """Calculate Exponential Moving Average."""
 
     @abstractmethod
-    def calculate_rsi(self, data: "pd.Series", period: int=14) -> "pd.Series":
+    def calculate_rsi(self, data: pd.Series, period: int=14) -> pd.Series:
         """Calculate Relative Strength Index."""
 
     @abstractmethod
-    def calculate_bollinger_bands(self, data: "pd.Series", period: int=20, std: float=2) -> tuple["pd.Series", "pd.Series", "pd.Series"]:
+    def calculate_bollinger_bands(self, data: pd.Series, period: int=20, std: float=2) -> tuple[pd.Series, pd.Series, pd.Series]:
         """Calculate Bollinger Bands."""
 
     @abstractmethod
-    def calculate_macd(self, data: "pd.Series", fast: int=12, slow: int=26, signal: int=9) -> tuple["pd.Series", "pd.Series"]:
+    def calculate_macd(self, data: pd.Series, fast: int=12, slow: int=26, signal: int=9) -> tuple[pd.Series, pd.Series]:
         """Calculate MACD."""
 
 class ITradingStrategy(ABC):
     """Interface for trading strategies."""
 
     @abstractmethod
-    async def generate_signal(self, symbol: str, market_data: "pd.DataFrame") -> TradingSignal | None:
+    async def generate_signal(self, symbol: str, market_data: pd.DataFrame) -> TradingSignal | None:
         """Generate trading signal based on market data."""
 
     @abstractmethod
@@ -304,15 +302,15 @@ class IMLModel(ABC):
     """Interface for machine learning models."""
 
     @abstractmethod
-    async def train(self, features: "pd.DataFrame", targets: "pd.Series") -> None:
+    async def train(self, features: pd.DataFrame, targets: pd.Series) -> None:
         """Train the model."""
 
     @abstractmethod
-    async def predict(self, features: "pd.DataFrame") -> "np.ndarray":
+    async def predict(self, features: pd.DataFrame) -> "np.ndarray":
         """Make predictions."""
 
     @abstractmethod
-    async def predict_proba(self, features: "pd.DataFrame") -> "np.ndarray":
+    async def predict_proba(self, features: pd.DataFrame) -> "np.ndarray":
         """Get prediction probabilities."""
 
     @abstractmethod
@@ -327,7 +325,7 @@ class IFeatureEngineer(ABC):
     """Interface for feature engineering."""
 
     @abstractmethod
-    async def engineer_features(self, market_data: "pd.DataFrame") -> "pd.DataFrame":
+    async def engineer_features(self, market_data: pd.DataFrame) -> pd.DataFrame:
         """Engineer features from market data."""
 
     @abstractmethod
@@ -335,7 +333,7 @@ class IFeatureEngineer(ABC):
         """Get list of feature names."""
 
     @abstractmethod
-    async def update_features(self, new_data: "pd.DataFrame") -> "pd.DataFrame":
+    async def update_features(self, new_data: pd.DataFrame) -> pd.DataFrame:
         """Update features with new data."""
 
 class IMetricsCollector(ABC):


### PR DESCRIPTION
Title: Fix pandas typing references in interfaces

Context:
- Ruff flagged forward references such as `"pd.DataFrame"` in `ai_trading/core/interfaces.py` because the module relied on a lazily loaded helper for pandas that type-checkers could not resolve.
- The interfaces module is imported widely, so resolving the typing alias without introducing runtime imports keeps import-time costs low while satisfying static analysis.

Problem:
- `ai_trading/core/interfaces.py` defined `pd = load_pandas()` inside a `TYPE_CHECKING` block, leaving `pd` undefined to static tooling.
- Multiple interface annotations referenced `"pd.DataFrame"`/`"pd.Series"`, which Ruff treats as unknown names without a discoverable alias.

Scope:
- ai_trading/core/interfaces.py

Acceptance Criteria:
- Provide a guarded pandas import that is discoverable to static tooling without impacting runtime import cost.
- Update pandas annotations to use the new alias directly so Ruff can resolve them.
- Preserve existing runtime behavior and avoid introducing new runtime pandas imports.

Changes:
- Swapped the lazy loader for a straightforward `import pandas as pd` guarded by `TYPE_CHECKING`.
- Replaced string-based pandas annotations with direct `pd.DataFrame`/`pd.Series` references across the interface methods.

Validation:
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check`
- `mypy .`
- `pytest -q` *(aborted due to large number of pre-existing failures; see run log for details.)*

Risk:
- Low risk: type-hint only adjustments guarded under `TYPE_CHECKING` and no runtime code path changes. Static tooling now recognizes pandas types without altering runtime behavior.

------
https://chatgpt.com/codex/tasks/task_e_68df3454614483309ae43c5cf0fe0f5b