### PR TITLE
Improve minute feed diagnostics and reset fallback state

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -1076,6 +1076,43 @@ def _used_fallback(symbol: str, timeframe: str, start: _dt.datetime, end: _dt.da
     return _fallback_key(symbol, timeframe, start, end) in _FALLBACK_WINDOWS
 
 
+def _clear_minute_fallback_state(
+    symbol: str,
+    timeframe: str,
+    start: _dt.datetime,
+    end: _dt.datetime,
+    *,
+    primary_label: str | None = None,
+    backup_label: str | None = None,
+) -> bool:
+    """Clear cached fallback hints when the primary feed is healthy again."""
+
+    key = _fallback_key(symbol, timeframe, start, end)
+    tf_key = (symbol, timeframe)
+    cleared = False
+    if key in _FALLBACK_WINDOWS:
+        _FALLBACK_WINDOWS.discard(key)
+        cleared = True
+    if key in _FALLBACK_METADATA:
+        _FALLBACK_METADATA.pop(key, None)
+        cleared = True
+    if tf_key in _FALLBACK_UNTIL:
+        _FALLBACK_UNTIL.pop(tf_key, None)
+        cleared = True
+    if cleared and primary_label and backup_label:
+        try:
+            provider_monitor.update_data_health(
+                primary_label,
+                backup_label,
+                healthy=True,
+                reason="primary_recovered",
+                severity="good",
+            )
+        except Exception:
+            pass
+    return cleared
+
+
 def _annotate_df_source(
     df: pd.DataFrame | None,
     *,
@@ -7105,6 +7142,15 @@ def get_minute_df(
             _record_minute_fallback(frame=df)
             fallback_logged = True
         _IEX_EMPTY_COUNTS.pop(tf_key, None)
+    if backup_label and not used_backup:
+        _clear_minute_fallback_state(
+            symbol,
+            "1Min",
+            start_dt,
+            end_dt,
+            primary_label=primary_label,
+            backup_label=backup_label,
+        )
     source_label = (
         resolved_backup_provider
         if used_backup


### PR DESCRIPTION
## Context
* Add structured logging around stale IEX minute data events so on-call engineers can see which provider actually served the frame.
* Ensure provider failover state is cleared once the Alpaca primary feed delivers healthy data so we do not remain pinned to Yahoo.

## Problem
* `IEX_MINUTE_DATA_STALE` warnings did not expose `df.attrs`, making it hard to confirm the active feed when debugging.
* Fallback TTL metadata and `provider_monitor` state were not cleared after recovery, leaving the runtime biased toward the backup provider.

## Scope
* Runtime changes in `ai_trading.core.bot_engine` and `ai_trading.data.fetch`.
* Unit tests covering the new helpers and fallback cleanup.
* Runbook update in `docs/OPERATIONS.md` describing the operational recovery steps.

## Acceptance Criteria
* Stale-minute warnings include feed metadata from the DataFrame attributes.
* Successful primary-feed fetches clear fallback metadata and notify `provider_monitor`.
* Tests covering the new helpers pass.
* Documentation tells operators how to validate entitlements and reset provider state.

## Changes
* Added `_minute_frame_attrs` / `_log_iex_minute_stale` helpers and reused them for both the IEX stale warning and fallback staleness logging.
* Introduced `_clear_minute_fallback_state` to purge fallback caches and notify `provider_monitor` once primary data is healthy, and wired it into the minute fetch path.
* Documented Alpaca market-data troubleshooting (entitlement verification, SDK pinning, metadata inspection, and provider reset) in the operations runbook.
* Added focused unit tests for the new helpers and fallback cleanup behaviour.

## Validation
* `pip install -r requirements.txt`
* `python -m py_compile $(git ls-files '*.py')`
* `pytest tests/bot_engine/test_fetch_minute_df_safe.py::test_minute_frame_attrs_extracts_known_keys tests/bot_engine/test_fetch_minute_df_safe.py::test_log_iex_minute_stale_includes_attrs tests/data/test_get_minute_df_fetch_logging.py::test_clear_minute_fallback_state_clears_all_metadata -q`
* `ruff check ai_trading/core/bot_engine.py ai_trading/data/fetch/__init__.py tests/bot_engine/test_fetch_minute_df_safe.py tests/data/test_get_minute_df_fetch_logging.py`
* `mypy ai_trading/core/bot_engine.py ai_trading/data/fetch/__init__.py`
* Attempted full `pytest -q` run; aborted due to numerous pre-existing failures unrelated to these changes.

## Risk
* Low: changes are localized to logging, fallback metadata handling, and documentation. The new helper only executes on stale-minute paths and unit tests cover the added functionality.

------
https://chatgpt.com/codex/tasks/task_e_68e00d788d508330a5717a2af03671b7