### PR TITLE
Fix minute index normalization for SIP fallback and legacy feeds

### DIFF
--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -1361,6 +1361,7 @@ def test_data_fetcher_stale_iex_retries_realtime_feed(monkeypatch):
     assert captured["max_age"] == 900
     assert isinstance(result, pd.DataFrame)
     pd.testing.assert_index_equal(result.index, fresh_idx)
+    assert result.index.name is None
     assert fetcher._minute_cache["AAPL"].index[-1] == fresh_idx[-1]
     assert fetcher._minute_timestamps["AAPL"] == base_now
 
@@ -1388,17 +1389,18 @@ def test_get_minute_df_handles_missing_safe_get(monkeypatch):
 
     def fake_get_stock_bars(client, req, symbol, context=None):
         calls.append(context or "")
-        return pd.DataFrame(
+        legacy_payload = pd.DataFrame(
             {
+                "timestamp": list(idx),
                 "open": [1.0, 1.01, 1.02],
                 "high": [1.1, 1.11, 1.12],
                 "low": [0.9, 0.91, 0.92],
                 "close": [1.0, 1.01, 1.02],
                 "volume": [100, 110, 120],
                 "symbol": [symbol] * len(idx),
-            },
-            index=idx,
+            }
         )
+        return legacy_payload.reset_index(drop=True)
 
     class FrozenDatetime(datetime):
         @classmethod
@@ -1434,10 +1436,11 @@ def test_get_minute_df_handles_missing_safe_get(monkeypatch):
     result = fetcher.get_minute_df(ctx, "AAPL", lookback_minutes=2)
 
     assert isinstance(result, pd.DataFrame)
+    assert isinstance(result.index, pd.DatetimeIndex)
     expected_idx = idx.rename("timestamp")
     pd.testing.assert_index_equal(result.index, expected_idx)
-    assert idx.name is None
     assert result.index.name == "timestamp"
+    assert idx.name is None
     assert result.index.tz is not None
     assert result.index.tz.tzname(None) == UTC.tzname(None)
     assert list(result.columns[:5]) == ["open", "high", "low", "close", "volume"]


### PR DESCRIPTION
### Title
Fix minute index normalization for SIP fallback and legacy feeds

### Context
SIP retry paths were returning minute DataFrames whose timestamp indexes lost their original metadata, breaking expectations in `test_data_fetcher_stale_iex_retries_realtime_feed`. Legacy fallback paths also need deterministic index naming.

### Problem
`_normalize_minute_index` always renamed indices to `"timestamp"`, so SIP fallback results (which should retain an unnamed tz-aware index) failed equality checks. Conversely, legacy data lacking an index still required the canonical `"timestamp"` index name. Tests didn’t cover both paths.

### Scope
- `ai_trading/core/bot_engine.py`
- `tests/bot_engine/test_fetch_minute_df_safe.py`

### Acceptance Criteria
- SIP fallback keeps the original unnamed UTC index when already tz-aware.
- Legacy minute frames without a proper index are normalized to `"timestamp"`.
- Updated tests cover both retry paths.

### Changes
- Refactored `_normalize_minute_index` to return both the normalized DataFrame and a preserve flag, honoring unnamed tz-aware indexes only when allowed.
- Added `_finalize_minute_index` support for the preserve flag and enforced post-normalization renaming when needed.
- Ensured legacy fallback frames without an index are reindexed from their `timestamp` column.
- Extended SIP retry test to assert index metadata preservation and updated legacy fallback test to reflect the timestamp-column payload.

### Validation
- `python -m py_compile $(git ls-files '*.py')` (pass) 【62011f†L1-L1】
- `ruff check .` (pass) 【d1ca2e†L1-L2】
- `mypy .` (pass) 【b1a741†L1-L1】
- `pytest tests/bot_engine/test_fetch_minute_df_safe.py` (pass) 【0b078b†L1-L3】
- `pytest -q` (aborted due to pre-existing failures; command emitted numerous failing cases before manual interrupt) 【320580†L1-L2】

### Risk
Low — changes are localized to minute data normalization logic and associated tests. Potential risk lies in unforeseen data sources relying on previous renaming behavior, mitigated by updated coverage for both SIP and legacy flows.

------
https://chatgpt.com/codex/tasks/task_e_68df499613e4833093683003f80b14d4