### PR TITLE
Fix order monitor timeout under frozen clock

### DIFF
--- a/tests/execution/test_order_monitor_timeouts.py
+++ b/tests/execution/test_order_monitor_timeouts.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ai_trading.core.enums import OrderSide, OrderStatus, OrderType
+from ai_trading.execution.engine import Order, OrderManager
+
+
+def test_monitor_orders_uses_monotonic_for_expiry(monkeypatch):
+    """Orders expire even when wall-clock time is frozen."""
+
+    manager = OrderManager()
+    manager.order_timeout = 1
+
+    order = Order("SPY", OrderSide.BUY, 10, order_type=OrderType.MARKET)
+    order._created_monotonic = 0.0
+    order.created_at = datetime(2024, 1, 1, 9, 30, tzinfo=UTC)
+
+    manager.active_orders[order.id] = order
+
+    events: list[tuple[str, str]] = []
+    manager.execution_callbacks.append(lambda o, ev: events.append((o.id, ev)))
+
+    freeze_ts = datetime(2024, 1, 1, 9, 30, tzinfo=UTC)
+    monkeypatch.setattr("ai_trading.execution.engine.safe_utcnow", lambda: freeze_ts)
+    monkeypatch.setattr("ai_trading.execution.engine.monotonic_time", lambda: 2.0)
+    monkeypatch.setattr(
+        "ai_trading.execution.reconcile.reconcile_positions_and_orders", lambda *args, **kwargs: None
+    )
+
+    manager._monitor_orders_tick()
+
+    assert order.id not in manager.active_orders
+    assert order.status == OrderStatus.EXPIRED
+    assert (order.id, "expired") in events


### PR DESCRIPTION
Title: Fix order monitor timeout under frozen clock

Context (WORKLOG):
- Order monitoring threads were hanging whenever Freezegun or other frozen clocks were active, blocking shutdown paths.

Problem:
- Timeout watchdogs observed the monitor thread stuck in `_monitor_orders`, preventing expiry processing and keeping tests spinning indefinitely when wall-clock time stopped advancing.

Scope:
- Execution order lifecycle monitoring and its associated regression tests.

Acceptance Criteria:
- Order expiry logic must be independent of wall-clock time patches.
- Monitoring loop should exit promptly once stop is requested.
- Regression tests capture the frozen-clock scenario.

Changes (PATCHSET):
- Record a monotonic timestamp alongside `created_at` for new orders and switch `_monitor_orders` to a single-iteration helper that bases expiry on monotonic time with a datetime fallback.
- Added a regression test ensuring orders expire when wall-clock time is frozen by patching the monotonic clock.

Validation:
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/execution/test_order_monitor_timeouts.py -q`
- `pytest -q` *(fails early due to numerous pre-existing suite failures; run interrupted after verifying repeated failures)*
- `ruff check ai_trading/execution/engine.py tests/execution/test_order_monitor_timeouts.py`
- `mypy ai_trading/execution/engine.py`

Risk & Rollback:
- Medium: changes touch central order monitoring flow; rollback by reverting commit 3f8bccdeb7c19c38ee5a6eb7dbbd188446c0e748 if monotonic handling causes regressions.

------
https://chatgpt.com/codex/tasks/task_e_68e3ee03cb4c8330947997f53aae730d