### PR TITLE
Fix Alpaca APIError test doubles

### DIFF
--- a/tests/execution/test_broker_capacity_preflight.py
+++ b/tests/execution/test_broker_capacity_preflight.py
@@ -2,14 +2,28 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from types import SimpleNamespace
 
 from ai_trading.execution import live_trading as lt
 
 
 class DummyAPIError(lt.APIError):
-    def __init__(self, status_code=403, code="40310000", message="insufficient day trading buying power"):
-        super().__init__(message)
+    def __init__(
+        self,
+        status_code: int | None = 403,
+        code: str | None = "40310000",
+        message: str = "insufficient day trading buying power",
+    ) -> None:
+        payload = {"message": message, "code": code}
+        http_error = None
+        if status_code is not None:
+            http_error = SimpleNamespace(
+                response=SimpleNamespace(status_code=status_code),
+                request=None,
+            )
+        super().__init__(json.dumps(payload), http_error=http_error)
         self._status_code = status_code
         self._code = code
         self._message = message
@@ -18,25 +32,13 @@ class DummyAPIError(lt.APIError):
     def status_code(self):  # type: ignore[override]
         return self._status_code
 
-    @status_code.setter
-    def status_code(self, value):  # type: ignore[override]
-        self._status_code = value
-
     @property
     def code(self):  # type: ignore[override]
         return self._code
 
-    @code.setter
-    def code(self, value):  # type: ignore[override]
-        self._code = value
-
     @property
     def message(self):  # type: ignore[override]
         return self._message
-
-    @message.setter
-    def message(self, value):  # type: ignore[override]
-        self._message = value
 
 
 def _engine() -> lt.ExecutionEngine:


### PR DESCRIPTION
Title: Fix Alpaca APIError test doubles

Context:
- The Alpaca SDK exposes APIError properties (code, message, status_code) as read-only values derived from captured payloads.
- Our execution tests fabricate APIError subclasses for exercising capacity-handling logic.

Problem:
- The prior DummyAPIError implementations tried to assign to read-only APIError properties, causing AttributeError during test setup when the SDK-backed base class is present.

Scope:
- Update the DummyAPIError helpers in broker capacity preflight and error mapping tests to model Alpaca's APIError initialization contract.

AC:
- Tests relying on DummyAPIError construct instances without raising AttributeError when alpaca-trade-api is installed.
- DummyAPIError exposes code/message/status_code consistent with the expectations in the execution engine.
- Existing assertions in the affected test modules continue to pass.

Changes:
- Instantiate DummyAPIError with serialized payloads and lightweight http_error stand-ins that supply status codes.
- Return stored code/message/status_code values via read-only properties that mirror the Alpaca interface.

Validation:
- python -m py_compile $(git ls-files '*.py')
- pytest tests/execution/test_broker_capacity_preflight.py -q
- pytest tests/execution/test_broker_error_mapping.py -q
- ruff check tests/execution/test_broker_capacity_preflight.py tests/execution/test_broker_error_mapping.py
- mypy tests/execution/test_broker_capacity_preflight.py tests/execution/test_broker_error_mapping.py
- Note: Full `pytest -q` run aborted due to numerous unrelated suite failures present on the branch.

Risk:
- Low; changes are confined to test doubles used in execution-layer unit tests.

------
https://chatgpt.com/codex/tasks/task_e_68e3ec3308dc8330b74d2e5d897293fb