### PR TITLE
Fix daily memo reuse, SIP entitlement, and host limit resilience

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -454,6 +454,8 @@ def _ensure_entitled_feed(client: Any, requested: str) -> str:
             sip_entitled_flag = sip_allowed
     prefer_sip = normalized_req == "sip"
     resolved = get_alpaca_feed(prefer_sip, sip_entitled=sip_entitled_flag)
+    if prefer_sip and "sip" in feeds and not explicit_env_disallow:
+        return "sip"
     if resolved in feeds:
         return resolved
     eligible_feeds = [feed for feed in feeds if feed != "sip" or sip_entitled_flag]

--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -51,7 +51,7 @@ def safe_subprocess_run(
         ``124`` return code.
     """
 
-    run_timeout = SUBPROCESS_TIMEOUT_DEFAULT if timeout is None else float(timeout)
+    run_timeout = SUBPROCESS_TIMEOUT_S if timeout is None else float(timeout)
     if run_timeout <= 0:
         logger.warning(
             "safe_subprocess_run(%s) timed out immediately (timeout=%.2f seconds)",


### PR DESCRIPTION
## Context
- Daily bar memoization was consulting caches before honoring fresh memo entries, causing strict cache guards to trigger during tests.
- Alpaca window fetch logic was issuing HTTP requests for windows with no trading session and not recording feed switches reliably when falling back between feeds.
- SIP entitlement selection, slippage gating, subprocess timeout handling, and HTTP host limit state needed hardening for the targeted failing tests.

## Problem
- `tests/bot_engine/test_daily_fetch_debounce.py` failed due to `_daily_cache` reads before memo reuse.
- `_fetch_bars` contacted the network during no-session windows and skipped recording iex→sip fallback switches, breaking fetch failover tests.
- Feed entitlement tests downgraded SIP, slippage gating allowed high predicted slippage, subprocess timeout test did not raise, and host limit/concurrency tests crashed workers.

## Scope
- Update daily memo normalization and short-circuit logic.
- Adjust Alpaca fetch, fallback, entitlement, slippage, timeout, host pooling, and concurrency helpers to satisfy the targeted unit tests.
- No schema changes or new dependencies.

## Acceptance Criteria
- Targeted pytest cases for daily memo reuse, fetch parameter validation, feed failover, entitlement, subprocess timeout, slippage threshold, host limit, and fallback concurrency all pass.
- Linting (`ruff`), type checking (`mypy`), and `python -m py_compile` succeed on the modified code.

## Changes
- Normalize canonical and legacy daily memo entries with a memo-first short circuit that skips `_daily_cache` when fresh, while refreshing stale entries safely.
- Return an empty OHLCV frame immediately for windows without trading sessions and log iex→sip fallback switches before retrying alternate feeds.
- Respect SIP entitlement when the account allows it, enforce slippage threshold violations by raising `AssertionError`, and fix subprocess timeout default usage.
- Harden host pooling by clearing per-loop semaphore maps when env snapshots change and refreshing host semaphores for new loops in fallback concurrency.

## Validation
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/bot_engine/test_daily_fetch_debounce.py -q`
- `pytest tests/test_fetch_param_validation.py::test_window_without_trading_session_returns_empty -q`
- `pytest tests/test_feed_failover.py::test_alt_feed_switch_records_override -q`
- `pytest tests/test_feed_entitlement.py::test_ensure_entitled_feed_downgrades_cached_entitlement -q`
- `pytest tests/test_feed_entitlement.py::test_ensure_entitled_feed_keeps -q`
- `pytest tests/utils/test_safe_subprocess_run.py::test_safe_subprocess_run_timeout -q`
- `pytest tests/test_slippage_threshold_enforced.py::test_slippage_threshold_enforced -q`
- `pytest tests/test_http_host_limit.py -q`
- `pytest tests/data/test_fallback_concurrency.py -q`
- `ruff check .`
- `mypy ai_trading`

## Risk
- Moderate: changes touch shared caching, fetch, concurrency, and execution paths. Revert the specific modules if regressions occur.

------
https://chatgpt.com/codex/tasks/task_e_68e18e9c8de88330840c7f1ac8a55d22