### PR TITLE
Pin alpaca-trade-api 3.2.0 runtime dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 - **Structured logging only**. Use existing JSON logging helpers; do not print().
 - **Use `runtime`** (an instance of `BotRuntime`) across hot paths. **Do not introduce `ctx`**.
 - Keep `ai_trading` imports stable; avoid dynamic `exec`/`eval`.
-- **Single Alpaca SDK**: use only `alpaca-py`. Remove legacy `alpaca-trade-api` (`pip uninstall -y alpaca-trade-api`).
+- **Alpaca SDK policy**: runtime pins to `alpaca-trade-api==3.2.0`; keep `alpaca-py==0.42.1` for tests and helper tooling only.
 
 ## Runtime & Config
 - `TradingConfig`: read-only settings (broker creds, paths, limits).

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -35,6 +35,10 @@ This guide covers deployment strategies, environment setup, CI/CD configuration,
 - **Disk**: 100GB SSD
 - **Network**: Redundant connections, <50ms latency to exchanges
 
+#### Broker SDK Versions
+- **alpaca-trade-api**: `3.2.0` (runtime pin; rebuild images after upgrading).
+- **alpaca-py**: `0.42.1` (installed for tests and tooling; exclude from runtime containers when possible).
+
 ### Development Environment
 
 #### Local Setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV AI_TRADING_MODEL_MODULE=ai_trading.model_loader \
 COPY . .
 RUN mkdir -p $AI_TRADING_DATA_DIR $AI_TRADING_CACHE_DIR $AI_TRADING_LOG_DIR \
     && chmod 700 $AI_TRADING_DATA_DIR $AI_TRADING_CACHE_DIR $AI_TRADING_LOG_DIR \
-    && (pip uninstall -y alpaca-trade-api || true) \
     && pip install -r requirements.txt \
     && pip install .[ml]
 VOLUME ["/var/lib/ai-trading-bot", "/var/cache/ai-trading-bot", "/var/log/ai-trading-bot"]

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ A sophisticated **AI-powered algorithmic trading system** that combines machine 
 
 ```bash
 python -m pip install -U pip
-pip install -e .  # installs alpaca-py==0.42.0
-python -c "from alpaca.trading.client import TradingClient"  # verify alpaca-py
+pip install -e .  # installs alpaca-trade-api==3.2.0 and alpaca-py==0.42.1
+python -c "import alpaca_trade_api, pkgutil; assert alpaca_trade_api.__version__=='3.2.0'"  # verify runtime SDK pin
 python -m ai_trading --dry-run
 ruff check .
 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q
@@ -28,7 +28,7 @@ curl -s http://127.0.0.1:9101/healthz
 curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:9101/metrics
 ```
 
-The import test confirms the Alpaca SDK is ready; if it fails, install it with `pip install alpaca-py`.
+The runtime SDK check ensures `alpaca-trade-api==3.2.0` is active; install it explicitly with `pip install alpaca-trade-api==3.2.0` if the assertion fails.
 
 The dry run exits with status **0** and prints `INDICATOR_IMPORT_OK`, confirming optional indicator modules are available.
 
@@ -39,8 +39,7 @@ Set `RUN_HEALTHCHECK=1` to launch the lightweight Flask app that serves:
 
 The health server binds to `HEALTHCHECK_PORT` (default **9101**) and must not reuse the API port (**9001**).
 
-Use **one** Alpaca SDK in production (recommended: `alpaca-py`).
-Remove legacy `alpaca-trade-api` if present (`pip uninstall -y alpaca-trade-api`).
+Runtime pins to **`alpaca-trade-api==3.2.0`**; the repo also installs **`alpaca-py==0.42.1`** for tests and helper utilities.
 Startup validates required environment variables (API keys, feed selection, risk
 parameters) at launch and exits early with clear remediation hints if
 configuration is missing.

