### PR TITLE
Decouple SIP auth from IEX flow

### DIFF
--- a/docs/DEPLOYING.md
+++ b/docs/DEPLOYING.md
@@ -33,6 +33,13 @@ operators can request entitlements before launch.
 * `AI_TRADING_HALT_FLAG_PATH` — Override the default `halt.flag` location used
   by provider safe-mode.
 
+### Troubleshooting SIP flags
+
+`ALPACA_SIP_UNAUTHORIZED=1` only disables the SIP path when
+`DATA_FEED_INTRADAY=sip`. Deployments running with `DATA_FEED_INTRADAY=iex`
+ignore this flag so primary IEX orders continue flowing. Clear the flag once
+SIP entitlements are restored before switching the intraday feed to `sip`.
+
 ### Validation Checklist
 
 1. Export the required variables in the deployment environment.

--- a/tests/config/test_sip_fast_fail.py
+++ b/tests/config/test_sip_fast_fail.py
@@ -1,0 +1,16 @@
+import pytest
+
+from ai_trading.config import runtime
+
+
+def test_sip_requires_entitlement(monkeypatch) -> None:
+    monkeypatch.setenv("DATA_FEED_INTRADAY", "sip")
+    monkeypatch.delenv("ALPACA_ALLOW_SIP", raising=False)
+    monkeypatch.delenv("ALPACA_HAS_SIP", raising=False)
+    monkeypatch.setenv("MAX_DRAWDOWN_THRESHOLD", "0.1")
+    runtime.get_trading_config.cache_clear()
+
+    with pytest.raises(ValueError) as excinfo:
+        runtime.TradingConfig.from_env(allow_missing_drawdown=True)
+
+    assert "DATA_FEED_INTRADAY=sip" in str(excinfo.value)

--- a/tests/data/test_fetch_feed_modes.py
+++ b/tests/data/test_fetch_feed_modes.py
@@ -1,0 +1,36 @@
+from collections import deque
+
+from ai_trading.data import fetch as data_fetcher
+from ai_trading.data import provider_monitor as pm
+
+
+def test_iex_ignores_sip_unauthorized(monkeypatch) -> None:
+    monitor = pm.ProviderMonitor()
+    monkeypatch.setattr(pm, "provider_monitor", monitor)
+    monkeypatch.setattr(data_fetcher, "provider_monitor", monitor)
+    monkeypatch.setattr(pm, "_SAFE_MODE_ACTIVE", False, raising=False)
+    monkeypatch.setattr(pm, "_SAFE_MODE_REASON", None, raising=False)
+    monkeypatch.setattr(pm, "_sip_auth_events", deque(), raising=False)
+
+    monkeypatch.setenv("DATA_FEED_INTRADAY", "iex")
+    monkeypatch.setenv("ALPACA_ALLOW_SIP", "1")
+    monkeypatch.setenv("ALPACA_SIP_UNAUTHORIZED", "1")
+    monkeypatch.setattr(data_fetcher, "_ALLOW_SIP", True, raising=False)
+    monkeypatch.setattr(data_fetcher, "_SIP_PRECHECK_DONE", False, raising=False)
+    monkeypatch.setattr(data_fetcher, "_SIP_DISALLOWED_WARNED", False, raising=False)
+    monkeypatch.setattr(data_fetcher, "_SIP_UNAUTHORIZED", True, raising=False)
+    monkeypatch.setattr(data_fetcher, "_SIP_UNAUTHORIZED_UNTIL", None, raising=False)
+    monkeypatch.setattr(data_fetcher, "_alpaca_disabled_until", None, raising=False)
+
+    class _DummyResponse:
+        status_code = 401
+
+    class _DummySession:
+        def get(self, *args, **kwargs):
+            return _DummyResponse()
+
+    allowed = data_fetcher._sip_fallback_allowed(_DummySession(), {}, "1Min")
+    assert allowed is False
+    assert "alpaca" not in monitor.fail_counts
+    assert data_fetcher.is_primary_provider_enabled() is True
+    assert pm.is_safe_mode_active() is False

