### PR TITLE
Remove debug hooks from daily data fetcher

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -7957,7 +7957,6 @@ class DataFetcher:
             _is_trading_day = None  # type: ignore[assignment]
 
         ref_date = now_utc.date()
-        print("ref_date", ref_date)
         if not is_market_open():
             for _ in range(10):  # safety bound
                 ref_date = ref_date - timedelta(days=1)
@@ -7988,7 +7987,6 @@ class DataFetcher:
         timeframe_key = "1Day"
         memo_key = (symbol, timeframe_key, start_ts.isoformat(), end_ts.isoformat())
         legacy_memo_key = (symbol, fetch_date.isoformat())
-        import pdb; pdb.set_trace()
         min_interval = self._daily_fetch_min_interval(ctx)
         now_monotonic = float(monotonic_fn())
         ttl_window = (
@@ -8205,7 +8203,6 @@ class DataFetcher:
             (legacy_memo_key, memo_key),
         )
         for candidate_key, counterpart_key in memo_check_pairs:
-            print("memo candidate", candidate_key, counterpart_key)
             entry = _memo_get_entry(candidate_key)
             if entry is None:
                 continue
@@ -8223,12 +8220,10 @@ class DataFetcher:
                     min_interval if min_interval > 0 else ttl_window
                 )
             )
-            print("memo entry", entry_ts, age, is_fresh)
             if not is_fresh:
                 continue
             memo_hit = True
             normalized_pair = (now_monotonic, payload)
-            import pdb; pdb.set_trace()
             with cache_lock:
                 _memo_set_entry(candidate_key, normalized_pair)
                 if counterpart_key != candidate_key:


### PR DESCRIPTION
## Title
Remove debug hooks from daily data fetcher

## Context
An audit revealed stray debugger and print statements lingering in the daily data retrieval path after prior diagnostics. These hooks interfere with automation and can stall batch runs.

## Problem
`DataFetcher.get_daily_df` still emitted console noise and halted execution when memoization paths were exercised, because `print` and `pdb.set_trace()` calls remained in the routine.

## Scope
Limit changes to removing transient debugging hooks from `DataFetcher.get_daily_df` while keeping its logic intact.

## Acceptance Criteria
- Service boots without unexpected stdout chatter from daily fetch logic.
- No debugger breakpoints remain in `DataFetcher.get_daily_df`.
- Repository continues to lint and type-check cleanly.
- Test suite (make test-all) is exercised; pre-existing dependency conflicts are documented if blocking.

## Changes
- Deleted the `print` statements and inline `pdb.set_trace()` calls from the daily fetch memoization flow in `ai_trading/core/bot_engine.py`.

## Validation
- `pip install -r requirements.txt` *(pass)*
- `python -m py_compile $(git ls-files '*.py')` *(pass)*
- `make test-all VERBOSE=1` *(fails: dependency conflict between yfinance pins in requirements vs. constraints)*
- `pytest -q` *(aborted after observing numerous existing test failures; suite remains red upstream)*
- `ruff check ai_trading/core/bot_engine.py` *(pass)*
- `mypy ai_trading/core/bot_engine.py` *(pass)*

## Risk
Low. Removal of debugging statements does not alter functional behavior, only prevents unintended execution pauses and stdout leakage. Roll back by reverting commit ef73b26 if unexpected issues arise.


------
https://chatgpt.com/codex/tasks/task_e_68e33bcdd7a4833088218d4f0c1713ed