### PR TITLE
Honor SIP entitlement when no explicit disable flag is set

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -433,24 +433,25 @@ def _ensure_entitled_feed(client: Any, requested: str) -> str:
     if env_flag is None:
         env_flag = _env_bool("ALPACA_HAS_SIP")
 
-    sip_allowed = not sip_disallowed()
+    base_allowed = not sip_disallowed()
     explicit_env_disallow = allow_explicit_disallow or env_flag is False
     explicit_env_allow = allow_override is True or env_flag is True
 
-    if allow_override is True:
-        sip_allowed = True
-    elif explicit_env_disallow:
+    sip_allowed = base_allowed
+    if explicit_env_disallow:
         sip_allowed = False
-    elif sip_capability and not sip_allowed and sip_credentials_missing():
-        sip_allowed = True
+    else:
+        if explicit_env_allow or sip_capability:
+            sip_allowed = True
+        elif not sip_allowed and sip_credentials_missing():
+            sip_allowed = True
 
     sip_entitled_flag = False
     if explicit_env_disallow:
         sip_entitled_flag = False
-    elif explicit_env_allow:
-        sip_entitled_flag = True
-    elif sip_capability and sip_allowed:
-        sip_entitled_flag = True
+    else:
+        if explicit_env_allow or sip_capability:
+            sip_entitled_flag = sip_allowed
     prefer_sip = normalized_req == "sip"
     resolved = get_alpaca_feed(prefer_sip, sip_entitled=sip_entitled_flag)
     if resolved in feeds:

--- a/tests/test_feed_entitlement.py
+++ b/tests/test_feed_entitlement.py
@@ -129,3 +129,25 @@ def test_ensure_entitled_feed_downgrades_when_allow_flag_disables(monkeypatch):
     monkeypatch.delenv("ALPACA_SECRET", raising=False)
     client = _Client(['sip', 'iex'])
     assert bars._ensure_entitled_feed(client, 'sip') == 'iex'
+
+
+def test_ensure_entitled_feed_trusts_account_when_sip_disallowed_advisory(monkeypatch):
+    bars._ENTITLE_CACHE.clear()
+    for key in ("ALPACA_ALLOW_SIP", "ALPACA_SIP_ENTITLED", "ALPACA_HAS_SIP"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("ALPACA_KEY", "test-key")
+    monkeypatch.setenv("ALPACA_SECRET", "test-secret")
+    monkeypatch.setattr(bars, "sip_disallowed", lambda: True)
+    client = _Client(['sip'])
+    assert bars._ensure_entitled_feed(client, 'sip') == 'sip'
+
+
+def test_ensure_entitled_feed_respects_explicit_entitlement_false(monkeypatch):
+    bars._ENTITLE_CACHE.clear()
+    monkeypatch.delenv("ALPACA_ALLOW_SIP", raising=False)
+    monkeypatch.setenv("ALPACA_SIP_ENTITLED", "0")
+    monkeypatch.setenv("ALPACA_KEY", "test-key")
+    monkeypatch.setenv("ALPACA_SECRET", "test-secret")
+    monkeypatch.setattr(bars, "sip_disallowed", lambda: False)
+    client = _Client(['sip', 'iex'])
+    assert bars._ensure_entitled_feed(client, 'sip') == 'iex'


### PR DESCRIPTION
Title: Honor SIP entitlement when no explicit disable flag is set

Context:
- SIP market data was being downgraded despite account entitlement when advisory checks flagged disallow conditions.
- Environment flags should remain the source of truth for explicitly disabling SIP usage.

Problem:
- `_ensure_entitled_feed` relied on `sip_disallowed()` even when the account advertised SIP access, causing unnecessary downgrades whenever credentials were present.
- Tests lacked coverage for advisory disallow scenarios and explicit entitlement false flags.

Scope:
- Runtime entitlement resolution for Alpaca data feeds.
- Unit tests validating SIP entitlement behavior.

AC:
- SIP remains selected when the account reports entitlement and no explicit false flag is set.
- SIP downgrades only occur when environment variables explicitly disable it.
- Existing entitlement cache logic and alternate feed fallbacks continue to function.

Changes:
- Treat `sip_disallowed()` as advisory by default, allowing account entitlement or explicit true flags to override unless an explicit false flag is present.
- Preserve entitlement flags only when SIP is both allowed and supported, ensuring consistent downstream feed selection.
- Added unit tests covering advisory disallow overrides and explicit entitlement false flags.

Validation:
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/test_feed_entitlement.py`
- `ruff check ai_trading/data/bars.py tests/test_feed_entitlement.py`
- `mypy ai_trading/data/bars.py`

Risk:
- Low: Changes are isolated to SIP entitlement resolution with focused unit tests ensuring regressions are caught quickly.

------
https://chatgpt.com/codex/tasks/task_e_68e182d353c4833096411aadec709325