### PR TITLE
Ensure SIP fallback overrides persist after empty frames

### DIFF
--- a/ai_trading/data/fetch/__init__.py
+++ b/ai_trading/data/fetch/__init__.py
@@ -6673,14 +6673,10 @@ def get_minute_df(
                 _register_backup_skip()
             elif _frame_has_rows(df):
                 primary_frame_acquired = True
-            if (
-                proactive_switch
-                and feed_to_use != initial_feed
-                and df is not None
-                and not getattr(df, "empty", True)
-            ):
-                _record_feed_switch(symbol, "1Min", initial_feed, feed_to_use)
-                switch_recorded = True
+            if proactive_switch and feed_to_use != initial_feed:
+                if not switch_recorded:
+                    _record_feed_switch(symbol, "1Min", initial_feed, feed_to_use)
+                    switch_recorded = True
         except (EmptyBarsError, ValueError, RuntimeError, AttributeError) as e:
             provider_feed_label = f"alpaca_{feed_to_use}"
             if isinstance(e, EmptyBarsError):
@@ -6904,7 +6900,6 @@ def get_minute_df(
 
     if (
         df is not None
-        and not getattr(df, "empty", True)
         and feed is None
         and feed_to_use != initial_feed
         and not switch_recorded


### PR DESCRIPTION
Title: Ensure SIP fallback overrides persist after empty frames

Context:
- Feed failover logic must persist SIP overrides even when the fallback call returns no data so repeated retries do not thrash primary IEX.

Problem:
- `get_minute_df` only recorded overrides when SIP delivered data, leaving `_FEED_OVERRIDE_BY_TF` and switch history untouched after empty fallback frames. Subsequent calls retried the failing feed and lost bookkeeping.

Scope:
- Minute-bar failover logic and associated unit test coverage.

Acceptance Criteria:
- Switching to an alternate Alpaca feed records override state even if the fetched frame is empty.
- `_FEED_OVERRIDE_BY_TF` and `_FEED_SWITCH_HISTORY` stay in sync with attempted overrides.
- Tests covering SIP fallback on empty data validate logging and override persistence.

Changes:
- Updated `get_minute_df` to persist feed switch bookkeeping immediately after committing to an alternate feed instead of requiring non-empty data, and to relax the override persistence guard for empty results.
- Extended `test_alt_feed_switch_records_override` to capture structured logging and assert the `ALPACA_FEED_SWITCH` event fires when SIP fallback returns an empty frame.

Validation:
- `pip install -r requirements.txt`
- `pytest -q tests/test_feed_failover.py::test_alt_feed_switch_records_override`
- `pytest -q` *(fails: large suite has numerous pre-existing failures; run aborted after confirming persistent failures)*
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check`
- `mypy ai_trading`

Risk:
- Low. Changes confine to minute feed failover bookkeeping and its targeted unit test; behavior is additive and keeps existing success paths unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68e1712008d083308289d9bb9b9ba550