### PR TITLE
Enforce Alpaca safe mode on provider outages

### DIFF
--- a/ai_trading/config/runtime.py
+++ b/ai_trading/config/runtime.py
@@ -1624,7 +1624,11 @@ class TradingConfig:
             and not values.get("alpaca_has_sip")
         ):
             raise ValueError(
-                "DATA_FEED_INTRADAY=sip requires ALPACA_ALLOW_SIP=1 or ALPACA_HAS_SIP=1"
+                (
+                    "DATA_FEED_INTRADAY=sip requires SIP entitlements. Set ALPACA_ALLOW_SIP=1 or "
+                    "ALPACA_HAS_SIP=1. Ensure ALPACA_API_KEY, ALPACA_SECRET_KEY, and DATA_FEED_INTRADAY are "
+                    "configured. See docs/DEPLOYING.md#alpaca-feed-selection for setup guidance."
+                )
             )
 
         # Derived convenience fields expected by legacy callers.

--- a/ai_trading/monitoring/alerts.py
+++ b/ai_trading/monitoring/alerts.py
@@ -28,6 +28,7 @@ class AlertType(Enum):
     EXECUTION = 'execution'
     SYSTEM = 'system'
     COMPLIANCE = 'compliance'
+    PROVIDER_OUTAGE = 'provider_outage'
 
 class Alert:
     """

--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -1,0 +1,43 @@
+# Deployment Guide: Alpaca Feed Selection
+
+## Intraday Feed Options
+
+The trading bot supports multiple Alpaca intraday data feeds. Configure the
+feed via the `DATA_FEED_INTRADAY` environment variable:
+
+| Value | Description | SIP entitlement required |
+|-------|-------------|--------------------------|
+| `iex` | Default retail feed (15-minute IEX snapshot). | No |
+| `sip` | Consolidated SIP tape (full NBBO coverage). | **Yes** |
+
+### Required Environment Variables
+
+Regardless of feed selection the following variables must be present at
+startup:
+
+* `ALPACA_API_KEY`
+* `ALPACA_SECRET_KEY`
+* `DATA_FEED_INTRADAY`
+
+When `DATA_FEED_INTRADAY=sip`, Alpaca must confirm SIP access via one of:
+
+* `ALPACA_ALLOW_SIP=1`
+* `ALPACA_HAS_SIP=1`
+
+If neither flag is set the service now fails fast with an actionable error so
+operators can request entitlements before launch.
+
+### Optional Overrides
+
+* `ALPACA_FEED_FAILOVER` — Comma-separated backup order for Alpaca data feeds.
+* `AI_TRADING_HALT_FLAG_PATH` — Override the default `halt.flag` location used
+  by provider safe-mode.
+
+### Validation Checklist
+
+1. Export the required variables in the deployment environment.
+2. Run `pip show alpaca-trade-api` to confirm runtime pins `3.2.0`.
+3. Start the service and watch for
+   `TRADING_PARAMS_VALIDATED`/`DATA_PROVIDER_READY` logs.
+4. For SIP, call `alpaca-proxy/data/v2/stocks/AAPL/bars` with the deployment
+   credentials to verify the consolidated feed before enabling live trading.

--- a/tests/core/bot_engine/test_safe_mode.py
+++ b/tests/core/bot_engine/test_safe_mode.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import types
+
+import ai_trading.core.bot_engine as bot_engine
+
+
+def test_enter_long_blocks_when_primary_provider_disabled(monkeypatch):
+    monkeypatch.setattr(
+        bot_engine.data_fetcher_module,
+        "is_primary_provider_enabled",
+        lambda: False,
+        raising=False,
+    )
+    state = types.SimpleNamespace(degraded_providers=set())
+    ctx = types.SimpleNamespace()
+    blocked = bot_engine._enter_long(
+        ctx,
+        state,
+        "AAPL",
+        1000.0,
+        object(),
+        1.0,
+        0.8,
+        "test",
+    )
+    assert blocked is True
+
+
+def test_enter_long_blocks_when_safe_mode_active(monkeypatch):
+    monkeypatch.setattr(
+        bot_engine.data_fetcher_module,
+        "is_primary_provider_enabled",
+        lambda: True,
+        raising=False,
+    )
+    monkeypatch.setattr(bot_engine, "is_safe_mode_active", lambda: True)
+    monkeypatch.setattr(bot_engine, "safe_mode_reason", lambda: "provider_safe_mode")
+    state = types.SimpleNamespace(degraded_providers=set())
+    ctx = types.SimpleNamespace()
+    blocked = bot_engine._enter_long(
+        ctx,
+        state,
+        "AAPL",
+        1000.0,
+        object(),
+        1.0,
+        0.8,
+        "test",
+    )
+    assert blocked is True
+
+
+def test_should_skip_order_for_fallback_price(monkeypatch):
+    state = types.SimpleNamespace(auth_skipped_symbols=set())
+    assert bot_engine._should_skip_order_for_alpaca_unavailable(state, "AAPL", "yahoo")

--- a/tests/data/test_provider_monitor_safe_mode.py
+++ b/tests/data/test_provider_monitor_safe_mode.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+
+import ai_trading.data.provider_monitor as pm
+from ai_trading.monitoring.alerts import AlertType, AlertSeverity
+
+
+class _DummyAlerts:
+    def __init__(self) -> None:
+        self.events: list[tuple[AlertType, AlertSeverity, str, dict | None]] = []
+
+    def create_alert(
+        self,
+        alert_type: AlertType,
+        severity: AlertSeverity,
+        message: str,
+        *,
+        metadata: dict | None = None,
+    ) -> None:
+        self.events.append((alert_type, severity, message, metadata))
+
+
+@pytest.mark.parametrize(
+    ("record_name", "expected_reason"),
+    [
+        ("record_unauthorized_sip_event", "unauthorized_sip"),
+        ("record_minute_gap_event", "minute_gap"),
+    ],
+)
+def test_provider_monitor_safe_mode_triggers_and_resets(
+    tmp_path, monkeypatch, record_name: str, expected_reason: str
+) -> None:
+    dummy_alerts = _DummyAlerts()
+    monitor = pm.ProviderMonitor(alert_manager=dummy_alerts, cooldown=1, threshold=3)
+    disable_calls: list[tuple[str, float]] = []
+
+    def _capture(provider: str, duration) -> None:
+        seconds = float(duration.total_seconds()) if duration else 0.0
+        disable_calls.append((provider, seconds))
+
+    monitor.register_disable_callback("alpaca", lambda duration: _capture("alpaca", duration))
+    monitor.register_disable_callback(
+        "alpaca_sip", lambda duration: _capture("alpaca_sip", duration)
+    )
+    monkeypatch.setattr(pm, "provider_monitor", monitor)
+    monkeypatch.setattr(pm, "_sip_auth_events", deque(), raising=False)
+    monkeypatch.setattr(pm, "_gap_events", deque(), raising=False)
+    monkeypatch.setattr(pm, "_SAFE_MODE_ACTIVE", False, raising=False)
+    monkeypatch.setattr(pm, "_SAFE_MODE_REASON", None, raising=False)
+    monkeypatch.setattr(pm, "_last_halt_reason", None, raising=False)
+    monkeypatch.setattr(pm, "_last_halt_ts", 0.0, raising=False)
+    monkeypatch.setattr(pm, "_HALT_SUPPRESS_SECONDS", 0.0, raising=False)
+
+    halt_path = tmp_path / "halt.flag"
+    monkeypatch.setattr(
+        pm,
+        "get_settings",
+        lambda: SimpleNamespace(halt_flag_path=str(halt_path)),
+    )
+
+    record_func = getattr(pm, record_name)
+    for _ in range(3):
+        record_func({"symbol": "AAPL"})
+
+    assert halt_path.exists()
+    assert pm.is_safe_mode_active() is True
+    assert pm.safe_mode_reason() == expected_reason
+    assert any(event[0] == AlertType.PROVIDER_OUTAGE for event in dummy_alerts.events)
+    providers = {name for name, _ in disable_calls}
+    assert {"alpaca", "alpaca_sip"}.issubset(providers)
+    assert monitor.is_disabled("alpaca") is True
+
+    monitor.record_success("alpaca")
+    assert pm.is_safe_mode_active() is False


### PR DESCRIPTION
## Title
Enforce Alpaca safe mode on provider outages

## Context
Alpaca SIP entitlement gaps and degraded minute coverage were not halting the trading loop. Operations needs explicit guardrails so the bot fails fast when SIP access is misconfigured and enters an operator-visible safe mode during repeated feed failures.

## Problem
* `DATA_FEED_INTRADAY=sip` accepted misconfigured environments, hiding missing entitlement keys.
* Provider monitor logged repeated `UNAUTHORIZED_SIP` / `MINUTE_GAPS_*` events but never escalated or halted trading.
* The core engine continued to generate signals and submit orders using fallback quotes, risking decisions on stale data.
* Execution paths lacked a final guard to block orders while the feed was degraded.
* Docs did not explain the required SIP keys or the operational halt workflow.

## Scope
* Runtime SIP entitlement validation.
* Provider monitor safe-mode triggers, halt flag management, and disable escalation.
* Core trading engine data gating and safe-mode blocks.
* Execution layer halt guardrails.
* Fetch pipeline integrations for event recording.
* Alert type extension and documentation updates.
* Regression tests for provider halt/resume and core safe-mode behavior.

## Acceptance Criteria
* Startup fails fast with actionable guidance when SIP is selected without entitlement keys.
* Repeated SIP auth or minute-gap issues raise a critical outage alert, write the halt flag, disable Alpaca, and mark safe mode active.
* Core trading loop skips signal evaluation and order placement whenever the primary provider is disabled or safe mode is active; fallback-priced quotes are rejected.
* Execution guard blocks submissions whenever safe mode or the halt flag is active.
* Regression tests cover provider halt/resume and core safe-mode blocking.
* Docs describe SIP env requirements and the outage playbook.

## Changes
* Hardened SIP startup validation with explicit env key guidance and doc link.
* Added provider-monitor safe-mode state, halt flag writer, outage alerts, disable escalation, and reset on recovery; exposed helper APIs.
* Hooked Alpaca fetch fallbacks and tolerated gap logs into safe-mode event tracking.
* Updated core bot engine to consult safe-mode helpers, block fallback quotes, and respect halt state in trade logic.
* Added execution-layer `_safe_mode_guard` to block submissions when halt or provider degradation is active.
* Extended `AlertType` with `PROVIDER_OUTAGE` for structured alerting.
* Documented deployment feed matrix and outage response procedures.
* Added targeted regression tests for provider halt handling and core safe-mode blocking.

## Validation
* `pip install -r requirements.txt`
* `python -m py_compile $(git ls-files '*.py')`
* `ruff check`
* `mypy ai_trading`
* `pytest -q tests/data/test_provider_monitor_safe_mode.py`
* `pytest -q tests/core/bot_engine/test_safe_mode.py`
* (Full `pytest -q` produces numerous pre-existing failures across unrelated suites; ran targeted tests instead.)

## Risk
Medium – aggressive safe-mode triggers could halt trading on noisy incidents. Thresholds and cooldowns can be tuned, and operators can clear the halt flag once service health is restored.

------
https://chatgpt.com/codex/tasks/task_e_68e43ebb45c483309c0571c9634891a9