### PR TITLE
Ensure safe_subprocess timeout branch re-raises with enriched metadata

### DIFF
--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -6,7 +6,7 @@ import shlex
 import subprocess
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import NoReturn, Sequence
+from typing import Sequence
 
 from ai_trading.logging import get_logger
 
@@ -76,7 +76,7 @@ def safe_subprocess_run(
         stdout_text, stderr_text = proc.communicate(timeout=run_timeout)
     except subprocess.TimeoutExpired as exc:
         exc.timeout = run_timeout
-        _augment_timeout_exception(proc, exc)
+        raise _augment_timeout_exception(proc, exc)
     except subprocess.SubprocessError as exc:
         with suppress(ProcessLookupError):
             proc.kill()
@@ -107,7 +107,7 @@ def _normalize_stream(stream: str | bytes | None) -> str:
 def _augment_timeout_exception(
     proc: subprocess.Popen[bytes] | subprocess.Popen[str],
     exc: subprocess.TimeoutExpired,
-) -> NoReturn:
+) -> subprocess.TimeoutExpired:
     """Populate timeout exception metadata before re-raising."""
 
     with suppress(ProcessLookupError):
@@ -133,4 +133,4 @@ def _augment_timeout_exception(
     exc.stdout = collected_stdout
     exc.stderr = collected_stderr
     exc.result = result
-    raise exc
+    return exc

--- a/tests/utils/test_safe_subprocess_run.py
+++ b/tests/utils/test_safe_subprocess_run.py
@@ -32,6 +32,9 @@ def test_safe_subprocess_run_timeout(caplog):
     assert excinfo.value.result == expected_result
     assert excinfo.value.stdout == "ready\n"
     assert excinfo.value.stderr == "warn\n"
+    assert excinfo.value.timeout == pytest.approx(0.3)
+    assert excinfo.value.result.stdout == excinfo.value.stdout
+    assert excinfo.value.result.stderr == excinfo.value.stderr
     assert excinfo.value.__cause__ is None
     assert not caplog.records  # timeout should not emit warnings
 
@@ -94,6 +97,8 @@ def test_safe_subprocess_run_timeout_without_captured_output(monkeypatch, caplog
     assert result.stderr == ""
     assert excinfo.value.stdout == ""
     assert excinfo.value.stderr == ""
+    assert excinfo.value.result.stdout == excinfo.value.stdout
+    assert excinfo.value.result.stderr == excinfo.value.stderr
     assert calls["args"] == (["dummy"],)
     assert calls["kwargs"]["stdout"] == subprocess.PIPE
     assert calls["kwargs"]["stderr"] == subprocess.PIPE
@@ -141,6 +146,8 @@ def test_safe_subprocess_run_timeout_with_captured_output(monkeypatch):
     assert result.stderr == "partial stderr"
     assert excinfo.value.stdout == "partial stdout"
     assert excinfo.value.stderr == "partial stderr"
+    assert excinfo.value.result.stdout == excinfo.value.stdout
+    assert excinfo.value.result.stderr == excinfo.value.stderr
     assert isinstance(excinfo.value.result, SafeSubprocessResult)
     assert state["instance"]._killed is True
     assert state["communicate_calls"] == [0.25, None]
@@ -186,6 +193,8 @@ def test_safe_subprocess_run_timeout_attaches_result_bytes(monkeypatch):
     assert result.stderr == "late stderr"
     assert excinfo.value.stdout == "late stdout"
     assert excinfo.value.stderr == "late stderr"
+    assert excinfo.value.result.stdout == excinfo.value.stdout
+    assert excinfo.value.result.stderr == excinfo.value.stderr
     assert state["init_kwargs"]["stdout"] == subprocess.PIPE
     assert state["init_kwargs"]["stderr"] == subprocess.PIPE
     assert state["init_kwargs"]["text"] is True
@@ -229,3 +238,5 @@ def test_safe_subprocess_run_timeout_populates_result_and_returncode(monkeypatch
     assert result.stdout == ""
     assert result.stderr == ""
     assert excinfo.value.timeout == pytest.approx(0.3)
+    assert excinfo.value.result.stdout == excinfo.value.stdout
+    assert excinfo.value.result.stderr == excinfo.value.stderr


### PR DESCRIPTION
## Title
Ensure safe_subprocess timeout branch re-raises with enriched metadata

## Context
Timeout handling in `safe_subprocess_run` needed to re-raise enriched `TimeoutExpired` exceptions explicitly while retaining the attached metadata.

## Problem
The timeout `except` block invoked `_augment_timeout_exception` but did not explicitly re-raise, making the propagation semantics ambiguous. We also lacked test coverage proving the enriched stdout/stderr/result propagated with the thrown exception.

## Scope
- `ai_trading/utils/safe_subprocess.py`
- `tests/utils/test_safe_subprocess_run.py`

## Acceptance Criteria
- Timeout branch explicitly re-raises the enriched exception without logging warnings.
- Other error flows continue to return `SafeSubprocessResult`.
- Timeout unit tests assert the exception carries enriched stdout/stderr/result metadata.
- Updated tests pass locally.

## Changes
- Return the augmented `TimeoutExpired` instance from `_augment_timeout_exception` and re-raise it in `safe_subprocess_run` so propagation is explicit while preserving the attached metadata.
- Extended timeout-focused unit tests to assert the raised exception exposes the enriched stdout/stderr/result fields and timeout value.

## Validation
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/utils/test_safe_subprocess_run.py`
- `pytest -q` *(fails: existing suite has many failing tests; run interrupted after repeated failures)*
- `ruff check ai_trading/utils/safe_subprocess.py tests/utils/test_safe_subprocess_run.py`
- `mypy ai_trading/utils/safe_subprocess.py`

## Risk
Low. The change narrows behavior to always re-raise the same enriched `TimeoutExpired` while leaving other execution paths untouched. Unit tests confirm the attached metadata remains accessible.

------
https://chatgpt.com/codex/tasks/task_e_68e16dde64b083308b37b0615679b4b8