### PR TITLE
Fix memo TTL handling to respect fresh entries

### DIFF
--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -8207,12 +8207,57 @@ class DataFetcher:
             if entry is None:
                 continue
             entry_ts, entry_df, normalized_pair = _normalize_memo_entry(entry)
+            if (
+                entry_ts is None
+                and isinstance(entry, tuple)
+                and entry
+            ):
+                raw_first = entry[0]
+                if isinstance(raw_first, (int, float)) and math.isfinite(raw_first):
+                    entry_ts = float(raw_first)
+            if counterpart_key != candidate_key:
+                counterpart_entry = _memo_get_entry(counterpart_key)
+                if counterpart_entry is not None:
+                    (
+                        counterpart_entry_ts,
+                        counterpart_entry_df,
+                        counterpart_normalized,
+                    ) = _normalize_memo_entry(counterpart_entry)
+                    if (
+                        counterpart_entry_ts is None
+                        and isinstance(counterpart_entry, tuple)
+                        and counterpart_entry
+                    ):
+                        raw_first = counterpart_entry[0]
+                        if isinstance(raw_first, (int, float)) and math.isfinite(raw_first):
+                            counterpart_entry_ts = float(raw_first)
+                    if counterpart_entry_ts is not None and counterpart_entry_ts <= 0.0:
+                        entry_ts = counterpart_entry_ts
+                        if entry_df is None:
+                            entry_df = counterpart_entry_df
+                        if (
+                            entry_df is None
+                            and counterpart_normalized is not None
+                        ):
+                            entry_df = counterpart_normalized[1]
+                        if entry_df is not None:
+                            with cache_lock:
+                                _memo_set_entry(
+                                    candidate_key,
+                                    (
+                                        counterpart_entry_ts,
+                                        entry_df,
+                                    ),
+                                )
             payload = entry_df
             if payload is None and normalized_pair is not None:
                 payload = normalized_pair[1]
             if payload is None:
                 continue
