### PR TITLE
Data feed hardening and paper safe-mode bypass

### DIFF
--- a/ai_trading/config/__init__.py
+++ b/ai_trading/config/__init__.py
@@ -152,6 +152,7 @@ EXECUTION_MODE = str(getattr(_CFG, "execution_mode", "sim") or "sim").lower()
 SHADOW_MODE = bool(getattr(_CFG, "shadow_mode", False))
 DATA_FEED_INTRADAY = _derive_intraday_feed()
 SLIPPAGE_LIMIT_BPS = int(getattr(_CFG, "slippage_limit_bps", getattr(_CFG, "max_slippage_bps", 75)))
+SAFE_MODE_ALLOW_PAPER = bool(getattr(_CFG, "safe_mode_allow_paper", False))
 PRICE_PROVIDER_ORDER = tuple(getattr(_CFG, "price_provider_order", (
     "alpaca_quote",
     "alpaca_trade",

--- a/ai_trading/config/runtime.py
+++ b/ai_trading/config/runtime.py
@@ -636,8 +636,15 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
         field="data_provider_priority",
         env=("DATA_PROVIDER_PRIORITY",),
         cast="tuple[str]",
-        default=("alpaca_iex", "alpaca_sip", "yahoo"),
+        default=("alpaca_iex", "yahoo"),
         description="Global fetch priority order for data providers.",
+    ),
+    ConfigSpec(
+        field="safe_mode_allow_paper",
+        env=("AI_TRADING_SAFE_MODE_ALLOW_PAPER",),
+        cast="bool",
+        default=False,
+        description="Allow paper execution to bypass provider safe-mode blocks.",
     ),
     ConfigSpec(
         field="max_data_fallbacks",

--- a/ai_trading/config/settings.py
+++ b/ai_trading/config/settings.py
@@ -42,7 +42,7 @@ def provider_priority(s: Settings | None = None) -> tuple[str, ...]:
     """Return configured data provider priority order."""
     s = s or get_settings()
     return tuple(getattr(s, 'data_provider_priority', ())) or (
-        'alpaca_iex', 'alpaca_sip', 'yahoo'
+        'alpaca_iex', 'yahoo'
     )
 
 def max_data_fallbacks(s: Settings | None = None) -> int:

--- a/ai_trading/data/provider_monitor.py
+++ b/ai_trading/data/provider_monitor.py
@@ -209,6 +209,13 @@ def _record_event(
     reason: str,
     metadata: Mapping[str, Any] | None = None,
 ) -> None:
+    if reason == "minute_gap" and metadata is not None:
+        provider_name = str(metadata.get("provider", "") or "").strip().lower()
+        residual_flag = metadata.get("residual_gap")
+        if provider_name == "yahoo":
+            return
+        if residual_flag is False:
+            return
     now = monotonic_time()
     bucket.append(now)
     cutoff = now - _HALT_EVENT_WINDOW_SECONDS

--- a/ai_trading/settings.py
+++ b/ai_trading/settings.py
@@ -275,7 +275,8 @@ class Settings(_ModelConfigCompatMixin, BaseSettings):
     alpaca_feed_failover: tuple[str, ...] = Field(("sip",), env="ALPACA_FEED_FAILOVER")
     alpaca_empty_to_backup: bool = Field(True, env="ALPACA_EMPTY_TO_BACKUP")
     alpaca_adjustment: Literal["all", "raw"] = Field("all", env="ALPACA_ADJUSTMENT")
-    data_provider_priority: tuple[str, ...] = Field(("alpaca_iex", "alpaca_sip", "yahoo"), env="DATA_PROVIDER_PRIORITY")
+    data_provider_priority: tuple[str, ...] = Field(("alpaca_iex", "yahoo"), env="DATA_PROVIDER_PRIORITY")
+    safe_mode_allow_paper: bool = Field(False, env="AI_TRADING_SAFE_MODE_ALLOW_PAPER")
     max_data_fallbacks: int = Field(2, env="MAX_DATA_FALLBACKS")
     minute_data_freshness_tolerance_seconds: int = Field(
         900,

--- a/tests/data/test_alpaca_key_warning.py
+++ b/tests/data/test_alpaca_key_warning.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+
+def test_missing_alpaca_warning_skipped_when_keys_present(monkeypatch):
+    from ai_trading.data import fetch as fetch_mod
+
+    settings = SimpleNamespace(
+        data_provider="alpaca",
+        alpaca_api_key="key",
+        alpaca_secret_key="secret",
+        alpaca_data_feed="iex",
+    )
+
+    monkeypatch.setattr(fetch_mod, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        fetch_mod,
+        "broker_keys",
+        lambda _: {"ALPACA_API_KEY": "key", "ALPACA_SECRET_KEY": "secret"},
+    )
+    monkeypatch.setattr(fetch_mod, "get_data_feed_override", lambda: None)
+    monkeypatch.setattr(fetch_mod, "resolve_alpaca_feed", lambda _: "iex")
+
+    should_warn, extra = fetch_mod._missing_alpaca_warning_context()
+
+    assert should_warn is False
+    assert "missing_keys" not in extra

--- a/tests/data/test_minute_coverage_tolerance.py
+++ b/tests/data/test_minute_coverage_tolerance.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+
+def test_repair_rth_minute_gaps_backfill_suppresses_safe_mode(monkeypatch):
+    pd = pytest.importorskip("pandas")
+
+    from ai_trading.data import fetch as fetch_mod
+
+    start = datetime(2024, 1, 2, 14, 30, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=3)
+    base_index = pd.date_range(start, periods=3, freq="min", tz="UTC")
+
+    df = pd.DataFrame(
+        {
+            "timestamp": [base_index[0].isoformat(), base_index[2].isoformat()],
+            "open": [100.0, 101.0],
+            "high": [100.5, 101.5],
+            "low": [99.5, 100.5],
+            "close": [100.2, 101.2],
+            "volume": [1000, 1200],
+        }
+    )
+    df.attrs["data_provider"] = "alpaca"
+
+    fallback_df = pd.DataFrame(
+        {
+            "timestamp": [base_index[1].isoformat()],
+            "open": [100.4],
+            "high": [100.6],
+            "low": [100.1],
+            "close": [100.5],
+            "volume": [1100],
+        }
+    )
+
+    events: list[dict] = []
+
+    monkeypatch.setattr(fetch_mod, "_safe_backup_get_bars", lambda *_, **__: fallback_df)
+    monkeypatch.setattr(fetch_mod, "record_minute_gap_event", lambda payload: events.append(payload))
+
+    repaired, metadata, used_backup = fetch_mod._repair_rth_minute_gaps(
+        df,
+        symbol="AAPL",
+        start=start,
+        end=end,
+        tz=ZoneInfo("America/New_York"),
+    )
+
+    assert used_backup is True
+    assert metadata["missing_after"] == 0
+    assert metadata["residual_gap"] is False
+    assert repaired is not None
+    assert len(repaired) == 3
+    assert events == []

--- a/tests/execution/test_paper_bypass.py
+++ b/tests/execution/test_paper_bypass.py
@@ -1,0 +1,12 @@
+def test_safe_mode_guard_allows_paper_bypass(monkeypatch):
+    import ai_trading.execution.live_trading as live
+
+    monkeypatch.delenv("AI_TRADING_HALT", raising=False)
+    monkeypatch.setattr(live, "is_safe_mode_active", lambda: True)
+    monkeypatch.setattr(live, "safe_mode_reason", lambda: "minute_gap")
+    monkeypatch.setattr(live.provider_monitor, "is_disabled", lambda provider: False)
+    monkeypatch.setattr(live, "_safe_mode_policy", lambda: (True, "paper"))
+
+    blocked = live._safe_mode_guard(symbol="AAPL", side="buy", quantity=5)
+
+    assert blocked is False


### PR DESCRIPTION
## Title
* Data feed hardening and paper safe-mode bypass

## Context
* Frequent SIP entitlement churn and false Alpaca credential alerts were forcing unnecessary fallback behaviour and blocking paper-mode execution.

## Problem
* SIP was still being scheduled when the environment explicitly forbade it, generating `ALPACA_FEED_UNENTITLED` noise.
* `_warn_missing_alpaca` emitted warnings even when valid keys were configured.
* Minute gap remediation still escalated safe-mode despite full backfills/tolerances.
* Paper mode orders were rejected by provider safe-mode, preventing test trades.

## Scope
* Tighten feed entitlement logic, credential detection, and provider safe-mode handling.
* Add configuration wiring and tests to cover the corrected behaviours.

## Acceptance Criteria
* SIP is skipped when priority/execution env disallows it.
* Missing Alpaca warnings only fire when keys are absent.
* Minute-gap safe-mode ignores fully remediated/tolerated windows.
* Paper-mode orders can bypass provider safe-mode when enabled by config.

## Changes
* Updated fetcher minute-gap remediation to record provider metadata, avoid safe-mode events when gaps are cleared, and only warn for genuinely missing keys.
* Adjusted provider monitor to drop non-residual Yahoo/tolerated minute-gap events.
* Reworked Alpaca feed entitlement to honour priority/env/SIP lockouts and default priority away from SIP.
* Added safe-mode policy helpers to honour a new `AI_TRADING_SAFE_MODE_ALLOW_PAPER` flag and ignore halt flags in simulation.
* Introduced regression tests for Alpaca credential warnings, minute-gap tolerance, and paper safe-mode bypass.

## Validation
* `pip install -r requirements.txt`
* `python -m py_compile $(git ls-files '*.py')`
* `pytest -q --maxfail=1` *(fails: external slippage/market data dependency)*
* `pytest tests/data/test_minute_coverage_tolerance.py tests/data/test_alpaca_key_warning.py tests/execution/test_paper_bypass.py -q`
* `ruff check ai_trading/data/fetch/__init__.py ai_trading/data/provider_monitor.py ai_trading/data/bars.py ai_trading/execution/live_trading.py tests/data/test_minute_coverage_tolerance.py tests/data/test_alpaca_key_warning.py tests/execution/test_paper_bypass.py`
* `mypy ai_trading/data/fetch/__init__.py ai_trading/data/provider_monitor.py ai_trading/data/bars.py ai_trading/execution/live_trading.py`

## Risk
* Low-medium: Alters feed selection and safe-mode gating; mitigated via targeted unit tests and config gating.

------
https://chatgpt.com/codex/tasks/task_e_68e5325475b8833093ae154342860a5e