### PR TITLE
Harden per-host concurrency limiter and subprocess timeout handling

### DIFF
--- a/tests/utils/test_safe_subprocess_run.py
+++ b/tests/utils/test_safe_subprocess_run.py
@@ -63,35 +63,14 @@ def test_safe_subprocess_run_nonzero_exit(caplog):
 
 
 def test_safe_subprocess_run_timeout_without_captured_output(monkeypatch, caplog):
-    calls: dict[str, object] = {"communicate_calls": [], "wait_calls": []}
+    captured: dict[str, object] = {}
 
-    class FakeProc:
-        def __init__(self, *args, **kwargs):
-            calls["args"] = args
-            calls["kwargs"] = kwargs
-            self._killed = False
-            self.returncode = None
-            calls["instance"] = self
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout"))
 
-        def communicate(self, timeout=None):
-            calls["communicate_calls"].append(timeout)
-            if timeout is not None and not self._killed:
-                raise subprocess.TimeoutExpired(cmd=calls["args"][0], timeout=timeout)
-            self.returncode = 124
-            return "", ""
-
-        def kill(self):
-            self._killed = True
-            calls["killed"] = True
-
-        def wait(self, timeout=None):
-            calls["wait_calls"].append(timeout)
-            if timeout == 0:
-                raise subprocess.TimeoutExpired(cmd=calls["args"][0], timeout=timeout)
-            self.returncode = 124
-            return 124
-
-    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.Popen", FakeProc)
+    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.run", fake_run)
 
     with caplog.at_level("WARNING"):
         with pytest.raises(subprocess.TimeoutExpired) as excinfo:
