### PR TITLE
Add dummy Alpaca client fixture for unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -298,3 +298,21 @@ def dummy_order():
         filled_qty=0,
         symbol="TEST",
     )
+
+
+@pytest.fixture
+def dummy_alpaca_client():
+    """Provide a callable-recording Alpaca client substitute for unit tests."""
+
+    class _DummyClient:
+        def __init__(self):
+            self.calls: list[dict[str, object]] = []
+            self.last_call: dict[str, object] | None = None
+
+        def submit_order(self, *args, **kwargs):
+            call = {"args": args, "kwargs": kwargs}
+            self.calls.append(call)
+            self.last_call = call
+            return {"id": f"dummy-order-{len(self.calls)}"}
+
+    return _DummyClient()


### PR DESCRIPTION
# Title
Add dummy Alpaca client fixture for Alpaca API unit tests

# Context
The Alpaca API unit test `test_submit_order_uses_client_and_returns` expects a `dummy_alpaca_client` fixture that records order submissions. The repository previously lacked this fixture, causing attribute errors in the test when attempting to access call metadata.

# Problem
Without a purpose-built dummy client, the test cannot verify that `submit_order` interacts with the provided client and returns an order identifier, impeding regression coverage for Alpaca order submission behavior.

# Scope
- Define a reusable pytest fixture under `tests/conftest.py` that mimics the Alpaca client's `submit_order` interface and records invocations.

# Acceptance Criteria
- `dummy_alpaca_client` fixture exposes `submit_order`, `calls`, and related metadata used by the unit test.
- Fixture returns a minimal dictionary containing an order `id` for each submission.
- Unit test can utilize the fixture without additional setup.

# Changes
- Added `dummy_alpaca_client` fixture to `tests/conftest.py`, providing call recording and deterministic order IDs for submitted orders.

# Validation
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails fast due to pre-existing suite failures; run interrupted once fixture behavior was validated separately).* 
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_alpaca_api.py::test_submit_order_uses_client_and_returns -q` *(fails earlier because `alpaca_api` lacks `DRY_RUN`; fixture executes and records calls when invoked manually via its wrapped function).* 
- `ruff check tests/conftest.py`
- `mypy tests/conftest.py`

# Risk
Low. The new fixture is isolated to tests and introduces no runtime behavior changes.

------
https://chatgpt.com/codex/tasks/task_e_68e3437c0db8833092b450a78e50bf2d