### PR TITLE
Fix `_log_iex_minute_stale` logging fallback

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -6649,7 +6649,28 @@ def _log_iex_minute_stale(
         extra["minute_attrs"] = attrs
     if phase:
         extra["phase"] = phase
-    logger.log(level, "IEX_MINUTE_DATA_STALE", extra=extra)
+    message = "IEX_MINUTE_DATA_STALE"
+    if level == logging.WARNING:
+        warn_fn = getattr(logger, "warning", None)
+        if callable(warn_fn):
+            warn_fn(message, extra=extra)
+            return
+
+    log_fn = getattr(logger, "log", None)
+    if callable(log_fn):
+        log_fn(level, message, extra=extra)
+        return
+
+    level_name = logging.getLevelName(level)
+    if isinstance(level_name, str):
+        level_method = getattr(logger, level_name.lower(), None)
+        if callable(level_method):
+            level_method(message, extra=extra)
+            return
+
+    warn_fn = getattr(logger, "warning", None)
+    if callable(warn_fn):
+        warn_fn(message, extra=extra)
 
 
 def _env_float(default: float | str, *keys: str) -> float:

--- a/tests/bot_engine/test_fetch_minute_df_safe.py
+++ b/tests/bot_engine/test_fetch_minute_df_safe.py
@@ -64,12 +64,15 @@ def test_log_iex_minute_stale_includes_attrs(monkeypatch):
     recorder = _Recorder()
     monkeypatch.setattr(bot_engine, "logger", recorder)
 
-    bot_engine._log_iex_minute_stale(
-        symbol="AAPL",
-        age_seconds=720,
-        retry_feed="sip",
-        frame=frame,
-    )
+    try:
+        bot_engine._log_iex_minute_stale(
+            symbol="AAPL",
+            age_seconds=720,
+            retry_feed="sip",
+            frame=frame,
+        )
+    except Exception as exc:  # pragma: no cover - explicit guard for stub compatibility
+        pytest.fail(f"_log_iex_minute_stale raised unexpectedly: {exc!r}")
 
     assert recorder.calls
     message, extra = recorder.calls[-1]


### PR DESCRIPTION
Title: Fix `_log_iex_minute_stale` logging fallback

Context:
- `_log_iex_minute_stale` previously invoked `logger.log` for all severities, which breaks with the lightweight logger doubles used in tests.
- The helper needs to degrade gracefully when certain logging APIs are absent.

Problem:
- Test doubles without `log` raised `AttributeError`, preventing coverage of stale-minute logging.
- Lack of a defensive call path risked missing warnings in production.

Scope:
- Limit changes to `ai_trading/core/bot_engine.py` and its companion test in `tests/bot_engine/test_fetch_minute_df_safe.py`.

Acceptance Criteria:
- `_log_iex_minute_stale` prefers `logger.warning` for WARNING-level records and safely falls back when methods are missing.
- Updated unit test explicitly asserts the helper does not raise.

Changes:
- Added defensive fallbacks in `_log_iex_minute_stale`, preferring `logger.warning`, then gracefully using `logger.log` or level-specific methods.
- Hardened the unit test to fail if `_log_iex_minute_stale` raises while still validating emitted metadata.

Validation:
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: suite times out with numerous pre-existing failures; see run log)*
- `ruff check ai_trading/core/bot_engine.py tests/bot_engine/test_fetch_minute_df_safe.py`
- `mypy ai_trading/core/bot_engine.py tests/bot_engine/test_fetch_minute_df_safe.py`

Risk:
- Low. Change is limited to logging helpers and their unit coverage with conservative fallbacks.

------
https://chatgpt.com/codex/tasks/task_e_68e037dc419c8330aac19c02c7b7a0b1