### PR TITLE
Short-circuit empty trading window fetch

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -4552,6 +4552,12 @@ def _fetch_bars(
         short_circuit_empty = True
     else:
         _state["skip_empty_metrics"] = False
+    if short_circuit_empty:
+        if not _state.get("empty_metric_emitted"):
+            _incr("data.fetch.empty", value=1.0, tags=_tags())
+            _state["empty_metric_emitted"] = True
+        empty_df = _empty_ohlcv_frame(pd)
+        return empty_df if empty_df is not None else pd.DataFrame()
     if not _has_alpaca_keys():
         global _ALPACA_KEYS_MISSING_LOGGED
         if not _ALPACA_KEYS_MISSING_LOGGED:


### PR DESCRIPTION
Title: Short-circuit empty trading window fetch

Context:
- Ensure `_fetch_bars` exits early for non-session windows without hitting provider failover logic.
- Maintain existing empty-metric accounting and avoid unintended network calls during empty-window paths.

Problem:
- `_fetch_bars` marked `short_circuit_empty` but still progressed through credential and provider checks, creating unnecessary side effects for windows with no trading session.

Scope:
- `ai_trading/data/fetch/__init__.py` only.

Acceptance Criteria:
- Empty trading windows return the canonical empty OHLCV frame before credential or network logic runs.
- Empty fetch metrics emit once even when the function short-circuits.
- Existing unit tests that assert no network access for empty windows remain valid.

Changes:
- Emit the empty-fetch metric (if not already recorded) and return the empty OHLCV frame immediately when `short_circuit_empty` is set.
- Preserve the previous `skip_empty_metrics` flag handling for downstream logic.

Validation:
- `pip install -r requirements.txt` *(pass)*
- `python -m py_compile $(git ls-files '*.py')` *(pass)*
- `pytest -q` *(fails: widespread pre-existing failures; run terminated after timeout stack trace)*
- `ruff check` *(pass)*
- `mypy ai_trading/data/fetch/__init__.py` *(pass)*

Risk:
- Low; change is localized to the empty-window branch and keeps metric emission semantics intact.

------
https://chatgpt.com/codex/tasks/task_e_68e042f523088330be61256117dfc563