--- a/tests/data/test_get_minute_df_fetch_logging.py
+++ b/tests/data/test_get_minute_df_fetch_logging.py
@@ -72,6 +72,7 @@ def test_sip_unauthorized_branch_annotates_backup(monkeypatch, caplog):
         "get_settings",
         lambda: types.SimpleNamespace(backup_data_provider="yahoo"),
     )
+    monkeypatch.setenv("DATA_FEED_INTRADAY", "sip")
 
     with caplog.at_level(logging.INFO):
         result = data_fetcher.get_minute_df("AAPL", start, end, feed="sip")

--- a/tests/data/test_provider_monitor_safe_mode.py
+++ b/tests/data/test_provider_monitor_safe_mode.py
@@ -63,6 +63,10 @@ def test_provider_monitor_safe_mode_triggers_and_resets(
     )
 
     record_func = getattr(pm, record_name)
+    if record_name == "record_unauthorized_sip_event":
+        monkeypatch.setenv("DATA_FEED_INTRADAY", "sip")
+    else:
+        monkeypatch.delenv("DATA_FEED_INTRADAY", raising=False)
     for _ in range(3):
         record_func({"symbol": "AAPL"})
 

--- a/tests/data/test_provider_switchover.py
+++ b/tests/data/test_provider_switchover.py
@@ -26,6 +26,7 @@ def test_missing_alpaca_warning_suppressed_for_backup_provider(monkeypatch):
 def test_missing_alpaca_warning_suppressed_when_sip_locked(monkeypatch):
     _reset_emit_once(monkeypatch)
     monkeypatch.setenv("ALPACA_SIP_UNAUTHORIZED", "1")
+    monkeypatch.setenv("DATA_FEED_INTRADAY", "sip")
     monkeypatch.setattr(fetch, "_is_sip_unauthorized", lambda: True)
     monkeypatch.setattr(fetch, "get_settings", lambda: SimpleNamespace(data_provider="alpaca"))
     monkeypatch.setattr(fetch, "get_data_feed_override", lambda: None)


### PR DESCRIPTION
# Title
Decouple SIP authorization from IEX flow; gate safe-mode to SIP feed

# Context
SIP entitlement flags were muting IEX data collection and triggering provider safe mode, blocking order flow when running with `DATA_FEED_INTRADAY=iex`.

# Problem
`ALPACA_SIP_UNAUTHORIZED=1` and related lock-outs were treated as global Alpaca outages. Even in IEX mode this disabled the primary provider, raised safe-mode halts, and prevented orders.

# Scope
- Runtime fetch path for Alpaca minute data
- Provider monitor safe-mode logic
- Associated regression tests and docs

# Acceptance Criteria
- SIP lock-outs no longer disable IEX or trigger safe-mode when `DATA_FEED_INTRADAY=iex`
- SIP mode continues to fail fast without entitlements
- Tests cover IEX/SIP separation and SIP fail-fast behaviour

# Changes
- Added helpers to resolve the active intraday feed and limited SIP-derived disablement/metrics to SIP mode only
- Prevented provider monitor from recording SIP auth failures when SIP is not the active feed
- Logged SIP unavailability explicitly during fallback and adjusted warning context logic to ignore SIP locks in IEX mode
- Updated SIP-related tests to configure feed context and added new regression tests plus documentation note on flag behaviour

# Validation
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/data/test_fetch_feed_modes.py tests/config/test_sip_fast_fail.py`
- `pytest -q tests/data/test_provider_monitor_safe_mode.py`
- `pytest -q tests/data/test_get_minute_df_fetch_logging.py`
- `pytest -q tests/data`
- `ruff check .`
- `mypy ai_trading`
- Full `pytest -q` hits widespread existing failures (see commit log)

# Risk
Medium – adjusts provider gating logic; mitigated with focused tests and documentation.

------
https://chatgpt.com/codex/tasks/task_e_68e4454362e883309afd43b79431e85f