### PR TITLE
Fix SIP entitlement preservation and Alpaca backoff fallback

### DIFF
--- a/ai_trading/data/fetch/backoff.py
+++ b/ai_trading/data/fetch/backoff.py
@@ -49,12 +49,20 @@ def _next_feed(cur_feed: str) -> str | None:
     try:
         idx = prio.index(f"alpaca_{cur_feed}")
     except ValueError:
-        return None
+        try:
+            limit = max_data_fallbacks()
+        except Exception:
+            limit = 1
+        if limit <= 0:
+            return None
+        fallback_map = {"iex": "sip", "sip": "iex"}
+        return fallback_map.get(cur_feed)
     limit = max_data_fallbacks()
     for prov in prio[idx + 1 : idx + 1 + limit]:
         if prov.startswith("alpaca_"):
             return prov.split("_", 1)[1]
-    return None
+    fallback_map = {"iex": "sip", "sip": "iex"}
+    return fallback_map.get(cur_feed)
 
 
 def _http_fallback(


### PR DESCRIPTION
## Context
- SIP entitlement handling was downgrading accounts that actually advertise SIP access.
- Alpaca empty-bar backoff skipped the alternate feed when provider priorities omitted explicit SIP entries.

## Problem
- `DataFetcher` users lost SIP access despite entitlement signals.
- Backoff retries fell through to Yahoo immediately, breaking the expected two-call retry path.

## Scope
- Adjust entitlement resolution logic.
- Ensure backoff prioritises the sibling Alpaca feed even when not listed in provider priorities.

## Acceptance Criteria
- SIP requests remain on SIP when entitlement or account flags indicate access.
- Backoff retry executes the alternate Alpaca feed before non-Alpaca providers.
- Targeted regression tests covering entitlement and backoff logic pass.

## Changes
- Normalised SIP entitlement evaluation in `ai_trading/data/bars.py` to trust account- and env-derived signals, prefer SIP when permitted, and only downgrade on explicit denials.
- Updated `_next_feed` in `ai_trading/data/fetch/backoff.py` to default to the sibling Alpaca feed when priorities lack explicit SIP entries, respecting fallback limits.

## Validation
- `pytest -q tests/bot_engine/test_daily_fetch_debounce.py::test_daily_fetch_memo_reuses_recent_result ... tests/data/test_fallback_concurrency.py::test_run_with_concurrency_peak_counter_is_monotonic_across_runs`
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check`
- `mypy .`
- Full `pytest -q` attempted; existing unrelated failures remain (see run log).

## Risk
- Low: changes are localised to entitlement selection and Alpaca fallback ordering with targeted regression coverage.


------
https://chatgpt.com/codex/tasks/task_e_68e576f5510c83308568b97e9cca361c