--- a/ci/scripts/forbid_alpaca_trade_api.sh
+++ b/ci/scripts/forbid_alpaca_trade_api.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Fail if legacy alpaca-trade-api is installed
-if pip show alpaca-trade-api >/dev/null 2>&1; then
-  echo "alpaca-trade-api detected; only alpaca-py is supported" >&2
+# Ensure the runtime Alpaca SDK is present at the supported version
+REQUIRED_VERSION="3.2.0"
+if ! pip show alpaca-trade-api >/dev/null 2>&1; then
+  echo "alpaca-trade-api==${REQUIRED_VERSION} is required" >&2
+  exit 1
+fi
+
+version=$(pip show alpaca-trade-api | awk '/^Version: / {print $2}')
+if [ "${version}" != "${REQUIRED_VERSION}" ]; then
+  echo "alpaca-trade-api==${REQUIRED_VERSION} required; found ${version}" >&2
   exit 1
 fi

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -10,6 +10,7 @@ aiohttp==3.12.15
     # via -r requirements.txt
 aiosignal==1.4.0
     # via aiohttp
+alpaca-trade-api==3.2.0
 alpaca-py==0.42.1
     # via
     #   -r requirements-dev.txt
@@ -127,7 +128,7 @@ markupsafe==3.0.2
     #   werkzeug
 mpmath==1.3.0
     # via sympy
-msgpack==1.1.1
+msgpack==1.0.3
     # via
     #   -r requirements.txt
     #   alpaca-py
@@ -276,7 +277,7 @@ python-dotenv==1.1.1
     # via
     #   -r requirements.txt
     #   pydantic-settings
-pyyaml==6.0.2
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   huggingface-hub
@@ -367,11 +368,11 @@ tzdata==2025.2
     #   exchange-calendars
     #   pandas
     #   pandas-market-calendars
-urllib3==2.5.0
+urllib3==1.26.20
     # via
     #   -r requirements.txt
     #   requests
-websockets==15.0.1
+websockets==10.4
     # via
     #   -r requirements.txt
     #   alpaca-py

--- a/constraints.txt
+++ b/constraints.txt
@@ -10,6 +10,7 @@ aiohttp==3.12.15
     # via -r requirements.txt
 aiosignal==1.4.0
     # via aiohttp
+alpaca-trade-api==3.2.0
 alpaca-py==0.42.1
     # via -r requirements.txt
 annotated-types==0.7.0
@@ -101,7 +102,7 @@ markupsafe==3.0.2
     #   werkzeug
 mpmath==1.3.0
     # via sympy
-msgpack==1.1.1
+msgpack==1.0.3
     # via
     #   -r requirements.txt
     #   alpaca-py
@@ -216,7 +217,7 @@ python-dotenv==1.1.1
     # via
     #   -r requirements.txt
     #   pydantic-settings
-pyyaml==6.0.2
+pyyaml==6.0.1
     # via
     #   -r requirements.txt
     #   huggingface-hub
@@ -294,11 +295,11 @@ tzdata==2025.2
     #   exchange-calendars
     #   pandas
     #   pandas-market-calendars
-urllib3==2.5.0
+urllib3==1.26.20
     # via
     #   -r requirements.txt
     #   requests
