### PR TITLE
Fix SIP feed entitlement override handling

### DIFF
--- a/ai_trading/data/bars.py
+++ b/ai_trading/data/bars.py
@@ -453,12 +453,13 @@ def _ensure_entitled_feed(client: Any, requested: str) -> str:
         if explicit_env_allow or sip_capability:
             sip_entitled_flag = sip_allowed
     prefer_sip = normalized_req == "sip"
-    if normalized_req == "sip" and "sip" in feeds:
+    sip_return_allowed = sip_allowed and sip_entitled_flag
+    if prefer_sip and sip_return_allowed and "sip" in feeds:
         return "sip"
-    resolved = get_alpaca_feed(prefer_sip, sip_entitled=sip_entitled_flag)
+    resolved = get_alpaca_feed(prefer_sip, sip_entitled=sip_return_allowed)
     if resolved in feeds:
         return resolved
-    eligible_feeds = [feed for feed in feeds if feed != "sip" or sip_entitled_flag]
+    eligible_feeds = [feed for feed in feeds if feed != "sip" or sip_return_allowed]
     if eligible_feeds:
         alt = eligible_feeds[0]
         if resolved != alt:

--- a/tests/test_feed_entitlement.py
+++ b/tests/test_feed_entitlement.py
@@ -131,6 +131,17 @@ def test_ensure_entitled_feed_downgrades_when_allow_flag_disables(monkeypatch):
     assert bars._ensure_entitled_feed(client, 'sip') == 'iex'
 
 
+def test_ensure_entitled_feed_blocks_direct_sip_when_allow_flag_disables(monkeypatch):
+    bars._ENTITLE_CACHE.clear()
+    monkeypatch.setenv("ALPACA_ALLOW_SIP", "0")
+    for key in ("ALPACA_SIP_ENTITLED", "ALPACA_HAS_SIP"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("ALPACA_KEY", raising=False)
+    monkeypatch.delenv("ALPACA_SECRET", raising=False)
+    client = _Client(['sip'])
+    assert bars._ensure_entitled_feed(client, 'sip') == 'iex'
+
+
 def test_ensure_entitled_feed_trusts_account_when_sip_disallowed_advisory(monkeypatch):
     bars._ENTITLE_CACHE.clear()
     for key in ("ALPACA_ALLOW_SIP", "ALPACA_SIP_ENTITLED", "ALPACA_HAS_SIP"):
@@ -150,4 +161,15 @@ def test_ensure_entitled_feed_respects_explicit_entitlement_false(monkeypatch):
     monkeypatch.setenv("ALPACA_SECRET", "test-secret")
     monkeypatch.setattr(bars, "sip_disallowed", lambda: False)
     client = _Client(['sip', 'iex'])
+    assert bars._ensure_entitled_feed(client, 'sip') == 'iex'
+
+
+def test_ensure_entitled_feed_blocks_direct_sip_when_explicit_entitlement_false(monkeypatch):
+    bars._ENTITLE_CACHE.clear()
+    monkeypatch.delenv("ALPACA_ALLOW_SIP", raising=False)
+    monkeypatch.setenv("ALPACA_SIP_ENTITLED", "0")
+    monkeypatch.setenv("ALPACA_KEY", "test-key")
+    monkeypatch.setenv("ALPACA_SECRET", "test-secret")
+    monkeypatch.setattr(bars, "sip_disallowed", lambda: False)
+    client = _Client(['sip'])
     assert bars._ensure_entitled_feed(client, 'sip') == 'iex'


### PR DESCRIPTION
# Title
Fix SIP feed entitlement override handling

# Context
Environment entitlement flags were being ignored whenever SIP was requested explicitly, causing the wrong feed to be returned.

# Problem
`_ensure_entitled_feed` returned `"sip"` as soon as the account advertised SIP access, even when environment overrides explicitly disabled SIP entitlement. This bypassed configuration meant requests could still use SIP despite `ALPACA_ALLOW_SIP=0` or `ALPACA_SIP_ENTITLED=0`.

# Scope
- Runtime entitlement resolution in `ai_trading.data.bars`.
- Unit tests in `tests/test_feed_entitlement.py`.

# Acceptance Criteria
- Explicit SIP disallow flags prevent `_ensure_entitled_feed` from returning `"sip"`.
- Feed selection honors the computed SIP allowance state.
- Unit tests cover both explicit disallow paths (allow flag and entitlement flag).

# Changes
- Gate SIP returns on combined `sip_allowed` and `sip_entitled_flag` state and propagate the stricter flag to downstream selection.
- Add regression tests ensuring explicit SIP disallow signals block direct SIP selection even when it is the requested feed.

# Validation
- `pip install -r requirements.txt` *(already satisfied in environment)*
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_feed_entitlement.py`
- `pytest -q` *(fails early across the suite; aborted after confirming numerous pre-existing failures unrelated to this change)*
- `ruff check`
- `mypy ai_trading/data/bars.py tests/test_feed_entitlement.py`

# Risk & Rollback
Low risk: changes scoped to SIP entitlement gating and associated tests. Rollback by reverting the commit if any entitlement regressions are observed.


------
https://chatgpt.com/codex/tasks/task_e_68e345c9d30483308cb7116f5a09cb6e