### PR TITLE
Fix TradingConfig env override handling and order fallback IDs

### DIFF
--- a/ai_trading/config/management.py
+++ b/ai_trading/config/management.py
@@ -176,10 +176,28 @@ def validate_required_env(
     env_snapshot: dict[str, str] = {
         k: v for k, v in os.environ.items() if isinstance(v, str)
     }
+    overrides: dict[str, str] | None = None
+    config_overrides: dict[str, str] | None = None
     if env is not None:
-        env_snapshot.update({k: str(v) for k, v in env.items() if v is not None})
+        overrides = {
+            str(key).upper(): str(value)
+            for key, value in env.items()
+            if value is not None
+        }
+        if overrides:
+            env_snapshot.update(overrides)
+            config_overrides = {
+                key: value for key, value in overrides.items() if key in SPEC_BY_ENV
+            }
+            if not config_overrides:
+                config_overrides = None
+        else:
+            overrides = None
+            config_overrides = None
 
-    cfg = TradingConfig.from_env(env_snapshot, allow_missing_drawdown=True)
+    cfg = TradingConfig.from_env(
+        config_overrides, allow_missing_drawdown=True
+    )
 
     required_fields = {
         "ALPACA_API_KEY": cfg.alpaca_api_key,

--- a/ai_trading/core/bot_engine.py
+++ b/ai_trading/core/bot_engine.py
@@ -632,8 +632,7 @@ __all__ = [
 # AI-AGENT-REF: custom exception surfaced by fetch helpers
 
 
-class DataFetchError(RuntimeError):
-    """Raised when required market data is unavailable."""  # AI-AGENT-REF
+DataFetchError = data_fetcher_module.DataFetchError
 
 
 COMMON_EXC = COMMON_EXC + (DataFetchError,)  # AI-AGENT-REF: broaden common exceptions


### PR DESCRIPTION
### Title
Fix TradingConfig env override handling and order fallback IDs

### Context
Production startup was failing because `TradingConfig.from_env` rejected standard environment snapshots, and execution regression tests were asserting on fallback order identifiers.

### Problem
* `validate_required_env` forwarded the entire environment snapshot to `TradingConfig.from_env`, triggering strict override validation against non-config keys during systemd launches.
* Order submission fallbacks always synthesized `alpaca-pending-*` identifiers, ignoring legitimate `client_order_id` values returned by Alpaca or tests.
* Reloading `ai_trading.core.bot_engine` during tests produced distinct `DataFetchError` classes, destabilizing exception handling across modules.

### Scope
* Sanitize env overrides before feeding `TradingConfig.from_env`.
* Normalize execution fallback IDs and client order IDs.
* Re-export a single shared `DataFetchError` class from `bot_engine`.

### Acceptance Criteria
* Service boot no longer fails due to unknown override keys.
* Fallback order identifiers preserve real IDs when provided, while keeping deterministic behavior when no broker response is returned.
* Tests relying on shared `DataFetchError` identity continue to pass.

### Changes
* Filter env overrides passed to `TradingConfig.from_env`, splitting config-specific overrides from general env updates.【F:ai_trading/config/management.py†L176-L200】
* Adjust fallback order handling to reuse broker-provided IDs when present and only synthesize `alpaca-pending-*` IDs when no identifier exists, keeping client/order IDs aligned for empty responses.【F:ai_trading/execution/live_trading.py†L2072-L2155】
* Alias `ai_trading.core.bot_engine.DataFetchError` to the canonical definition from `ai_trading.data.fetch` to avoid duplicate class identities after module reloads.【F:ai_trading/core/bot_engine.py†L632-L638】

### Validation
* `python -m py_compile $(git ls-files '*.py')`【ad756c†L1-L1】
* `pytest tests/execution/test_execution_empty_response.py -q`【e22976†L1-L3】
* `pytest tests/execution/test_fetch_minute_df_safe_empty.py -q`【85350f†L1-L3】
* `pytest -q` *(fails: missing fixture `dummy_data_fetcher_empty` in integration suite)*【ad8d58†L1-L23】
* `ruff check ai_trading/config/management.py ai_trading/execution/live_trading.py`【8cdbdc†L1-L2】
* `mypy ai_trading/config/management.py ai_trading/execution/live_trading.py`【0a36d4†L1-L2】

### Risk
Medium: changes touch configuration validation and live order execution fallback paths. Rollback via `git revert 79b1cb4` if unexpected startup or execution regressions occur.


------
https://chatgpt.com/codex/tasks/task_e_68e40b569f6c833082943b2e927ebc98