### PR TITLE
Ensure fallback switch recorded for empty minute results

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -4894,10 +4894,12 @@ def _fetch_bars(
                     _state.pop("defer_success_metric", None)
                 else:
                     _state["defer_success_metric"] = prev_defer
-            if result is not None and not getattr(result, "empty", True):
+            result_has_rows = result is not None and not getattr(result, "empty", True)
+            if result_has_rows:
                 tags = _tags()
                 _record_fallback_success_metric(tags)
                 _record_success_metric(tags, prefer_fallback=True)
+            if result is not None:
                 _record_feed_switch(symbol, fb_interval, from_feed, fb_feed)
             if result is not None and not _used_fallback(symbol, fb_interval, fb_start, fb_end):
                 _mark_fallback(


### PR DESCRIPTION
# Title
Ensure fallback switch recorded for empty minute results

# Context
Minute bar fetches must respect feed overrides so repeated empty windows do not loop on degraded providers.

# Problem
When Alpaca minute data fell back to an alternate feed (e.g., SIP) but returned an empty frame, the switchover was not recorded. Subsequent fetches ignored the fallback override and retried the depleted primary feed, and observability missed the attempted switch.

# Scope
- Runtime fallback handling inside `ai_trading.data.fetch.get_minute_df`.
- Feed failover regression coverage.

# Acceptance Criteria
- Feed overrides are recorded even if the fallback dataframe is empty.
- Switch logging/history stays in sync with the override state.
- Regression test covers empty-frame fallbacks without raising.
- Provider monitor state is reset between relevant tests.

# Changes
- Record fallback feed switches after Alpaca fallback attempts regardless of dataframe emptiness so overrides persist. 【F:ai_trading/data/fetch/__init__.py†L4880-L4915】
- Reset provider monitor state in `_reset_state()` to prevent cross-test contamination. 【F:tests/test_feed_failover.py†L45-L72】
- Extend `test_alt_feed_switch_records_override` with a spy asserting the switch log is written even when the fallback frame is empty. 【F:tests/test_feed_failover.py†L481-L521】

# Validation
- `pip install -r requirements.txt` 【0a5aca†L1-L12】
- `python -m py_compile $(git ls-files '*.py')` 【5df11f†L1-L1】
- `pytest -q` *(fails early due to numerous pre-existing suite failures; change-specific check below)* 【b2da5f†L1-L1】【5dd452†L1-L1】
- `pytest tests/test_feed_failover.py::test_alt_feed_switch_records_override -q` 【f82bf7†L1-L1】【899d81†L1-L2】
- `ruff check ai_trading/data/fetch/__init__.py tests/test_feed_failover.py` 【53c804†L1-L2】
- `mypy ai_trading/data/fetch/__init__.py tests/test_feed_failover.py` 【002b69†L1-L1】【af14ed†L1-L2】

# Risk
Low – change only adjusts fallback bookkeeping and accompanying tests; no new external dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68e0588f60c4833082e8101d869bd90c