### PR TITLE
Harden fallback concurrency rebinding and tracking

### DIFF
--- a/tests/data/test_fallback_concurrency_async.py
+++ b/tests/data/test_fallback_concurrency_async.py
@@ -1,0 +1,141 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from ai_trading.data.fallback import concurrency
+
+
+def test_worker_closure_preserves_foreign_host_semaphore() -> None:
+    concurrency.reset_tracking_state()
+    concurrency.reset_peak_simultaneous_workers()
+
+    host_limit = 2
+    host_semaphore = asyncio.Semaphore(host_limit)
+    setattr(host_semaphore, "_loop", object())
+    setattr(host_semaphore, "_ai_trading_host_limit", host_limit)
+    setattr(host_semaphore, "_ai_trading_host_limit_version", 1)
+
+    holder = SimpleNamespace(semaphore=host_semaphore)
+
+    symbols = ["ASYNC_A", "ASYNC_B"]
+
+    async def orchestrate() -> tuple[dict[str, str | None], set[str], set[str]]:
+        async def worker(symbol: str) -> str:
+            assert holder.semaphore is host_semaphore
+            await asyncio.sleep(0)
+            return symbol
+
+        return await concurrency.run_with_concurrency(
+            symbols,
+            worker,
+            max_concurrency=host_limit,
+        )
+
+    results, succeeded, failed = asyncio.run(orchestrate())
+
+    assert results == {symbol: symbol for symbol in symbols}
+    assert succeeded == set(symbols)
+    assert not failed
+    assert holder.semaphore is host_semaphore
+
+
+def test_foreign_host_semaphore_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    concurrency.reset_tracking_state()
+    concurrency.reset_peak_simultaneous_workers()
+
+    host_limit = 2
+    foreign_loop = object()
+    host_semaphore = asyncio.Semaphore(host_limit)
+    setattr(host_semaphore, "_loop", foreign_loop)
+    setattr(host_semaphore, "_ai_trading_host_limit", host_limit)
+    setattr(host_semaphore, "_ai_trading_host_limit_version", 1)
+
+    monkeypatch.setattr(concurrency, "_get_effective_host_limit", lambda: host_limit)
+    monkeypatch.setattr(concurrency, "_get_host_limit_semaphore", lambda: host_semaphore)
+
+    tracker_lock = asyncio.Lock()
+    running = 0
+    peak = 0
+
+    symbols = [f"ASYNC_SEM{i}" for i in range(4)]
+
+    async def orchestrate() -> tuple[dict[str, str | None], set[str], set[str]]:
+        async def worker(symbol: str) -> str:
+            nonlocal running, peak
+            async with tracker_lock:
+                running += 1
+                peak = max(peak, running)
+            try:
+                await asyncio.sleep(0)
+                return symbol
+            finally:
+                async with tracker_lock:
+                    running -= 1
+
+        return await concurrency.run_with_concurrency(
+            symbols,
+            worker,
+            max_concurrency=5,
+        )
+
+    results, succeeded, failed = asyncio.run(orchestrate())
+
+    assert results == {symbol: symbol for symbol in symbols}
+    assert succeeded == set(symbols)
+    assert not failed
+    assert peak == host_limit
+    assert host_semaphore._value == host_limit
+    assert concurrency.LAST_RUN_PEAK_SIMULTANEOUS_WORKERS == host_limit
+    assert concurrency.PEAK_SIMULTANEOUS_WORKERS >= host_limit
+
+
+def test_peak_counter_remains_monotonic_without_reset() -> None:
+    concurrency.reset_tracking_state()
+    concurrency.reset_peak_simultaneous_workers()
+
+    tracker_lock = asyncio.Lock()
+    running = 0
+    peak = 0
+
+    symbols = [f"ASYNC_MONO{i}" for i in range(6)]
+
+    async def run_once(limit: int) -> tuple[dict[str, str | None], set[str], set[str]]:
+        async def worker(symbol: str) -> str:
+            nonlocal running, peak
+            async with tracker_lock:
+                running += 1
+                peak = max(peak, running)
+            try:
+                await asyncio.sleep(0.01)
+                return symbol
+            finally:
+                async with tracker_lock:
+                    running -= 1
+
+        return await concurrency.run_with_concurrency(
+            symbols,
+            worker,
+            max_concurrency=limit,
+        )
+
+    results, succeeded, failed = asyncio.run(run_once(3))
+
+    assert results == {symbol: symbol for symbol in symbols}
+    assert succeeded == set(symbols)
+    assert not failed
+    assert peak == 3
+    assert concurrency.LAST_RUN_PEAK_SIMULTANEOUS_WORKERS == 3
+    assert concurrency.PEAK_SIMULTANEOUS_WORKERS >= 3
+
+    peak = 0
+    running = 0
+
+    results, succeeded, failed = asyncio.run(run_once(1))
+
+    assert results == {symbol: symbol for symbol in symbols}
+    assert succeeded == set(symbols)
+    assert not failed
+    assert peak == 1
+    assert concurrency.LAST_RUN_PEAK_SIMULTANEOUS_WORKERS == 1
+    assert concurrency.PEAK_SIMULTANEOUS_WORKERS >= 3

