### PR TITLE
Decouple SIP lockout from IEX order flow

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -79,6 +79,11 @@ startup the validation result is cached and `/healthz` reuses it, returning
 
 \* `sip` is honoured only when the account has SIP access (`ALPACA_ALLOW_SIP=1`).
 
+#### SIP authorization flags
+
+- Set `DATA_FEED_INTRADAY=sip` **only** when the account is entitled for SIP. Startup fails fast with a clear error if neither `ALPACA_ALLOW_SIP` nor `ALPACA_HAS_SIP` is true.
+- When operating in `DATA_FEED_INTRADAY=iex`, `ALPACA_SIP_UNAUTHORIZED=1` simply disables SIP fallbacks; it no longer triggers safe-mode or blocks order routing.
+
 ### Persistent directories
 
 The service writes state, cache, logs, models, and run outputs to paths governed by the environment variables `AI_TRADING_DATA_DIR`, `AI_TRADING_CACHE_DIR`, `AI_TRADING_LOG_DIR`, `AI_TRADING_MODELS_DIR`, and `AI_TRADING_OUTPUT_DIR`.

--- a/ai_trading/config/runtime.py
+++ b/ai_trading/config/runtime.py
@@ -1624,7 +1624,8 @@ class TradingConfig:
             and not values.get("alpaca_has_sip")
         ):
             raise ValueError(
-                "DATA_FEED_INTRADAY=sip requires ALPACA_ALLOW_SIP=1 or ALPACA_HAS_SIP=1"
+                "DATA_FEED_INTRADAY=sip requires ALPACA_ALLOW_SIP=1 or ALPACA_HAS_SIP=1. "
+                "See DEPLOYING.md#alpaca-intraday-feed for entitlement setup."
             )
 
         # Derived convenience fields expected by legacy callers.

--- a/tests/config/test_sip_fast_fail.py
+++ b/tests/config/test_sip_fast_fail.py
@@ -1,0 +1,18 @@
+import importlib
+
+import pytest
+
+
+def test_sip_requires_entitlement(monkeypatch):
+    monkeypatch.delenv("ALPACA_ALLOW_SIP", raising=False)
+    monkeypatch.delenv("ALPACA_HAS_SIP", raising=False)
+    monkeypatch.setenv("DATA_FEED_INTRADAY", "sip")
+
+    runtime = importlib.import_module("ai_trading.config.runtime")
+
+    with pytest.raises(ValueError) as excinfo:
+        runtime.TradingConfig.from_env(allow_missing_drawdown=True)
+
+    message = str(excinfo.value)
+    assert "DATA_FEED_INTRADAY=sip" in message
+    assert "DEPLOYING.md#alpaca-intraday-feed" in message

--- a/tests/data/test_fetch_feed_modes.py
+++ b/tests/data/test_fetch_feed_modes.py
@@ -1,0 +1,26 @@
+import importlib
+
+import ai_trading.core.bot_engine as bot_engine_module
+import ai_trading.data.fetch as fetch_module
+
+
+def test_iex_ignores_sip_unauthorized(monkeypatch):
+    with monkeypatch.context() as patch:
+        patch.delenv("PYTEST_RUNNING", raising=False)
+        patch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        patch.delenv("ALPACA_DATA_FEED", raising=False)
+        patch.delenv("ALPACA_FEED_FAILOVER", raising=False)
+        patch.delenv("ALPACA_ALLOW_SIP", raising=False)
+        patch.delenv("ALPACA_HAS_SIP", raising=False)
+        patch.setenv("DATA_FEED_INTRADAY", "iex")
+        patch.setenv("ALPACA_SIP_UNAUTHORIZED", "1")
+
+        fetch = importlib.reload(fetch_module)
+        bot_engine = importlib.reload(bot_engine_module)
+
+        assert fetch._sip_lock_relevant() is False
+        assert fetch.is_primary_provider_enabled() is True
+        assert bot_engine._sip_lockout_active() is False
+
+    importlib.reload(fetch_module)
+    importlib.reload(bot_engine_module)


### PR DESCRIPTION
### Title
Decouple SIP lockout from IEX order flow

### Context
- Running with `DATA_FEED_INTRADAY=iex` while `ALPACA_SIP_UNAUTHORIZED=1` should not trigger provider cooldowns or safe-mode, but the existing logic tied SIP lockouts directly to the primary provider health checks.
- Safe-mode gating in the bot engine and runtime validation still need to enforce SIP entitlements when SIP is the selected feed.

### Problem
- SIP authorization failures were treated as primary-provider degradation regardless of the active feed, causing IEX sessions to enter fallback/safe-mode and suppress orders.

### Scope
- Restrict SIP lockout handling in the Alpaca fetcher, provider gating, and runtime validation so that IEX data flow remains healthy when SIP is unavailable, while preserving fail-fast behaviour for SIP mode.
- Document the intended behaviour and add regression tests.

### Acceptance Criteria
- IEX mode ignores `ALPACA_SIP_UNAUTHORIZED` for provider health and safe-mode decisions.
- SIP mode without entitlements fails fast with actionable messaging.
- Regression tests cover both scenarios.

### Changes
- Added `_active_intraday_feed`/`_sip_lock_relevant` helpers in `ai_trading.data.fetch` to gate SIP lockouts and updated rate-limit/disable paths to respect the active feed.
- Updated `_sip_lockout_active` in `ai_trading.core.bot_engine` to ignore SIP lockouts when the primary intraday feed is not SIP.
- Clarified the runtime configuration error message and deployment guide regarding SIP entitlements.
- Introduced tests for the IEX + SIP-lock scenario and SIP entitlement validation.

### Validation
- `pip install -r requirements.txt`
- `pytest -q tests/data/test_fetch_feed_modes.py`
- `pytest -q tests/config/test_sip_fast_fail.py`
- `PYTEST_ADDOPTS=--maxfail=1 pytest -q` *(fails at existing Finnhub fallback smoke test; manual rerun of the test alone passes)*
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check ai_trading/data/fetch/__init__.py ai_trading/core/bot_engine.py ai_trading/config/runtime.py tests/data/test_fetch_feed_modes.py tests/config/test_sip_fast_fail.py`
- `mypy ai_trading/data/fetch/__init__.py ai_trading/core/bot_engine.py ai_trading/config/runtime.py`

### Risk
- Low; changes constrain SIP lockout handling to SIP mode. If other code relies on cross-feed SIP state, additional adjustments may be needed, but regression tests exercise the critical paths.

------
https://chatgpt.com/codex/tasks/task_e_68e441476dc08330bc152733ff5dba05