### PR TITLE
Pin yfinance to 0.2.58 and add resolver constraints

### DIFF
--- a/constraints.lock
+++ b/constraints.lock
@@ -1,0 +1,14 @@
+###############################
+# Minimal resolver constraints #
+###############################
+# Keep Alpaca SDKs and Yahoo Finance compatible.
+
+# Alpaca compatibility: <2
+urllib3==1.26.20
+
+# Satisfies alpaca-trade-api (<11) and alpaca-py (>=10.4)
+websockets==10.4
+
+# Avoids websockets>=13 pull from newer yfinance
+yfinance==0.2.58
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ requires-python = ">=3.12,<3.13"
 dependencies = [
   "numpy==1.26.4",  # AI-AGENT-REF: pin NumPy to 1.x for pandas-ta compatibility
   "requests>=2.31,<3",
-  "urllib3==1.26.20",  # AI-AGENT-REF: align with alpaca-trade-api 3.2.0
+  # Stay on urllib3<2 to satisfy alpaca-trade-api 3.2.0
+  "urllib3==1.26.20",
   "certifi>=2023.7.22",
   "charset-normalizer>=3.2,<4",
   "idna>=3.4,<4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,9 @@ scikit-learn==1.5.1
 scipy==1.13.1
 threadpoolctl==3.5.0
 pandas==2.2.2
-yfinance>=0.2.38,<0.3  # AI-AGENT-REF: Yahoo Finance data fetch
+# Pin yfinance before it introduced a hard dependency on websockets>=13
+# to remain compatible with alpaca-trade-api (<11) and alpaca-py (>=10.4)
+yfinance==0.2.58  # AI-AGENT-REF: Yahoo Finance data fetch (pre-websockets 13)
 pybreaker==1.4.0
 numba>=0.57  # AI-AGENT-REF: enable JIT-optimized indicators
 statsmodels==0.14.5


### PR DESCRIPTION
## Title
Pin yfinance to 0.2.58 and add resolver constraints

## Context
Recent yfinance releases require websockets>=13, which conflicts with the pinned websockets==10.4 required by alpaca-trade-api. We need to realign our dependency pins and give installers a deterministic resolver path.

## Problem
* pip installs were backtracking and ultimately demanding websockets>=13 when yfinance pulled it in.
* urllib3 drift risks reintroducing the alpaca-trade-api incompatibility if not reaffirmed.
* Without a constraints file, repeated installs trigger long resolution times and conflicting versions.

## Scope
* Dependency metadata in `requirements.txt` and `pyproject.toml`.
* New resolver constraints file captured under version control.

## Acceptance Criteria
* yfinance is frozen to a version compatible with websockets 10.4.
* urllib3 remains pinned below 2.0 in both requirements listings.
* Repository ships a constraints file suitable for `pip install -c` usage.

## Changes
* Pinned yfinance to 0.2.58 with inline rationale in `requirements.txt`.
* Added a comment-only guard before the urllib3 pin in `pyproject.toml`.
* Added `constraints.lock` capturing the pinned trio (urllib3, websockets, yfinance) for deterministic installs.

## Validation
* `pip install -c constraints.lock -r requirements.txt`
* `python -m py_compile $(git ls-files '*.py')`
* `pytest -q` *(fails: suite times out after numerous pre-existing failures; interrupted after 2 minutes timeout stack trace)*
* `ruff check`
* `mypy ai_trading`

## Risk
Low: dependency pin adjustments only; functional code remains untouched. Potential for stale caches requiring reinstall with `-c constraints.lock` but mitigated by documentation in comments.

------
https://chatgpt.com/codex/tasks/task_e_68e013884110833084b02353dec96d4e