### PR TITLE
Fix daily memo bypass and Alpaca fallback semantics

### DIFF
--- a/ai_trading/data/fetch/fallback_concurrency.py
+++ b/ai_trading/data/fetch/fallback_concurrency.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+
+
+def _MAX() -> int:
+    try:
+        return max(1, int(os.getenv("FALLBACK_MAX_CONCURRENCY", "2")))
+    except Exception:
+        return 2
+
+
+_sem = threading.BoundedSemaphore(_MAX())
+_lock = threading.Lock()
+_current = 0
+_peak = 0
+
+
+def _refresh_if_needed() -> None:
+    global _sem
+    desired = _MAX()
+    value = getattr(_sem, "_value", None)
+    initial = getattr(_sem, "_initial_value", None)
+    if value is not None and initial is not None and initial != desired:
+        _sem = threading.BoundedSemaphore(desired)
+    elif initial is None and getattr(_sem, "maxvalue", None) not in (None, desired):
+        _sem = threading.BoundedSemaphore(desired)
+
+
+@contextlib.contextmanager
+def fallback_slot():
+    global _current, _peak
+    _refresh_if_needed()
+    _sem.acquire()
+    try:
+        with _lock:
+            _current += 1
+            if _current > _peak:
+                _peak = _current
+        yield
+    finally:
+        with _lock:
+            _current -= 1
+        _sem.release()
+
+
+def current_concurrency() -> int:
+    with _lock:
+        return _current
+
+
+def peak_concurrency() -> int:
+    with _lock:
+        return _peak

--- a/ai_trading/data/fetch/http_limit.py
+++ b/ai_trading/data/fetch/http_limit.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import threading
+
+_HOST_LIMITERS: dict[str, tuple[int, threading.BoundedSemaphore]] = {}
+_HOST_LOCK = threading.RLock()
+
+
+def _current_limit() -> int:
+    try:
+        return max(1, int(os.getenv("HTTP_HOST_LIMIT", "8")))
+    except Exception:
+        return 8
+
+
+@contextlib.contextmanager
+def acquire_host_slot(host: str):
+    limit = _current_limit()
+    with _HOST_LOCK:
+        current = _HOST_LIMITERS.get(host)
+        if current is None or current[0] != limit:
+            _HOST_LIMITERS[host] = (limit, threading.BoundedSemaphore(limit))
+        semaphore = _HOST_LIMITERS[host][1]
+    semaphore.acquire()
+    try:
+        yield
+    finally:
+        semaphore.release()

--- a/ai_trading/utils/safe_subprocess.py
+++ b/ai_trading/utils/safe_subprocess.py
@@ -79,6 +79,7 @@ def safe_subprocess_run(
             **popen_args,
         )
     except subprocess.TimeoutExpired as exc:
+        logger.info("SUBPROCESS_TIMEOUT")
         _prepare_timeout_exception(exc, run_timeout)
         raise
     except OSError as exc:


### PR DESCRIPTION
Title: Fix daily memo bypass and Alpaca fallback semantics

Context:
- Tighten data-fetch caching and fallback logic exercised by new regression tests.
- Ensure subprocess timeout semantics match expectations.

Problem:
- Daily fetch memo results were bypassing strict-cache guards, triggering errors.
- Alpaca HTTP fetches did not retry alternate feeds before Yahoo, nor persist override TTLs.
- SIP entitlement handling and subprocess timeouts diverged from desired behavior.
- Host limit and fallback concurrency guards were missing.

Scope:
- Data fetch memoization, Alpaca HTTP fallback sequencing, entitlement helpers, concurrency limiters, subprocess wrapper.

AC:
- Fresh daily memo entries short-circuit prior to strict cache access.
- Empty Alpaca responses trigger alternate feed HTTP retries and record overrides with TTL respect.
- Backoff flow switches feeds and shrinks windows before Yahoo fallback.
- SIP entitlement trusts account/env signals while downgrading only when clearly unauthorized.
- `safe_subprocess_run` re-raises `TimeoutExpired` with structured logging.
- HTTP host slots and fallback concurrency honor dynamic env limits without crashes.