@@ -106,50 +85,25 @@ def test_safe_subprocess_run_timeout_without_captured_output(monkeypatch, caplog
     assert excinfo.value.stderr == ""
     assert excinfo.value.result.stdout == excinfo.value.stdout
     assert excinfo.value.result.stderr == excinfo.value.stderr
-    assert calls["args"] == (["dummy"],)
-    assert calls["kwargs"]["stdout"] == subprocess.PIPE
-    assert calls["kwargs"]["stderr"] == subprocess.PIPE
-    assert calls["kwargs"]["text"] is True
-    assert calls.get("killed") is True
-    assert calls["instance"]._killed is True
-    assert calls["communicate_calls"] == [0.25, 0]
-    assert calls["wait_calls"] == [0.25]
+    assert captured["args"] == (["dummy"],)
+    assert captured["kwargs"]["stdout"] == subprocess.PIPE
+    assert captured["kwargs"]["stderr"] == subprocess.PIPE
+    assert captured["kwargs"]["text"] is True
+    assert captured["kwargs"]["timeout"] == 0.25
     assert not caplog.records
 
 
 def test_safe_subprocess_run_timeout_with_captured_output(monkeypatch):
-    state: dict[str, object] = {"communicate_calls": [], "wait_calls": []}
+    captured: dict[str, object] = {}
 
-    class FakeProc:
-        def __init__(self, *args, **kwargs):
-            self.returncode = None
-            self._killed = False
-            self.args = args
-            state["instance"] = self
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        raise subprocess.TimeoutExpired(
+            cmd=args[0], timeout=kwargs.get("timeout"), output="partial stdout", stderr="partial stderr"
+        )
 
-        def communicate(self, timeout=None):
-            state.setdefault("communicate_calls", []).append(timeout)
-            if timeout is not None and not self._killed:
-                raise subprocess.TimeoutExpired(
-                    cmd=self.args[0],
-                    timeout=timeout,
-                    output="partial stdout",
-                    stderr="partial stderr",
-                )
-            self.returncode = 124
-            return "partial stdout", "partial stderr"
-
-        def kill(self):
-            self._killed = True
-
-        def wait(self, timeout=None):
-            state.setdefault("wait_calls", []).append(timeout)
-            if timeout == 0:
-                raise subprocess.TimeoutExpired(cmd=self.args[0], timeout=timeout)
-            self.returncode = 124
-            return 124
-
-    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.Popen", FakeProc)
+    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.run", fake_run)
 
     with pytest.raises(subprocess.TimeoutExpired) as excinfo:
         safe_subprocess_run(["dummy"], timeout=0.25)
@@ -164,51 +118,24 @@ def test_safe_subprocess_run_timeout_with_captured_output(monkeypatch):
     assert excinfo.value.result.stdout == excinfo.value.stdout
     assert excinfo.value.result.stderr == excinfo.value.stderr
     assert isinstance(excinfo.value.result, SafeSubprocessResult)
-    assert state["instance"]._killed is True
-    assert state["communicate_calls"] == [0.25, 0]
-    assert state["wait_calls"] == [0.25]
+    assert captured["kwargs"]["timeout"] == 0.25
 
 
 def test_safe_subprocess_run_timeout_attaches_result_bytes(monkeypatch):
-    state: dict[str, object] = {"communicate_calls": [], "wait_calls": []}
+    captured: dict[str, object] = {}
 
-    class FakeProc:
-        def __init__(self, *args, **kwargs):
-            state["init_args"] = args
-            state["init_kwargs"] = kwargs
-            self._killed = False
-            self.returncode = None
-            state["instance"] = self
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        raise subprocess.TimeoutExpired(
+            cmd=["dummy"], timeout=kwargs.get("timeout"), output=b"late stdout", stderr=b"late stderr"
+        )
 
-        def communicate(self, timeout=None):
-            state["communicate_calls"].append(timeout)
-            if timeout is not None and not self._killed:
-                raise subprocess.TimeoutExpired(
-                    cmd=["dummy"],
-                    timeout=timeout,
-                    output=b"late stdout",
-                    stderr=b"late stderr",
-                )
-            self.returncode = 124
-            return b"late stdout", b"late stderr"
-
-        def kill(self):
-            self._killed = True
-
-        def wait(self, timeout=None):
-            state.setdefault("wait_calls", []).append(timeout)
-            if timeout == 0:
-                raise subprocess.TimeoutExpired(cmd=["dummy"], timeout=timeout)
-            self.returncode = 124
-            return 124
-
-    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.Popen", FakeProc)
+    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.run", fake_run)
 
     with pytest.raises(subprocess.TimeoutExpired) as excinfo:
-        safe_subprocess_run(["dummy"], timeout=0.1)
+        safe_subprocess_run(["dummy"], timeout=0.25)
 
-    assert state["communicate_calls"] == [0.1, 0]
-    assert state["wait_calls"] == [0.1]
     result = excinfo.value.result
     assert isinstance(result, SafeSubprocessResult)
     assert result.timeout is True
@@ -219,58 +146,29 @@ def test_safe_subprocess_run_timeout_attaches_result_bytes(monkeypatch):
     assert excinfo.value.stderr == "late stderr"
     assert excinfo.value.result.stdout == excinfo.value.stdout
     assert excinfo.value.result.stderr == excinfo.value.stderr
-    assert state["init_kwargs"]["stdout"] == subprocess.PIPE
-    assert state["init_kwargs"]["stderr"] == subprocess.PIPE
-    assert state["init_kwargs"]["text"] is True
-    assert state["instance"]._killed is True
+    assert captured["kwargs"]["timeout"] == 0.25
 
 
 def test_safe_subprocess_run_timeout_cleanup_timeout(monkeypatch, caplog):
-    state: dict[str, object] = {"communicate_calls": [], "wait_calls": []}
+    captured: dict[str, object] = {}
 
-    class FakeProc:
-        def __init__(self, *args, **kwargs):
-            state["init_args"] = args
-            state["init_kwargs"] = kwargs
-            self._killed = False
-            self.returncode = None
-            state["instance"] = self
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        raise subprocess.TimeoutExpired(
+            cmd=["dummy"],
+            timeout=kwargs.get("timeout"),
+            output="after kill stdout",
+            stderr="after kill stderr",
+        )
 
-        def communicate(self, timeout=None):
-            state["communicate_calls"].append(timeout)
-            if len(state["communicate_calls"]) == 1:
-                raise subprocess.TimeoutExpired(
-                    cmd=["dummy"],
-                    timeout=timeout,
-                    output="",
-                    stderr="",
-                )
-            raise subprocess.TimeoutExpired(
-                cmd=["dummy"],
-                timeout=timeout,
-                output="after kill stdout",
-                stderr="after kill stderr",
-            )
-
-        def kill(self):
-            self._killed = True
-            state["killed"] = True
-
-        def wait(self, timeout=None):
-            state.setdefault("wait_calls", []).append(timeout)
-            self.returncode = 124
-            return 124
-
-    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.Popen", FakeProc)
+    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.run", fake_run)
 
     with caplog.at_level("WARNING"):
         with pytest.raises(subprocess.TimeoutExpired) as excinfo:
             safe_subprocess_run(["dummy"], timeout=0.2)
 
     assert not caplog.records
-    assert state["communicate_calls"] == [0.2, 0]
-    assert state["wait_calls"] == [0.2]
-    assert state.get("killed") is True
 
     result = excinfo.value.result
     assert isinstance(result, SafeSubprocessResult)
@@ -278,52 +176,26 @@ def test_safe_subprocess_run_timeout_cleanup_timeout(monkeypatch, caplog):
     assert result.returncode == 124
     assert result.stdout == "after kill stdout"
     assert result.stderr == "after kill stderr"
+    assert excinfo.value.timeout == pytest.approx(0.2)
     assert excinfo.value.stdout == "after kill stdout"
     assert excinfo.value.stderr == "after kill stderr"
     assert excinfo.value.result.stdout == excinfo.value.stdout
     assert excinfo.value.result.stderr == excinfo.value.stderr
-    assert state["init_kwargs"]["stdout"] == subprocess.PIPE
-    assert state["init_kwargs"]["stderr"] == subprocess.PIPE
-    assert state["init_kwargs"]["text"] is True
+    assert captured["kwargs"]["timeout"] == 0.2
 
 
 def test_safe_subprocess_run_timeout_populates_result_and_returncode(monkeypatch):
-    state: dict[str, object] = {"communicate_calls": [], "wait_calls": []}
+    captured: dict[str, object] = {}
 
-    class FakeProc:
-        def __init__(self, *args, **kwargs):
-            state["init_args"] = args
-            state["init_kwargs"] = kwargs
-            self.returncode = None
-            self._killed = False
-            state["instance"] = self
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        raise subprocess.TimeoutExpired(cmd=["dummy"], timeout=kwargs.get("timeout"))
 
-        def communicate(self, timeout=None):
-            state["communicate_calls"].append(timeout)
-            if timeout is not None and not self._killed:
-                raise subprocess.TimeoutExpired(cmd=["dummy"], timeout=timeout)
-            return "", ""
-
-        def kill(self):
-            self._killed = True
-
-        def wait(self, timeout=None):
-            state.setdefault("wait_calls", []).append(timeout)
-            if timeout == 0:
-                raise subprocess.TimeoutExpired(cmd=["dummy"], timeout=timeout)
-            self.returncode = 124
-            return 124
-
-    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.Popen", FakeProc)
+    monkeypatch.setattr("ai_trading.utils.safe_subprocess.subprocess.run", fake_run)
 
     with pytest.raises(subprocess.TimeoutExpired) as excinfo:
         safe_subprocess_run(["dummy"], timeout=0.3)
-
-    assert state["communicate_calls"] == [0.3, 0]
-    assert state["wait_calls"] == [0.3]
-    proc_instance = state["instance"]
-    assert proc_instance._killed is True
-    assert proc_instance.returncode == 124
 
     result = excinfo.value.result
     assert isinstance(result, SafeSubprocessResult)
@@ -334,3 +206,4 @@ def test_safe_subprocess_run_timeout_populates_result_and_returncode(monkeypatch
     assert excinfo.value.timeout == pytest.approx(0.3)
     assert excinfo.value.result.stdout == excinfo.value.stdout
     assert excinfo.value.result.stderr == excinfo.value.stderr
+    assert captured["kwargs"]["timeout"] == 0.3


### PR DESCRIPTION
# Title
Harden per-host concurrency limiter and subprocess timeout handling

# Context
Per-host concurrency limits were occasionally exceeded when semaphores were over-released, and subprocess timeout handling swallowed `TimeoutExpired`, breaking caller expectations.

# Problem
* Async host semaphores allowed double-releases, causing xdist workers to crash under limit churn.
* `safe_subprocess_run` used `Popen`/`communicate` plumbing that suppressed native timeout exceptions, so the timeout test failed.

# Scope
Runtime concurrency limiter and subprocess helper modules, with focused unit tests validating timeout propagation.

# Acceptance Criteria
* `tests/test_http_host_limit.py::{test_host_limit_enforced,test_host_limit_updates_when_env_changes}` pass without worker crashes.
* `tests/data/test_fallback_concurrency.py::{test_run_with_concurrency_respects_limit_minimal,test_run_with_concurrency_peak_counter_respects_limit_minimal,test_run_with_concurrency_peak_counter_is_monotonic_across_runs}` pass.
* `tests/utils/test_safe_subprocess_run.py::test_safe_subprocess_run_timeout` raises `TimeoutExpired`.

# Changes
* Construct async host semaphores with `BoundedSemaphore` when available and guard acquisition/release tracking in `AsyncHostLimiter`.
* Simplify `safe_subprocess_run` to defer to `subprocess.run`, preserving native `TimeoutExpired` while still annotating timeout exceptions with metadata.
* Updated subprocess timeout tests to monkeypatch `subprocess.run`, covering scenarios with and without captured output.

# Validation
* `python -m py_compile $(git ls-files '*.py')`
* `ruff check`
* `mypy .`
* `pytest -q tests/utils/test_safe_subprocess_run.py::test_safe_subprocess_run_timeout`
* `pytest -q tests/test_http_host_limit.py::test_host_limit_enforced`
* `pytest -q tests/test_http_host_limit.py::test_host_limit_updates_when_env_changes`
* `pytest -q tests/data/test_fallback_concurrency.py::test_run_with_concurrency_respects_limit_minimal`
* `pytest -q tests/data/test_fallback_concurrency.py::test_run_with_concurrency_peak_counter_respects_limit_minimal`
* `pytest -q tests/data/test_fallback_concurrency.py::test_run_with_concurrency_peak_counter_is_monotonic_across_runs`
* `pytest -q` (fails due to unrelated pre-existing suite issues)

# Risk
Low; changes are localized to concurrency limiter mechanics and subprocess helper, and validated by targeted unit tests. Roll back by reverting commit 63d2427.


------
https://chatgpt.com/codex/tasks/task_e_68e48535969c83308a1f771f5947f88d