### PR TITLE
Stabilize unittest.mock.patch.dict monkeypatch typing

### DIFF
--- a/usercustomize.py
+++ b/usercustomize.py
@@ -1,36 +1,37 @@
 """Extend unittest.mock.patch.dict to keep sys.modules stable during tests."""
 from __future__ import annotations
 
+from collections.abc import MutableMapping
+from typing import cast
 import sys
 import types
 import unittest.mock as _mock
-
-_ORIGINAL_PATCH_DICT = _mock.patch.dict
 _ORIGINAL_MODULES: dict[str, types.ModuleType | None] = dict(sys.modules)
 
 
-def _safe_patch_dict(in_dict, values=(), clear: bool = False, **kwargs):  # pragma: no cover
-    ctx = _ORIGINAL_PATCH_DICT(in_dict, values, clear, **kwargs)
-    if clear and in_dict is sys.modules:
-        original_enter = ctx.__enter__
-        original_exit = ctx.__exit__
-
-        def _enter():
-            result = original_enter()
-            sys.modules.update({k: v for k, v in _ORIGINAL_MODULES.items() if v is not None})
-            return result
-
-        def _exit(exc_type, exc, tb):
-            try:
-                return original_exit(exc_type, exc, tb)
-            finally:
-                sys.modules.update({k: v for k, v in _ORIGINAL_MODULES.items() if v is not None})
-
-        ctx.__enter__ = _enter
-        ctx.__exit__ = _exit
-    return ctx
+def _restore_modules() -> None:
+    sys.modules.update({name: module for name, module in _ORIGINAL_MODULES.items() if module is not None})
 
 
-_mock.patch.dict = _safe_patch_dict
-if hasattr(_mock.patch, 'dict'):
-    _mock.patch.dict = _safe_patch_dict
+class _SafePatchDict(_mock._patch_dict):  # pragma: no cover - behavior exercised indirectly in tests
+    def __enter__(self) -> MutableMapping[object, object]:
+        result = cast(MutableMapping[object, object], super().__enter__())
+        self._maybe_restore_modules()
+        return result
+
+    def __exit__(self, *args: object) -> bool:
+        exit_result = False
+        try:
+            exit_result = cast(bool, super().__exit__(*args))
+        finally:
+            self._maybe_restore_modules()
+        return exit_result
+
+    def _maybe_restore_modules(self) -> None:
+        if self.clear and self.in_dict is sys.modules:
+            _restore_modules()
+
+
+if hasattr(_mock.patch, "dict"):
+    _mock.patch.dict = _SafePatchDict
+setattr(_mock, "_patch_dict", _SafePatchDict)


### PR DESCRIPTION
## Title
Stabilize unittest.mock.patch.dict monkeypatch typing

## Context
`usercustomize.py` overrides `unittest.mock.patch.dict` so tests that clear `sys.modules` do not destabilize the import cache. Recent mypy runs report multiple `no-untyped-def` and assignment errors against this customization.

## Problem
The existing implementation wraps the runtime context manager returned by `patch.dict` and replaces `patch.dict` with that wrapper function. Typeshed models `patch.dict` as the `_patch_dict` class, so mypy flags the function assignment and the untyped wrapper.

## Scope
Single file (`usercustomize.py`).

## Acceptance Criteria
- The monkeypatch keeps `sys.modules` intact when `patch.dict(..., clear=True)` targets it.
- Type checking (`mypy usercustomize.py`) succeeds without ignores.
- Repository linting and bytecode compilation remain clean.

## Changes
- Capture the original module table and expose a `_restore_modules()` helper.
- Subclass `unittest.mock._patch_dict` to restore `sys.modules` on `__enter__`/`__exit__` when the clear flag targets the module cache.
- Rebind `patch.dict` and the private `_patch_dict` symbol to the typed subclass without touching other behavior.

## Validation
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check usercustomize.py`
- `mypy usercustomize.py`
- `pytest -q` *(times out amid numerous pre-existing failing suites; see logs for details)*

## Risk
Low. The change only alters our test-specific monkeypatch and keeps behavior aligned with the original `_patch_dict` implementation, adding type annotations without affecting production paths.

------
https://chatgpt.com/codex/tasks/task_e_68e3eaa8599c8330a50be9a26836dd34