### PR TITLE
Avoid remote fetch when window lacks trading session

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -4480,6 +4480,8 @@ def _fetch_bars(
         )
         _state["skip_empty_metrics"] = True
         short_circuit_empty = True
+        empty_df = _empty_ohlcv_frame(pd)
+        return empty_df if empty_df is not None else pd.DataFrame()
     else:
         _state["skip_empty_metrics"] = False
     if not _has_alpaca_keys():


### PR DESCRIPTION
### Title
* Avoid remote fetch when window lacks trading session

### Context
* Primary provider requests were triggered even when the requested window had no overlapping trading session, causing unnecessary HTTP calls and breaking validation tests.

### Problem
* `_fetch_bars` continued into the Alpaca/fallback execution path despite `_window_has_trading_session` returning `False`, so tests expecting an immediate empty frame received network requests instead.

### Scope
* ai_trading/data/fetch/__init__.py

### Acceptance Criteria
* `_fetch_bars` must return an empty OHLCV frame without attempting HTTP requests when a window lacks trading sessions.
* Existing empty-window metrics/logging continue to fire once.
* Targeted param-validation and related fetch tests pass.

### Changes
* Add an early return inside `_fetch_bars` that hands back `_empty_ohlcv_frame(pd)` once `window_has_session` evaluates false, after emitting the expected metric/log entry.

### Validation
* `python -m py_compile $(git ls-files '*.py')`
* `python -m pytest tests/test_fetch_param_validation.py -q`
* `python -m pytest tests/test_fetch_empty_early_exit.py -q`
* `python -m pytest tests/test_minute_cache_helpers.py -q`
* `ruff check ai_trading/data/fetch/__init__.py`
* `mypy ai_trading/data/fetch/__init__.py`

### Risk
* Low — change short-circuits only the branch where no session exists and preserves existing logging/metrics behavior before returning the cached empty frame.

------
https://chatgpt.com/codex/tasks/task_e_68dfe8b0b3748330881b4ad23f1d11d7