### PR TITLE
Propagate minute fallback skip state across Alpaca retries

### DIFF
--- a/tests/test_fallback_cache.py
+++ b/tests/test_fallback_cache.py
@@ -52,6 +52,11 @@ def test_alpaca_skipped_after_yahoo_fallback(monkeypatch):
     out1 = data_fetcher.get_minute_df("AAPL", start, end)
     assert not out1.empty
     assert yahoo_calls["n"] == 1
+    tf_key = ("AAPL", "1Min")
+    skip_until = data_fetcher._BACKUP_SKIP_UNTIL.get(tf_key)
+    assert skip_until is not None
+    assert skip_until > int(datetime.now(UTC).timestamp()) - 1
+    assert tf_key in data_fetcher._SKIPPED_SYMBOLS
     first_calls = calls["alpaca"]
 
     out2 = data_fetcher.get_minute_df("AAPL", start, end)


### PR DESCRIPTION
### Title
Propagate minute fallback skip state across Alpaca retries

### Context
Yahoo fallback fetches were not reliably short-circuiting subsequent Alpaca minute requests, causing redundant upstream calls after a successful backup retrieval.

### Problem
`get_minute_df` registered Yahoo fallback responses but did not mark `_SKIPPED_SYMBOLS` or maintain skip metadata consistently. As a result, later requests could continue to hit Alpaca despite a fresh Yahoo frame, defeating the fallback memoization.

### Scope
- Runtime logic in `ai_trading/data/fetch/__init__.py`
- Associated test in `tests/test_fallback_cache.py`

### Acceptance Criteria
- Successful Yahoo fallback adds the `(symbol, timeframe)` pair to the skip memo.
- Subsequent `get_minute_df` calls avoid Alpaca while the skip TTL is active.
- `_record_feed_switch` bookkeeping remains intact.
- Unit test asserts the skip state.

### Changes
- Added `_set_backup_skip` / `_clear_backup_skip` helpers that update `_BACKUP_SKIP_UNTIL` and `_SKIPPED_SYMBOLS`, and invoked them whenever a non-empty fallback frame is observed.
- Adjusted `get_minute_df` to honor the forced skip window without raising `EmptyBarsError`, and ensured all fallback retrieval paths route through the skip registration helper.
- Extended the fallback cache test to assert the skip flag is set after a Yahoo response and that Alpaca is not re-invoked.

### Validation
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails due to unrelated baseline suite issues; see agent report)*
- `pytest tests/test_fallback_cache.py -q`
- `ruff check ai_trading/data/fetch/__init__.py tests/test_fallback_cache.py`
- `mypy ai_trading/data/fetch/__init__.py`

### Risk
Low: changes are localized to backup skip bookkeeping and associated tests. Rollback by reverting this commit.

------
https://chatgpt.com/codex/tasks/task_e_68e04ec7b89883308d55b01cc28533b1