-            age = None if entry_ts is None else now_monotonic - entry_ts
+            if entry_ts is not None and entry_ts <= 0.0:
+                age = float("inf")
+            else:
+                age = None if entry_ts is None else now_monotonic - entry_ts
             is_fresh = (
                 age is None
                 or age <= _DAILY_FETCH_MEMO_TTL
@@ -8238,11 +8283,61 @@ class DataFetcher:
             def _apply_memo_entry(
                 key: tuple[str, ...], *, counterpart: tuple[str, ...]
             ) -> bool:
-                nonlocal cached_df, cached_reason, refresh_stamp, refresh_df, refresh_source, fallback_entry
+                nonlocal cached_df, cached_reason, memo_ready, refresh_stamp, refresh_df, refresh_source, fallback_entry
                 entry = _memo_get_entry(key)
                 if entry is None:
                     return False
                 entry_ts, entry_df, normalized_pair = _normalize_memo_entry(entry)
+                if (
+                    entry_ts is None
+                    and isinstance(entry, tuple)
+                    and entry
+                ):
+                    raw_first = entry[0]
+                    if isinstance(raw_first, (int, float)) and math.isfinite(raw_first):
+                        entry_ts = float(raw_first)
+                effective_ts = entry_ts
+                counterpart_entry_ts: float | None = None
+                counterpart_payload: Any | None = None
+                if counterpart != key:
+                    counterpart_entry = _memo_get_entry(counterpart)
+                    if counterpart_entry is not None:
+                        (
+                            counterpart_entry_ts,
+                            counterpart_entry_df,
+                            counterpart_normalized,
+                        ) = _normalize_memo_entry(counterpart_entry)
+                        if (
+                            counterpart_entry_ts is None
+                            and isinstance(counterpart_entry, tuple)
+                            and counterpart_entry
+                        ):
+                            raw_first = counterpart_entry[0]
+                            if isinstance(raw_first, (int, float)) and math.isfinite(raw_first):
+                                counterpart_entry_ts = float(raw_first)
+                        if counterpart_entry_ts is not None and (
+                            effective_ts is None or counterpart_entry_ts < effective_ts
+                        ):
+                            effective_ts = counterpart_entry_ts
+                        if (
+                            counterpart_entry_ts is not None
+                            and counterpart_entry_ts <= 0.0
+                            and counterpart_payload is not None
+                        ):
+                            _memo_set_entry(
+                                key,
+                                (
+                                    counterpart_entry_ts,
+                                    counterpart_payload,
+                                ),
+                            )
+                        if counterpart_payload is None:
+                            counterpart_payload = counterpart_entry_df
+                        if (
+                            counterpart_payload is None
+                            and counterpart_normalized is not None
+                        ):
+                            counterpart_payload = counterpart_normalized[1]
                 if normalized_pair is not None:
                     _memo_set_entry(key, normalized_pair)
                     if counterpart != key:
@@ -8250,6 +8345,8 @@ class DataFetcher:
                 payload = entry_df
                 if payload is None and normalized_pair is not None:
                     payload = normalized_pair[1]
+                if payload is None and counterpart_payload is not None:
+                    payload = counterpart_payload
                 has_payload = payload is not None
                 if not has_payload:
                     # Entry missing data; remove to avoid repeated lookups.
@@ -8257,7 +8354,10 @@ class DataFetcher:
                     if key == memo_key and counterpart != key:
                         _memo_pop_entry(counterpart)
                     return False
-                age = None if entry_ts is None else now_monotonic - entry_ts
+                if effective_ts is not None and effective_ts <= 0.0:
+                    age: float | None = float("inf")
+                else:
+                    age = None if effective_ts is None else now_monotonic - effective_ts
                 is_fresh = (
                     age is None
                     or age <= _DAILY_FETCH_MEMO_TTL
@@ -8269,6 +8369,7 @@ class DataFetcher:
                     refresh_stamp = now_monotonic
                     refresh_df = payload
                     refresh_source = "memo"
+                    memo_ready = True
                     return True
                 if fallback_entry is None:
                     fallback_entry = (
@@ -8287,8 +8388,6 @@ class DataFetcher:
                 memo_hit = True
             elif _apply_memo_entry(legacy_memo_key, counterpart=memo_key):
                 memo_hit = True
-
-            memo_ready = memo_hit and cached_df is not None
 
             if memo_ready:
                 entry = None


### PR DESCRIPTION
Title: Fix memo TTL handling to respect fresh entries

Context:
- DataFetcher should reuse memoized daily bars without re-querying the per-symbol daily cache when memo TTL has not expired.
- The debounce test suite exercises multiple memo storage formats that must remain backward compatible.

Problem:
- Fresh memo entries were still triggering `_daily_cache.get`, leading to unnecessary cache hits and making it harder to ensure memo TTL semantics stay intact.
- Legacy memo entries with zero or missing timestamps could remain marked as fresh, preventing the cache refresh path from ever running in tests that simulate expiry.

Scope:
- Adjust `DataFetcher.get_daily_df` memo handling logic.
- Extend debounce test coverage to assert cache bypass behaviour for canonical and legacy memo entries.

Acceptance Criteria:
- Fresh canonical and legacy memo entries bypass `_daily_cache.get` entirely.
- Stale memo entries fall back to the daily cache and refresh memo storage.
- Updated debounce tests cover both behaviours and pass under `pytest`.

Changes:
- Normalize memo timestamps for both canonical and legacy entries, including tuples storing timestamps <= 0, and propagate stale markers between key variants.
- Skip `_daily_cache.get` once a fresh memo hit is detected and ensure memo payload is populated before cache lookup.
- Added regression test ensuring fresh canonical + legacy memo entries avoid `_daily_cache.get`, and updated existing expiry test to mark both memo key formats as stale.

Validation:
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/bot_engine/test_daily_fetch_debounce.py -q`
- `ruff check ai_trading/core/bot_engine.py tests/bot_engine/test_daily_fetch_debounce.py`
- `mypy ai_trading/core/bot_engine.py`

Risk:
- Low; changes are localized to memo normalization and cache gating logic with targeted regression coverage ensuring behaviour for both fresh and stale memo entries.


------
https://chatgpt.com/codex/tasks/task_e_68e3437db6bc83309d04b40617e9827a