-websockets==15.0.1
+websockets==10.4
     # via
     #   -r requirements.txt
     #   alpaca-py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,14 @@ requires-python = ">=3.12,<3.13"
 dependencies = [
   "numpy==1.26.4",  # AI-AGENT-REF: pin NumPy to 1.x for pandas-ta compatibility
   "requests>=2.31,<3",
-  "urllib3==2.5.0",  # AI-AGENT-REF: align with Alpaca SDK
+  "urllib3==1.26.20",  # AI-AGENT-REF: align with alpaca-trade-api 3.2.0
   "certifi>=2023.7.22",
   "charset-normalizer>=3.2,<4",
   "idna>=3.4,<4",
   "psutil>=5.9,<6",
   "portalocker==2.7.0",
-  "alpaca-py>=0.42.1,<1",  # AI-AGENT-REF: include Alpaca SDK
+  "alpaca-trade-api==3.2.0",  # AI-AGENT-REF: runtime Alpaca SDK pin
+  "alpaca-py>=0.42.1,<1",  # AI-AGENT-REF: dev/test helper SDK
   "joblib>=1.3,<2",
   "Flask>=3,<4",
   "beautifulsoup4>=4.12,<5",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,4 +14,5 @@ gymnasium>=0.29
 portalocker>=2.7
 joblib>=1.3
 requests>=2.31,<3
+alpaca-trade-api==3.2.0
 alpaca-py==0.42.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,17 +7,18 @@ charset-normalizer>=3.2,<4
 idna>=3.4,<4
 psutil>=5.9,<6
 portalocker==2.7.0
-alpaca-py==0.42.1  # AI-AGENT-REF: official Alpaca SDK (prod)
+alpaca-trade-api==3.2.0  # AI-AGENT-REF: runtime SDK pin
+alpaca-py==0.42.1  # AI-AGENT-REF: dev/test helpers and compat checks
 finnhub-python>=2.4,<3  # AI-AGENT-REF: optional Finnhub provider
 joblib>=1.3,<2
 Flask>=3,<4
 beautifulsoup4>=4.12,<5
 lxml>=5,<6
 aiohttp>=3.9,<4
-msgpack>=1.1.1
-pyyaml>=6.0.2
-urllib3>=2.5.0
-websockets>=15.0.1
+msgpack==1.0.3  # AI-AGENT-REF: constrained by alpaca-trade-api 3.2.0
+pyyaml==6.0.1  # AI-AGENT-REF: constrained by alpaca-trade-api 3.2.0
+urllib3==1.26.20  # AI-AGENT-REF: aligned with alpaca-trade-api 3.2.0
+websockets==10.4  # AI-AGENT-REF: compatible with alpaca-trade-api 3.2.0
 # Explicit Pydantic v2 + settings
 pydantic==2.8.2
 pydantic-settings>=2.2,<3

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 # AI-AGENT-REF: install runtime and dev dependencies
-python -m pip uninstall -y alpaca-trade-api || true
 python -m pip install --upgrade pip
 python -m pip install -r requirements.txt -r requirements-dev.txt
 ci/scripts/forbid_alpaca_trade_api.sh

--- a/scripts/quick_verify.sh
+++ b/scripts/quick_verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run fast sanity checks: compilation, lint, type-check, and tests.
-# Fails on usage of legacy imports or alpaca-trade-api.
+# Fails if unsupported Alpaca SDK versions are installed or legacy imports exist.
 set -euo pipefail
 
 ci/scripts/forbid_alpaca_trade_api.sh

--- a/scripts/setup_dependencies.sh
+++ b/scripts/setup_dependencies.sh
@@ -54,7 +54,6 @@ fi
 
 # Install Python dependencies
 echo "Installing Python dependencies..."
-pip uninstall -y alpaca-trade-api || true
 pip install --upgrade pip
 pip install -r requirements.txt
 "$ROOT_DIR/ci/scripts/forbid_alpaca_trade_api.sh"


### PR DESCRIPTION
## Title
Pin alpaca-trade-api 3.2.0 runtime dependency

## Context
Runtime builds were drifting onto unintended Alpaca SDK versions, reintroducing adapter warnings and breaking helper wiring across environments. We need a single, documented SDK target.

## Problem
- Runtime environments sometimes installed whatever alpaca-trade-api version happened to be available, regressing adapter behavior.
- Tooling still uninstalled alpaca-trade-api even though the runtime now depends on it.
- Deployment docs didn’t capture the supported SDK version, making rebuilds fragile.

## Scope
- Update dependency pins and constraints for the Alpaca SDKs and their transitive requirements.
- Align scripts and docs with the runtime policy.
- Leave trading logic unchanged.

## Acceptance Criteria
- alpaca-trade-api is pinned at 3.2.0 across runtime, dev, and test requirements.
- Tooling validates the installed alpaca-trade-api version instead of uninstalling it.
- Deployment documentation calls out the supported SDK versions.

## Changes
- Added alpaca-trade-api==3.2.0 to runtime/test requirements and adjusted msgpack, PyYAML, urllib3, and websockets pins for compatibility.
- Mirrored the pins in pyproject.toml, constraints, and dev tooling scripts.
- Updated quick verify, run_checks, and setup scripts to enforce the version check rather than uninstalling the package.
- Documented the SDK policy in README, CONTRIBUTING, and DEPLOYMENT guides.
- Simplified Dockerfile dependency install now that alpaca-trade-api is required.

## Validation
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check .`
- `pytest -q` *(fails: environment missing numerous optional ML/torch dependencies; abort after repeated failures)*
- `mypy ai_trading tests`

## Risk
Medium: dependency pinning can surface incompatibilities in downstream environments; ensure build images are rebuilt with the new pins before deployment.


------
https://chatgpt.com/codex/tasks/task_e_68e00e3882d48330982bc00882fa0df2