### PR TITLE
Fix entitlement cache refresh and add downgrade test

### DIFF
--- a/tests/test_feed_entitlement.py
+++ b/tests/test_feed_entitlement.py
@@ -28,6 +28,14 @@ def test_ensure_entitled_feed_upgrades_cached_entitlement():
     assert bars._ensure_entitled_feed(client, 'sip') == 'sip'
 
 
+def test_ensure_entitled_feed_downgrades_cached_entitlement():
+    bars._ENTITLE_CACHE.clear()
+    client = _Client(['sip'])
+    assert bars._ensure_entitled_feed(client, 'sip') == 'sip'
+    client._feeds = ['iex']
+    assert bars._ensure_entitled_feed(client, 'sip') == 'iex'
+
+
 def test_ensure_entitled_feed_keeps():
     bars._ENTITLE_CACHE.clear()
     client = _Client(['sip'])


### PR DESCRIPTION
Title: Fix entitlement cache refresh and add downgrade test

Context:
- Reliability review exposed stale feed cache entries keeping accounts on the IEX feed despite upgraded SIP access.
- Entitlement decisions drive downstream bar fetch selection and must honor live account capabilities even before TTL expiry.

Problem:
- `_get_entitled_feeds` returned cached SIP entitlements without revalidating, preventing downgrades and delaying SIP upgrades.
- `_ensure_entitled_feed` logic needed to preserve SIP allowance when credentials are absent but the account reports SIP capability.

Scope:
- `ai_trading/data/bars.py` entitlement cache refresh logic and associated regression coverage.
- Entitlement unit tests in `tests/test_feed_entitlement.py`.

AC:
- Entitlement cache refreshes whenever the feed set changes, regardless of TTL.
- SIP availability overrides prior IEX-only cache snapshots.
- SIP entitlement logic remains intact when credentials are missing but SIP is advertised.
- Regression coverage for both upgrade and downgrade scenarios.

Changes:
- Reworked entitlement cache refresh to reuse cached data only when appropriate while honoring feed changes and SIP upgrades.
- Added downgrade regression ensuring cached SIP entries fall back to IEX when the account feed set contracts.

Validation:
- `pytest tests/test_feed_entitlement.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` (times out with numerous pre-existing failures; interrupted after timeout stack trace)
- `ruff check .`
- `mypy .`

Risk:
- Low: targeted cache refresh adjustments and unit test additions confined to entitlement logic.

------
https://chatgpt.com/codex/tasks/task_e_68dffa5b03308330a747bb3b83f27c5c