### PR TITLE
Ensure safe_subprocess_run re-raises augmented timeouts

### DIFF
--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -76,7 +76,8 @@ def safe_subprocess_run(
         stdout_text, stderr_text = proc.communicate(timeout=run_timeout)
     except subprocess.TimeoutExpired as exc:
         exc.timeout = run_timeout
-        raise _augment_timeout_exception(proc, exc)
+        _augment_timeout_exception(proc, exc)
+        raise
     except subprocess.SubprocessError as exc:
         with suppress(ProcessLookupError):
             proc.kill()
@@ -107,7 +108,7 @@ def _normalize_stream(stream: str | bytes | None) -> str:
 def _augment_timeout_exception(
     proc: subprocess.Popen[bytes] | subprocess.Popen[str],
     exc: subprocess.TimeoutExpired,
-) -> subprocess.TimeoutExpired:
+) -> None:
     """Populate timeout exception metadata before re-raising."""
 
     with suppress(ProcessLookupError):
@@ -133,4 +134,3 @@ def _augment_timeout_exception(
     exc.stdout = collected_stdout
     exc.stderr = collected_stderr
     exc.result = result
-    return exc


### PR DESCRIPTION
### Title
Ensure safe_subprocess_run re-raises augmented timeouts

### Context
Timeout handling in `safe_subprocess_run` must guarantee that the augmented `subprocess.TimeoutExpired` escapes the helper without being swallowed, while still enriching the exception with captured output for downstream assertions.

### Problem
The timeout branch relied on returning the augmented exception from `_augment_timeout_exception` and immediately raising that return value. This pattern risked future regressions where the helper stopped raising and the timeout path would silently fall through, breaking the guarantees exercised by the timeout-focused tests.

### Scope
- `ai_trading/utils/safe_subprocess.py`

### Acceptance Criteria
- Timeout exceptions are always re-raised after augmentation.
- Augmented timeout exceptions continue to surface `result`, `stdout`, and `stderr` attributes as asserted in the test suite.
- No other behavior of `safe_subprocess_run` changes.

### Changes
- Invoke `_augment_timeout_exception` for its side effects and immediately re-raise the active exception, ensuring propagation cannot be bypassed.
- Adjust the helper’s signature to return `None` so callers cannot rely on (or accidentally ignore) a return value, keeping its role purely mutative.

### Validation
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check ai_trading/utils/safe_subprocess.py`
- `mypy ai_trading/utils/safe_subprocess.py`
- `pytest tests/utils/test_safe_subprocess_run.py -q`
- `pytest -q` *(fails: existing suite failures outside the touched module; command interrupted after repeated failures)*

### Risk
Low. The change only alters the timeout error path to re-raise the already augmented exception and updates the helper signature to reflect its side-effect-only contract.


------
https://chatgpt.com/codex/tasks/task_e_68e1860358348330bd77e87c3ecc5abd