--- a/tests/data/test_get_minute_df_fetch_logging.py
+++ b/tests/data/test_get_minute_df_fetch_logging.py
@@ -40,6 +40,9 @@ class _DummyProviderMonitor:
     def register_disable_callback(self, *args, **kwargs):
         return None
 
+    def update_data_health(self, *args, **kwargs):
+        return None
+
 
 def test_sip_unauthorized_branch_annotates_backup(monkeypatch, caplog):
     start, end = _dt_range()


### PR DESCRIPTION
Title: Harden fallback concurrency rebinding and tracking

Context:
- Fallback fetch workers previously reused foreign event-loop locks and under-reported cross-run concurrency peaks.
- Tests needed coverage for preserving externally provided semaphores and for the new per-run peak counter.

Problem:
- Closure rebinding mutated arbitrary captured objects, risking crashes when encountering foreign host semaphores.
- Global peak tracking was reset between runs, losing the historical maximum required for diagnostics.
- Existing regression tests did not exercise async semaphore handling paths or validate the per-run peak metric.

Scope:
- Limit edits to `ai_trading.data.fallback.concurrency` and the fallback data test modules.
- Add async-focused regression coverage mirroring existing synchronous scenarios.

Acceptance Criteria:
- `_rebind_worker_closure` avoids rewriting closures already bound to compatible primitives and preserves foreign host semaphores.
- `PEAK_SIMULTANEOUS_WORKERS` is monotonic across runs while `LAST_RUN_PEAK_SIMULTANEOUS_WORKERS` captures per-run peaks.
- Async regression tests pass, ensuring concurrency limits and host semaphore handling remain correct.

Changes:
- Added `_should_replace_closure_cell` to guard closure cell reassignment and tightened host semaphore acquisition to skip foreign loops.
- Introduced `LAST_RUN_PEAK_SIMULTANEOUS_WORKERS` alongside monotonic global tracking and reset helpers.
- Expanded regression tests to validate concurrency limits, peak tracking, and foreign semaphore handling, including new async suites and fallback fetch harness stubs.

Validation:
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check ai_trading/data/fallback/concurrency.py tests/data/test_fallback_concurrency.py tests/data/test_fallback_concurrency_async.py tests/data/test_get_minute_df_fetch_logging.py tests/data/test_yahoo_intraday_reliability.py`
- `mypy ai_trading/data/fallback/concurrency.py`
- `pytest -q tests/data/test_fallback_concurrency.py tests/data/test_fallback_concurrency_async.py`
- `pytest -q tests/data/test_get_minute_df_fetch_logging.py tests/data/test_yahoo_intraday_reliability.py` (Yahoo path skipped without backup invocation)
- `pytest -q` (aborted after numerous pre-existing failures outside scope)

Risk:
- Low; concurrency changes confined to lock rebinding and peak accounting with thorough targeted tests. Residual risk stems from unaddressed legacy test failures outside this scope.

------
https://chatgpt.com/codex/tasks/task_e_68e1659872f08330a70a17472cbb2c18