### PR TITLE
Fix limit order error handling and add regression tests

### DIFF
--- a/tests/execution/test_live_trading_error_handling.py
+++ b/tests/execution/test_live_trading_error_handling.py
@@ -1,0 +1,78 @@
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+
+import ai_trading.execution.live_trading as lt
+
+
+@pytest.fixture
+def engine_factory(monkeypatch):
+    """Provide a minimally wired execution engine for limit order tests."""
+
+    monkeypatch.setattr(lt, "_safe_mode_guard", lambda *_, **__: False)
+
+    def _capacity_stub(symbol, side, price_hint, quantity, broker, account_snapshot, preflight_fn=None):
+        return lt.CapacityCheck(True, int(quantity))
+
+    monkeypatch.setattr(lt, "_call_preflight_capacity", _capacity_stub)
+    monkeypatch.setattr(lt, "get_tick_size", lambda symbol: Decimal("0.01"))
+
+    def _build_engine(execute_behavior):
+        engine = object.__new__(lt.ExecutionEngine)
+        engine._refresh_settings = lambda: None
+        engine.is_initialized = True
+        engine._ensure_initialized = lambda: True
+        engine._pre_execution_checks = lambda: True
+        engine._get_account_snapshot = lambda: None
+        engine._should_skip_for_pdt = lambda _account, _closing: (False, None, {})
+        engine._execute_with_retry = lambda submit_fn, order_data: execute_behavior(order_data)
+        engine._submit_order_to_alpaca = lambda order_data: {"id": "abc123", "order_data": order_data}
+        engine.shadow_mode = False
+        engine.trading_client = SimpleNamespace()
+        engine.stats = {
+            "total_execution_time": 0.0,
+            "total_orders": 0,
+            "successful_orders": 0,
+            "failed_orders": 0,
+        }
+        return engine
+
+    return _build_engine
+
+
+def test_submit_limit_order_success_path(engine_factory):
+    engine = engine_factory(lambda order_data: {"id": "ok", **order_data})
+
+    result = engine.submit_limit_order("AAPL", "buy", 10, 123.45)
+
+    assert result["id"] == "ok"
+    assert engine.stats["successful_orders"] == 1
+    assert engine.stats["failed_orders"] == 0
+
+
+def test_submit_limit_order_nonretryable_logs_detail(engine_factory, caplog):
+    detail_message = "broker rejected"
+
+    def _raise_nonretryable(_order_data):
+        raise lt.NonRetryableBrokerError("rejected", code="R1", detail=detail_message)
+
+    engine = engine_factory(_raise_nonretryable)
+
+    with caplog.at_level("DEBUG", logger=lt.logger.name):
+        result = engine.submit_limit_order("AAPL", "buy", 5, 101.0)
+
+    assert result is None
+    info_records = [record for record in caplog.records if record.msg == "ORDER_SKIPPED_NONRETRYABLE"]
+    assert info_records, "Expected ORDER_SKIPPED_NONRETRYABLE log entry"
+    debug_records = [record for record in caplog.records if record.msg == "ORDER_SKIPPED_NONRETRYABLE_DETAIL"]
+    assert debug_records, "Expected ORDER_SKIPPED_NONRETRYABLE_DETAIL log entry"
+    assert debug_records[0].detail == detail_message
+
+
+def test_submit_limit_order_unexpected_exception_propagates(engine_factory):
+    engine = engine_factory(lambda _order_data: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError):
+        engine.submit_limit_order("AAPL", "buy", 2, 55.0)


### PR DESCRIPTION
## Title
Fix limit order error handling and add regression tests

## Context
- Live trading execution raised `UnboundLocalError` while logging limit order diagnostics when no exception object was in scope.
- The trading loop must continue processing symbols even when a broker rejects an order.

## Problem
- `submit_limit_order` referenced `exc` outside its `except` block, crashing when formatting non-retryable outcomes.
- Diagnostic logging was brittle and could raise secondary exceptions instead of recording broker responses.

## Scope
- Harden exception handling inside live trading market/limit order submission paths.
- Add regression tests covering success, non-retryable, and unexpected exception flows for limit orders.

## Acceptance Criteria
- Non-retryable order rejections no longer raise `UnboundLocalError`.
- Structured logs retain existing keys while safely handling missing detail/code values.
- Regression tests cover success, non-retryable, and unexpected exception scenarios for limit orders.

## Changes
- Added `_extract_error_detail` and `_extract_error_code` helpers for safe exception attribute access and reused them in market/limit order submissions.
- Ensured both market and limit order submission paths track a guarded exception context before logging.
- Introduced `tests/execution/test_live_trading_error_handling.py` to exercise success, non-retryable, and unexpected exception limit-order flows.

## Validation
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q tests/execution/test_live_trading_error_handling.py`
- `ruff check ai_trading/execution/live_trading.py tests/execution/test_live_trading_error_handling.py`
- `mypy ai_trading/execution/live_trading.py tests/execution/test_live_trading_error_handling.py`
- Attempted `pytest -q` for the full suite; aborted due to extensive pre-existing failures.

## Risk
- Low. Reverting this commit restores prior behavior (including the original crash).


------
https://chatgpt.com/codex/tasks/task_e_68e67f201f34833084402db4d3e0fe66