### PR TITLE
Short-circuit empty Alpaca fetch windows

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -4641,6 +4641,10 @@ def _fetch_bars(
     else:
         _state["skip_empty_metrics"] = False
 
+    if short_circuit_empty:
+        empty_df = _empty_ohlcv_frame(pd)
+        return empty_df if empty_df is not None else pd.DataFrame()
+
     if not _has_alpaca_keys():
         global _ALPACA_KEYS_MISSING_LOGGED
         if not _ALPACA_KEYS_MISSING_LOGGED:


### PR DESCRIPTION
### Title
Short-circuit empty Alpaca fetch windows

### Context
Empty-market windows were still flowing through the Alpaca credential checks and occasionally the HTTP stack, creating needless network churn during planned market closures.

### Problem
When `_window_has_trading_session` detects an empty trading window, `_fetch_bars` still evaluated credential state and could reach the HTTP client before returning, despite having already emitted the empty-window metric/log.

### Scope
- `ai_trading/data/fetch/__init__.py`
- `tests/test_fetch_param_validation.py`

### Acceptance Criteria
- Empty window detection exits `_fetch_bars` before any Alpaca credential or HTTP logic runs.
- Existing empty-window metric/log fire once.
- Tests cover the zero-request guarantee.

### Changes
- Return an empty OHLCV frame immediately after setting the `short_circuit_empty` flag.
- Extend the empty-window unit test to capture metric emissions and prove `_HTTP_SESSION.get` stays untouched.

### Validation
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_fetch_param_validation.py::test_window_without_trading_session_returns_empty -q`
- `pytest -q` *(fails due to pre-existing suite failures; aborted after multiple unrelated failures)*
- `ruff check ai_trading/data/fetch/__init__.py tests/test_fetch_param_validation.py`
- `mypy ai_trading/data/fetch/__init__.py tests/test_fetch_param_validation.py`

### Risk
Low. The change short-circuits an already-flagged code path and is backed by targeted unit coverage.


------
https://chatgpt.com/codex/tasks/task_e_68e16599a5d48330aee471e7d3412a8c