### PR TITLE
Fix host semaphore reload and concurrency peak tracking

### DIFF
--- a/ai_trading/data/fallback/concurrency.py
+++ b/ai_trading/data/fallback/concurrency.py
@@ -591,12 +591,18 @@ async def run_with_concurrency(
 
     limit = _normalise_positive_int(max_concurrency) or 1
     host_limit = _get_effective_host_limit()
-    host_semaphore: asyncio.Semaphore | None = None
     if host_limit is not None:
         host_limit_value = _normalise_positive_int(host_limit)
         if host_limit_value is not None:
             limit = min(limit, host_limit_value)
-        host_semaphore = _get_host_limit_semaphore()
+
+    host_semaphore = _get_host_limit_semaphore()
+    if host_semaphore is not None:
+        semaphore_limit = _normalise_positive_int(
+            getattr(host_semaphore, "_ai_trading_host_limit", None)
+        )
+        if semaphore_limit is not None:
+            limit = min(limit, semaphore_limit)
 
     limit = max(1, limit)
 


### PR DESCRIPTION
## Title
Fix host semaphore reload and concurrency peak tracking

## Context
- **WORKLOG:** Host semaphore cache failed to notice first-acquisition env changes and concurrency tests reported peaks above live limits.
- Pooling metadata was stale, leaving fallback concurrency blind to updated caps.

## Problem
- `get_host_semaphore` skipped `reload_host_limit_if_env_changed` on cold caches, so env/config updates could leave legacy semaphores in place.
- Newly minted semaphores missed limit/version annotations, preventing downstream observers from reading fresh bounds.
- Fallback concurrency trusted only the configured limit and ignored host semaphore metadata, so the peak counter could drift from the real cap; tests lacked coverage for this regression.

## Scope
- Pooling host semaphore construction and acquisition.
- Fallback concurrency limit resolution and peak tracking.
- HTTP host limit and fallback concurrency test suites.

## Acceptance Criteria
- Service boots without import errors.
- Trading configuration remains validated.
- Host semaphores refresh on env/config updates with accurate metadata.
- Fallback concurrency peak count matches both requested and host-throttled limits.
- Unit tests and linters (`pytest`, `ruff`, `mypy`, `py_compile`) succeed.

## Changes
- Annotated semaphores with `_ai_trading_host_limit` metadata on creation and reuse, and always reload host limits before snapshotting in `ai_trading/http/pooling.py`.
- Honored semaphore-observed limits within `run_with_concurrency`, ensuring peak tracking aligns with throttled caps.
- Extended HTTP host limit tests to assert limit/version metadata refresh.
- Added a new fallback concurrency test exercising host semaphore metadata driven peaks.

## Validation
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_http_host_limit.py tests/data/test_fallback_concurrency.py`
- `ruff check ai_trading/http/pooling.py ai_trading/data/fallback/concurrency.py tests/test_http_host_limit.py tests/data/test_fallback_concurrency.py`
- `mypy ai_trading/http/pooling.py ai_trading/data/fallback/concurrency.py`

## Risk
- **Risk & Rollback:** Low risk; changes are confined to pooling/concurrency helpers and related tests. Roll back by reverting this commit if semaphore behaviour regresses.

------
https://chatgpt.com/codex/tasks/task_e_68e042f61b6083309be70fdc6e46dfff