### PR TITLE
Fix daily memo short-circuit before cache lookup

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8199,13 +8199,14 @@ class DataFetcher:
                 if normalized_pair is not None:
                     _memo_set_entry(memo_key, normalized_pair)
                     _memo_set_entry(legacy_memo_key, normalized_pair)
-                if entry_df is not None:
+                has_payload = entry_df is not None or normalized_pair is not None
+                if has_payload:
                     age = None if entry_ts is None else now_monotonic - entry_ts
                     if age is None or age <= _DAILY_FETCH_MEMO_TTL or age <= window_limit:
                         cached_df = entry_df
                         cached_reason = "memo"
                         refresh_stamp = now_monotonic
-                        refresh_df = cached_df
+                        refresh_df = entry_df
                         refresh_source = "memo"
                         memo_hit = True
                     else:
@@ -8224,7 +8225,7 @@ class DataFetcher:
                             _memo_pop_entry(legacy_memo_key)
                 else:
                     _memo_pop_entry(memo_key)
-            if not memo_hit and cached_df is None:
+            if not memo_hit:
                 legacy_entry = _memo_get_entry(legacy_memo_key)
                 if legacy_entry is not None:
                     entry_ts, entry_df, normalized_pair = _normalize_memo_entry(
@@ -8233,13 +8234,14 @@ class DataFetcher:
                     if normalized_pair is not None:
                         _memo_set_entry(memo_key, normalized_pair)
                         _memo_set_entry(legacy_memo_key, normalized_pair)
-                    if entry_df is not None:
+                    has_payload = entry_df is not None or normalized_pair is not None
+                    if has_payload:
                         age = None if entry_ts is None else now_monotonic - entry_ts
                         if age is None or age <= _DAILY_FETCH_MEMO_TTL or age <= window_limit:
                             cached_df = entry_df
                             cached_reason = "memo"
                             refresh_stamp = now_monotonic
-                            refresh_df = cached_df
+                            refresh_df = entry_df
                             refresh_source = "memo"
                             memo_hit = True
                         else:
@@ -8257,7 +8259,7 @@ class DataFetcher:
                                 _memo_pop_entry(legacy_memo_key)
                     else:
                         _memo_pop_entry(legacy_memo_key)
-            if not memo_hit and cached_df is None:
+            if not memo_hit:
                 entry = self._daily_cache.get(symbol)
                 if entry and entry[0] == fetch_date:
                     cached_df = entry[1]


### PR DESCRIPTION
# Title
Fix daily memo short-circuit before cache lookup

# Context
DataFetcher daily memo retrieval could fall through to the intraprocess cache before memo normalization completed, especially for legacy memo shapes.

# Problem
Memo hits were not definitively recorded before consulting `_daily_cache`, allowing stale cache entries to override fresh memo data and leaving legacy memo tuples/dicts without normalized `(timestamp, payload)` pairs.

# Scope
- ai_trading/core/bot_engine.py
- tests/bot_engine/test_daily_fetch_debounce.py

# Acceptance Criteria
- Daily memo hits short-circuit `_daily_cache` lookups.
- Legacy memo entries normalize to `(timestamp, payload)`.
- Memo reuse refreshes stored timestamps.
- Updated unit tests cover memo bypass of `_daily_cache`.
- Default repo validation commands run (pytest module + suite, ruff, mypy, py_compile).

# Changes
- Guard the daily cache fallback purely on a definitive memo hit and treat normalized legacy payloads as valid, ensuring memo hits set `cached_reason` before the cache lookup.
- Preserve normalized memo payloads for both canonical and legacy keys while still purging stale entries.
- Harden memo debounce tests with a strict cache sentinel, assert timestamp refresh, and permit cache usage only after memo expiry.

# Validation
- `pip install -r requirements.txt`
- `pytest tests/bot_engine/test_daily_fetch_debounce.py -q`
- `pytest -q` *(aborted at ~31% due to numerous pre-existing failures; daily memo module passes)*
- `ruff check ai_trading/core/bot_engine.py tests/bot_engine/test_daily_fetch_debounce.py`
- `mypy ai_trading/core/bot_engine.py`
- `python -m py_compile $(git ls-files '*.py')`

# Risk
Low. Changes are confined to memo gating logic and supporting tests. Regression risk limited to daily data fetch caching pathways.

------
https://chatgpt.com/codex/tasks/task_e_68e16596fbe08330a1cb05ecf800fffc