### PR TITLE
Fix SIP entitlement cache refresh logic and expand tests

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -411,9 +411,9 @@ def _get_entitled_feeds(client: Any) -> set[str]:
     else:
         cached_feeds = cached_entry.feeds
         feeds_changed = entry.feeds != cached_feeds
-        generation_increased = entry.generation > cached_entry.generation
+        generation_changed = entry.generation != cached_entry.generation
         sip_upgrade = "sip" in entry.feeds and "sip" not in cached_feeds
-        if feeds_changed or generation_increased or sip_upgrade:
+        if feeds_changed or generation_changed or sip_upgrade:
             _ENTITLE_CACHE[key] = entry
         else:
             entry = cached_entry


### PR DESCRIPTION
Title: Fix SIP entitlement cache refresh logic and expand tests

Context:
- Ensure Alpaca market data entitlement decisions stay fresh within the cache TTL window.
- Maintain SIP eligibility when the account advertises access even without stored credentials.

Problem:
- `_get_entitled_feeds` failed to refresh cached entitlements when the account reported a new generation timestamp that was not greater than the previous one.
- Test coverage around entitlement cache refresh scenarios (upgrade/downgrade/keep) did not assert cache behavior, risking regressions.

Scope:
- Runtime entitlement selection logic in `ai_trading/data/bars.py`.
- Unit tests in `tests/test_feed_entitlement.py`.

AC:
- Cache refreshes whenever Alpaca account feeds or generation metadata change, even inside the TTL window.
- `_ensure_entitled_feed` continues to surface SIP when the account advertises it, default env flags are unset, and credentials may be absent.
- Tests cover upgrade, downgrade, and unchanged SIP scenarios, exercising cache refresh behavior.

Changes:
- Update `_get_entitled_feeds` to treat any generation delta as a cache refresh trigger in addition to feed changes.
- Expand entitlement tests with controllable account generation metadata to validate upgrade, downgrade, and generation-only refresh paths.

Validation:
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_feed_entitlement.py -q`
- `pytest -q` *(fails widely on unrelated suites; run aborted for time after repeated failures)*
- `ruff check .`
- `mypy ai_trading/data/bars.py tests/test_feed_entitlement.py`

Risk:
- Low. Changes are isolated to entitlement cache logic and unit tests; fallbacks remain unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68e16de0170883308011bf455bad8da9