### PR TITLE
Raise MissingOHLCVColumnsError when OHLCV columns missing

### DIFF
--- a/tests/data/test_alpaca_iex_field_aliases.py
+++ b/tests/data/test_alpaca_iex_field_aliases.py
@@ -681,11 +681,15 @@ def test_ensure_ohlcv_schema_logs_payload_columns(caplog: pytest.LogCaptureFixtu
     records = [record for record in caplog.records if record.message == "OHLCV_COLUMNS_MISSING"]
     assert records, "expected OHLCV_COLUMNS_MISSING to be logged"
     logged = records[-1]
+    assert logged.levelno == logging.ERROR
     assert getattr(logged, "raw_payload_columns", None) == ["t", "volume"]
     assert getattr(logged, "raw_payload_feed", None) == "iex"
     assert getattr(logged, "raw_payload_timeframe", None) == "1Min"
     assert getattr(logged, "raw_payload_symbol", None) == "AAPL"
+
     err = excinfo.value
     assert getattr(err, "raw_payload_columns", None) == ("t", "volume")
     assert getattr(err, "raw_payload_feed", None) == "iex"
     assert getattr(err, "raw_payload_symbol", None) == "AAPL"
+    assert err.metadata["missing_columns"] == ["open", "high", "low", "close"]
+    assert err.metadata["columns"] == ["t", "volume"]


### PR DESCRIPTION
## Title
* Raise MissingOHLCVColumnsError when OHLCV columns missing

## Context
* The OHLCV schema normalizer previously logged missing-column payloads only at DEBUG and returned `None`, making upstream fallback logic swallow the issue.
* Downstream diagnostics also needed structured access to the captured payload metadata when the schema is incomplete.

## Problem
* Missing OHLCV columns were silently ignored, complicating provider debugging and allowing downstream code to continue without required price fields.
* Exceptions raised later on lacked the raw payload metadata that tests and handlers need for observability.

## Scope
* `ai_trading/data/fetch/__init__.py`
* `tests/data/test_alpaca_iex_field_aliases.py`

## Acceptance Criteria
* Missing columns trigger an error-level log and a raised `MissingOHLCVColumnsError` populated with the captured payload metadata.
* Tests assert the log level escalation and the presence of raw payload attributes on the raised exception.

## Changes
* Extend `MissingOHLCVColumnsError` to accept payload metadata, normalize raw payload sequences, and expose attributes for downstream inspection.
* Promote the missing-column log to `ERROR`, raise `MissingOHLCVColumnsError` with attached metadata, and keep the existing metadata collection intact.
* Update the Alpaca IEX schema test to assert the log level, the preserved raw payload metadata, and the metadata stored on the exception.

## Validation
* `python -m py_compile $(git ls-files '*.py')`
* `pytest -q` *(fails/timed out due to numerous pre-existing suite failures; aborted after repeated errors and a pytest timeout during imports)*
* `ruff check ai_trading/data/fetch/__init__.py tests/data/test_alpaca_iex_field_aliases.py`
* `mypy ai_trading/data/fetch/__init__.py`

## Risk
* Low: changes are limited to error handling paths and associated tests; primary risk is increased strictness when providers omit columns, which is desirable to surface issues earlier.


------
https://chatgpt.com/codex/tasks/task_e_68e04843d2c48330af224de215ccf42e