Changes:
- Added daily memo unpack/freshness helpers to bypass strict cache, reusing canonical/legacy entries.
- Introduced Alpaca feed override cache with TTL, alternate-feed HTTP retry before Yahoo, and updated backoff sequencing.
- Relaxed SIP entitlement downgrade rules and ensured cache updates reflect SIP availability.
- Implemented host-slot limiter and fallback concurrency semaphore modules.
- Ensured subprocess timeout handler re-raises with attached result metadata.

Validation:
- `pip install -r requirements.txt`
- `pytest -q tests/bot_engine/test_daily_fetch_debounce.py::test_daily_fetch_memo_reuses_recent_result tests/bot_engine/test_daily_fetch_debounce.py::test_daily_fetch_legacy_memo_dict_short_circuits[legacy_entry0] tests/bot_engine/test_daily_fetch_debounce.py::test_daily_fetch_legacy_memo_dict_short_circuits[legacy_entry1] tests/bot_engine/test_daily_fetch_debounce.py::test_daily_fetch_legacy_tuple_normalizes_and_skips_daily_cache tests/bot_engine/test_daily_fetch_debounce.py::test_daily_fetch_canonical_and_legacy_memo_bypass_daily_cache`
- `pytest -q tests/data/test_empty_responses.py::test_alpaca_empty_responses_trigger_backup tests/test_feed_failover.py::test_cached_override_respects_ttl tests/test_fetch_backoff.py::test_fetch_feed_switches_to_alternate_and_shrinks_window`
- `pytest -q tests/utils/test_safe_subprocess_run.py::test_safe_subprocess_run_timeout`
- `pytest -q tests/test_feed_entitlement.py::test_ensure_entitled_feed_downgrades_cached_entitlement tests/test_feed_entitlement.py::test_ensure_entitled_feed_keeps tests/test_feed_entitlement.py::test_ensure_entitled_feed_keeps_when_env_unset tests/test_feed_entitlement.py::test_ensure_entitled_feed_keeps_when_account_advertises_sip tests/test_feed_entitlement.py::test_ensure_entitled_feed_keeps_when_account_reports_sip_without_creds tests/test_feed_entitlement.py::test_ensure_entitled_feed_trusts_account_when_sip_disallowed_advisory`
- `pytest -q tests/test_http_host_limit.py::test_host_limit_enforced tests/test_http_host_limit.py::test_host_limit_updates_when_env_changes`
- `pytest -q tests/data/test_fallback_concurrency.py::test_run_with_concurrency_respects_limit_minimal tests/data/test_fallback_concurrency.py::test_run_with_concurrency_peak_counter_respects_limit_minimal tests/data/test_fallback_concurrency.py::test_run_with_concurrency_peak_counter_is_monotonic_across_runs`
- `pytest -q tests/test_feed_entitlement.py::test_ensure_entitled_feed_keeps`
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check ai_trading/core/bot_engine.py ai_trading/data/bars.py ai_trading/data/fetch/__init__.py ai_trading/data/fetch/backoff.py ai_trading/utils/safe_subprocess.py ai_trading/data/fetch/fallback_concurrency.py ai_trading/data/fetch/http_limit.py`
- `mypy ai_trading/core/bot_engine.py ai_trading/data/bars.py ai_trading/data/fetch/__init__.py ai_trading/data/fetch/backoff.py ai_trading/utils/safe_subprocess.py ai_trading/data/fetch/fallback_concurrency.py ai_trading/data/fetch/http_limit.py`
- Full-suite `pytest -q` still fails across many pre-existing tests; run aborted after repeated unrelated failures.

Risk:
- Moderate: affects data-fetch pathways and concurrency controls; relies on new TTL caching and alternate feed behavior. Targeted tests passing mitigate regression risk; monitor for unforeseen interactions in production data flows.

------
https://chatgpt.com/codex/tasks/task_e_68e58f5c3bf4833084ca9917535aeef5