### PR TITLE
Add ConfigDict stub for runtime compatibility

### DIFF
--- a/tests/stubs/pydantic/__init__.py
+++ b/tests/stubs/pydantic/__init__.py
@@ -23,6 +23,13 @@ class FieldInfo:
 def Field(default: Any = None, *_, **__):
     return default
 
+
+class ConfigDict(dict):
+    """Lightweight runtime-compatible stand-in for :class:`pydantic.ConfigDict`."""
+
+    def __init__(self, **config: Any):
+        super().__init__(config)
+
 class AliasChoices(tuple):
     def __new__(cls, *names: str):
         return super().__new__(cls, names)


### PR DESCRIPTION
# Title
Add ConfigDict stub for runtime compatibility

## Context
- Runtime configuration module now imports `pydantic.ConfigDict`, which was missing from the in-repo stub used by subprocessed tests.

## Problem
- Without a stubbed `ConfigDict`, importing `ai_trading.config.runtime` under the stubbed environment raises `ImportError`, breaking systemd startup compatibility tests.

## Scope
- Update `tests/stubs/pydantic/__init__.py` to provide a lightweight `ConfigDict` implementation while preserving existing stub behaviour.

## Acceptance Criteria
- `pydantic.ConfigDict` is available to runtime modules during stubbed imports.
- No regressions to other stubbed `pydantic` features (`BaseModel`, decorators, etc.).
- Targeted systemd startup test passes.

## Changes
- Added a minimal `ConfigDict` subclass of `dict` that mirrors pydantic's runtime behaviour within the stub.

## Validation
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_systemd_startup.py::TestSystemdStartupCompatibility::test_import_no_crash_without_credentials`
- `ruff check tests/stubs/pydantic/__init__.py`
- `mypy tests/stubs/pydantic/__init__.py`

## Risk
- Low: change is isolated to test stub and adds missing functionality without altering existing interfaces.

------
https://chatgpt.com/codex/tasks/task_e_68e064588e208330acce0863dd86ad10