### PR TITLE
Add pending order lock exports for Alpaca API

### DIFF
--- a/ai_trading/alpaca_api.py
+++ b/ai_trading/alpaca_api.py
@@ -8,6 +8,7 @@ import uuid
 import inspect
 from dataclasses import dataclass
 from typing import Any, Optional, TYPE_CHECKING
+from threading import RLock
 
 try:
     from alpaca.trading.client import TradingClient
@@ -77,6 +78,8 @@ def _lazy_http_session() -> "Optional[HTTPSession]":
 
 
 _HTTP_SESSION: "Optional[HTTPSession]" = None
+_pending_orders_lock = RLock()
+_pending_orders: dict[str, dict[str, Any]] = {}
 
 
 def _get_http_session() -> "HTTPSession":
@@ -1421,4 +1424,6 @@ __all__ = [
     "start_trade_updates_stream",
     "initialize",
     "_HTTP",
+    "_pending_orders_lock",
+    "_pending_orders",
 ]


### PR DESCRIPTION
Title
-----
Add pending order lock exports for Alpaca API

Context
-------
Expose synchronization primitives for pending-order bookkeeping through the thin `alpaca_api` proxy so tests and helpers can coordinate safely.

Problem
-------
`tests/unit/test_alpaca_api.py::test_pending_orders_lock_exists_and_is_lock` expects `_pending_orders_lock` and `_pending_orders` to be available from the proxy module, but they were never defined in `ai_trading.alpaca_api` nor exported, causing import failures.

Scope
-----
Runtime adjustments within `ai_trading/alpaca_api.py`; no broader refactors.

Acceptance Criteria
-------------------
* Define a module-level lock and pending-orders dictionary.
* Ensure they are exported through the thin proxy.
* Maintain existing runtime behavior and typing/lint baselines.
* Unit test `tests/unit/test_alpaca_api.py::test_pending_orders_lock_exists_and_is_lock` passes.

Changes
-------
* Added a module-level `RLock` and dictionary for pending order tracking in `ai_trading.alpaca_api`.
* Updated the module's `__all__` to export the new helpers through the proxy layer.

Validation
----------
* `python -m py_compile $(git ls-files '*.py')`
* `ruff check ai_trading/alpaca_api.py`
* `mypy ai_trading/alpaca_api.py`
* `pytest -q` *(fails due to pre-existing suite failures; change is isolated)*
* `pytest tests/unit/test_alpaca_api.py::test_pending_orders_lock_exists_and_is_lock -q`

Risk
----
Low. The new lock and dictionary are inert until used and simply expose synchronization primitives anticipated by the tests. Existing runtime flows remain unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68e3437c744083309e440d8b5197eeb4