### PR TITLE
Fix SIP failover ordering and entitlement guards

### DIFF
--- a/ai_trading/data/fallback/concurrency.py
+++ b/ai_trading/data/fallback/concurrency.py
@@ -712,7 +712,11 @@ async def run_with_concurrency(
                 peak_this_run = active_workers
                 LAST_RUN_PEAK_SIMULTANEOUS_WORKERS = peak_this_run
                 if peak_this_run > PEAK_SIMULTANEOUS_WORKERS:
-                    PEAK_SIMULTANEOUS_WORKERS = peak_this_run
+                    try:
+                        current_peak = int(PEAK_SIMULTANEOUS_WORKERS)
+                    except (TypeError, ValueError):
+                        current_peak = 0
+                    PEAK_SIMULTANEOUS_WORKERS = max(current_peak, int(peak_this_run))
 
     async def _mark_worker_end(started: bool) -> None:
         nonlocal active_workers
@@ -778,7 +782,11 @@ async def run_with_concurrency(
             LAST_RUN_PEAK_SIMULTANEOUS_WORKERS, peak_this_run
         )
         if peak_this_run > PEAK_SIMULTANEOUS_WORKERS:
-            PEAK_SIMULTANEOUS_WORKERS = peak_this_run
+            try:
+                current_peak = int(PEAK_SIMULTANEOUS_WORKERS)
+            except (TypeError, ValueError):
+                current_peak = 0
+            PEAK_SIMULTANEOUS_WORKERS = max(current_peak, int(peak_this_run))
         raise
     for task, outcome in zip(tasks, outcomes):
         symbol = task_to_symbol.get(task)
@@ -790,7 +798,11 @@ async def run_with_concurrency(
 
     LAST_RUN_PEAK_SIMULTANEOUS_WORKERS = max(LAST_RUN_PEAK_SIMULTANEOUS_WORKERS, peak_this_run)
     if peak_this_run > PEAK_SIMULTANEOUS_WORKERS:
-        PEAK_SIMULTANEOUS_WORKERS = peak_this_run
+        try:
+            current_peak = int(PEAK_SIMULTANEOUS_WORKERS)
+        except (TypeError, ValueError):
+            current_peak = 0
+        PEAK_SIMULTANEOUS_WORKERS = max(current_peak, int(peak_this_run))
 
     return results, set(SUCCESSFUL_SYMBOLS), set(FAILED_SYMBOLS)
 

--- a/ai_trading/http/pooling.py
+++ b/ai_trading/http/pooling.py
@@ -483,10 +483,17 @@ def reload_host_limit_if_env_changed() -> HostLimitSnapshot:
 
     limit, version = _resolve_limit()
     cache = _LIMIT_CACHE
-    if cache is not None:
-        snapshot = HostLimitSnapshot(cache.limit, cache.version)
-    else:
-        snapshot = HostLimitSnapshot(limit, version)
+    if cache is None:
+        cache = _ResolvedLimitCache(
+            env_key=None,
+            raw_env=None,
+            limit=limit,
+            version=version,
+            config_id=None,
+            env_snapshot=env_snapshot,
+        )
+        _LIMIT_CACHE = cache
+    snapshot = HostLimitSnapshot(cache.limit, cache.version)
     _LAST_LIMIT_ENV_SNAPSHOT = env_snapshot
     _set_pooling_limit_state(snapshot.limit, snapshot.version)
     return snapshot


### PR DESCRIPTION
# Title
Fix SIP failover ordering and entitlement guards

# Context
Daily bar memoization and Alpaca fallback handling regressed, breaking the SIP-before-backup contract and host-limit accounting. Env-based entitlement toggles were also ignored, letting SIP slip through during disallow windows.

# Problem
- Daily memo hits still touched the disk cache, triggering strict cache test guards.
- IEX empty responses skipped SIP in no-session windows, causing extra HTTP calls and cache corruption.
- SIP override TTLs and entitlement env flags were ignored, and subprocess timeouts were silently swallowed.
- Host-limit hot reloads and fallback concurrency counters could regress on reload, tripping concurrency tests.

# Scope
- `ai_trading/core/bot_engine.py`
- `ai_trading/data/bars.py`
- `ai_trading/data/fetch/__init__.py`
- `ai_trading/data/fallback/concurrency.py`
- `ai_trading/http/pooling.py`
- `ai_trading/utils/safe_subprocess.py`

# Acceptance Criteria
- Daily fetch memo short-circuits without hitting the daily cache when fresh.
- IEX empty payloads always attempt SIP once before HTTP backup, even for no-session windows.
- SIP entitlement honors explicit `ALPACA_ALLOW_SIP`/`ALPACA_SIP_ENTITLED` false flags.
- Host-limit snapshots reload safely and concurrency peak counters remain monotonic.
- Subprocess helper raises `TimeoutExpired` at the configured timeout.
- Targeted unit suites covering the above behaviors pass.

# Changes
- Short-circuit daily memo reads before cache access in `DataFetcher.get_daily_df`.
- Gate SIP entitlement on explicit env disallow/unenitled flags, leaving advisory downgrades to existing logic.
- Force SIP-first handling for empty IEX windows, respect no-session short-circuits, and skip HTTP fallback for empty windows.
- Make fallback concurrency peak updates resilient to stale state and reload host-limit cache defensively.
- Propagate timeout kwargs through `safe_subprocess_run` and re-raise `TimeoutExpired` with captured streams.

# Validation
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/bot_engine/test_daily_fetch_debounce.py -q`
- `pytest tests/data/test_empty_responses.py::test_alpaca_empty_responses_trigger_backup -q`
- `pytest tests/test_feed_failover.py::test_cached_override_respects_ttl -q`
- `pytest tests/test_feed_failover.py::test_no_session_empty_payload_uses_sip_before_backup -q`
- `pytest tests/test_feed_entitlement.py -q`
- `pytest tests/utils/test_safe_subprocess_run.py::test_safe_subprocess_run_timeout -q`
- `pytest tests/test_http_host_limit.py -q`
- `pytest tests/data/test_fallback_concurrency.py -q`
- `ruff check ai_trading/core/bot_engine.py ai_trading/data/bars.py ai_trading/data/fallback/concurrency.py ai_trading/data/fetch/__init__.py ai_trading/http/pooling.py ai_trading/utils/safe_subprocess.py`
- `mypy ai_trading/core/bot_engine.py ai_trading/data/bars.py ai_trading/data/fallback/concurrency.py ai_trading/data/fetch/__init__.py ai_trading/http/pooling.py ai_trading/utils/safe_subprocess.py`
- `pytest -q` *(fails: suite still has numerous unrelated failures; command aborted after repeated errors)*

# Risk
Medium – touches core data fetching and concurrency logic. Targeted regression tests mitigate risk, but monitor production fallback metrics after deployment.

------
https://chatgpt.com/codex/tasks/task_e_68e499ef20888330af5d9346c7375136