### PR TITLE
Improve Yahoo fallback batching and screening throttles

### DIFF
--- a/ai_trading/data/fetch_yf.py
+++ b/ai_trading/data/fetch_yf.py
@@ -1,0 +1,125 @@
+"""Yahoo Finance batch download helpers."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+import yfinance as yf
+
+from ai_trading.config.management import get_env
+from ai_trading.data.normalize import ensure_ohlcv
+
+
+def _env_float(name: str, default: float) -> float:
+    value = get_env(name, str(default), cast=float)
+    return float(default if value is None else value)
+
+
+def _env_int(name: str, default: int) -> int:
+    value = get_env(name, str(default), cast=int)
+    return int(default if value is None else value)
+
+
+YF_TIMEOUT = _env_float("YF_TIMEOUT", 8.0)
+YF_RETRIES = _env_int("YF_RETRIES", 3)
+YF_BACKOFF = _env_float("YF_BACKOFF", 0.7)
+YF_CHUNK_SIZE = _env_int("YF_CHUNK_SIZE", 40)
+YF_CACHE_DIR = Path(get_env("YF_CACHE_DIR", "/var/cache/ai-trading-bot/yf"))
+YF_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _sleep_backoff(attempt: int) -> None:
+    delay = max(0.1, (attempt + 1) * YF_BACKOFF)
+    time.sleep(delay)
+
+
+def _download_batch(
+    tickers: List[str], *, start=None, end=None, period="1y", interval="1d"
+) -> pd.DataFrame:
+    return yf.download(
+        tickers=" ".join(tickers),
+        period=period if start is None else None,
+        start=start,
+        end=end,
+        interval=interval,
+        group_by="ticker",
+        auto_adjust=False,
+        progress=False,
+        timeout=YF_TIMEOUT,
+        threads=False,
+        repair=True,
+    )
+
+
+def _cache_key(tickers: List[str], start, end, period: str, interval: str) -> str:
+    payload = json.dumps([tickers, str(start), str(end), period, interval])
+    digest = hashlib.sha256(payload.encode()).hexdigest()[:16]
+    day = dt.date.today().isoformat()
+    return f"{day}-{interval}-{digest}.parquet"
+
+
+def _cache_read_or_none(key: str) -> Optional[pd.DataFrame]:
+    path = YF_CACHE_DIR / key
+    if not path.exists():
+        return None
+    try:
+        return pd.read_parquet(path)
+    except Exception:
+        return None
+
+
+def _cache_write(key: str, df: pd.DataFrame) -> None:
+    path = YF_CACHE_DIR / key
+    try:
+        df.to_parquet(path)
+    except Exception:
+        pass
+
+
+def fetch_yf_batched(
+    tickers: Iterable[str], *, start=None, end=None, period="1y", interval="1d"
+) -> Dict[str, Optional[pd.DataFrame]]:
+    tickers_list = [t.strip().upper() for t in tickers if str(t).strip()]
+    tickers_unique = list(dict.fromkeys(tickers_list))
+    out: Dict[str, Optional[pd.DataFrame]] = {ticker: None for ticker in tickers_unique}
+
+    for i in range(0, len(tickers_unique), YF_CHUNK_SIZE):
+        chunk = tickers_unique[i : i + YF_CHUNK_SIZE]
+        cache_key = _cache_key(chunk, start, end, period, interval)
+        df: pd.DataFrame | None = _cache_read_or_none(cache_key)
+        if df is None:
+            for attempt in range(max(1, YF_RETRIES)):
+                try:
+                    df = _download_batch(
+                        chunk, start=start, end=end, period=period, interval=interval
+                    )
+                    break
+                except Exception as exc:  # pragma: no cover - network error surface
+                    _sleep_backoff(attempt)
+                    df = None
+            if df is None:
+                continue
+            _cache_write(cache_key, df)
+        if isinstance(df.columns, pd.MultiIndex):
+            level0 = df.columns.get_level_values(0)
+            for symbol in chunk:
+                if symbol in level0:
+                    slice_df = df[symbol].copy()
+                else:
+                    slice_df = pd.DataFrame()
+                out[symbol] = ensure_ohlcv(slice_df)
+        else:
+            symbol = chunk[0] if chunk else None
+            if symbol:
+                out[symbol] = ensure_ohlcv(df.copy())
+    return out
+
+
+__all__ = ["fetch_yf_batched"]
+

--- a/ai_trading/data/normalize.py
+++ b/ai_trading/data/normalize.py
@@ -1,0 +1,35 @@
+"""Utilities for normalizing OHLCV data returned by third-party providers."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def ensure_ohlcv(df: pd.DataFrame | None) -> pd.DataFrame | None:
+    """Return a normalized OHLCV frame or ``None`` when the data is unusable."""
+
+    if df is None or df.empty:
+        return None
+
+    cols = {col: str(col).strip().lower() for col in df.columns}
+    df = df.rename(columns=cols)
+
+    if "adj close" in df.columns and "close" not in df.columns:
+        df["close"] = df["adj close"]
+
+    required = ["open", "high", "low", "close", "volume"]
+    missing = [col for col in required if col not in df.columns]
+    if missing:
+        return None
+
+    if isinstance(df.index, pd.DatetimeIndex):
+        df = df[~df.index.duplicated(keep="last")].sort_index()
+        if df.index.tz is None:
+            df.index = df.index.tz_localize("UTC")
+
+    df["volume"] = pd.to_numeric(df["volume"], errors="coerce").fillna(0).astype("int64")
+    return df[required]
+
+
+__all__ = ["ensure_ohlcv"]
+


### PR DESCRIPTION
## Context
* Harden Yahoo Finance fallbacks and reduce screening churn per reliability request.

## Problem
* Legacy yfinance calls were per-symbol, noisy, and lacked normalization.
* Screening retried too aggressively, spamming logs and hitting rate limits.
* Minute-data stale alarms triggered fallback during off hours.

## Scope
* Yahoo Finance data path, screening pipeline, log throttling, and minute-data guard rails.

## Acceptance Criteria
* Batched Yahoo backup fetch with normalized OHLCV output.
* Screening reuses cached symbols, respects refetch delays, and batches backup fetches.
* Minute-data stale checks respect new tolerances and skip closed-market noise.
* LOG_THROTTLE_SUMMARY emits at most once per key per hour.

## Changes
* Added `ai_trading/data/fetch_yf.py` with cached batched download plus `ensure_ohlcv` helper.
* Updated fetcher to consume batched Yahoo data, soft-skip missing OHLCV, and expose `fetch_daily_backup`.
* Throttled screener with env knobs, batch iteration, and single-call Yahoo backup usage.
* Tuned minute-data stale handling with env overrides and skip logic for closed markets.
* Capped LOG_THROTTLE_SUMMARY emissions per key per hour to cut log noise.

## Validation
* ⚠️ `pip install -r requirements.txt` *(cancelled after repeated GPU package downloads; environment lacks bandwidth for 700MB+ CUDA wheels)*
* ✅ `python -m py_compile $(git ls-files '*.py')`
* ❌ `pytest -q` *(fails: pandas missing because pip install aborted early)*
* ✅ `ruff check .`
* ✅ `mypy .`

## Risk
* Medium: touches data fetch pipeline and screening flow; verify in staging with live data feeds before deployment.


------
https://chatgpt.com/codex/tasks/task_e_68e01bc357c0833093810616af962762